### PR TITLE
Add record and intent for signal subcription

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -620,6 +620,7 @@
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
+        #     signalSubscription: true
         #     timer: true
         #     variable: true
         #     variableDocument: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -558,6 +558,7 @@
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
+        #     signalSubscription: true
         #     timer: true
         #     variable: true
         #     variableDocument: true

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -99,6 +99,7 @@ exporters:
         processInstanceCreation: false
         processInstanceModification: false
         processMessageSubscription: false
+        signalSubscription: false
         variable: false
         variableDocument: false
 ```
@@ -147,6 +148,7 @@ More specifically, each option configures the following:
   be exported; if false, ignored.
 * `processMessageSubscription` (`boolean`): if true, records related to process message
   subscriptions will be exported; if false, ignored.
+* `signalSubscription` (`boolean`): if true, records related to signal subscription will be exported; if false, ignored.
 * `timer` (`boolean`): if true, records related to timers will be exported; if false, ignored.
 * `variable` (`boolean`): if true, records related to variables will be exported; if false, ignored.
 * `variableDocument` (`boolean`): if true, records related to variable documents will be exported;
@@ -208,6 +210,7 @@ exporters:
         processInstanceCreation: true
         processInstanceModification: true
         processMessageSubscription: true
+        signalSubscription: true
         timer: true
         variable: true
         variableDocument: true

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -263,6 +263,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.escalation) {
         createValueIndexTemplate(ValueType.ESCALATION);
       }
+      if (index.signalSubscription) {
+        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -99,6 +99,8 @@ public class ElasticsearchExporterConfiguration {
         return index.deploymentDistribution;
       case ESCALATION:
         return index.escalation;
+      case SIGNAL_SUBSCRIPTION:
+        return index.signalSubscription;
       default:
         return false;
     }
@@ -154,6 +156,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean processEvent = false;
     public boolean deploymentDistribution = true;
     public boolean escalation = true;
+    public boolean signalSubscription = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -233,6 +236,8 @@ public class ElasticsearchExporterConfiguration {
           + deploymentDistribution
           + ", escalation="
           + escalation
+          + ", signalSubscription="
+          + signalSubscription
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-signal-subscription-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_signal-subscription_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-signal-subscription": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "catchEventId": {
+              "type": "keyword"
+            },
+            "catchEventInstanceKey": {
+              "type": "long"
+            },
+            "signalName": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -72,6 +72,7 @@ final class TestSupport {
       case PROCESS_EVENT -> config.processEvent = value;
       case DEPLOYMENT_DISTRIBUTION -> config.deploymentDistribution = value;
       case ESCALATION -> config.escalation = value;
+      case SIGNAL_SUBSCRIPTION -> config.signalSubscription = value;
       default -> throw new IllegalArgumentException(
           "No known indexing configuration option for value type " + valueType);
     }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.signal;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+import org.agrona.DirectBuffer;
+
+public final class SignalSubscriptionRecord extends UnifiedRecordValue
+    implements SignalSubscriptionRecordValue {
+
+  private final LongProperty processDefinitionKeyProp =
+      new LongProperty("processDefinitionKey", -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final StringProperty signalNameProp = new StringProperty("signalName", "");
+  private final StringProperty catchEventIdProp = new StringProperty("catchEventId", "");
+  private final LongProperty catchEventInstanceKeyProp =
+      new LongProperty("catchEventInstanceKey", -1L);
+
+  public SignalSubscriptionRecord() {
+    declareProperty(processDefinitionKeyProp)
+        .declareProperty(signalNameProp)
+        .declareProperty(catchEventIdProp)
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(catchEventInstanceKeyProp);
+  }
+
+  public void wrap(final SignalSubscriptionRecord record) {
+    processDefinitionKeyProp.setValue(record.getProcessDefinitionKey());
+    bpmnProcessIdProp.setValue(record.getBpmnProcessIdBuffer());
+    signalNameProp.setValue(record.getSignalNameBuffer());
+    catchEventIdProp.setValue(record.getCatchEventId());
+    catchEventInstanceKeyProp.setValue(record.getCatchEventInstanceKey());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getSignalNameBuffer() {
+    return signalNameProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getCatchEventIdBuffer() {
+    return catchEventIdProp.getValue();
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  @Override
+  public String getCatchEventId() {
+    return bufferAsString(catchEventIdProp.getValue());
+  }
+
+  @Override
+  public long getCatchEventInstanceKey() {
+    return catchEventInstanceKeyProp.getValue();
+  }
+
+  @Override
+  public String getSignalName() {
+    return bufferAsString(signalNameProp.getValue());
+  }
+
+  public SignalSubscriptionRecord setSignalName(final DirectBuffer signalName) {
+    signalNameProp.setValue(signalName);
+    return this;
+  }
+
+  public SignalSubscriptionRecord setCatchEventInstanceKey(final long catchEventInstanceKey) {
+    catchEventInstanceKeyProp.setValue(catchEventInstanceKey);
+    return this;
+  }
+
+  public SignalSubscriptionRecord setCatchEventId(final DirectBuffer catchEventId) {
+    catchEventIdProp.setValue(catchEventId);
+    return this;
+  }
+
+  public SignalSubscriptionRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public SignalSubscriptionRecord setProcessDefinitionKey(final long key) {
+    processDefinitionKeyProp.setValue(key);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
@@ -1083,6 +1084,42 @@ final class JsonSerializableToJsonTest {
               "catchElementId": ""
           }
           """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// SignalSubscriptionRecord ///////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "SignalSubscriptionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String signalName = "name";
+              final String catchEventId = "startEvent";
+              final int processDefinitionKey = 22334;
+              final String bpmnProcessId = "process";
+
+              return new SignalSubscriptionRecord()
+                  .setSignalName(wrapString(signalName))
+                  .setCatchEventId(wrapString(catchEventId))
+                  .setProcessDefinitionKey(processDefinitionKey)
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setCatchEventInstanceKey(3L);
+            },
+        "{'processDefinitionKey':22334,'signalName':'name','catchEventId':'startEvent','bpmnProcessId':'process','catchEventInstanceKey':3}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty SignalSubscriptionRecord /////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty SignalStartEventSubscriptionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final int processDefinitionKey = 22334;
+
+              return new SignalSubscriptionRecord().setProcessDefinitionKey(processDefinitionKey);
+            },
+        "{'processDefinitionKey':22334,'signalName':'','catchEventId':'','bpmnProcessId':'','catchEventInstanceKey':-1}"
       },
     };
   }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1105,7 +1105,15 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setCatchEventInstanceKey(3L);
             },
-        "{'processDefinitionKey':22334,'signalName':'name','catchEventId':'startEvent','bpmnProcessId':'process','catchEventInstanceKey':3}"
+        """
+          {
+            "processDefinitionKey":22334,
+            "signalName": "name",
+            "catchEventId": "startEvent",
+            "bpmnProcessId": "process",
+            "catchEventInstanceKey":3
+          }
+          """
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -1119,7 +1127,15 @@ final class JsonSerializableToJsonTest {
 
               return new SignalSubscriptionRecord().setProcessDefinitionKey(processDefinitionKey);
             },
-        "{'processDefinitionKey':22334,'signalName':'','catchEventId':'','bpmnProcessId':'','catchEventInstanceKey':-1}"
+        """
+          {
+              "processDefinitionKey":22334,
+              "signalName":"",
+              "catchEventId":"",
+              "bpmnProcessId":"",
+              "catchEventInstanceKey":-1
+          }
+          """
       },
     };
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -57,6 +58,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
@@ -176,6 +178,9 @@ public final class ValueTypeMapping {
         ValueType.CHECKPOINT, new Mapping<>(CheckpointRecordValue.class, CheckpointIntent.class));
     mapping.put(
         ValueType.ESCALATION, new Mapping<>(EscalationRecordValue.class, EscalationIntent.class));
+    mapping.put(
+        ValueType.SIGNAL_SUBSCRIPTION,
+        new Mapping<>(SignalSubscriptionRecordValue.class, SignalSubscriptionIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -46,7 +46,8 @@ public interface Intent {
           MessageStartEventSubscriptionIntent.class,
           ProcessInstanceResultIntent.class,
           CheckpointIntent.class,
-          ProcessInstanceModificationIntent.class);
+          ProcessInstanceModificationIntent.class,
+          SignalSubscriptionIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -116,6 +117,8 @@ public interface Intent {
         return EscalationIntent.from(intent);
       case PROCESS_INSTANCE_MODIFICATION:
         return ProcessInstanceModificationIntent.from(intent);
+      case SIGNAL_SUBSCRIPTION:
+        return SignalSubscriptionIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -175,6 +178,8 @@ public interface Intent {
         return CheckpointIntent.valueOf(intent);
       case ESCALATION:
         return EscalationIntent.valueOf(intent);
+      case SIGNAL_SUBSCRIPTION:
+        return SignalSubscriptionIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalSubscriptionIntent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum SignalSubscriptionIntent implements Intent {
+  CREATED((short) 0),
+  DELETED((short) 1);
+
+  private final short value;
+
+  SignalSubscriptionIntent(final short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATED;
+      case 1:
+        return DELETED;
+      default:
+        return UNKNOWN;
+    }
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/SignalSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/SignalSubscriptionRecordValue.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
+import org.immutables.value.Value;
+
+/**
+ * Represents signal event subscription commands and events
+ *
+ * <p>See {@link SignalSubscriptionIntent} for intents.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableSignalSubscriptionRecordValue.Builder.class)
+public interface SignalSubscriptionRecordValue extends RecordValue {
+
+  /**
+   * @return the process key tied to the subscription
+   */
+  long getProcessDefinitionKey();
+
+  /**
+   * @return the BPMN process id tied to the subscription
+   */
+  String getBpmnProcessId();
+
+  /**
+   * @return the id of the catch event tied to the subscription
+   */
+  String getCatchEventId();
+
+  /**
+   * @return the key of the catch event instance key tied to the subscription
+   */
+  long getCatchEventInstanceKey();
+
+  /**
+   * @return the name of the signal
+   */
+  String getSignalName();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -44,6 +44,7 @@
       <validValue name="DECISION_EVALUATION">27</validValue>
       <validValue name="PROCESS_INSTANCE_MODIFICATION">28</validValue>
       <validValue name="ESCALATION">29</validValue>
+      <validValue name="SIGNAL_SUBSCRIPTION">30</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -73,6 +73,8 @@ final class IntentEncodingDecodingTest {
     result.addAll(buildParameterSets(VariableIntent.class, VariableIntent::from));
     result.addAll(buildParameterSets(CheckpointIntent.class, CheckpointIntent::from));
     result.addAll(buildParameterSets(EscalationIntent.class, EscalationIntent::from));
+    result.addAll(
+        buildParameterSets(SignalSubscriptionIntent.class, SignalSubscriptionIntent::from));
 
     return result.stream();
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -724,7 +724,7 @@ public class CompactRecordLogger {
         .append("\"")
         .append(value.getSignalName())
         .append("\"")
-        .append(" starting <process ")
+        .append(" <process ")
         .append(formatId(value.getBpmnProcessId()))
         .toString();
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationVariableInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
@@ -85,7 +86,8 @@ public class CompactRecordLogger {
           entry("_ELEMENT", ""),
           entry("EVENT", "EVNT"),
           entry("DECISION_REQUIREMENTS", "DRG"),
-          entry("EVALUATION", "EVAL"));
+          entry("EVALUATION", "EVAL"),
+          entry("SIGNAL_SUBSCRIPTION", "SIG_SUB"));
 
   private static final Map<RecordType, Character> RECORD_TYPE_ABBREVIATIONS =
       ofEntries(
@@ -128,6 +130,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.DECISION_REQUIREMENTS, this::summarizeDecisionRequirements);
     valueLoggers.put(ValueType.DECISION, this::summarizeDecision);
     valueLoggers.put(ValueType.DECISION_EVALUATION, this::summarizeDecisionEvaluation);
+    valueLoggers.put(ValueType.SIGNAL_SUBSCRIPTION, this::summarizeSignalSubscription);
   }
 
   public CompactRecordLogger(final Collection<Record<?>> records) {
@@ -714,6 +717,17 @@ public class CompactRecordLogger {
     return String.format(" of <decision %s[%s]>", formatId(decisionId), formatKey(decisionKey));
   }
 
+  private String summarizeSignalSubscription(final Record<?> record) {
+    final var value = (SignalSubscriptionRecordValue) record.getValue();
+
+    return new StringBuilder()
+        .append("\"")
+        .append(value.getSignalName())
+        .append("\"")
+        .append(" starting <process ")
+        .append(formatId(value.getBpmnProcessId()))
+        .toString();
+  }
   /**
    * Shortens and formats the key and stores it in the key substitutions, that is printed in the
    * list of decomposed keys for debugging at the end.

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -41,6 +42,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
@@ -296,6 +298,16 @@ public final class RecordingExporter implements Exporter {
   public static DecisionEvaluationRecordStream decisionEvaluationRecords() {
     return new DecisionEvaluationRecordStream(
         records(ValueType.DECISION_EVALUATION, DecisionEvaluationRecordValue.class));
+  }
+
+  public static SignalSubscriptionRecordStream signalSubscriptionRecords() {
+    return new SignalSubscriptionRecordStream(
+        records(ValueType.SIGNAL_SUBSCRIPTION, SignalSubscriptionRecordValue.class));
+  }
+
+  public static SignalSubscriptionRecordStream signalSubscriptionRecords(
+      final SignalSubscriptionIntent intent) {
+    return signalSubscriptionRecords().withIntent(intent);
   }
 
   public static class AwaitingRecordIterator implements Iterator<Record<?>> {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/SignalSubscriptionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/SignalSubscriptionRecordStream.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+import java.util.stream.Stream;
+
+public final class SignalSubscriptionRecordStream
+    extends ExporterRecordStream<SignalSubscriptionRecordValue, SignalSubscriptionRecordStream> {
+
+  public SignalSubscriptionRecordStream(
+      final Stream<Record<SignalSubscriptionRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected SignalSubscriptionRecordStream supply(
+      final Stream<Record<SignalSubscriptionRecordValue>> wrappedStream) {
+    return new SignalSubscriptionRecordStream((wrappedStream));
+  }
+
+  public SignalSubscriptionRecordStream withBpmnProcessId(final String bpmnProcessId) {
+    return valueFilter(v -> bpmnProcessId.equals(v.getBpmnProcessId()));
+  }
+
+  public SignalSubscriptionRecordStream withProcessDefinitionKey(final long processDefinitionKey) {
+    return valueFilter(v -> v.getProcessDefinitionKey() == processDefinitionKey);
+  }
+
+  public SignalSubscriptionRecordStream withCatchEventId(final String catchEventId) {
+    return valueFilter(v -> catchEventId.equals(v.getCatchEventId()));
+  }
+
+  public SignalSubscriptionRecordStream withCatchEventInstanceKey(
+      final long catchEventInstanceKey) {
+    return valueFilter(v -> v.getCatchEventInstanceKey() == catchEventInstanceKey);
+  }
+
+  public SignalSubscriptionRecordStream withSignalName(final String signalName) {
+    return valueFilter(v -> signalName.equals(v.getSignalName()));
+  }
+}


### PR DESCRIPTION
## Description

Add record, intent, stream and export to es for signal subscription.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11202 
closes #11208 
<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
