### PR TITLE
fix(gateway): don't log IllegalArgumentException as errors

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -189,8 +189,7 @@ public final class RequestMapper {
         return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value));
       } catch (final RuntimeException e) {
         final var cause = e.getCause();
-        if (cause instanceof JsonParseException) {
-          final var parseException = (JsonParseException) cause;
+        if (cause instanceof final JsonParseException parseException) {
 
           final var descriptiveException =
               new JsonParseException(
@@ -201,6 +200,9 @@ public final class RequestMapper {
 
           rethrowUnchecked(descriptiveException);
           return DocumentValue.EMPTY_DOCUMENT; // bogus return statement
+        } else if (cause instanceof IllegalArgumentException) {
+          rethrowUnchecked(cause);
+          return DocumentValue.EMPTY_DOCUMENT;
         } else {
           throw e;
         }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -76,6 +76,9 @@ public final class GrpcErrorMapper {
     } else if (error instanceof JsonParseException) {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
       logger.debug("Expected to handle gRPC request, but JSON property was invalid", rootError);
+    } else if (error instanceof IllegalArgumentException) {
+      builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
+      logger.debug("Expected to handle gRPC request, but JSON property was invalid 123", rootError);
     } else if (error instanceof PartitionNotFoundException) {
       builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
       logger.debug(

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -18,6 +18,10 @@ public class RequestMapperTest {
   private static final String INVALID_VARIABLES =
       "{ \"test\": \"value\", \"error\": \"errorrvalue }";
 
+  // BigInteger larger than 2^64-1
+  private static final String BIG_INTEGER =
+      "{\"mybigintistoolong\": 123456789012345678901234567890}";
+
   @Test
   public void shouldThrowHelpfulExceptionIfJsonIsInvalid() {
     // when + then
@@ -26,5 +30,13 @@ public class RequestMapperTest {
         .hasMessageContaining("Invalid JSON", INVALID_VARIABLES)
         .cause()
         .isInstanceOf(JsonParseException.class);
+  }
+
+  @Test
+  public void shouldThrowHelpfulExceptionIfJsonHasBigInteger() {
+    // when + then
+    assertThatThrownBy(() -> RequestMapper.ensureJsonSet(BIG_INTEGER))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("MessagePack cannot serialize BigInteger larger than 2^64-1");
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -77,7 +77,11 @@ public final class MsgPackConverter {
 
       return outputStream.toByteArray();
     } catch (final Exception e) {
-      throw new RuntimeException("Failed to convert JSON to MessagePack", e);
+      if (e instanceof IllegalArgumentException) {
+        throw new IllegalArgumentException("Failed to convert JSON to MessagePack", e);
+      } else {
+        throw new RuntimeException("Failed to convert JSON to MessagePack", e);
+      }
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
@@ -94,6 +94,21 @@ public final class CompleteJobTest {
   }
 
   @Test
+  public void shouldRejectIfVariableIsBigIntTooLong() {
+    // when
+    assertThatThrownBy(
+            () ->
+                CLIENT_RULE
+                    .getClient()
+                    .newCompleteCommand(jobKey)
+                    .variables("{\"mybigintistoolong\":123456789012345678901234567890}")
+                    .send()
+                    .join())
+        .isInstanceOf(ClientStatusException.class)
+        .hasMessageContaining("MessagePack cannot serialize BigInteger larger than 2^64-1");
+  }
+
+  @Test
   public void shouldRejectIfJobIsAlreadyCompleted() {
     // given
     CLIENT_RULE.getClient().newCompleteCommand(jobKey).send().join();


### PR DESCRIPTION
## Description

IllegalArgumentException get thrown when a user passes variables in their request which cannot be converted to message pack. Currently these are being logged as errors. Since this a fault by the user we should log these as debug.

User input should not lead to reported errors, but user command should be rejected with a helpful message.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9832

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
