### PR TITLE
Enable standalone Decision execution in the workflow engine.

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -94,8 +94,6 @@ public final class BpmnDecisionBehavior {
                   decisionBehavior.createDecisionEvaluationEvent(decision, evaluationResult);
               writeDecisionEvaluationEvent(eventTuple, context);
 
-              decisionBehavior.updateDecisionMetrics(evaluationResult);
-
               if (evaluationResult.isFailure()) {
                 return Either.left(
                     new Failure(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -58,6 +58,12 @@ public class DecisionBehavior {
         .mapLeft(failure -> formatDecisionLookupFailure(failure, decisionId));
   }
 
+  public Either<Failure, PersistedDecision> findDecisionByKey(final long decisionKey) {
+    return Either.ofOptional(decisionState.findDecisionByKey(decisionKey))
+        .orElse(new Failure("no decision found for key '%s'".formatted(decisionKey)))
+        .mapLeft(failure -> formatDecisionLookupFailure(failure, decisionKey));
+  }
+
   public Either<Failure, ParsedDecisionRequirementsGraph> findAndParseDrgByDecision(
       final PersistedDecision persistedDecision) {
     return findDrgByDecision(persistedDecision)
@@ -66,6 +72,10 @@ public class DecisionBehavior {
             failure ->
                 formatDecisionLookupFailure(
                     failure, BufferUtil.bufferAsString(persistedDecision.getDecisionId())));
+  }
+
+  public Failure formatDecisionLookupFailure(final Failure failure, final long decisionKey) {
+    return formatDecisionLookupFailure(failure, String.valueOf(decisionKey));
   }
 
   public Failure formatDecisionLookupFailure(final Failure failure, final String decisionId) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -88,7 +88,12 @@ public class DecisionBehavior {
       final String decisionId,
       final DirectBuffer variables) {
     final var evaluationContext = new VariablesContext(MsgPackConverter.convertToMap(variables));
-    return decisionEngine.evaluateDecisionById(drg, decisionId, evaluationContext);
+    final var evaluationResult =
+        decisionEngine.evaluateDecisionById(drg, decisionId, evaluationContext);
+
+    updateDecisionMetrics(evaluationResult);
+
+    return evaluationResult;
   }
 
   public Tuple<DecisionEvaluationIntent, DecisionEvaluationRecord> createDecisionEvaluationEvent(
@@ -138,7 +143,7 @@ public class DecisionBehavior {
     return new Tuple<>(decisionEvaluationIntent, decisionEvaluationEvent);
   }
 
-  public void updateDecisionMetrics(final DecisionEvaluationResult evaluationResult) {
+  private void updateDecisionMetrics(final DecisionEvaluationResult evaluationResult) {
     if (evaluationResult.isFailure()) {
       metrics.increaseFailedEvaluatedDmnElements(evaluationResult.getEvaluatedDecisions().size());
     } else {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/EvaluateDecisionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/EvaluateDecisionProcessor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.dmn;
+
+import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
+import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.collection.Tuple;
+
+public class EvaluateDecisionProcessor implements CommandProcessor<DecisionEvaluationRecord> {
+
+  private static final String ERROR_MESSAGE_NO_IDENTIFIER_SPECIFIED =
+      "Expected either a decisionId or a decisionKey greater than -1, but none or both provided";
+
+  private final DecisionBehavior decisionBehavior;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+  private boolean success;
+
+  public EvaluateDecisionProcessor(
+      final DecisionBehavior decisionBehavior,
+      final KeyGenerator keyGenerator,
+      final Writers writers) {
+
+    this.decisionBehavior = decisionBehavior;
+    this.keyGenerator = keyGenerator;
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+  }
+
+  @Override
+  public boolean onCommand(
+      final TypedRecord<DecisionEvaluationRecord> command,
+      final CommandControl<DecisionEvaluationRecord> commandControl) {
+
+    final DecisionEvaluationRecord record = command.getValue();
+    final Either<Failure, PersistedDecision> decisionOrFailure = getDecision(record);
+
+    decisionOrFailure
+        .flatMap(persistedDecision -> decisionBehavior.findAndParseDrgByDecision(persistedDecision))
+        .ifRightOrLeft(
+            drg -> {
+              final var decision = decisionOrFailure.get();
+              final var variables = record.getVariablesBuffer();
+              final var evaluationResult =
+                  decisionBehavior.evaluateDecisionInDrg(
+                      drg, BufferUtil.bufferAsString(decision.getDecisionId()), variables);
+
+              // update metrics and write events
+              final Tuple<DecisionEvaluationIntent, DecisionEvaluationRecord>
+                  evaluationRecordTuple =
+                      decisionBehavior.createDecisionEvaluationEvent(decision, evaluationResult);
+              decisionBehavior.updateDecisionMetrics(evaluationResult);
+
+              success = true;
+              commandControl.accept(
+                  evaluationRecordTuple.getLeft(), evaluationRecordTuple.getRight());
+            },
+            failure -> {
+              success = false;
+              final String reason = failure.getMessage();
+              commandControl.reject(RejectionType.INVALID_ARGUMENT, reason);
+            });
+
+    return success;
+  }
+
+  private Either<Failure, PersistedDecision> getDecision(final DecisionEvaluationRecord record) {
+
+    final String decisionId = record.getDecisionId();
+    final long decisionKey = record.getDecisionKey();
+
+    final var decisionIdProvided = !decisionId.isEmpty();
+    final var decisionKeyProvided = (decisionKey != -1L);
+
+    if (decisionIdProvided == decisionKeyProvided) {
+      // XNOR if both ID and KEY are provided/missing
+      return Either.left(new Failure(ERROR_MESSAGE_NO_IDENTIFIER_SPECIFIED));
+    }
+
+    if (decisionIdProvided) {
+      return decisionBehavior.findDecisionById(decisionId);
+      // TODO: expand DecisionState API to find decisions by ID AND VERSION (#11230)
+    } else {
+      return decisionBehavior.findDecisionByKey(decisionKey);
+    }
+  }
+
+  private RejectionType determineRejectionType(final Failure failure) {
+    final ErrorType errorType = failure.getErrorType();
+    if (errorType == ErrorType.DECISION_EVALUATION_ERROR) {
+      return RejectionType.PROCESSING_ERROR;
+    } else {
+      return RejectionType.INVALID_ARGUMENT;
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -103,6 +103,12 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
+  public Optional<PersistedDecision> findDecisionByKey(final long decisionKey) {
+    dbDecisionKey.wrapLong(decisionKey);
+    return Optional.ofNullable(decisionsByKey.get(dbDecisionKey)).map(PersistedDecision::copy);
+  }
+
+  @Override
   public Optional<PersistedDecisionRequirements> findLatestDecisionRequirementsById(
       final DirectBuffer decisionRequirementsId) {
     dbDecisionRequirementsId.wrapBuffer(decisionRequirementsId);
@@ -135,11 +141,6 @@ public final class DbDecisionState implements MutableDecisionState {
         }));
 
     return decisions;
-  }
-
-  private Optional<PersistedDecision> findDecisionByKey(final long decisionKey) {
-    dbDecisionKey.wrapLong(decisionKey);
-    return Optional.ofNullable(decisionsByKey.get(dbDecisionKey)).map(PersistedDecision::copy);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -25,6 +25,14 @@ public interface DecisionState {
   Optional<PersistedDecision> findLatestDecisionById(DirectBuffer decisionId);
 
   /**
+   * Query decisions by the given decision key and return the decision.
+   *
+   * @param decisionKey the key of the decision
+   * @return the decision, or {@link Optional#empty()} if no decision is deployed with the given key
+   */
+  Optional<PersistedDecision> findDecisionByKey(long decisionKey);
+
+  /**
    * Query decision requirements (DRGs) by the given decision requirements id and return the latest
    * version of the DRG.
    *

--- a/engine/src/test/java/io/camunda/zeebe/engine/dmn/DecisionEvaluationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/dmn/DecisionEvaluationTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.dmn;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DecisionEvaluationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String DMN_RESOURCE = "/dmn/drg-force-user.dmn";
+  private static final String DECISION_ID = "jedi_or_sith";
+  private static final String EXPECTED_DECISION_OUTPUT = "\"Jedi\"";
+  private static final String EXPECTED_FAILURE_MSG =
+      "Expected to evaluate decision 'jedi_or_sith', but failed to evaluate expression 'lightsaberColor': no variable found for name 'lightsaberColor'";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldEvaluateDecisionById() {
+    // given
+    ENGINE.deployment().withXmlClasspathResource(DMN_RESOURCE).deploy();
+
+    // when
+    final Record<DecisionEvaluationRecordValue> record =
+        ENGINE
+            .decision()
+            .ofDecisionId(DECISION_ID)
+            .withVariable("lightsaberColor", "blue")
+            .evaluate();
+
+    // then
+    assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATED);
+    assertThat(record.getValue()).hasDecisionOutput(EXPECTED_DECISION_OUTPUT);
+  }
+
+  @Test
+  public void shouldFailEvaluationOfDecisionById() {
+    // given
+    ENGINE.deployment().withXmlClasspathResource(DMN_RESOURCE).deploy();
+
+    // when
+    final Record<DecisionEvaluationRecordValue> record =
+        ENGINE.decision().ofDecisionId(DECISION_ID).expectFailure().evaluate();
+
+    // then
+    assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.FAILED);
+    assertThat(record.getValue()).hasFailedDecisionId(DECISION_ID);
+    assertThat(record.getValue()).hasEvaluationFailureMessage(EXPECTED_FAILURE_MSG);
+  }
+
+  @Test
+  public void shouldEvaluateDecisionByKey() {
+    // given
+    final Record<DeploymentRecordValue> deploymentRecord =
+        ENGINE.deployment().withXmlClasspathResource(DMN_RESOURCE).deploy();
+    final DecisionRecordValue decisionRecord =
+        deploymentRecord.getValue().getDecisionsMetadata().stream()
+            .filter(decisionRecordValue -> decisionRecordValue.getDecisionId().equals(DECISION_ID))
+            .findAny()
+            .get();
+    final long decisionKey = decisionRecord.getDecisionKey();
+
+    // when
+    final Record<DecisionEvaluationRecordValue> record =
+        ENGINE
+            .decision()
+            .ofDecisionKey(decisionKey)
+            .withVariable("lightsaberColor", "blue")
+            .evaluate();
+
+    // then
+    assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATED);
+    assertThat(record.getValue()).hasDecisionOutput(EXPECTED_DECISION_OUTPUT);
+  }
+
+  @Test
+  public void shouldRejectDecisionUsingIdAndKey() {
+    // when
+    final Record<DecisionEvaluationRecordValue> record =
+        ENGINE.decision().ofDecisionId("falseId").ofDecisionKey(123L).expectRejection().evaluate();
+
+    // then
+    assertThat(record.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
+    assertThat(record.getRejectionReason())
+        .isEqualTo(
+            "Expected either a decisionId or a decisionKey greater than -1, but none or both provided");
+  }
+
+  @Test
+  public void shouldRejectDecisionWithoutIdAndKey() {
+    // when
+    final Record<DecisionEvaluationRecordValue> record =
+        ENGINE.decision().ofDecisionId("").ofDecisionKey(-1L).expectRejection().evaluate();
+
+    // then
+    assertThat(record.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
+    assertThat(record.getRejectionReason())
+        .isEqualTo(
+            "Expected either a decisionId or a decisionKey greater than -1, but none or both provided");
+  }
+
+  @Test
+  public void shouldRejectDecisionOnFalseId() {
+    // given
+    final var falseDecisionId = "falseId";
+
+    // when
+    final Record<DecisionEvaluationRecordValue> record =
+        ENGINE.decision().ofDecisionId(falseDecisionId).expectRejection().evaluate();
+
+    // then
+    assertThat(record.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
+    assertThat(record.getRejectionReason())
+        .isEqualTo(
+            "Expected to evaluate decision '"
+                + falseDecisionId
+                + "', but no decision found for id '"
+                + falseDecisionId
+                + "'");
+  }
+
+  @Test
+  public void shouldRejectDecisionOnFalseKey() {
+    // given
+    final var falseDecisionKey = 123L;
+
+    // when
+    final Record<DecisionEvaluationRecordValue> record =
+        ENGINE.decision().ofDecisionKey(falseDecisionKey).expectRejection().evaluate();
+
+    // then
+    assertThat(record.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
+    assertThat(record.getRejectionReason())
+        .isEqualTo(
+            "Expected to evaluate decision '"
+                + falseDecisionKey
+                + "', but no decision found for key '"
+                + falseDecisionKey
+                + "'");
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/StandaloneDecisionEvaluationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/StandaloneDecisionEvaluationTest.java
@@ -133,7 +133,7 @@ public class StandaloneDecisionEvaluationTest {
     assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
     assertThat(record.getRejectionReason())
         .isEqualTo(
-            "Expected either a decisionId or a decisionKey greater than -1, but none or both provided");
+            "Expected either a decision id or a valid decision key, but none or both provided");
   }
 
   @Test
@@ -147,7 +147,7 @@ public class StandaloneDecisionEvaluationTest {
     assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
     assertThat(record.getRejectionReason())
         .isEqualTo(
-            "Expected either a decisionId or a decisionKey greater than -1, but none or both provided");
+            "Expected either a decision id or a valid decision key, but none or both provided");
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/StandaloneDecisionEvaluationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/StandaloneDecisionEvaluationTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.dmn;
+package io.camunda.zeebe.engine.processing.dmn;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -86,14 +86,12 @@ public class StandaloneDecisionEvaluationTest {
             .evaluate();
 
     // then
-    final int deployedVersion = deploymentEvent
-        .getValue()
-        .getDecisionsMetadata()
-        .stream()
-        .filter(decisionRecordValue -> decisionRecordValue.getDecisionId().equals(DECISION_ID))
-        .findFirst()
-        .get()
-        .getVersion();
+    final int deployedVersion =
+        deploymentEvent.getValue().getDecisionsMetadata().stream()
+            .filter(decisionRecordValue -> decisionRecordValue.getDecisionId().equals(DECISION_ID))
+            .findFirst()
+            .get()
+            .getVersion();
     assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATED);
     assertThat(record.getValue()).hasDecisionOutput(EXPECTED_DECISION_OUTPUT);
     assertThat(record.getValue()).hasDecisionVersion(deployedVersion);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -35,9 +35,19 @@ public final class DecisionStateTest {
 
   @DisplayName("should return empty if no decision is deployed")
   @Test
-  void shouldReturnEmptyIfNoDecisionIsDeployed() {
+  void shouldReturnEmptyIfNoDecisionIsDeployedForDeploymentId() {
     // when
     final var persistedDecision = decisionState.findLatestDecisionById(wrapString("decision-1"));
+
+    // then
+    assertThat(persistedDecision).isEmpty();
+  }
+
+  @DisplayName("should return empty if no decision is deployed")
+  @Test
+  void shouldReturnEmptyIfNoDecisionIsDeployedForDeploymentKey() {
+    // when
+    final var persistedDecision = decisionState.findDecisionByKey(1L);
 
     // then
     assertThat(persistedDecision).isEmpty();
@@ -119,6 +129,36 @@ public final class DecisionStateTest {
     assertThat(persistedDecision2).isNotEmpty();
     assertThat(bufferAsString(persistedDecision2.get().getDecisionId()))
         .isEqualTo(decisionRecord2.getDecisionId());
+  }
+
+  @DisplayName("should find deployed decision by KEY")
+  @Test
+  void shouldFindDeployedDecisionByKey() {
+    // given
+    final var decisionRecord1 =
+        sampleDecisionRecord().setDecisionId("decision-1").setDecisionKey(1L);
+    final var decisionRecord2 =
+        sampleDecisionRecord().setDecisionId("decision-2").setDecisionKey(2L);
+    final var drg = sampleDecisionRequirementsRecord();
+    decisionState.storeDecisionRequirements(drg);
+
+    decisionState.storeDecisionRecord(decisionRecord1);
+    decisionState.storeDecisionRecord(decisionRecord2);
+
+    // when
+    final var persistedDecision1 =
+        decisionState.findDecisionByKey(decisionRecord1.getDecisionKey());
+    final var persistedDecision2 =
+        decisionState.findDecisionByKey(decisionRecord2.getDecisionKey());
+
+    // then
+    assertThat(persistedDecision1).isNotEmpty();
+    assertThat(persistedDecision1.get().getDecisionKey())
+        .isEqualTo(decisionRecord1.getDecisionKey());
+
+    assertThat(persistedDecision2).isNotEmpty();
+    assertThat(persistedDecision2.get().getDecisionKey())
+        .isEqualTo(decisionRecord2.getDecisionKey());
   }
 
   @DisplayName("should return the latest version of the deployed decision by ID")

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSen
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ZeebeDbState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
 import io.camunda.zeebe.engine.util.client.JobActivationClient;
@@ -292,6 +293,10 @@ public final class EngineRule extends ExternalResource {
 
   public ProcessInstanceClient processInstance() {
     return new ProcessInstanceClient(environmentRule);
+  }
+
+  public DecisionEvaluationClient decision() {
+    return new DecisionEvaluationClient((environmentRule));
   }
 
   public PublishMessageClient message() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -296,7 +296,7 @@ public final class EngineRule extends ExternalResource {
   }
 
   public DecisionEvaluationClient decision() {
-    return new DecisionEvaluationClient((environmentRule));
+    return new DecisionEvaluationClient(environmentRule);
   }
 
   public PublishMessageClient message() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/DecisionEvaluationClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/DecisionEvaluationClient.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.engine.util.StreamProcessorRule;
+import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import java.util.function.Function;
+
+public class DecisionEvaluationClient {
+
+  private static final Function<Long, Record<DecisionEvaluationRecordValue>> SUCCESS_EXPECTATION =
+      (position) ->
+          RecordingExporter.decisionEvaluationRecords()
+              .withIntent(DecisionEvaluationIntent.EVALUATED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private static final Function<Long, Record<DecisionEvaluationRecordValue>> FAILURE_EXPECTATION =
+      (position) ->
+          RecordingExporter.decisionEvaluationRecords()
+              .withIntent(DecisionEvaluationIntent.FAILED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private static final Function<Long, Record<DecisionEvaluationRecordValue>> REJECTION_EXPECTATION =
+      (position) ->
+          RecordingExporter.decisionEvaluationRecords()
+              .onlyCommandRejections()
+              .withIntent(DecisionEvaluationIntent.EVALUATE)
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private final StreamProcessorRule environmentRule;
+  private final DecisionEvaluationRecord decisionEvaluationRecord = new DecisionEvaluationRecord();
+  private Function<Long, Record<DecisionEvaluationRecordValue>> expectation = SUCCESS_EXPECTATION;
+
+  public DecisionEvaluationClient(final StreamProcessorRule environmentRule) {
+    this.environmentRule = environmentRule;
+  }
+
+  public DecisionEvaluationClient ofDecisionId(final String decisionId) {
+    decisionEvaluationRecord.setDecisionId(decisionId);
+    return this;
+  }
+
+  public DecisionEvaluationClient ofDecisionIdAndVersion(
+      final String decisionId, final int version) {
+    ofDecisionId(decisionId);
+    decisionEvaluationRecord.setDecisionVersion(version);
+    return this;
+  }
+
+  public DecisionEvaluationClient ofDecisionKey(final long decisionKey) {
+    decisionEvaluationRecord.setDecisionKey(decisionKey);
+    return this;
+  }
+
+  public DecisionEvaluationClient withVariables(final Map<String, Object> variables) {
+    decisionEvaluationRecord.setVariables(MsgPackUtil.asMsgPack(variables));
+    return this;
+  }
+
+  public DecisionEvaluationClient withVariables(final String variables) {
+    decisionEvaluationRecord.setVariables(MsgPackUtil.asMsgPack(variables));
+    return this;
+  }
+
+  public DecisionEvaluationClient withVariable(final String key, final Object value) {
+    decisionEvaluationRecord.setVariables(MsgPackUtil.asMsgPack(key, value));
+    return this;
+  }
+
+  public Record<DecisionEvaluationRecordValue> evaluate() {
+    final long position =
+        environmentRule.writeCommand(DecisionEvaluationIntent.EVALUATE, decisionEvaluationRecord);
+
+    return expectation.apply(position);
+  }
+
+  public DecisionEvaluationClient expectFailure() {
+    expectation = FAILURE_EXPECTATION;
+    return this;
+  }
+
+  public DecisionEvaluationClient expectRejection() {
+    expectation = REJECTION_EXPECTATION;
+    return this;
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/DecisionEvaluationClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/DecisionEvaluationClient.java
@@ -54,13 +54,6 @@ public class DecisionEvaluationClient {
     return this;
   }
 
-  public DecisionEvaluationClient ofDecisionIdAndVersion(
-      final String decisionId, final int version) {
-    ofDecisionId(decisionId);
-    decisionEvaluationRecord.setDecisionVersion(version);
-    return this;
-  }
-
   public DecisionEvaluationClient ofDecisionKey(final long decisionKey) {
     decisionEvaluationRecord.setDecisionKey(decisionKey);
     return this;

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -42,6 +42,9 @@
             "decisionOutput": {
               "enabled": false
             },
+            "variables": {
+              "enabled": false
+            },
             "bpmnProcessId": {
               "type": "keyword"
             },

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -906,6 +906,7 @@ final class JsonSerializableToJsonTest {
                       .setDecisionRequirementsKey(2L)
                       .setDecisionRequirementsId("decision-requirements-id")
                       .setDecisionOutput(toMessagePack("'decision-output'"))
+                      .setVariables(VARIABLES_MSGPACK)
                       .setProcessDefinitionKey(3L)
                       .setBpmnProcessId("bpmn-process-id")
                       .setDecisionVersion(1)
@@ -952,6 +953,9 @@ final class JsonSerializableToJsonTest {
               "decisionRequirementsKey":2,
               "decisionRequirementsId":"decision-requirements-id",
               "decisionOutput":'"decision-output"',
+              "variables": {
+                "foo": "bar"
+              },
               "processDefinitionKey":3,
               "bpmnProcessId":"bpmn-process-id",
               "processInstanceKey":4,
@@ -1022,6 +1026,7 @@ final class JsonSerializableToJsonTest {
               "decisionRequirementsKey":2,
               "decisionRequirementsId":"decision-requirements-id",
               "decisionOutput":"null",
+              "variables":{},
               "processDefinitionKey":3,
               "bpmnProcessId":"bpmn-process-id",
               "processInstanceKey":4,

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1002,36 +1002,22 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Empty DecisionEvaluationRecord",
-        (Supplier<UnifiedRecordValue>)
-            () ->
-                new DecisionEvaluationRecord()
-                    .setDecisionKey(1L)
-                    .setDecisionId("decision-id")
-                    .setDecisionName("decision-name")
-                    .setDecisionVersion(1)
-                    .setDecisionRequirementsKey(2L)
-                    .setDecisionRequirementsId("decision-requirements-id")
-                    .setProcessDefinitionKey(3L)
-                    .setBpmnProcessId("bpmn-process-id")
-                    .setDecisionVersion(1)
-                    .setProcessInstanceKey(4L)
-                    .setElementInstanceKey(5L)
-                    .setElementId("element-id"),
+        (Supplier<UnifiedRecordValue>) () -> new DecisionEvaluationRecord(),
         """
           {
-              "decisionKey":1,
-              "decisionId":"decision-id",
-              "decisionName":"decision-name",
-              "decisionVersion":1,
-              "decisionRequirementsKey":2,
-              "decisionRequirementsId":"decision-requirements-id",
+              "decisionKey":-1,
+              "decisionId":"",
+              "decisionName":"",
+              "decisionVersion":-1,
+              "decisionRequirementsKey":-1,
+              "decisionRequirementsId":"",
               "decisionOutput":"null",
               "variables":{},
-              "processDefinitionKey":3,
-              "bpmnProcessId":"bpmn-process-id",
-              "processInstanceKey":4,
-              "elementInstanceKey":5,
-              "elementId":"element-id",
+              "processDefinitionKey":-1,
+              "bpmnProcessId":"",
+              "processInstanceKey":-1,
+              "elementInstanceKey":-1,
+              "elementId":"",
               "evaluatedDecisions":[],
               "evaluationFailureMessage":"",
               "failedDecisionId":""

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
@@ -16,9 +16,9 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum DecisionEvaluationIntent implements Intent {
-  EVALUATE(0),
-  EVALUATED(1),
-  FAILED(2);
+  EVALUATED(0),
+  FAILED(1),
+  EVALUATE(2);
 
   private final short value;
 
@@ -33,11 +33,11 @@ public enum DecisionEvaluationIntent implements Intent {
   public static Intent from(final short value) {
     switch (value) {
       case 0:
-        return EVALUATE;
-      case 1:
         return EVALUATED;
-      case 2:
+      case 1:
         return FAILED;
+      case 2:
+        return EVALUATE;
       default:
         return UNKNOWN;
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
@@ -16,8 +16,9 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum DecisionEvaluationIntent implements Intent {
-  EVALUATED(0),
-  FAILED(1);
+  EVALUATE(0),
+  EVALUATED(1),
+  FAILED(2);
 
   private final short value;
 
@@ -32,8 +33,10 @@ public enum DecisionEvaluationIntent implements Intent {
   public static Intent from(final short value) {
     switch (value) {
       case 0:
-        return EVALUATED;
+        return EVALUATE;
       case 1:
+        return EVALUATED;
+      case 2:
         return FAILED;
       default:
         return UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
@@ -17,13 +17,14 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import java.util.List;
 import org.immutables.value.Value;
 
 /** Represents the evaluation of a DMN decision. */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableDecisionEvaluationRecordValue.Builder.class)
-public interface DecisionEvaluationRecordValue extends RecordValue {
+public interface DecisionEvaluationRecordValue extends RecordValue, RecordValueWithVariables {
 
   /**
    * @return the key of the evaluated decision

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -704,6 +704,7 @@ public class CompactRecordLogger {
     return new StringBuilder()
         .append(value.getDecisionOutput())
         .append(summarizeDecisionInformation(value.getDecisionId(), value.getDecisionKey()))
+        .append(summarizeVariables(value.getVariables()))
         .append(
             summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
         .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()))


### PR DESCRIPTION
## Description

Enable standalone Decision execution in the workflow engine.

## Related issues

closes #11039 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
