### PR TITLE
Fail take backup request if a checkpoint with same or higher id exists

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupAlreadyExistsException.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupAlreadyExistsException.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.backup.management;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupStatus;
 
-public class BackupAlreadyExistsException extends RuntimeException {
+class BackupAlreadyExistsException extends RuntimeException {
 
-  public BackupAlreadyExistsException(final BackupIdentifier id, final BackupStatus status) {
+  BackupAlreadyExistsException(final BackupIdentifier id, final BackupStatus status) {
     super("Backup with id %s already exists, status of the backup is %s".formatted(id, status));
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupAlreadyExistException.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupAlreadyExistException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+public class BackupAlreadyExistException extends RuntimeException {
+
+  public BackupAlreadyExistException(final long expectedBackupId, final long latestBackupId) {
+    super(
+        "Requested backup has id %d. The latest backup has id %d. Id of new backups must be higher than the previous one. "
+            .formatted(expectedBackupId, latestBackupId));
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupResponse.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+/**
+ * Response of take backup request, received from the broker.
+ *
+ * @param created true when backup is created, false when it is rejected because the checkpoint
+ *     already exists
+ * @param checkpointId if created = false then the latest checkpointId in the partition, otherwise
+ *     same as the backupId in the request.
+ */
+public record BackupResponse(boolean created, long checkpointId) {}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupStub.java
@@ -12,15 +12,14 @@ import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerError;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerErrorResponse;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
-import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import java.util.HashMap;
 import java.util.Map;
 
 public class BackupStub
-    implements RequestStub<BrokerBackupRequest, BrokerResponse<CheckpointRecord>> {
+    implements RequestStub<BrokerBackupRequest, BrokerResponse<BackupResponse>> {
 
-  private final Map<Integer, BrokerResponse<CheckpointRecord>> responses = new HashMap<>();
+  private final Map<Integer, BrokerResponse<BackupResponse>> responses = new HashMap<>();
 
   @Override
   public void registerWith(final StubbedBrokerClient gateway) {
@@ -28,17 +27,20 @@ public class BackupStub
   }
 
   @Override
-  public BrokerResponse<CheckpointRecord> handle(final BrokerBackupRequest request)
-      throws Exception {
+  public BrokerResponse<BackupResponse> handle(final BrokerBackupRequest request) throws Exception {
     return responses.getOrDefault(
         request.getPartitionId(),
-        new BrokerResponse<>(
-            new CheckpointRecord().setCheckpointId(1), request.getPartitionId(), -1));
+        new BrokerResponse<>(new BackupResponse(true, 1), request.getPartitionId(), -1));
   }
 
   public BackupStub withErrorResponseFor(final int partitionId) {
     responses.put(
         partitionId, new BrokerErrorResponse<>(new BrokerError(ErrorCode.INTERNAL_ERROR, "ERROR")));
+    return this;
+  }
+
+  public BackupStub withResponse(final BackupResponse response, final int partitionId) {
+    responses.put(partitionId, new BrokerResponse<>(response, partitionId, -1));
     return this;
   }
 }


### PR DESCRIPTION
## Description

According to new spec for take backup api, we must return an error if backup id exists or a higher backup id exists. In this PR, we updated the handling of take request to aggregate responses from all partitions. The response is calculated as follows:
1. response = sucsess if all partition returned a `Checkpoint:CREATED` record
2. response = success if some partition returned created and some returned Checkpoint:IGNORED record with the same backupId from the request. This case is not considered as failure because the partition may have rejected the command because a concurrent inter-partition message triggered the backup. 
3. response = failed if all partition returned ignored, or some partition returned ignored with a higher checkpointId.

Note: Endpoint is not yet updated.

## Related issues

related #11124