### PR TITLE
Return 409 if Id is lower than the latest backupId when requesting a new backup

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import io.camunda.zeebe.gateway.admin.backup.BackupAlreadyExistException;
 import io.camunda.zeebe.gateway.admin.backup.BackupApi;
 import io.camunda.zeebe.gateway.admin.backup.BackupRequestHandler;
 import io.camunda.zeebe.gateway.admin.backup.BackupStatus;
@@ -63,9 +64,11 @@ final class BackupEndpoint {
                       .formatted(backupId, backupId)),
           202);
     } catch (final CompletionException e) {
-      return new WebEndpointResponse<>(
-          new Error().message(e.getCause().getMessage()),
-          WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+      final var errorCode =
+          e.getCause() instanceof BackupAlreadyExistException
+              ? 409
+              : WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR;
+      return new WebEndpointResponse<>(new Error().message(e.getCause().getMessage()), errorCode);
     } catch (final Exception e) {
       return new WebEndpointResponse<>(
           new Error().message(e.getMessage()), WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupErrorResponseTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupErrorResponseTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.gateway.admin.backup.BackupAlreadyExistException;
+import io.camunda.zeebe.gateway.admin.backup.BackupRequestHandler;
+import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
+import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class BackupErrorResponseTest {
+
+  @Container private static final MinioContainer S3 = new MinioContainer();
+  private BackupRequestHandler backupRequestHandler;
+  private String bucketName;
+
+  @RegisterExtension
+  private final ClusteringRuleExtension clusteringRule =
+      new ClusteringRuleExtension(1, 1, 1, this::configureBackupStore);
+
+  private void configureBackupStore(final BrokerCfg config) {
+    config.getExperimental().getFeatures().setEnableBackup(true);
+
+    final var backupConfig = config.getData().getBackup();
+    backupConfig.setStore(BackupStoreType.S3);
+
+    final var s3Config = backupConfig.getS3();
+
+    generateBucketName();
+
+    s3Config.setBucketName(bucketName);
+    s3Config.setEndpoint(S3.externalEndpoint());
+    s3Config.setRegion(S3.region());
+    s3Config.setAccessKey(S3.accessKey());
+    s3Config.setSecretKey(S3.secretKey());
+    s3Config.setForcePathStyleAccess(true);
+  }
+
+  private void generateBucketName() {
+    // Generate only once per test
+    if (bucketName == null) {
+      bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    }
+  }
+
+  void createBucket() {
+    // Create bucket before for storing backups
+    final var s3ClientConfig =
+        new Builder()
+            .withBucketName(bucketName)
+            .withEndpoint(S3.externalEndpoint())
+            .withRegion(S3.region())
+            .withCredentials(S3.accessKey(), S3.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(15))
+            .forcePathStyleAccess(true)
+            .build();
+    try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
+      s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();
+    }
+  }
+
+  @BeforeEach
+  void setup() {
+    backupRequestHandler = new BackupRequestHandler(clusteringRule.getGateway().getBrokerClient());
+    createBucket();
+  }
+
+  @AfterEach
+  void close() {
+    // reset so that each test can use a different bucket name
+    bucketName = null;
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1,1", "2,1"})
+  @Timeout(value = 60)
+  void shouldFailTakeBackupIfCheckpointAlreadyExists(
+      final long existingCheckpoint, final long backupIdToTake) {
+    // given
+    backupRequestHandler.takeBackup(existingCheckpoint).toCompletableFuture().join();
+
+    // when - then
+    assertThat(backupRequestHandler.takeBackup(backupIdToTake))
+        .failsWithin(Duration.ofSeconds(30))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(BackupAlreadyExistException.class);
+  }
+}


### PR DESCRIPTION
## Description

Follow up of #11151 This PR update the endpoint to return HTTP code 409 when the checkpoint already exists.

## Related issues

related #11124 

