### PR TITLE
Catch errors without errorCode

### DIFF
--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -51,7 +51,8 @@
           "code": "java.method.addedToInterface",
           "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeCandidateUsersExpression(java.lang.String)",
           "justification": "Ignore new methods for user task properties builder."
-        },{
+        },
+        {
           "ignore": true,
           "code": "java.method.removed",
           "old": "method void io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder<B extends io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder<B, E>, E extends io.camunda.zeebe.model.bpmn.instance.BaseElement>::resizeSubProcess(io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape)",
@@ -70,6 +71,12 @@
           "code": "java.method.addedToInterface",
           "new": "method java.util.Optional<T> io.camunda.zeebe.model.bpmn.Query<T extends org.camunda.bpm.model.xml.instance.ModelElementInstance>::findSingleResult()",
           "justification": "add optional method findSingleResult() for the usage of get single result"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.List<java.lang.String> io.camunda.zeebe.model.bpmn.util.ModelUtil::getDuplicateMessageNames(java.util.stream.Stream<io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition>)",
+          "justification": "Remove unused method"
         }
       ]
     }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
@@ -315,13 +315,6 @@ public class ModelUtil {
             .map(error -> Optional.ofNullable(error.getErrorCode()))
             .collect(groupingBy(errorCode -> errorCode, counting()));
 
-    if (definitionWithoutErrorCount >= 1 && !errorCodeOccurrences.isEmpty()) {
-      errorCollector.accept(
-          "The same scope can not contain an error catch event without error code "
-              + "and another one with error code. An error catch event without "
-              + "error code catches all errors.");
-    }
-
     errorCodeOccurrences.forEach(
         (errorCode, occurrences) -> {
           if (occurrences > 1) {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
@@ -109,20 +109,6 @@ public class ModelUtil {
         .collect(Collectors.toList());
   }
 
-  public static List<String> getDuplicateMessageNames(
-      final Stream<MessageEventDefinition> eventDefinitions) {
-
-    final Stream<Message> messages =
-        eventDefinitions
-            .map(MessageEventDefinition::getMessage)
-            .filter(m -> m.getName() != null && !m.getName().isEmpty());
-
-    return messages.collect(groupingBy(Message::getName, counting())).entrySet().stream()
-        .filter(e -> e.getValue() > 1)
-        .map(Entry::getKey)
-        .collect(Collectors.toList());
-  }
-
   public static void verifyNoDuplicatedBoundaryEvents(
       final Activity activity, final Consumer<String> errorCollector) {
 
@@ -345,12 +331,6 @@ public class ModelUtil {
   private static String duplicatedMessageNames(final String messageName) {
     return String.format(
         "Multiple message event definitions with the same name '%s' are not allowed.", messageName);
-  }
-
-  private static String duplicatedErrorCodes(final String errorCode) {
-    return String.format(
-        "Multiple error event definitions with the same errorCode '%s' are not allowed.",
-        errorCode);
   }
 
   private static String duplicatedSignalNames(final String signalName) {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ErrorEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ErrorEventDefinitionValidator.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
-import io.camunda.zeebe.model.bpmn.instance.CatchEvent;
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.Error;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
@@ -36,21 +36,24 @@ public class ErrorEventDefinitionValidator implements ModelElementValidator<Erro
       final ErrorEventDefinition element,
       final ValidationResultCollector validationResultCollector) {
 
+    final ModelElementInstance parentElement = element.getParentElement();
     final Error error = element.getError();
-    if (error == null) {
-      validationResultCollector.addError(0, "Must reference an error");
-
-    } else {
-      final String errorCode = error.getErrorCode();
-      if (errorCode == null || errorCode.isEmpty()) {
-        validationResultCollector.addError(0, "ErrorCode must be present and not empty");
-        return;
+    if (parentElement instanceof EndEvent) {
+      if (error == null) {
+        validationResultCollector.addError(0, "Must reference an error");
+      } else {
+        final String errorCode = error.getErrorCode();
+        if (errorCode == null || errorCode.isEmpty()) {
+          validationResultCollector.addError(0, "ErrorCode must be present and not empty");
+        }
       }
-
-      final ModelElementInstance parentElement = element.getParentElement();
-      if (errorCode.startsWith(ZEEBE_EXPRESSION_PREFIX) && parentElement instanceof CatchEvent) {
-        validationResultCollector.addError(
-            0, "The errorCode of the error catch event is not allowed to be an expression");
+    } else {
+      if (error != null) {
+        final String errorCode = error.getErrorCode();
+        if (errorCode != null && errorCode.startsWith(ZEEBE_EXPRESSION_PREFIX)) {
+          validationResultCollector.addError(
+              0, "The errorCode of the error catch event is not allowed to be an expression");
+        }
       }
     }
   }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeErrorEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeErrorEventValidationTest.java
@@ -183,21 +183,6 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
       },
       {
         Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", t -> t.zeebeJobType("type"))
-            .boundaryEvent("catch-1", AbstractBoundaryEventBuilder::error)
-            .endEvent()
-            .moveToActivity("task")
-            .boundaryEvent("catch-2", b -> b.error("ERROR"))
-            .endEvent()
-            .done(),
-        singletonList(
-            expect(
-                ServiceTask.class,
-                "The same scope can not contain an error catch event without error code and another one with error code. An error catch event without error code catches all errors."))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
             .eventSubProcess("sub-1", s -> s.startEvent().interrupting(true).error().endEvent())
             .eventSubProcess("sub-2", s -> s.startEvent().interrupting(true).error().endEvent())
             .startEvent()
@@ -233,19 +218,6 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
             expect(
                 Process.class,
                 "The same scope can not contain more than one error catch event without error code. An error catch event without error code catches all errors."))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .eventSubProcess("sub-1", s -> s.startEvent().interrupting(true).error().endEvent())
-            .eventSubProcess(
-                "sub-2", s -> s.startEvent().interrupting(true).error("ERROR").endEvent())
-            .startEvent()
-            .endEvent()
-            .done(),
-        singletonList(
-            expect(
-                Process.class,
-                "The same scope can not contain an error catch event without error code and another one with error code. An error catch event without error code catches all errors."))
       },
     };
   }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeErrorEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeErrorEventValidationTest.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.ex
 import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractBoundaryEventBuilder;
 import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Process;
@@ -31,24 +32,6 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
   @Parameters(name = "{index}: {1}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", t -> t.zeebeJobType("type"))
-            .boundaryEvent("catch", b -> b.error(""))
-            .endEvent()
-            .done(),
-        singletonList(expect(ErrorEventDefinition.class, "ErrorCode must be present and not empty"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", t -> t.zeebeJobType("type"))
-            .boundaryEvent("catch", b -> b.errorEventDefinition())
-            .endEvent()
-            .done(),
-        singletonList(expect(ErrorEventDefinition.class, "Must reference an error"))
-      },
       {
         Bpmn.createExecutableProcess("process")
             .startEvent()
@@ -82,7 +65,7 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 ServiceTask.class,
-                "Multiple error event definitions with the same errorCode 'ERROR' are not allowed."))
+                "Multiple error catch events with the same error code 'ERROR' are not supported on the same scope."))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -95,29 +78,7 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 SubProcess.class,
-                "Multiple error event definitions with the same errorCode 'ERROR' are not allowed."))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .subProcess(
-                "sub",
-                s ->
-                    s.embeddedSubProcess()
-                        .startEvent()
-                        .serviceTask("task", t -> t.zeebeJobType("type"))
-                        .boundaryEvent("catch", b -> b.error(""))
-                        .endEvent())
-            .done(),
-        singletonList(expect(ErrorEventDefinition.class, "ErrorCode must be present and not empty"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .eventSubProcess("sub", s -> s.startEvent().error("").endEvent())
-            .startEvent()
-            .endEvent()
-            .done(),
-        singletonList(expect(ErrorEventDefinition.class, "ErrorCode must be present and not empty"))
+                "Multiple error catch events with the same error code 'ERROR' are not supported on the same scope."))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -152,7 +113,7 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 Process.class,
-                "Multiple error event definitions with the same errorCode 'ERROR' are not allowed."))
+                "Multiple error catch events with the same error code 'ERROR' are not supported on the same scope."))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -174,7 +135,7 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 SubProcess.class,
-                "Multiple error event definitions with the same errorCode 'ERROR' are not allowed."))
+                "Multiple error catch events with the same error code 'ERROR' are not supported on the same scope."))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -189,6 +150,102 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
             .endEvent("error", e -> e.errorEventDefinition())
             .done(),
         singletonList(expect(ErrorEventDefinition.class, "Must reference an error"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .boundaryEvent("catch-1", AbstractBoundaryEventBuilder::error)
+            .endEvent()
+            .moveToActivity("task")
+            .boundaryEvent("catch-2", AbstractBoundaryEventBuilder::error)
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ServiceTask.class,
+                "The same scope can not contain more than one error catch event without error code. An error catch event without error code catches all errors."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .boundaryEvent("catch-1", AbstractBoundaryEventBuilder::errorEventDefinition)
+            .endEvent()
+            .moveToActivity("task")
+            .boundaryEvent("catch-2", AbstractBoundaryEventBuilder::errorEventDefinition)
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ServiceTask.class,
+                "The same scope can not contain more than one error catch event without error code. An error catch event without error code catches all errors."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .boundaryEvent("catch-1", AbstractBoundaryEventBuilder::error)
+            .endEvent()
+            .moveToActivity("task")
+            .boundaryEvent("catch-2", b -> b.error("ERROR"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ServiceTask.class,
+                "The same scope can not contain an error catch event without error code and another one with error code. An error catch event without error code catches all errors."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess("sub-1", s -> s.startEvent().interrupting(true).error().endEvent())
+            .eventSubProcess("sub-2", s -> s.startEvent().interrupting(true).error().endEvent())
+            .startEvent()
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                Process.class,
+                "The same scope can not contain more than one error catch event without error code. An error catch event without error code catches all errors."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess(
+                "sub-1",
+                s ->
+                    s.startEvent()
+                        .interrupting(true)
+                        .errorEventDefinition()
+                        .errorEventDefinitionDone()
+                        .endEvent())
+            .eventSubProcess(
+                "sub-2",
+                s ->
+                    s.startEvent()
+                        .interrupting(true)
+                        .errorEventDefinition()
+                        .errorEventDefinitionDone()
+                        .endEvent())
+            .startEvent()
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                Process.class,
+                "The same scope can not contain more than one error catch event without error code. An error catch event without error code catches all errors."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess("sub-1", s -> s.startEvent().interrupting(true).error().endEvent())
+            .eventSubProcess(
+                "sub-2", s -> s.startEvent().interrupting(true).error("ERROR").endEvent())
+            .startEvent()
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                Process.class,
+                "The same scope can not contain an error catch event without error code and another one with error code. An error catch event without error code catches all errors."))
       },
     };
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CatchEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CatchEventTransformer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableError;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEscalation;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableLink;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMessage;
@@ -145,7 +146,16 @@ public final class CatchEventTransformer implements ModelElementTransformer<Catc
       final ErrorEventDefinition errorEventDefinition) {
 
     final var error = errorEventDefinition.getError();
-    final var executableError = context.getError(error.getId());
+    final ExecutableError executableError;
+
+    // If 'errorRef' is omitted, an empty error without errorCode will be created to facilitate
+    // finding the corresponding catch event
+    if (error == null) {
+      executableError = new ExecutableError("");
+      executableError.setErrorCode(BufferUtil.wrapString(""));
+    } else {
+      executableError = context.getError(error.getId());
+    }
     executableElement.setError(executableError);
     executableElement.setEventType(BpmnEventType.ERROR);
   }
