### PR TITLE
Provide backupId in request body for take backup api

### DIFF
--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -21,8 +21,6 @@ import io.camunda.zeebe.gateway.admin.backup.BackupStatus;
 import io.camunda.zeebe.gateway.admin.backup.PartitionBackupStatus;
 import io.camunda.zeebe.gateway.admin.backup.State;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
-import io.camunda.zeebe.shared.management.BackupEndpoint.ErrorResponse;
-import io.camunda.zeebe.shared.management.BackupEndpoint.TakeBackupResponse;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.Error;
 import java.util.List;
@@ -54,8 +52,8 @@ final class BackupEndpointTest {
 
       // then
       assertThat(response.getBody())
-          .asInstanceOf(InstanceOfAssertFactories.type(ErrorResponse.class))
-          .isEqualTo(new ErrorResponse(1, "failure"));
+          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
+          .isEqualTo(new Error().message("failure"));
     }
 
     @Test
@@ -71,24 +69,8 @@ final class BackupEndpointTest {
 
       // then
       assertThat(response.getBody())
-          .asInstanceOf(InstanceOfAssertFactories.type(ErrorResponse.class))
-          .isEqualTo(new ErrorResponse(1, "failure"));
-    }
-
-    @Test
-    void shouldReturnNewBackupIdOnSuccess() {
-      // given
-      final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
-      doReturn(CompletableFuture.completedFuture(3L)).when(api).takeBackup(anyLong());
-
-      // when
-      final WebEndpointResponse<?> response = endpoint.take(1);
-
-      // then
-      assertThat(response.getBody())
-          .asInstanceOf(InstanceOfAssertFactories.type(TakeBackupResponse.class))
-          .isEqualTo(new TakeBackupResponse(3));
+          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
+          .isEqualTo(new Error().message("failure"));
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
@@ -12,13 +12,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
-import io.camunda.zeebe.qa.util.actuator.BackupActuator.TakeBackupResponse;
 import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.PartitionBackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.StateCode;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupRequest;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeNode;
@@ -124,10 +125,10 @@ final class BackupAcceptanceIT {
     }
 
     // when
-    final var response = actuator.take(1L);
+    final var response = actuator.take(new TakeBackupRequest().backupId(1L));
 
     // then
-    assertThat(response).isEqualTo(new TakeBackupResponse(1L));
+    assertThat(response).isInstanceOf(TakeBackupResponse.class);
     waitUntilBackupIsCompleted(actuator, 1L);
   }
 
@@ -157,8 +158,8 @@ final class BackupAcceptanceIT {
     }
 
     // when
-    actuator.take(1L);
-    actuator.take(2L);
+    actuator.take(new TakeBackupRequest().backupId(1L));
+    actuator.take(new TakeBackupRequest().backupId(2L));
 
     waitUntilBackupIsCompleted(actuator, 1L);
     waitUntilBackupIsCompleted(actuator, 2L);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.PartitionBackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.StateCode;
-import io.camunda.zeebe.shared.management.openapi.models.TakeBackupRequest;
 import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.containers.ZeebeBrokerNode;
@@ -125,7 +124,7 @@ final class BackupAcceptanceIT {
     }
 
     // when
-    final var response = actuator.take(new TakeBackupRequest().backupId(1L));
+    final var response = actuator.take(1);
 
     // then
     assertThat(response).isInstanceOf(TakeBackupResponse.class);
@@ -158,8 +157,8 @@ final class BackupAcceptanceIT {
     }
 
     // when
-    actuator.take(new TakeBackupRequest().backupId(1L));
-    actuator.take(new TakeBackupRequest().backupId(2L));
+    actuator.take(1);
+    actuator.take(2);
 
     waitUntilBackupIsCompleted(actuator, 1L);
     waitUntilBackupIsCompleted(actuator, 2L);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.StateCode;
-import io.camunda.zeebe.shared.management.openapi.models.TakeBackupRequest;
 import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
 import io.zeebe.containers.ZeebeContainer;
 import java.time.Duration;
