### PR TITLE
feat(gateway): allow configuring gRPC max message size

### DIFF
--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -47,6 +47,11 @@
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_MINKEEPALIVEINTERVAL.
       # minKeepAliveInterval: 30s
 
+      # Sets the maximum size of the incoming and outgoing messages (i.e. commands and events).
+      # Apply the same setting on the broker too, see ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_MAXMESSAGESIZE.
+      # maxMessageSize: 4MB
+
     # cluster:
       # Sets initial contact points (brokers), which the gateway should contact to
       # The contact points of the internal network configuration must be specified.

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -227,6 +227,11 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
     </dependency>
     <dependency>

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -149,7 +149,13 @@ public final class Gateway {
       throw new IllegalArgumentException("Minimum keep alive interval must be positive.");
     }
 
+    final var maxMessageSize = (int) cfg.getMaxMessageSize().toBytes();
+    if (maxMessageSize <= 0) {
+      throw new IllegalArgumentException("maxMessageSize must be positive");
+    }
+
     return NettyServerBuilder.forAddress(new InetSocketAddress(cfg.getHost(), cfg.getPort()))
+        .maxInboundMessageSize(maxMessageSize)
         .permitKeepAliveTime(minKeepAliveInterval.toMillis(), TimeUnit.MILLISECONDS)
         .permitKeepAliveWithoutCalls(false);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
@@ -12,12 +12,14 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Objects;
+import org.springframework.util.unit.DataSize;
 
 public final class NetworkCfg {
 
   private String host;
   private int port = DEFAULT_PORT;
   private Duration minKeepAliveInterval = Duration.ofSeconds(30);
+  private DataSize maxMessageSize = DataSize.ofMegabytes(4);
 
   public void init(final String defaultHost) {
     if (host == null) {
@@ -49,6 +51,15 @@ public final class NetworkCfg {
 
   public NetworkCfg setMinKeepAliveInterval(final Duration keepAlive) {
     minKeepAliveInterval = keepAlive;
+    return this;
+  }
+
+  public DataSize getMaxMessageSize() {
+    return maxMessageSize;
+  }
+
+  public NetworkCfg setMaxMessageSize(final DataSize maxMessageSize) {
+    this.maxMessageSize = maxMessageSize;
     return this;
   }
 


### PR DESCRIPTION
The gRPC `maxMessageSize` was not configured so the default value of 4MiB applied.

This adds a new setting to the gateways network config that is used when building the netty server for gRPC.

The broker's network config already has a `maxMessageSize` which, confusingly, was not used for the network configuration but for controlling the maximum batch size in the dispatcher. We are reusing this setting now to also configure gRPC max message size.

This may look somewhat confusing but both dispatcher and gRPC `maxMessageSize` are related. The dispatcher limit should not be smaller than the gRPC `maxMessageSize`. Additionally, the placement of `maxMessageSize` inside the network config suggests that it was always meant to be used as a limit on the network/gRPC side too.

closes #10417