### PR TITLE
Improve error message for SAXExceptions on deployment

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -229,24 +229,9 @@ public class DeploymentRejectionTest {
         .hasIntent(DeploymentIntent.CREATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT);
 
-    /*
-     The detail rejection reason is an i18n SAXException, so here use the matches instead.
-
-     In Chinese
-     "Expected to deploy new resources, but encountered the following errors:
-     '/processes/saxexception-error-8026.bpmn': SAXException Error: URI=null Line=33:
-     cvc-complex-type.3.2.2: 元素 'bpmndi:BPMNPlane' 中不允许出现属性 'stroke'。"
-
-     In English
-     "Expected to deploy new resources, but encountered the following errors:
-     '/processes/saxexception-error-8026.bpmn': SAXException Error: URI=null Line=33:
-     cvc-complex-type.3.2.2: Attribute 'stroke' is not allowed to appear in element
-     'bpmndi:BPMNPlane'.
-    */
-
     assertThat(deploymentRejection.getRejectionReason())
         .describedAs("rejection should contain enough detail rejection reason")
-        .contains("SAXException Error")
+        .contains("saxexception-error-8026.bpmn")
         .contains("cvc-complex-type.3.2.2")
         .contains("stroke")
         .contains("bpmndi:BPMNPlane");

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -21,9 +21,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,14 +49,13 @@ public class DeploymentRejectionTest {
   }
 
   @Test
-  public void shouldRejectDeploymentIfNotValidDesignTimeAspect() throws Exception {
+  public void shouldRejectDeploymentIfNotValidDesignTimeAspect() {
     // given
-    final Path path = Paths.get(getClass().getResource("/processes/invalid_process.bpmn").toURI());
-    final byte[] resource = Files.readAllBytes(path);
+    final String resource = "/processes/invalid_process.bpmn";
 
     // when
     final Record<DeploymentRecordValue> rejectedDeployment =
-        ENGINE.deployment().withXmlResource(resource).expectRejection().deploy();
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
 
     // then
     Assertions.assertThat(rejectedDeployment)
@@ -72,15 +68,13 @@ public class DeploymentRejectionTest {
   }
 
   @Test
-  public void shouldRejectDeploymentIfNotValidRuntimeAspect() throws Exception {
+  public void shouldRejectDeploymentIfNotValidRuntimeAspect() {
     // given
-    final Path path =
-        Paths.get(getClass().getResource("/processes/invalid_process_condition.bpmn").toURI());
-    final byte[] resource = Files.readAllBytes(path);
+    final String resource = "/processes/invalid_process_condition.bpmn";
 
     // when
     final Record<DeploymentRecordValue> rejectedDeployment =
-        ENGINE.deployment().withXmlResource(resource).expectRejection().deploy();
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
 
     // then
     Assertions.assertThat(rejectedDeployment)
@@ -94,18 +88,16 @@ public class DeploymentRejectionTest {
   }
 
   @Test
-  public void shouldRejectDeploymentIfOneResourceIsNotValid() throws Exception {
+  public void shouldRejectDeploymentIfOneResourceIsNotValid() {
     // given
-    final Path path1 = Paths.get(getClass().getResource("/processes/invalid_process.bpmn").toURI());
-    final Path path2 = Paths.get(getClass().getResource("/processes/collaboration.bpmn").toURI());
-    final byte[] resource1 = Files.readAllBytes(path1);
-    final byte[] resource2 = Files.readAllBytes(path2);
+    final String resource1 = "/processes/invalid_process.bpmn";
+    final String resource2 = "/processes/collaboration.bpmn";
 
     final Record<DeploymentRecordValue> rejectedDeployment =
         ENGINE
             .deployment()
-            .withXmlResource(resource1)
-            .withXmlResource(resource2)
+            .withXmlClasspathResource(resource1)
+            .withXmlClasspathResource(resource2)
             .expectRejection()
             .deploy();
 
@@ -197,12 +189,11 @@ public class DeploymentRejectionTest {
     Assertions.assertThat(deploymentRejection)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            "Expected to deploy new resources, but encountered the following errors:\n"
-                + "'p1.bpmn': - Element: start-event-1\n"
-                + "    - ERROR: Invalid timer cycle expression ("
-                + "failed to evaluate expression "
-                + "'INVALID_CYCLE_EXPRESSION': no variable found for name "
-                + "'INVALID_CYCLE_EXPRESSION')\n");
+            """
+                Expected to deploy new resources, but encountered the following errors:
+                'p1.bpmn': - Element: start-event-1
+                    - ERROR: Invalid timer cycle expression (failed to evaluate expression 'INVALID_CYCLE_EXPRESSION': no variable found for name 'INVALID_CYCLE_EXPRESSION')
+                """);
   }
 
   @Test
@@ -219,5 +210,45 @@ public class DeploymentRejectionTest {
     Assertions.assertThat(deploymentRejection)
         .hasRejectionType(RejectionType.EXCEEDED_BATCH_RECORD_SIZE)
         .hasRejectionReason("");
+  }
+
+  // https://github.com/camunda/zeebe/issues/8026
+  @Test
+  public void shouldRejectDeploymentOfSAXException() {
+    // given
+    final String resource = "/processes/saxexception-error-8026.bpmn";
+
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    /*
+     The detail rejection reason is an i18n SAXException, so here use the matches instead.
+
+     In Chinese
+     "Expected to deploy new resources, but encountered the following errors:
+     '/processes/saxexception-error-8026.bpmn': SAXException Error: URI=null Line=33:
+     cvc-complex-type.3.2.2: 元素 'bpmndi:BPMNPlane' 中不允许出现属性 'stroke'。"
+
+     In English
+     "Expected to deploy new resources, but encountered the following errors:
+     '/processes/saxexception-error-8026.bpmn': SAXException Error: URI=null Line=33:
+     cvc-complex-type.3.2.2: Attribute 'stroke' is not allowed to appear in element
+     'bpmndi:BPMNPlane'.
+    */
+
+    assertThat(deploymentRejection.getRejectionReason())
+        .describedAs("rejection should contain enough detail rejection reason")
+        .contains("SAXException Error")
+        .contains("cvc-complex-type.3.2.2")
+        .contains("stroke")
+        .contains("bpmndi:BPMNPlane");
   }
 }

--- a/engine/src/test/resources/processes/saxexception-error-8026.bpmn
+++ b/engine/src/test/resources/processes/saxexception-error-8026.bpmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" id="Definitions_0a084vr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <bpmn:process id="invalid" name="invalid process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>Flow_1p61drr</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>Flow_1p61drr</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1p61drr" sourceRef="start" targetRef="end" />
+  </bpmn:process>
+  <bpmn:message id="Message_09k35jn" name="vantage-transcode-completed">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=zeebeProcessId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_0kumuuf" name="vantage-transcode-failed">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=zeebeProcessId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1vf3iyi" name="vantage-transcode-status-update">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=zeebeProcessId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_0afsp8q" name="vantage-transcode-progress-update">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=zeebeProcessId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="invalid" stroke="#000" fill="#fff">
+      <bpmndi:BPMNEdge id="Flow_1p61drr_di" bpmnElement="Flow_1p61drr" bioc:stroke="#000" bioc:fill="#fff">
+        <di:waypoint x="208" y="100" />
+        <di:waypoint x="302" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start" bioc:stroke="#000" bioc:fill="#fff">
+        <dc:Bounds x="172" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="182" y="125" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mhoyjr_di" bpmnElement="end" bioc:stroke="#000" bioc:fill="#fff">
+        <dc:Bounds x="302" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="311" y="125" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

Error message for SAXException should contain enough detail for users to figure out what is wrong with the model.

e.g.
before:
org.camunda.bpm.model.xml.ModelParseException: SAXException while parsing input stream 

after:
org.xml.sax.SAXException: Error: URI=null Line=33: cvc-complex-type.3.2.2: Attribute 'stroke' is not allowed to appear in element 'bpmndi:BPMNPlane'.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8026
closes #5490

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
