### PR TITLE
Gateway can handle delete backup request

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -40,4 +40,11 @@ public interface BackupApi {
    * @return a list of available backups
    */
   CompletionStage<List<BackupStatus>> listBackups();
+
+  /**
+   * Deletes the backup with the given id
+   *
+   * @param backupId id of the backup to delete
+   */
+  CompletionStage<Void> deleteBackup(long backupId);
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupDeleteRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupDeleteRequest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
+import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
+import io.camunda.zeebe.protocol.management.BackupRequestType;
+import io.camunda.zeebe.protocol.management.BackupStatusResponseDecoder;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class BackupDeleteRequest extends BrokerRequest<BackupStatusResponse> {
+  protected final BackupRequest request = new BackupRequest();
+  protected final BackupStatusResponse response = new BackupStatusResponse();
+
+  public BackupDeleteRequest() {
+    super(BackupStatusResponseDecoder.SCHEMA_ID, BackupStatusResponseDecoder.TEMPLATE_ID);
+    request.setType(BackupRequestType.DELETE);
+  }
+
+  public long getBackupId() {
+    return request.getBackupId();
+  }
+
+  public void setBackupId(final long backupId) {
+    request.setBackupId(backupId);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return request.getPartitionId();
+  }
+
+  @Override
+  public void setPartitionId(final int partitionId) {
+    request.setPartitionId(partitionId);
+  }
+
+  @Override
+  public boolean addressesSpecificPartition() {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPartitionId() {
+    return true;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return null;
+  }
+
+  @Override
+  protected void setSerializedValue(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void wrapResponse(final DirectBuffer buffer) {
+    response.wrap(buffer, 0, buffer.capacity());
+  }
+
+  @Override
+  protected BrokerResponse<BackupStatusResponse> readResponse() {
+    return new BrokerResponse<>(response, response.getPartitionId(), -1);
+  }
+
+  @Override
+  protected BackupStatusResponse toResponseDto(final DirectBuffer buffer) {
+    return response;
+  }
+
+  @Override
+  public String getType() {
+    return "Backup#delete";
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.BACKUP;
+  }
+
+  @Override
+  public int getLength() {
+    return request.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    request.write(buffer, offset);
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -43,7 +43,7 @@ public final class BackupRequestHandler implements BackupApi {
             topology -> {
               final var backupsTaken =
                   topology.getPartitions().stream()
-                      .map(partitionId -> getBackupRequestForPartition(backupId, partitionId))
+                      .map(partitionId -> createBackupRequest(backupId, partitionId))
                       .map(brokerClient::sendRequestWithRetry)
                       .toList();
 
@@ -92,7 +92,7 @@ public final class BackupRequestHandler implements BackupApi {
             topology -> {
               final var statusesReceived =
                   topology.getPartitions().stream()
-                      .map(partitionId -> getStatusQueryForPartition(backupId, partitionId))
+                      .map(partitionId -> createStatusQueryRequest(backupId, partitionId))
                       .map(brokerClient::sendRequestWithRetry)
                       .toList();
 
@@ -117,7 +117,7 @@ public final class BackupRequestHandler implements BackupApi {
             topology -> {
               final var backupsReceived =
                   topology.getPartitions().stream()
-                      .map(this::getListRequest)
+                      .map(this::createListRequest)
                       .map(brokerClient::sendRequestWithRetry)
                       .toList();
 
@@ -133,7 +133,7 @@ public final class BackupRequestHandler implements BackupApi {
             topology ->
                 CompletableFuture.allOf(
                     topology.getPartitions().stream()
-                        .map(partitionId -> getDeleteRequest(backupId, partitionId))
+                        .map(partitionId -> createDeleteRequest(backupId, partitionId))
                         .map(brokerClient::sendRequestWithRetry)
                         .toArray(CompletableFuture[]::new)));
   }
@@ -259,15 +259,14 @@ public final class BackupRequestHandler implements BackupApi {
             .formatted(partitionStatuses));
   }
 
-  private BackupStatusRequest getStatusQueryForPartition(
-      final long backupId, final int partitionId) {
+  private BackupStatusRequest createStatusQueryRequest(final long backupId, final int partitionId) {
     final var request = new BackupStatusRequest();
     request.setBackupId(backupId);
     request.setPartitionId(partitionId);
     return request;
   }
 
-  private static BrokerBackupRequest getBackupRequestForPartition(
+  private static BrokerBackupRequest createBackupRequest(
       final long backupId, final int partitionId) {
     final var request = new BrokerBackupRequest();
     request.setBackupId(backupId);
@@ -275,13 +274,13 @@ public final class BackupRequestHandler implements BackupApi {
     return request;
   }
 
-  private BackupListRequest getListRequest(final Integer partitionId) {
+  private BackupListRequest createListRequest(final Integer partitionId) {
     final var request = new BackupListRequest();
     request.setPartitionId(partitionId);
     return request;
   }
 
-  private BackupDeleteRequest getDeleteRequest(final long backupId, final Integer partitionId) {
+  private BackupDeleteRequest createDeleteRequest(final long backupId, final Integer partitionId) {
     final var request = new BackupDeleteRequest();
     request.setPartitionId(partitionId);
     request.setBackupId(backupId);


### PR DESCRIPTION
## Description

- BackupRequestHandler sends delete request to all partitions and collect the responses.
- Request is failed if request to atleast one partition fails.

Note:- Connection errors are differentiated from other errors which is expected according to spec. This will be updated along with other operations. 

## Related issues

related #10209 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
