### PR TITLE
Store record counters as metadata of the Elasticsearch exporter

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -361,7 +361,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private void distributeExporterPositions() {
     final var exportPositionsMessage = new ExporterPositionsMessage();
-    state.visitPositions(exportPositionsMessage::putExporter);
+    state.visitExporterState(
+        (exporterId, exporterStateEntry) ->
+            exportPositionsMessage.putExporter(exporterId, exporterStateEntry.getPosition()));
     exporterDistributionService.distributeExporterPositions(exportPositionsMessage);
   }
 
@@ -433,10 +435,10 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     final List<String> exporterIds =
         containers.stream().map(ExporterContainer::getId).collect(Collectors.toList());
 
-    state.visitPositions(
-        (exporterId, position) -> {
+    state.visitExporterState(
+        (exporterId, exporterStateEntry) -> {
           if (!exporterIds.contains(exporterId)) {
-            state.removePosition(exporterId);
+            state.removeExporterState(exporterId);
             LOG.info(
                 "The exporter '{}' is not configured anymore. Its lastExportedPosition is removed from the state.",
                 exporterId);

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateEntry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateEntry.java
@@ -11,18 +11,18 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 
-public class ExporterPosition extends UnpackedObject implements DbValue {
+public class ExporterStateEntry extends UnpackedObject implements DbValue {
   private final LongProperty positionProp = new LongProperty("exporterPosition");
 
-  public ExporterPosition() {
+  public ExporterStateEntry() {
     declareProperty(positionProp);
   }
 
-  public void set(final long position) {
-    positionProp.setValue(position);
+  public long getPosition() {
+    return positionProp.getValue();
   }
 
-  public long get() {
-    return positionProp.getValue();
+  public void setPosition(final long position) {
+    positionProp.setValue(position);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateEntry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateEntry.java
@@ -9,20 +9,38 @@ package io.camunda.zeebe.broker.exporter.stream;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class ExporterStateEntry extends UnpackedObject implements DbValue {
+
+  private static final UnsafeBuffer EMPTY_METADATA = new UnsafeBuffer();
+
   private final LongProperty positionProp = new LongProperty("exporterPosition");
+  private final BinaryProperty metadataProp =
+      new BinaryProperty("exporterMetadata", EMPTY_METADATA);
 
   public ExporterStateEntry() {
-    declareProperty(positionProp);
+    declareProperty(positionProp).declareProperty(metadataProp);
   }
 
   public long getPosition() {
     return positionProp.getValue();
   }
 
-  public void setPosition(final long position) {
+  public ExporterStateEntry setPosition(final long position) {
     positionProp.setValue(position);
+    return this;
+  }
+
+  public DirectBuffer getMetadata() {
+    return metadataProp.getValue();
+  }
+
+  public ExporterStateEntry setMetadata(final DirectBuffer metadata) {
+    metadataProp.setValue(metadata);
+    return this;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -25,7 +25,6 @@ public final class ExportersState {
   private static final UnsafeBuffer METADATA_NOT_FOUND = new UnsafeBuffer();
 
   private final DbString exporterId;
-  private final ExporterStateEntry exporterStateEntry = new ExporterStateEntry();
   private final ColumnFamily<DbString, ExporterStateEntry> exporterPositionColumnFamily;
 
   public ExportersState(
@@ -33,7 +32,7 @@ public final class ExportersState {
     exporterId = new DbString();
     exporterPositionColumnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.EXPORTER, transactionContext, exporterId, exporterStateEntry);
+            ZbColumnFamilies.EXPORTER, transactionContext, exporterId, new ExporterStateEntry());
   }
 
   public void setPosition(final String exporterId, final long position) {
@@ -44,6 +43,8 @@ public final class ExportersState {
       final String exporterId, final long position, final DirectBuffer metadata) {
     this.exporterId.wrapString(exporterId);
 
+    final var exporterStateEntry =
+        findExporterStateEntry(exporterId).orElse(new ExporterStateEntry());
     exporterStateEntry.setPosition(position);
     if (metadata != null) {
       exporterStateEntry.setMetadata(metadata);

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -12,12 +12,17 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.util.Optional;
 import java.util.function.BiConsumer;
+import org.agrona.DirectBuffer;
 import org.agrona.collections.LongArrayList;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class ExportersState {
 
   public static final long VALUE_NOT_FOUND = -1;
+
+  private static final UnsafeBuffer METADATA_NOT_FOUND = new UnsafeBuffer();
 
   private final DbString exporterId;
   private final ExporterStateEntry exporterStateEntry = new ExporterStateEntry();
@@ -32,20 +37,35 @@ public final class ExportersState {
   }
 
   public void setPosition(final String exporterId, final long position) {
+    setExporterState(exporterId, position, null);
+  }
+
+  public void setExporterState(
+      final String exporterId, final long position, final DirectBuffer metadata) {
     this.exporterId.wrapString(exporterId);
-    setPosition(position);
+
+    exporterStateEntry.setPosition(position);
+    if (metadata != null) {
+      exporterStateEntry.setMetadata(metadata);
+    }
+    exporterPositionColumnFamily.upsert(this.exporterId, exporterStateEntry);
   }
 
   public long getPosition(final String exporterId) {
-    this.exporterId.wrapString(exporterId);
-
-    final ExporterStateEntry pos = exporterPositionColumnFamily.get(this.exporterId);
-    return pos == null ? VALUE_NOT_FOUND : pos.getPosition();
+    return findExporterStateEntry(exporterId)
+        .map(ExporterStateEntry::getPosition)
+        .orElse(VALUE_NOT_FOUND);
   }
 
-  private void setPosition(final long position) {
-    exporterStateEntry.setPosition(position);
-    exporterPositionColumnFamily.upsert(exporterId, exporterStateEntry);
+  public DirectBuffer getExporterMetadata(final String exporterId) {
+    return findExporterStateEntry(exporterId)
+        .map(ExporterStateEntry::getMetadata)
+        .orElse(METADATA_NOT_FOUND);
+  }
+
+  private Optional<ExporterStateEntry> findExporterStateEntry(final String exporterId) {
+    this.exporterId.wrapString(exporterId);
+    return Optional.ofNullable(exporterPositionColumnFamily.get(this.exporterId));
   }
 
   public void visitExporterState(final BiConsumer<String, ExporterStateEntry> consumer) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.util.function.BiConsumer;
-import org.agrona.DirectBuffer;
 import org.agrona.collections.LongArrayList;
 
 public final class ExportersState {
@@ -39,16 +38,8 @@ public final class ExportersState {
 
   public long getPosition(final String exporterId) {
     this.exporterId.wrapString(exporterId);
-    return getPosition();
-  }
 
-  public long getPosition(final DirectBuffer exporterId) {
-    this.exporterId.wrapBuffer(exporterId);
-    return getPosition();
-  }
-
-  private long getPosition() {
-    final ExporterStateEntry pos = exporterPositionColumnFamily.get(exporterId);
+    final ExporterStateEntry pos = exporterPositionColumnFamily.get(this.exporterId);
     return pos == null ? VALUE_NOT_FOUND : pos.getPosition();
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExportersStateTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExportersStateTest.java
@@ -119,6 +119,44 @@ public final class ExportersStateTest {
   }
 
   @Test
+  public void shouldNotClearMetadataIfEmpty() {
+    // given
+    final var exporterId = "e1";
+    final var exporterMetadata1 = BufferUtil.wrapString("metadata-1");
+    final var exporterPosition1 = 10L;
+
+    state.setExporterState(exporterId, exporterPosition1, exporterMetadata1);
+
+    // when
+    state.setExporterState(exporterId, exporterPosition1, null);
+
+    // then
+    assertThat(state.getPosition(exporterId)).isEqualTo(exporterPosition1);
+    assertThat(state.getExporterMetadata(exporterId)).isEqualTo(exporterMetadata1);
+  }
+
+  @Test
+  public void shouldSetExporterStateWithAndWithoutMetadata() {
+    // given
+    final var exporterId1 = "e1";
+    final var exporterMetadata1 = BufferUtil.wrapString("metadata-1");
+    final var exporterPosition1 = 10L;
+
+    final var exporterId2 = "e2";
+    final var exporterPosition2 = 20L;
+
+    // when
+    state.setExporterState(exporterId1, exporterPosition1, exporterMetadata1);
+    state.setExporterState(exporterId2, exporterPosition2, null);
+
+    // then
+    assertThat(state.getPosition(exporterId1)).isEqualTo(exporterPosition1);
+    assertThat(state.getExporterMetadata(exporterId1)).isEqualTo(exporterMetadata1);
+    assertThat(state.getPosition(exporterId2)).isEqualTo(exporterPosition2);
+    assertThat(state.getExporterMetadata(exporterId2)).isEqualTo(EMPTY_METADATA);
+  }
+
+  @Test
   public void shouldReturnUnknownPositionForUnknownExporter() {
     // given
     final String id = "exporter";

--- a/exporter-api/revapi.json
+++ b/exporter-api/revapi.json
@@ -10,5 +10,18 @@
         ]
       }
     }
+  },
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "justification": "The controller is used by the exporters. Extending the controller interface is not a breaking change.",
+          "code": "java.method.addedToInterface",
+          "classQualifiedName": "io.camunda.zeebe.exporter.api.context.Controller"
+        }
+      ]
+    }
   }
 ]

--- a/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Controller.java
+++ b/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Controller.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.exporter.api.context;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /** Controls various aspect of the exporting process. */
 public interface Controller {
@@ -25,7 +26,18 @@ public interface Controller {
    *
    * @param position the latest successfully exported record position
    */
-  void updateLastExportedRecordPosition(long position);
+  void updateLastExportedRecordPosition(final long position);
+
+  /**
+   * Signals to the broker that the exporter has successfully exported all records up to and
+   * including the record at {@param position}. Optionally, the exporter can provide arbitrary
+   * metadata that is stored in the broker and can be retrieved when the exporter opens. The
+   * metadata is stored only if the given position is greater than the previous exporter position.
+   *
+   * @param position the latest successfully exported record position
+   * @param metadata arbitrary metadata for the exporter (can be {@code null})
+   */
+  void updateLastExportedRecordPosition(long position, byte[] metadata);
 
   /**
    * Schedules a cancellable {@param task} to be ran after {@param delay} has expired.
@@ -35,4 +47,12 @@ public interface Controller {
    * @return cancellable task.
    */
   ScheduledTask scheduleCancellableTask(final Duration delay, final Runnable task);
+
+  /**
+   * Read arbitrary metadata of the exporter that was stored previously by using the exporter
+   * controller.
+   *
+   * @return the restored metadata, or {@link Optional#empty()} if no metadata exist
+   */
+  Optional<byte[]> readMetadata();
 }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.ExporterException;
@@ -15,6 +17,7 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import java.io.IOException;
 import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,12 +28,15 @@ public class ElasticsearchExporter implements Exporter {
   private static final int RECOMMENDED_MAX_BULK_MEMORY_LIMIT = 100 * 1024 * 1024;
 
   private Logger log = LoggerFactory.getLogger(getClass().getPackageName());
+  private final ObjectMapper exporterMetadataObjectMapper = new ObjectMapper();
 
-  private final ElasticsearchRecordCounters recordCounters = new ElasticsearchRecordCounters();
+  private final ElasticsearchExporterMetadata exporterMetadata =
+      new ElasticsearchExporterMetadata();
 
   private Controller controller;
   private ElasticsearchExporterConfiguration configuration;
   private ElasticsearchClient client;
+  private ElasticsearchRecordCounters recordCounters;
 
   private long lastPosition = -1;
   private boolean indexTemplatesCreated;
@@ -52,6 +58,14 @@ public class ElasticsearchExporter implements Exporter {
     this.controller = controller;
     client = createClient();
 
+    recordCounters =
+        controller
+            .readMetadata()
+            .map(this::deserializeExporterMetadata)
+            .map(ElasticsearchExporterMetadata::getRecordCountersByValueType)
+            .map(ElasticsearchRecordCounters::new)
+            .orElse(new ElasticsearchRecordCounters());
+
     scheduleDelayedFlush();
     log.info("Exporter opened");
   }
@@ -61,6 +75,7 @@ public class ElasticsearchExporter implements Exporter {
 
     try {
       flush();
+      updateLastExportedPosition();
     } catch (final Exception e) {
       log.warn("Failed to flush records before closing exporter.", e);
     }
@@ -86,8 +101,16 @@ public class ElasticsearchExporter implements Exporter {
 
     if (client.shouldFlush()) {
       flush();
+      // Update the record counters only after the flush was successful. If the synchronous flush
+      // fails then the exporter will be invoked with the same record again.
+      recordCounters.updateRecordCounters(record, recordSequence);
+      updateLastExportedPosition();
+    } else {
+      // If the exporter doesn't flush synchronously then it can update the record counters
+      // immediately. If the asynchronous flush fails then it will retry only the flush operation
+      // with the records in the pending bulk request.
+      recordCounters.updateRecordCounters(record, recordSequence);
     }
-    recordCounters.updateRecordCounters(record, recordSequence);
   }
 
   private void validate(final ElasticsearchExporterConfiguration configuration) {
@@ -127,6 +150,7 @@ public class ElasticsearchExporter implements Exporter {
   private void flushAndReschedule() {
     try {
       flush();
+      updateLastExportedPosition();
     } catch (final Exception e) {
       log.warn("Unexpected exception occurred on periodically flushing bulk, will retry later.", e);
     }
@@ -140,7 +164,28 @@ public class ElasticsearchExporter implements Exporter {
 
   private void flush() {
     client.flush();
-    controller.updateLastExportedRecordPosition(lastPosition);
+  }
+
+  private void updateLastExportedPosition() {
+    exporterMetadata.setRecordCountersByValueType(recordCounters.getRecordCounters());
+    final var serializeExporterMetadata = serializeExporterMetadata(exporterMetadata);
+    controller.updateLastExportedRecordPosition(lastPosition, serializeExporterMetadata);
+  }
+
+  private byte[] serializeExporterMetadata(final ElasticsearchExporterMetadata metadata) {
+    try {
+      return exporterMetadataObjectMapper.writeValueAsBytes(metadata);
+    } catch (final JsonProcessingException e) {
+      throw new ElasticsearchExporterException("Failed to serialize exporter metadata", e);
+    }
+  }
+
+  private ElasticsearchExporterMetadata deserializeExporterMetadata(final byte[] metadata) {
+    try {
+      return exporterMetadataObjectMapper.readValue(metadata, ElasticsearchExporterMetadata.class);
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException("Failed to deserialize exporter metadata", e);
+    }
   }
 
   private void createIndexTemplates() {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterMetadata.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterMetadata.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.EnumMap;
+import java.util.Map;
+
+public final class ElasticsearchExporterMetadata {
+
+  private Map<ValueType, Long> recordCountersByValueType = new EnumMap<>(ValueType.class);
+
+  public Map<ValueType, Long> getRecordCountersByValueType() {
+    return recordCountersByValueType;
+  }
+
+  public void setRecordCountersByValueType(final Map<ValueType, Long> recordCountersByValueType) {
+    this.recordCountersByValueType = recordCountersByValueType;
+  }
+}

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchRecordCounters.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchRecordCounters.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.EnumMap;
+import java.util.Map;
+
+public final class ElasticsearchRecordCounters {
+
+  private static final long INITIAL_RECORD_COUNTER = 0L;
+
+  /**
+   * Stores a counter per value type. The counter is used to create a sequence for a given record.
+   */
+  private final Map<ValueType, Long> recordCountersByValueType;
+
+  public ElasticsearchRecordCounters() {
+    recordCountersByValueType = new EnumMap<>(ValueType.class);
+  }
+
+  public ElasticsearchRecordCounters(final Map<ValueType, Long> recordCounters) {
+    recordCountersByValueType = new EnumMap<>(recordCounters);
+  }
+
+  public RecordSequence getNextRecordSequence(final Record<?> record) {
+    final var valueType = record.getValueType();
+    final long recordCounter =
+        recordCountersByValueType.getOrDefault(valueType, INITIAL_RECORD_COUNTER);
+
+    final long nextCounter = recordCounter + 1;
+    return new RecordSequence(record.getPartitionId(), nextCounter);
+  }
+
+  public void updateRecordCounters(final Record<?> record, final RecordSequence recordSequence) {
+    final var valueType = record.getValueType();
+    final var counter = recordSequence.counter();
+    recordCountersByValueType.put(valueType, counter);
+  }
+
+  public Map<ValueType, Long> getRecordCounters() {
+    return recordCountersByValueType;
+  }
+}


### PR DESCRIPTION
## Description

- extend the exporter controller API to store and read arbitrary metadata
- the controller stores the metadata together with the exported position in the exporter state
- the Elasticsearch exporter uses the new API to store the record counters as metadata in a JSON format 

## Related issues

part of #10568 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