@@ -113,7 +112,7 @@ final class RestoreAcceptanceIT {
             .build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
-    final var response = actuator.take(new TakeBackupRequest().backupId(BACKUP_ID));
+    final var response = actuator.take(BACKUP_ID);
     assertThat(response).isInstanceOf(TakeBackupResponse.class);
     Awaitility.await("until a backup exists with the given ID")
         .atMost(Duration.ofSeconds(30))
@@ -141,7 +140,7 @@ final class RestoreAcceptanceIT {
             .build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
-    final var response = actuator.take(new TakeBackupRequest().backupId(BACKUP_ID));
+    final var response = actuator.take(BACKUP_ID);
     assertThat(response).isInstanceOf(TakeBackupResponse.class);
     Awaitility.await("until a backup exists with the given ID")
         .atMost(Duration.ofSeconds(30))

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
@@ -15,12 +15,13 @@ import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
-import io.camunda.zeebe.qa.util.actuator.BackupActuator.TakeBackupResponse;
 import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.StateCode;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupRequest;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
 import io.zeebe.containers.ZeebeContainer;
 import java.time.Duration;
 import java.util.Map;
@@ -41,7 +42,7 @@ final class RestoreAcceptanceIT {
   private static final Network NETWORK = Network.newNetwork();
   private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
-  private static final int BACKUP_ID = 1;
+  private static final long BACKUP_ID = 1;
 
   @Container
   private static final MinioContainer MINIO =
@@ -72,7 +73,7 @@ final class RestoreAcceptanceIT {
           .withStartupCheckStrategy(
               new OneShotStartupCheckStrategy().withTimeout(Duration.ofMinutes(1)))
           .withEnv("ZEEBE_RESTORE", "true")
-          .withEnv("ZEEBE_RESTORE_FROM_BACKUP_ID", Integer.toString(BACKUP_ID))
+          .withEnv("ZEEBE_RESTORE_FROM_BACKUP_ID", Long.toString(BACKUP_ID))
           .withEnv("ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEBACKUP", "true")
           .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "S3")
           .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME", BUCKET_NAME)
@@ -112,14 +113,14 @@ final class RestoreAcceptanceIT {
             .build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
-    final var response = actuator.take(BACKUP_ID);
-    assertThat(response).isEqualTo(new TakeBackupResponse(BACKUP_ID));
+    final var response = actuator.take(new TakeBackupRequest().backupId(BACKUP_ID));
+    assertThat(response).isInstanceOf(TakeBackupResponse.class);
     Awaitility.await("until a backup exists with the given ID")
         .atMost(Duration.ofSeconds(30))
         .ignoreExceptions() // 404 NOT_FOUND throws exception
         .untilAsserted(
             () -> {
-              final var status = actuator.status(response.id());
+              final var status = actuator.status(BACKUP_ID);
               assertThat(status)
                   .extracting(BackupInfo::getBackupId, BackupInfo::getState)
                   .containsExactly(1L, StateCode.COMPLETED);
@@ -140,14 +141,14 @@ final class RestoreAcceptanceIT {
             .build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
-    final var response = actuator.take(BACKUP_ID);
-    assertThat(response).isEqualTo(new TakeBackupResponse(BACKUP_ID));
+    final var response = actuator.take(new TakeBackupRequest().backupId(BACKUP_ID));
+    assertThat(response).isInstanceOf(TakeBackupResponse.class);
     Awaitility.await("until a backup exists with the given ID")
         .atMost(Duration.ofSeconds(30))
         .ignoreExceptions() // 404 NOT_FOUND throws exception
         .untilAsserted(
             () -> {
-              final var status = actuator.status(response.id());
+              final var status = actuator.status(BACKUP_ID);
               assertThat(status)
                   .extracting(BackupInfo::getBackupId, BackupInfo::getState)
                   .containsExactly(1L, StateCode.COMPLETED);

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -82,10 +82,5 @@
       <artifactId>toxiproxy-java</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-    </dependency>
-
   </dependencies>
 </project>

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -81,5 +81,11 @@
       <groupId>eu.rekawek.toxiproxy</groupId>
       <artifactId>toxiproxy-java</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.qa.util.actuator;
 
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import feign.Body;
 import feign.Feign;
 import feign.FeignException;
 import feign.FeignException.InternalServerError;
@@ -24,7 +25,6 @@ import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator.ErrorResponse.Payload;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
-import io.camunda.zeebe.shared.management.openapi.models.TakeBackupRequest;
 import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
 import io.zeebe.containers.ZeebeNode;
 import java.io.IOException;
@@ -32,7 +32,6 @@ import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import org.springframework.web.bind.annotation.RequestBody;
 
 /**
  * Java interface for the node's backup actuator. To instantiate this interface, you can use {@link
@@ -82,7 +81,8 @@ public interface BackupActuator {
    */
   @RequestLine("POST /")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  TakeBackupResponse take(@RequestBody final TakeBackupRequest request);
+  @Body("%7B\"backupId\": \"{backupId}\"%7D")
+  TakeBackupResponse take(@Param("backupId") long backupId);
 
   @RequestLine("GET /{id}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -24,12 +24,15 @@ import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator.ErrorResponse.Payload;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupRequest;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
 import io.zeebe.containers.ZeebeNode;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import org.springframework.web.bind.annotation.RequestBody;
 
 /**
  * Java interface for the node's backup actuator. To instantiate this interface, you can use {@link
@@ -77,9 +80,9 @@ public interface BackupActuator {
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
-  @RequestLine("POST /{id}")
+  @RequestLine("POST /")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  TakeBackupResponse take(@Param final long id);
+  TakeBackupResponse take(@RequestBody final TakeBackupRequest request);
 
   @RequestLine("GET /{id}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
@@ -119,8 +122,6 @@ public interface BackupActuator {
       return FeignException.errorStatus(methodKey, response);
     }
   }
-
-  record TakeBackupResponse(long id) {}
 
   final class ErrorResponse extends InternalServerError {
     private final Payload payload;


### PR DESCRIPTION
## Description

To align with the spec:
- backupId is now expected in the request body instead of in the path
- Success response code is changed from 200 to 202 to indicate that backup is processed asyn
- Success response have also changed
- test `shouldReturnNewBackupIdOnSuccess` is removed because according new spec this should return an error. This is not the case now, but will be done in a followup.

The error codes are not yet updated to align with the spec. 

## Related issues

related #11124

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
