### PR TITLE
[Backport stable/8.1] Interrupt flow scope when a terminate end event is reached

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -101,7 +101,8 @@ public final class EventSubProcessProcessor
         final var terminated = stateTransitionBehavior.transitionToTerminated(flowScopeContext);
         stateTransitionBehavior.onElementTerminated(element, terminated);
 
-      } else if (flowScopeInstance.isActive()) {
+      } else if (stateBehavior.isInterruptedByTerminateEndEvent(
+          flowScopeContext, flowScopeInstance)) {
         // the child element instances were terminated by a terminate end event in the
         // event subprocess
         stateTransitionBehavior.completeElement(flowScopeContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -112,7 +112,9 @@ public final class SubProcessProcessor
     final var flowScopeInstance = stateBehavior.getFlowScopeInstance(subProcessContext);
     final var subProcessInstance = stateBehavior.getElementInstance(subProcessContext);
 
-    if (stateBehavior.isInterrupted(subProcessContext)) {
+    final boolean interruptedByTerminateEndEvent =
+        stateBehavior.isInterruptedByTerminateEndEvent(subProcessContext, subProcessInstance);
+    if (stateBehavior.isInterrupted(subProcessContext) && !interruptedByTerminateEndEvent) {
       // an interrupting event subprocess was triggered
       eventSubscriptionBehavior
           .findEventTrigger(subProcessContext)
@@ -146,7 +148,7 @@ public final class SubProcessProcessor
                       stateTransitionBehavior.transitionToTerminated(subProcessContext);
                   stateTransitionBehavior.onElementTerminated(element, terminated);
 
-                } else if (subProcessInstance.isActive()) {
+                } else if (interruptedByTerminateEndEvent) {
                   // the child element instances were terminated by a terminate end event in the
                   // subprocess
                   stateTransitionBehavior.completeElement(subProcessContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
@@ -67,6 +67,7 @@ final class ProcessInstanceElementCompletedApplier
 
     if (isTerminateEndEvent(value)) {
       flowScopeInstance.resetActiveSequenceFlows();
+      flowScopeInstance.setInterruptingElementId(value.getElementIdBuffer());
       elementInstanceState.updateInstance(flowScopeInstance);
     }
   }


### PR DESCRIPTION
# Description
Backport of #11178 to `stable/8.1`.

relates to #11121