### PR TITLE
feat(backup): return latest checkpoint info if a checkpoint already exists

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -64,10 +64,16 @@ public final class CheckpointCreateProcessor {
           record, CheckpointIntent.CREATED, followupRecord, resultBuilder);
     } else {
       metrics.ignored();
-      // A checkpoint already exists. Hence ignore the command. Note:- this is not an error, so not
-      // considered as a "rejection"
+      // A checkpoint already exists. Ignore the command. Use the latest checkpoint info in
+      // the record so that the response sent contains the latest checkpointId. This is useful to
+      // return useful information back to the client.
       return createFollowUpAndResponse(
-          record, CheckpointIntent.IGNORED, checkpointRecord, resultBuilder);
+          record,
+          CheckpointIntent.IGNORED,
+          new CheckpointRecord()
+              .setCheckpointId(checkpointState.getCheckpointId())
+              .setCheckpointPosition(checkpointState.getCheckpointPosition()),
+          resultBuilder);
     }
   }
 


### PR DESCRIPTION
## Description

According to spec for take backup api, we must send an error response if a checkpoint already exists. To provide meaningful information to the user we now add the latest checkpointId to the Checkpoint IGNORED record. 

Standard used in engine is to send a rejection in such cases. But with rejection we cannot send the latest checkpointId. So we chose to send the IGNORED record. Gateway request handling will be updated to interpret this info(#11151).

## Related issues

related #11124 
