### PR TITLE
ci(arm64): native arm64 runner for smoke test

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -41,6 +41,9 @@ runs:
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
+        # if we run on arm64 set equivalent architecture as input, else default to x64
+        # see https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
+        architecture: ${{ runner.arch == 'ARM64' && 'aarch64' || 'x64' }}
     - if: ${{ inputs.java == 'true' && inputs.maven == 'true' }}
       uses: stCarolas/setup-maven@v4.4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,6 @@ jobs:
           push: false
       - name: Run smoke test on ${{ matrix.arch }}
         env:
-          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
           # For non Linux runners there is no container available for testing, see build-docker job
           EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
           - os: linux
             runner: n1-standard-8-netssd-preempt
           - os: linux
-            runner: n1-standard-8-netssd-preempt
+            runner: [ self-hosted, linux, arm64, "4" ]
             arch: arm64
     env:
       JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64M

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   integration-tests:
     name: Integration tests
-    runs-on: [ self-hosted, linux, "16" ]
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 45
     env:
       TC_CLOUD_LOGS_VERBOSE: true
@@ -82,7 +82,7 @@ jobs:
           name: Integration Tests
   qa-update-tests:
     name: QA Update tests
-    runs-on: [ self-hosted, linux, "16" ]
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 45
     env:
       TC_CLOUD_LOGS_VERBOSE: true
@@ -139,7 +139,7 @@ jobs:
           name: QA Update Tests
   unit-tests:
     name: Unit tests
-    runs-on: [ self-hosted, linux, "16" ]
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -235,7 +235,7 @@ jobs:
           name: Smoke Tests on ${{ matrix.os }} with ${{ matrix.arch }}
   property-tests:
     name: Property Tests
-    runs-on: [ self-hosted, linux, "16" ]
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -340,7 +340,7 @@ jobs:
           name: Java 8 Client
   codeql:
     name: CodeQL
-    runs-on: [ self-hosted, linux, "16" ]
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     permissions:
       security-events: write
     steps:


### PR DESCRIPTION
## Description

Makes use of [native arm runners](https://github.com/zeebe-io/infra/pull/27) to build zeebe and run arm64 smoke test.

Additionally added an amd64 label to previous self-hosted runners, to prevent accidental use in case runners with same core count are added.

## Related issues

relates #11189


