### PR TITLE
Return specific error codes for backup request

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -216,6 +216,11 @@
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+
     <!-- /end -->
 
     <dependency>

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @WebEndpoint(id = "backups", enableByDefault = false)
-final class BackupEndpoint {
+public final class BackupEndpoint {
   private final BackupApi api;
 
   @SuppressWarnings("unused") // used by Spring

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -40,7 +40,10 @@ paths:
           description: Internal Error
           $ref: '#/components/responses/Error'
         '502':
-          description: Operation failed because connection to the broker or to the backup storage is lost.
+          description: Gateway failed to send request to the broker.
+          $ref: '#/components/responses/Error'
+        '504':
+          description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
     get:
       summary: Lists all available backups
@@ -58,7 +61,10 @@ paths:
           description: Internal Error
           $ref: '#/components/responses/Error'
         '502':
-          description: Operation failed because connection to the broker or to the backup storage is lost.
+          description: Gateway failed to send request to the broker.
+          $ref: '#/components/responses/Error'
+        '504':
+          description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
   /{backupId}:
     get:
@@ -80,7 +86,10 @@ paths:
           description: Internal Error
           $ref: '#/components/responses/Error'
         '502':
-          description: Operation failed because connection to the broker or to the backup storage is lost.
+          description: Gateway failed to send request to the broker.
+          $ref: '#/components/responses/Error'
+        '504':
+          description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
     delete:
       summary: Delete a backup
@@ -94,7 +103,10 @@ paths:
           description: Internal error
           $ref: '#/components/responses/Error'
         '502':
-          description: Operation failed because connection to the broker or to the backup storage is lost.
+          description: Gateway failed to send request to the broker.
+          $ref: '#/components/responses/Error'
+        '504':
+          description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
 
 components:

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -71,29 +71,13 @@ final class BackupEndpointTest {
               new BrokerErrorException(new BrokerError(ErrorCode.INTERNAL_ERROR, "failure")), 500),
           Arguments.of(
               new BrokerErrorException(new BrokerError(ErrorCode.UNSUPPORTED_MESSAGE, "failure")),
-              400));
+              400),
+          Arguments.of(new RuntimeException("failure"), 500));
     }
   }
 
   @Nested
   final class TakeTest {
-    @Test
-    void shouldReturnErrorOnCompletionException() {
-      // given
-      final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
-      final var failure = new RuntimeException("failure");
-      doReturn(CompletableFuture.failedFuture(failure)).when(api).takeBackup(anyLong());
-
-      // when
-      final WebEndpointResponse<?> response = endpoint.take(1);
-
-      // then
-      assertThat(response.getBody())
-          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
-          .isEqualTo(new Error().message("failure"));
-    }
-
     @Test
     void shouldReturnErrorOnException() {
       // given
@@ -136,30 +120,21 @@ final class BackupEndpointTest {
       final var endpoint = new BackupEndpoint(api);
       doReturn(CompletableFuture.failedFuture(error)).when(api).takeBackup(anyLong());
 
-      // when - then
-      assertThat(endpoint.take(1).getStatus()).isEqualTo(expectedCode);
+      // when
+      final var response = endpoint.take(1);
+
+      // then
+      assertThat(response.getStatus()).isEqualTo(expectedCode);
+      assertThat(response.getBody())
+          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
+          .extracting(Error::getMessage)
+          .asString()
+          .contains("failure");
     }
   }
 
   @Nested
   final class StatusTest {
-    @Test
-    void shouldReturnErrorOnCompletionException() {
-      // given
-      final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
-      final var failure = new RuntimeException("failure");
-      doReturn(CompletableFuture.failedFuture(failure)).when(api).getStatus(anyLong());
-
-      // when
-      final WebEndpointResponse<?> response = endpoint.status(1);
-
-      // then
-      assertThat(response.getBody())
-          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
-          .isEqualTo(new Error().message("failure"));
-    }
-
     @Test
     void shouldReturnErrorOnException() {
       // given
@@ -204,8 +179,16 @@ final class BackupEndpointTest {
       final var endpoint = new BackupEndpoint(api);
       doReturn(CompletableFuture.failedFuture(error)).when(api).getStatus(anyLong());
 
-      // when - then
-      assertThat(endpoint.status(1).getStatus()).isEqualTo(expectedCode);
+      // when
+      final var response = endpoint.status(1);
+
+      // then
+      assertThat(response.getStatus()).isEqualTo(expectedCode);
+      assertThat(response.getBody())
+          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
+          .extracting(Error::getMessage)
+          .asString()
+          .contains("failure");
     }
 
     @Test
@@ -351,23 +334,6 @@ final class BackupEndpointTest {
   @Nested
   final class ListTest {
     @Test
-    void shouldReturnErrorOnCompletionException() {
-      // given
-      final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
-      final var failure = new RuntimeException("failure");
-      doReturn(CompletableFuture.failedFuture(failure)).when(api).listBackups();
-
-      // when
-      final WebEndpointResponse<?> response = endpoint.list();
-
-      // then
-      assertThat(response.getBody())
-          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
-          .isEqualTo(new Error().message("failure"));
-    }
-
-    @Test
     void shouldReturnErrorOnException() {
       // given
       final var api = mock(BackupApi.class);
@@ -392,8 +358,16 @@ final class BackupEndpointTest {
       final var endpoint = new BackupEndpoint(api);
       doReturn(CompletableFuture.failedFuture(error)).when(api).listBackups();
 
-      // when - then
-      assertThat(endpoint.list().getStatus()).isEqualTo(expectedCode);
+      // when
+      final var response = endpoint.list();
+
+      // then
+      assertThat(response.getStatus()).isEqualTo(expectedCode);
+      assertThat(response.getBody())
+          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
+          .extracting(Error::getMessage)
+          .asString()
+          .contains("failure");
     }
 
     @Test
@@ -494,22 +468,6 @@ final class BackupEndpointTest {
 
   @Nested
   final class DeleteTest {
-    @Test
-    void shouldReturnErrorOnCompletionException() {
-      // given
-      final var api = mock(BackupApi.class);
-      final var endpoint = new BackupEndpoint(api);
-      final var failure = new RuntimeException("failure");
-      doReturn(CompletableFuture.failedFuture(failure)).when(api).deleteBackup(1);
-
-      // when
-      final WebEndpointResponse<?> response = endpoint.delete(1);
-
-      // then
-      assertThat(response.getBody())
-          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
-          .isEqualTo(new Error().message("failure"));
-    }
 
     @Test
     void shouldReturnErrorOnException() {
@@ -536,8 +494,16 @@ final class BackupEndpointTest {
       final var endpoint = new BackupEndpoint(api);
       doReturn(CompletableFuture.failedFuture(error)).when(api).deleteBackup(anyLong());
 
-      // when - then
-      assertThat(endpoint.delete(1).getStatus()).isEqualTo(expectedCode);
+      // when
+      final var response = endpoint.delete(1);
+
+      // then
+      assertThat(response.getStatus()).isEqualTo(expectedCode);
+      assertThat(response.getBody())
+          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
+          .extracting(Error::getMessage)
+          .asString()
+          .contains("failure");
     }
 
     @Test

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -16,28 +16,65 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import io.camunda.zeebe.gateway.admin.backup.BackupAlreadyExistException;
 import io.camunda.zeebe.gateway.admin.backup.BackupApi;
 import io.camunda.zeebe.gateway.admin.backup.BackupStatus;
 import io.camunda.zeebe.gateway.admin.backup.PartitionBackupStatus;
 import io.camunda.zeebe.gateway.admin.backup.State;
+import io.camunda.zeebe.gateway.cmd.BrokerErrorException;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerError;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.Error;
+import io.netty.channel.ConnectTimeoutException;
+import java.net.ConnectException;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class BackupEndpointTest {
+
+  static class Failures implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+      return Stream.of(
+          Arguments.of(new ConnectException("failure"), 502),
+          Arguments.of(new ConnectTimeoutException("failure"), 504),
+          Arguments.of(new TimeoutException("failure"), 504),
+          Arguments.of(new IncompleteTopologyException("failure"), 502),
+          Arguments.of(
+              new BrokerErrorException(
+                  new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "failure")),
+              502),
+          Arguments.of(
+              new BrokerErrorException(new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "failure")),
+              503),
+          Arguments.of(
+              new BrokerErrorException(new BrokerError(ErrorCode.INTERNAL_ERROR, "failure")), 500),
+          Arguments.of(
+              new BrokerErrorException(new BrokerError(ErrorCode.UNSUPPORTED_MESSAGE, "failure")),
+              400));
+    }
+  }
+
   @Nested
   final class TakeTest {
     @Test
@@ -89,6 +126,18 @@ final class BackupEndpointTest {
       // then
       assertThat(response.getStatus()).isEqualTo(409);
       assertThat(response.getBody()).isInstanceOf(Error.class);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(Failures.class)
+    void shouldReturnCorrectErrorCode(final Throwable error, final int expectedCode) {
+      // given
+      final var api = mock(BackupApi.class);
+      final var endpoint = new BackupEndpoint(api);
+      doReturn(CompletableFuture.failedFuture(error)).when(api).takeBackup(anyLong());
+
+      // when - then
+      assertThat(endpoint.take(1).getStatus()).isEqualTo(expectedCode);
     }
   }
 
@@ -145,6 +194,18 @@ final class BackupEndpointTest {
       assertThat(response.getBody())
           .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
           .isEqualTo(new Error().message("Backup with id 1 does not exist"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(Failures.class)
+    void shouldReturnCorrectErrorCode(final Throwable error, final int expectedCode) {
+      // given
+      final var api = mock(BackupApi.class);
+      final var endpoint = new BackupEndpoint(api);
+      doReturn(CompletableFuture.failedFuture(error)).when(api).getStatus(anyLong());
+
+      // when - then
+      assertThat(endpoint.status(1).getStatus()).isEqualTo(expectedCode);
     }
 
     @Test
@@ -323,6 +384,18 @@ final class BackupEndpointTest {
           .isEqualTo(new Error().message("failure"));
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(Failures.class)
+    void shouldReturnCorrectErrorCode(final Throwable error, final int expectedCode) {
+      // given
+      final var api = mock(BackupApi.class);
+      final var endpoint = new BackupEndpoint(api);
+      doReturn(CompletableFuture.failedFuture(error)).when(api).listBackups();
+
+      // when - then
+      assertThat(endpoint.list().getStatus()).isEqualTo(expectedCode);
+    }
+
     @Test
     void shouldReturnListOfBackups() throws JsonProcessingException {
       // given
@@ -453,6 +526,18 @@ final class BackupEndpointTest {
       assertThat(response.getBody())
           .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
           .isEqualTo(new Error().message("failure"));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(Failures.class)
+    void shouldReturnCorrectErrorCode(final Throwable error, final int expectedCode) {
+      // given
+      final var api = mock(BackupApi.class);
+      final var endpoint = new BackupEndpoint(api);
+      doReturn(CompletableFuture.failedFuture(error)).when(api).deleteBackup(anyLong());
+
+      // when - then
+      assertThat(endpoint.delete(1).getStatus()).isEqualTo(expectedCode);
     }
 
     @Test

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupErrorResponseTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupErrorResponseTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
 import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
 import io.camunda.zeebe.shared.management.BackupEndpoint;
@@ -20,6 +21,8 @@ import java.time.Duration;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,77 +33,81 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 class BackupErrorResponseTest {
 
-  @Container private static final MinioContainer S3 = new MinioContainer();
-  private BackupEndpoint backupEndpoint;
+  @Nested
+  final class DuplicateBackupIdTest {
 
-  private String bucketName;
+    @Container private static final MinioContainer S3 = new MinioContainer();
+    private BackupEndpoint backupEndpoint;
 
-  @RegisterExtension
-  private final ClusteringRuleExtension clusteringRule =
-      new ClusteringRuleExtension(1, 1, 1, this::configureBackupStore);
+    private String bucketName;
 
-  private void configureBackupStore(final BrokerCfg config) {
-    config.getExperimental().getFeatures().setEnableBackup(true);
+    @RegisterExtension
+    private final ClusteringRuleExtension clusteringRule =
+        new ClusteringRuleExtension(1, 1, 1, this::configureBackupStore);
 
-    final var backupConfig = config.getData().getBackup();
-    backupConfig.setStore(BackupStoreType.S3);
+    private void configureBackupStore(final BrokerCfg config) {
+      config.getExperimental().getFeatures().setEnableBackup(true);
 
-    final var s3Config = backupConfig.getS3();
+      final var backupConfig = config.getData().getBackup();
+      backupConfig.setStore(BackupStoreType.S3);
 
-    generateBucketName();
+      final var s3Config = backupConfig.getS3();
 
-    s3Config.setBucketName(bucketName);
-    s3Config.setEndpoint(S3.externalEndpoint());
-    s3Config.setRegion(S3.region());
-    s3Config.setAccessKey(S3.accessKey());
-    s3Config.setSecretKey(S3.secretKey());
-    s3Config.setForcePathStyleAccess(true);
-  }
+      generateBucketName();
 
-  private void generateBucketName() {
-    // Generate only once per test
-    if (bucketName == null) {
-      bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+      s3Config.setBucketName(bucketName);
+      s3Config.setEndpoint(S3.externalEndpoint());
+      s3Config.setRegion(S3.region());
+      s3Config.setAccessKey(S3.accessKey());
+      s3Config.setSecretKey(S3.secretKey());
+      s3Config.setForcePathStyleAccess(true);
     }
-  }
 
-  void createBucket() {
-    // Create bucket before for storing backups
-    final var s3ClientConfig =
-        new Builder()
-            .withBucketName(bucketName)
-            .withEndpoint(S3.externalEndpoint())
-            .withRegion(S3.region())
-            .withCredentials(S3.accessKey(), S3.secretKey())
-            .withApiCallTimeout(Duration.ofSeconds(15))
-            .forcePathStyleAccess(true)
-            .build();
-    try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
-      s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();
+    private void generateBucketName() {
+      // Generate only once per test
+      if (bucketName == null) {
+        bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+      }
     }
-  }
 
-  @BeforeEach
-  void setup() {
-    backupEndpoint = new BackupEndpoint(clusteringRule.getGateway().getBrokerClient());
-    createBucket();
-  }
+    void createBucket() {
+      // Create bucket before for storing backups
+      final var s3ClientConfig =
+          new Builder()
+              .withBucketName(bucketName)
+              .withEndpoint(S3.externalEndpoint())
+              .withRegion(S3.region())
+              .withCredentials(S3.accessKey(), S3.secretKey())
+              .withApiCallTimeout(Duration.ofSeconds(15))
+              .forcePathStyleAccess(true)
+              .build();
+      try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
+        s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();
+      }
+    }
 
-  @AfterEach
-  void close() {
-    // reset so that each test can use a different bucket name
-    bucketName = null;
-  }
+    @BeforeEach
+    void setup() {
+      backupEndpoint = new BackupEndpoint(clusteringRule.getGateway().getBrokerClient());
+      createBucket();
+    }
 
-  @ParameterizedTest
-  @CsvSource({"1,1", "2,1"})
-  @Timeout(value = 60)
-  void shouldFailTakeBackupIfCheckpointAlreadyExists(
-      final long existingCheckpoint, final long backupIdToTake) {
-    // given
-    backupEndpoint.take(existingCheckpoint);
+    @AfterEach
+    void close() {
+      // reset so that each test can use a different bucket name
+      bucketName = null;
+    }
 
-    // when - then
-    assertThat(backupEndpoint.take(backupIdToTake).getStatus()).isEqualTo(409);
+    @ParameterizedTest
+    @CsvSource({"1,1", "2,1"})
+    @Timeout(value = 60)
+    void shouldFailTakeBackupIfCheckpointAlreadyExists(
+        final long existingCheckpoint, final long backupIdToTake) {
+      // given
+      backupEndpoint.take(existingCheckpoint);
+
+      // when - then
+      assertThat(backupEndpoint.take(backupIdToTake).getStatus()).isEqualTo(409);
+    }
   }
 }


### PR DESCRIPTION
## Description

Return specific error codes for connection issues and when backup is not enabled.

We had decided to use 502 for connection errors. But it also makes sense to use 504 to denote timeouts (See https://github.com/camunda/zeebe/pull/11156#discussion_r1038220981). We now use both to distinguish different cases. I have also updated the spec. Operate and Optimize would probably return 502 for all connection issues.

## Related issues

closes #10849 #10209 #11124 #10967 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [
* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
