### PR TITLE
Ensure list operation fails if backup store is not reachable

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -155,6 +155,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -149,6 +149,12 @@
       <artifactId>aws-java-sdk-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriber.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriber.java
@@ -68,8 +68,8 @@ public class AsyncAggregatingSubscriber<T> implements Subscriber<CompletableFutu
             }
           } else {
             LOG.trace("Future failed.", throwable);
-            phaser.forceTermination();
             resultsFuture.completeExceptionally(throwable);
+            phaser.forceTermination();
           }
           return null;
         });
@@ -78,8 +78,8 @@ public class AsyncAggregatingSubscriber<T> implements Subscriber<CompletableFutu
   @Override
   public void onError(final Throwable t) {
     LOG.trace("Subscription failed.", t);
-    phaser.forceTermination();
     resultsFuture.completeExceptionally(t);
+    phaser.forceTermination();
   }
 
   @Override

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriber.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriber.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * futures are requested whenever a future completes. The maximum number of requested futures must
  * be provided in {@link AsyncAggregatingSubscriber#AsyncAggregatingSubscriber(long parallelism)}}
  *
- * <p>Futures that complete exceptionally are omitted from the result!
+ * <p>If a futures completes exceptionally, the result is completed exceptionally.
  */
 @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
 public class AsyncAggregatingSubscriber<T> implements Subscriber<CompletableFuture<T>> {
@@ -67,7 +67,7 @@ public class AsyncAggregatingSubscriber<T> implements Subscriber<CompletableFutu
               subscription.cancel();
             }
           } else {
-            LOG.warn("Future failed, omitted from result", throwable);
+            LOG.trace("Future failed.", throwable);
             phaser.forceTermination();
             resultsFuture.completeExceptionally(throwable);
           }

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
@@ -18,56 +18,34 @@ import java.util.concurrent.ExecutionException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 @Testcontainers
 final class ConnectionErrorTest {
   private static final String ACCESS_KEY = "letmein";
   private static final String SECRET_KEY = "letmein1234";
   private static final int DEFAULT_PORT = 9000;
-
-  @SuppressWarnings("resource")
-  @Container
-  private static final GenericContainer<?> S3 =
-      new GenericContainer<>(DockerImageName.parse("minio/minio"))
-          .withCommand("server /data")
-          .withExposedPorts(DEFAULT_PORT)
-          .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
-          .withEnv("MINIO_SECRET_KEY", SECRET_KEY)
-          .withEnv("MINIO_DOMAIN", "localhost")
-          .waitingFor(
-              new HttpWaitStrategy()
-                  .forPath("/minio/health/ready")
-                  .forPort(DEFAULT_PORT)
-                  .withStartupTimeout(Duration.ofMinutes(1)));
-
   private S3BackupStore store;
 
   @BeforeEach
-  void setupBucket() {
+  void createBackupStore() {
     final var config =
         new Builder()
             .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
-            .withEndpoint("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT)))
+            .withEndpoint("http://%s:%d".formatted("localhost", DEFAULT_PORT))
             .withRegion(Region.US_EAST_1.id())
             .withCredentials(ACCESS_KEY, SECRET_KEY)
             .forcePathStyleAccess(true)
             .build();
     final var client = S3BackupStore.buildClient(config);
     store = new S3BackupStore(config, client);
-    client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
   }
 
   @Test
   void shouldFailListWhenStoreIsNotReachable() {
     // given
-    S3.close();
+    // s3 container is not running
 
     // when
     final var res =
@@ -84,7 +62,7 @@ final class ConnectionErrorTest {
   @Test
   void shouldFailGetWhenStoreIsNotReachable() {
     // given
-    S3.close();
+    // s3 container is not running
 
     // when
     final var res = store.getStatus(new BackupIdentifierImpl(0, 1, 1));

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+@Testcontainers
+final class ConnectionErrorTest {
+  private static final String ACCESS_KEY = "letmein";
+  private static final String SECRET_KEY = "letmein1234";
+  private static final int DEFAULT_PORT = 9000;
+
+  @SuppressWarnings("resource")
+  @Container
+  private static final GenericContainer<?> S3 =
+      new GenericContainer<>(DockerImageName.parse("minio/minio"))
+          .withCommand("server /data")
+          .withExposedPorts(DEFAULT_PORT)
+          .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
+          .withEnv("MINIO_SECRET_KEY", SECRET_KEY)
+          .withEnv("MINIO_DOMAIN", "localhost")
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPath("/minio/health/ready")
+                  .forPort(DEFAULT_PORT)
+                  .withStartupTimeout(Duration.ofMinutes(1)));
+
+  private S3BackupStore store;
+
+  @BeforeEach
+  void setupBucket() {
+    final var config =
+        new Builder()
+            .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+            .withEndpoint("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT)))
+            .withRegion(Region.US_EAST_1.id())
+            .withCredentials(ACCESS_KEY, SECRET_KEY)
+            .forcePathStyleAccess(true)
+            .build();
+    final var client = S3BackupStore.buildClient(config);
+    store = new S3BackupStore(config, client);
+    client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
+  }
+
+  @Test
+  void shouldFailListWhenStoreIsNotReachable() {
+    // given
+    S3.close();
+
+    // when
+    final var res =
+        store.list(
+            new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(1), Optional.empty()));
+
+    // then
+    assertThat(res)
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Connection refused");
+  }
+
+  @Test
+  void shouldFailGetWhenStoreIsNotReachable() {
+    // given
+    S3.close();
+
+    // when
+    final var res = store.getStatus(new BackupIdentifierImpl(0, 1, 1));
+
+    // then
+    assertThat(res)
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(ExecutionException.class);
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriberTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriberTest.java
@@ -14,9 +14,9 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 final class AsyncAggregatingSubscriberTest {
 

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriberTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriberTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+final class AsyncAggregatingSubscriberTest {
+
+  @Test
+  void shouldCompleteOnlyAfterAllFuturesComplete() {
+    // given
+    final var aggregator = new AsyncAggregatingSubscriber<Integer>(16);
+    final var completed = CompletableFuture.completedFuture(1);
+    final var delayed = new CompletableFuture<Integer>();
+
+    aggregator.onSubscribe(mock(Subscription.class));
+    final CompletableFuture<Collection<Integer>> result = aggregator.result();
+
+    // when
+    aggregator.onNext(completed);
+    aggregator.onNext(delayed);
+    aggregator.onComplete();
+
+    // then
+    assertThat(result).isNotDone();
+
+    delayed.complete(2);
+    Awaitility.await().until(result::isDone);
+    assertThat(result.join()).containsExactlyInAnyOrder(1, 2);
+  }
+
+  @Test
+  void shouldFailIfOneFutureFails() {
+    // given
+    final var aggregator = new AsyncAggregatingSubscriber<Integer>(16);
+    final var completed = CompletableFuture.completedFuture(1);
+    final var failed = new CompletableFuture<Integer>();
+
+    aggregator.onSubscribe(mock(Subscription.class));
+    final CompletableFuture<Collection<Integer>> result = aggregator.result();
+
+    // when
+    aggregator.onNext(completed);
+    aggregator.onNext(failed);
+    aggregator.onComplete();
+
+    // then
+    failed.completeExceptionally(new RuntimeException("Failed"));
+
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(result)
+                    .failsWithin(Duration.ofMillis(100))
+                    .withThrowableOfType(ExecutionException.class)
+                    .withMessageContaining("Failed"));
+  }
+
+  @Test
+  void shouldFailsIfSubscriptionFails() {
+    // given
+    final var aggregator = new AsyncAggregatingSubscriber<Integer>(16);
+    final var completed = CompletableFuture.completedFuture(1);
+    final var failed = new CompletableFuture<Integer>();
+
+    aggregator.onSubscribe(mock(Subscription.class));
+    final CompletableFuture<Collection<Integer>> result = aggregator.result();
+
+    // when
+    aggregator.onNext(completed);
+    aggregator.onNext(failed);
+    aggregator.onError(new RuntimeException("Failed"));
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(result)
+                    .failsWithin(Duration.ofMillis(100))
+                    .withThrowableOfType(ExecutionException.class)
+                    .withMessageContaining("Failed"));
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -20,10 +20,7 @@ public interface BackupStore {
   /** Returns the status of the backup */
   CompletableFuture<BackupStatus> getStatus(BackupIdentifier id);
 
-  /**
-   * Uses the given wildcard to list all backups matching this wildcard. The result may be
-   * incomplete.
-   */
+  /** Uses the given wildcard to list all backups matching this wildcard. */
   CompletableFuture<Collection<BackupStatus>> list(BackupIdentifierWildcard wildcard);
 
   /**


### PR DESCRIPTION
## Description

Previously, the list operation was implemented in a best-effort way such that it returns an empty list if s3 store is not reachable. This was acceptable because of how it was used previously. But, now we rely on it for delete as well as list backup apis. So `backupStore:list` must be reliable and must fail if it cannot accurately list all requested ones. Otherwise, we would return incorrect information to the user. This PR fixes this and adds tests to verify this behavior.

## Related issues

related #10847 #10208 

