### PR TITLE
fix(gateway): omit failurereason from list response if status is not failed

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -174,7 +174,9 @@ public final class BackupRequestHandler implements BackupApi {
                             return new PartitionBackupStatus(
                                 status.partitionId(),
                                 status.status(),
-                                Optional.ofNullable(status.failureReason()),
+                                status.status() == BackupStatusCode.FAILED
+                                    ? Optional.ofNullable(status.failureReason())
+                                    : Optional.empty(),
                                 Optional.ofNullable(status.createdAt()),
                                 Optional.empty(),
                                 Optional.empty(),


### PR DESCRIPTION
## Description

sbe response contains and empty string, which was then considered as non-null when building the PartitionStatus response. Since it is not null, it is also serialized as an empty string. On the client side if we print the response of list, then it unnecessarily also include the failureReason. This is fixed in this commit by explicitly setting the `failureReason` as `Optional.empty`.