@@ -173,7 +183,7 @@ public final class CatchEventTransformer implements ModelElementTransformer<Catc
     final ExecutableEscalation executableEscalation;
 
     // If 'escalationRef' is omitted, an empty escalation without escalationCode will be created
-    // for the boundary event to facilitate finding the corresponding catch event
+    // to facilitate finding the corresponding catch event
     if (escalation == null) {
       executableEscalation = new ExecutableEscalation("");
       executableEscalation.setEscalationCode(BufferUtil.wrapString(""));

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractStartEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.camunda.zeebe.protocol.record.Record;
@@ -141,6 +142,208 @@ public class ErrorEventTest {
                 .withElementType(BpmnElementType.BOUNDARY_EVENT))
         .extracting(r -> r.getValue().getElementId())
         .containsOnly("error-2");
+  }
+
+  @Test
+  public void shouldCatchErrorEventsOnBoundaryEventWithoutErrorRef() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            process(
+                serviceTask ->
+                    serviceTask.boundaryEvent(
+                        "error",
+                        b -> b.errorEventDefinition().errorEventDefinitionDone().endEvent())))
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode("error")
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.BOUNDARY_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsOnly("error");
+  }
+
+  @Test
+  public void shouldCatchErrorEventsOnBoundaryEventWithoutErrorCode() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            process(serviceTask -> serviceTask.boundaryEvent("error", b -> b.error().endEvent())))
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode("error")
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.BOUNDARY_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsOnly("error");
+  }
+
+  @Test
+  public void shouldCatchErrorEventsOnBoundaryEventWithSpecificErrorCode() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            process(
+                serviceTask -> {
+                  serviceTask.boundaryEvent("catch-all", b -> b.error().endEvent());
+                  serviceTask.boundaryEvent("code-specific", b -> b.error(ERROR_CODE).endEvent());
+                }))
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.BOUNDARY_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsOnly("code-specific");
+  }
+
+  @Test
+  public void shouldCatchErrorEventsOnErrorStartEventWithoutErrorRef() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                "sub",
+                e ->
+                    e.startEvent("error", AbstractStartEventBuilder::errorEventDefinition)
+                        .endEvent())
+            .startEvent("start")
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode("errorCode")
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.START_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsSubsequence("start", "error");
+  }
+
+  @Test
+  public void shouldCatchErrorEventsOnErrorStartEventWithoutErrorCode() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                "sub", e -> e.startEvent("error", AbstractStartEventBuilder::error).endEvent())
+            .startEvent("start")
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode("errorCode")
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.START_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsSubsequence("start", "error");
+  }
+
+  @Test
+  public void shouldCatchErrorEventsOnErrorStartEventWithSpecificErrorCode() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                "sub-1",
+                e -> e.startEvent("catch-all", AbstractStartEventBuilder::error).endEvent())
+            .eventSubProcess(
+                "sub-2", e -> e.startEvent("code-specific", s -> s.error(ERROR_CODE)).endEvent())
+            .startEvent("start")
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.START_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsSubsequence("start", "code-specific");
   }
 
   @Test


### PR DESCRIPTION
## Description
As a user, I want to catch any errors via event subprocess with error start event or error boundary event.

* The error is caught on the error start event if the `errorRef` is omitted or the` errorCode` of referenced error is omitted.
* The error is caught on the boundary event if the `errorRef` is omitted or the `errorCode` of referenced error is omitted.
* If a start event has no `errorRef` or `errorCode` of referenced error then another event sub-process with an error start event in the same scope is not supported.

----
* Any errors thrown from `Task A` can be handled in the workflow by catching it on an event subprocess.

<img width="492" alt="image" src="https://user-images.githubusercontent.com/24605947/204488239-42419b5a-18c3-4e2d-8557-214a570d3edf.png">

* Any errors thrown from `Task A` can be handled in the workflow by catching it on boundary events.
<img width="368" alt="image" src="https://user-images.githubusercontent.com/24605947/204492191-f5e0145a-26d7-493a-827c-6a4f349bff93.png">


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11126


## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
