### PR TITLE
refactor(engine): refactor MessageStartEventSubscriptionManager

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -187,11 +187,7 @@ public final class EngineProcessors {
     // on other partitions DISTRIBUTE command is received and processed
     final DeploymentDistributeProcessor deploymentDistributeProcessor =
         new DeploymentDistributeProcessor(
-            zeebeState.getProcessState(),
-            zeebeState.getMessageStartEventSubscriptionState(),
-            deploymentDistributionCommandSender,
-            writers,
-            keyGenerator);
+            zeebeState, deploymentDistributionCommandSender, writers, keyGenerator);
     typedRecordProcessors.onCommand(
         ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTE, deploymentDistributeProcessor);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -111,7 +111,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
 
       deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key, sideEffects);
-      // manage the message, signal, conditional top-level start events subscription
+      // manage the top-level start event subscriptions except for timers
       startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
 
     } else {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -57,7 +57,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   private final KeyGenerator keyGenerator;
   private final ExpressionProcessor expressionProcessor;
   private final StateWriter stateWriter;
-  private final MessageStartEventSubscriptionManager messageStartEventSubscriptionManager;
+  private final StartEventSubscriptionManager startEventSubscriptionManager;
   private final DeploymentDistributionBehavior deploymentDistributionBehavior;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
@@ -79,9 +79,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     expressionProcessor = bpmnBehaviors.expressionBehavior();
     deploymentTransformer =
         new DeploymentTransformer(stateWriter, zeebeState, expressionProcessor, keyGenerator);
-    messageStartEventSubscriptionManager =
-        new MessageStartEventSubscriptionManager(
-            processState, zeebeState.getMessageStartEventSubscriptionState(), keyGenerator);
+    startEventSubscriptionManager = new StartEventSubscriptionManager(zeebeState, keyGenerator);
     deploymentDistributionBehavior =
         new DeploymentDistributionBehavior(
             writers, partitionsCount, deploymentDistributionCommandSender);
@@ -113,8 +111,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
 
       deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key, sideEffects);
-      messageStartEventSubscriptionManager.tryReOpenMessageStartEventSubscription(
-          deploymentEvent, stateWriter);
+      // manage the message, signal, conditional top-level start events subscription
+      startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
 
     } else {
       responseWriter.writeRejectionOnCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -82,13 +82,15 @@ public class StartEventSubscriptionManager {
   }
 
   private DeployedProcess findLastStartProcess(
-      final ProcessMetadata processRecord, final Predicate<ExecutableCatchEventElement> predicate) {
+      final ProcessMetadata processRecord,
+      final Predicate<ExecutableCatchEventElement> hasStartEventMatching) {
     for (int version = processRecord.getVersion() - 1; version > 0; --version) {
       final DeployedProcess lastStartProcess =
           processState.getProcessByProcessIdAndVersion(
               processRecord.getBpmnProcessIdBuffer(), version);
       if (lastStartProcess != null
-          && lastStartProcess.getProcess().getStartEvents().stream().anyMatch(predicate)) {
+          && lastStartProcess.getProcess().getStartEvents().stream()
+              .anyMatch(hasStartEventMatching)) {
         return lastStartProcess;
       }
     }
@@ -104,15 +106,14 @@ public class StartEventSubscriptionManager {
     final List<ExecutableStartEvent> startEvents = process.getStartEvents();
 
     for (final ExecutableStartEvent startEvent : startEvents) {
-      // if startEvent is message event
       if (startEvent.isMessage()) {
-        openMessageStartEventSubscriptions(
+        openMessageStartEventSubscription(
             processDefinition, processDefinitionKey, startEvent, stateWriter);
       }
     }
   }
 
-  private void openMessageStartEventSubscriptions(
+  private void openMessageStartEventSubscription(
       final DeployedProcess processDefinition,
       final long processDefinitionKey,
       final ExecutableStartEvent startEvent,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
@@ -7,12 +7,11 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.distribute;
 
-import io.camunda.zeebe.engine.processing.deployment.MessageStartEventSubscriptionManager;
+import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
-import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -20,21 +19,18 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public final class DeploymentDistributeProcessor implements TypedRecordProcessor<DeploymentRecord> {
 
-  private final MessageStartEventSubscriptionManager messageStartEventSubscriptionManager;
+  private final StartEventSubscriptionManager startEventSubscriptionManager;
 
   private final StateWriter stateWriter;
   private final DeploymentDistributionCommandSender deploymentDistributionCommandSender;
 
   public DeploymentDistributeProcessor(
-      final ProcessState processState,
-      final MessageStartEventSubscriptionState messageStartEventSubscriptionState,
+      final ZeebeState zeebeState,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
       final Writers writers,
       final KeyGenerator keyGenerator) {
     this.deploymentDistributionCommandSender = deploymentDistributionCommandSender;
-    messageStartEventSubscriptionManager =
-        new MessageStartEventSubscriptionManager(
-            processState, messageStartEventSubscriptionState, keyGenerator);
+    startEventSubscriptionManager = new StartEventSubscriptionManager(zeebeState, keyGenerator);
     stateWriter = writers.state();
   }
 
@@ -46,7 +42,6 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
     stateWriter.appendFollowUpEvent(deploymentKey, DeploymentIntent.DISTRIBUTED, deploymentEvent);
     deploymentDistributionCommandSender.completeOnPartition(deploymentKey);
 
-    messageStartEventSubscriptionManager.tryReOpenMessageStartEventSubscription(
-        deploymentEvent, stateWriter);
+    startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
   }
 }


### PR DESCRIPTION
## Description

As discussed at [Refactor MessageStartEventSubscriptionManager ](https://github.com/camunda/zeebe/issues/10777#issuecomment-1342307171) we need to refactor `MessageStartEventSubscriptionManager` to prepare for upcoming signal and conditional top-level start events

[[EPIC] Support signal events #10777](https://github.com/camunda/zeebe/issues/10777)
[[EPIC] Support conditional events #11217](https://github.com/camunda/zeebe/issues/11217)


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
