### PR TITLE
Remove spotless apply from maven release step

### DIFF
--- a/.ci/scripts/release/maven-release.sh
+++ b/.ci/scripts/release/maven-release.sh
@@ -11,6 +11,5 @@ mvn -s ${MAVEN_SETTINGS_XML} release:prepare release:perform -B \
     -DpushChanges=${PUSH_CHANGES} \
     -DremoteTagging=${PUSH_CHANGES} \
     -DlocalCheckout=${SKIP_DEPLOY} \
-    -DcompletionGoals="spotless:apply" \
     -P!autoFormat \
-    -Darguments='--settings=${MAVEN_SETTINGS_XML} -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dgpg.passphrase="${GPG_PASS}" -Dskip.central.release=${SKIP_DEPLOY} -Dskip.camunda.release=${SKIP_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR}'
+    -Darguments='--settings=${MAVEN_SETTINGS_XML} -P-autoFormat -DskipChecks=true -DskipTests=true -Dgpg.passphrase="${GPG_PASS}" -Dskip.central.release=${SKIP_DEPLOY} -Dskip.camunda.release=${SKIP_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR}'


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Spotless apply was added to prevent the maven-release-plugin from messing up the formatting of pom files. However, in version 8.0.X spotless was not yet introduced. Trying to execute this command here will cause the CI to fail.

<img width="1741" alt="image" src="https://user-images.githubusercontent.com/5787702/205924512-93fae896-2235-458d-b315-1cf6118a8c38.png">


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
