### PR TITLE
ci: fix renovate semantic commit type

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,9 +9,6 @@
     "stable/8.1"
   ],
   "dependencyDashboard": false,
-  "semanticCommits": "enabled",
-  "semanticCommitType": "deps",
-  "semanticCommitScope": "docker",
   "enabledManagers": [
     "dockerfile"
   ],
@@ -28,6 +25,9 @@
     }
   ],
   "dockerfile": {
+    "semanticCommits": "enabled",
+    "semanticCommitType": "deps",
+    "semanticCommitScope": "docker",
     "ignorePaths": [
       "benchmarks/**",
       "clients/go/vendor/**"


### PR DESCRIPTION
With the previous config, renovate was still creating "chore(docker)" commits where we want "deps(docker)". Maybe moving the config to the dockerfile manager helps.
