### PR TITLE
Interrupt flow scope when a terminate end event is reached

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -101,7 +101,8 @@ public final class EventSubProcessProcessor
         final var terminated = stateTransitionBehavior.transitionToTerminated(flowScopeContext);
         stateTransitionBehavior.onElementTerminated(element, terminated);
 
-      } else if (flowScopeInstance.isActive()) {
+      } else if (stateBehavior.isInterruptedByTerminateEndEvent(
+          flowScopeContext, flowScopeInstance)) {
         // the child element instances were terminated by a terminate end event in the
         // event subprocess
         stateTransitionBehavior.completeElement(flowScopeContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -112,7 +112,9 @@ public final class SubProcessProcessor
     final var flowScopeInstance = stateBehavior.getFlowScopeInstance(subProcessContext);
     final var subProcessInstance = stateBehavior.getElementInstance(subProcessContext);
 
-    if (stateBehavior.isInterrupted(subProcessContext)) {
+    final boolean interruptedByTerminateEndEvent =
+        stateBehavior.isInterruptedByTerminateEndEvent(subProcessContext, subProcessInstance);
+    if (stateBehavior.isInterrupted(subProcessContext) && !interruptedByTerminateEndEvent) {
       // an interrupting event subprocess was triggered
       eventSubscriptionBehavior
           .findEventTrigger(subProcessContext)
@@ -146,7 +148,7 @@ public final class SubProcessProcessor
                       stateTransitionBehavior.transitionToTerminated(subProcessContext);
                   stateTransitionBehavior.onElementTerminated(element, terminated);
 
-                } else if (subProcessInstance.isActive()) {
+                } else if (interruptedByTerminateEndEvent) {
                   // the child element instances were terminated by a terminate end event in the
                   // subprocess
                   stateTransitionBehavior.completeElement(subProcessContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
@@ -67,6 +67,7 @@ final class ProcessInstanceElementCompletedApplier
 
     if (isTerminateEndEvent(value)) {
       flowScopeInstance.resetActiveSequenceFlows();
+      flowScopeInstance.setInterruptingElementId(value.getElementIdBuffer());
       elementInstanceState.updateInstance(flowScopeInstance);
     }
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The terminate end event should mark its flow scope as interrupted when it's completed. Having an interrupted flow scope means other elements in this scope can no longer be activated or completed. Any ACTIVATE/COMPLETE command will be rejected.

If we do not interrupt the flowscope it is possible for the engine write a TERMINATE command as a result of the end event. It could then go on to process a COMPLETE command. This will not be rejected, and it will take outgoing sequence flows for this element. The TERMINATE will then be rejected as the element is no longer active. Since the flowscope now has an outgoing sequence flows it is considered to have active elements, it will not be terminated, as it should upon reaching a terminate end event.

Since the flow scope gets interrupted we will also have to change the logic in the processors of these possible flow scopes (`ProcessProcessor`, `SubProcessProcessors`, `EventSubProcessProcessor`). Here we need to verify that the scope was interrupted by a terminate end event, and if it is we need to make sure the scope gets completed, instead of terminated.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #11121 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
