### PR TITLE
New benchmark configurations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ on:
         default: europe-west1-b
         required: false
       bechmark-load:
-        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish'
+        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitary helm arguments, like --set starter.rate=100'
         required: false
   workflow_call:
     inputs:
@@ -42,7 +42,7 @@ on:
         type: string
         required: false
       bechmark-load:
-        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish'
+        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitary helm arguments, like --set starter.rate=100'
         type: string
         required: false
 jobs:

--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           echo "ref=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "cw=$(date +%V)" >> $GITHUB_OUTPUT
+
   setup-normal-benchmark:
     name: Setup normal benchmark
     needs:
@@ -66,3 +67,17 @@ jobs:
          --set timer.rate=50
          --set publisher.replica=1
          --set publisher.rate=50
+  setup-latency-benchmark:
+    name: Setup latency benchmark
+    uses: ./.github/workflows/benchmark.yaml
+    secrets: inherit
+    needs:
+      - benchmark-data
+    with:
+      name: medic-cw-${{ needs.benchmark-data.outputs.cw }}-${{ needs.benchmark-data.outputs.ref }}-benchmark-mixed
+      cluster: zeebe-cluster
+      cluster-region: europe-west1-b
+      ref: ${{ steps.data.outputs.ref }}
+      bechmark-load: >
+         --set starter.rate=1
+         --set worker.replicas=1

--- a/benchmarks/setup/default/starter.yaml
+++ b/benchmarks/setup/default/starter.yaml
@@ -24,7 +24,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl=default-zeebe-gateway:26500
-                -Dapp.starter.rate=200
+                -Dapp.starter.rate=75
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -XX:+HeapDumpOnOutOfMemoryError

--- a/benchmarks/setup/default/worker.yaml
+++ b/benchmarks/setup/default/worker.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: worker
-  replicas: 6
+  replicas: 3
   template:
     metadata:
       labels:
@@ -25,7 +25,7 @@ spec:
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl=default-zeebe-gateway:26500
                 -Dzeebe.client.requestTimeout=62000
-                -Dapp.worker.capacity=120
+                -Dapp.worker.capacity=60
                 -Dapp.worker.pollingDelay=1ms
                 -Dapp.worker.completionDelay=50ms
                 -XX:+HeapDumpOnOutOfMemoryError

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -16,9 +16,9 @@ zeebe:
   replicationFactor: "3"
 
   # CpuThreadCount defines how many threads can be used for the processing on each broker pod
-  cpuThreadCount: 4
+  cpuThreadCount: 3
   # IoThreadCount defines how many threads can be used for the exporting on each broker pod
-  ioThreadCount: 4
+  ioThreadCount: 3
 
   # ContainerSecurityContext defines the security options the Zeebe broker container should be run with
   containerSecurityContext:
@@ -67,11 +67,11 @@ zeebe:
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
   resources:
     limits:
-      cpu: 5
+      cpu: 960m
       memory: 4Gi
     requests:
-      cpu: 5
-      memory: 4Gi
+      cpu: 800m
+      memory: 2Gi
 
   # PvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
   pvcAccessMode: ["ReadWriteOnce"]
@@ -82,7 +82,8 @@ zeebe:
 
 zeebe-gateway:
   # Replicas defines how many standalone gateways are deployed
-  replicas: 3
+  replicas: 2
+
   # Image configuration to configure the zeebe-gateway image specifics
   image:
     # Image.repository defines which image repository to use
@@ -116,11 +117,11 @@ zeebe-gateway:
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
   resources:
     limits:
-      cpu: 1
-      memory: 512Mi
+      cpu: 450m
+      memory: 400Mi
     requests:
-      cpu: 1
-      memory: 512Mi
+      cpu: 450m
+      memory: 400Mi
 
 # RetentionPolicy configuration to configure the elasticsearch index retention policies
 retentionPolicy:
@@ -164,17 +165,17 @@ elasticsearch:
     storageClassName: "ssd"
     resources:
       requests:
-        storage: 50Gi
+        storage: 64Gi
 
-  esJavaOpts: "-Xmx4g -Xms4g"
+  esJavaOpts: "-Xmx3g -Xms3g"
 
   resources:
     requests:
-      cpu: 3
-      memory: 8Gi
+      cpu: 1
+      memory: 3Gi
     limits:
-      cpu: 3
-      memory: 8Gi
+      cpu: 2
+      memory: 6Gi
 
 # Disable the service monitor as we use Google Managed Prometheus
 prometheusServiceMonitor:


### PR DESCRIPTION
## Description

Adjust our current benchmarks configurations, in order to reduce the costs and make the benchmarks more meaningful. 

The benchmarks are now aligned to G3-S cluster plan, which is also used in SaaS. This makes them more realistic. Furthermore the default load was adjusted so we run a real throughput tests, to verify what is the maximum we can achieve with this resources.

The mixed benchmark workflow have been adjusted to setup, a default throughput test, a mixed benchmark (similar load to default) but using more symbols and a latency tests. The latency tests runs one process instance per second and allows to determine how our process instance execution time is over time.

### New throughput test:

In our recent throughput test we can see with the G3-S adjustment we are able to execute and complete ~60-65 instances per second.

![throughput-overview](https://user-images.githubusercontent.com/2758593/205228857-39064066-923d-4929-ab3a-7bc4b63ef149.png)

**Processing queue**
![throughput-processing](https://user-images.githubusercontent.com/2758593/205228855-1c9de9c3-56ea-4eaa-a568-1b2886a72185.png)

**Completions per second**
![throughput-completions](https://user-images.githubusercontent.com/2758593/205228860-550c4911-3620-4f03-82c1-415556216182.png)

### New Latency test

In our newest latency test we can see that we can execute a process instance in around 100-200 ms, but there are outliers which go up to 1.5 sec. This is something we should investigate.

![latency-overview](https://user-images.githubusercontent.com/2758593/205229094-3b98958a-ca04-4391-a87d-a17c16fa2104.png)

**Latency**
![latency-latency](https://user-images.githubusercontent.com/2758593/205229128-d0b49a0b-73ea-4e44-b9ed-82436ea5af0a.png)

**Latency last 6h**
![latency-latency-6h](https://user-images.githubusercontent.com/2758593/205229126-8bce562e-4ba9-4c5a-9573-00a4e07595d8.png)

![latency-latency-commit-6h](https://user-images.githubusercontent.com/2758593/205229122-30120a90-3cad-4b97-b158-d13c593353b6.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
