### PR TITLE
Reject modification command if ancestor does not exist or is not in an active state

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -99,7 +99,7 @@ public final class ProcessInstanceModificationProcessor
   private static final String ERROR_MESSAGE_ANCESTOR_NOT_FOUND =
       """
       Expected to modify instance of process '%s' but it contains one or more activate instructions \
-      with an an ancestor scope key that does not exist, or is not in an active state: '%s'""";
+      with an ancestor scope key that does not exist, or is not in an active state: '%s'""";
 
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       Set.of(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -96,6 +96,11 @@ public final class ProcessInstanceModificationProcessor
       the instance. The instance was created by a call activity in the parent process. \
       To terminate this instance please modify the parent process instead.""";
 
+  private static final String ERROR_MESSAGE_ANCESTOR_NOT_FOUND =
+      """
+      Expected to modify instance of process '%s' but it contains one or more activate instructions \
+      with an an ancestor scope key that does not exist, or is not in an active state: '%s'""";
+
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       Set.of(
           BpmnElementType.UNSPECIFIED,
@@ -281,6 +286,7 @@ public final class ProcessInstanceModificationProcessor
         .flatMap(valid -> validateElementInstanceExists(process, terminateInstructions))
         .flatMap(valid -> validateVariableScopeExists(process, activateInstructions))
         .flatMap(valid -> validateVariableScopeIsFlowScope(process, activateInstructions))
+        .flatMap(valid -> validateAncestorExistsAndIsActive(process, value))
         .map(valid -> VALID);
   }
 
@@ -398,6 +404,33 @@ public final class ProcessInstanceModificationProcessor
             usedUnsupportedElementIds,
             "The activation of elements with type '%s' is not supported. Supported element types are: %s"
                 .formatted(usedUnsupportedElementTypes, SUPPORTED_ELEMENT_TYPES));
+    return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
+  }
+
+  private Either<Rejection, ?> validateAncestorExistsAndIsActive(
+      final DeployedProcess process, final ProcessInstanceModificationRecord record) {
+    final Set<String> invalidAncestorKeys =
+        record.getActivateInstructions().stream()
+            .map(ProcessInstanceModificationActivateInstructionValue::getAncestorScopeKey)
+            .distinct()
+            .filter(ancestorKey -> ancestorKey > 0)
+            .filter(
+                ancestorKey -> {
+                  final var elementInstance = elementInstanceState.getInstance(ancestorKey);
+                  return elementInstance == null || !elementInstance.isActive();
+                })
+            .map(String::valueOf)
+            .collect(Collectors.toSet());
+
+    if (invalidAncestorKeys.isEmpty()) {
+      return VALID;
+    }
+
+    final String reason =
+        String.format(
+            ERROR_MESSAGE_ANCESTOR_NOT_FOUND,
+            BufferUtil.bufferAsString(process.getBpmnProcessId()),
+            String.join("', '", invalidAncestorKeys));
     return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -465,7 +465,7 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             ("Expected to modify instance of process '%s' but it contains one or more activate"
-                    + " instructions with an an ancestor scope key that does not exist, or is not in an"
+                    + " instructions with an ancestor scope key that does not exist, or is not in an"
                     + " active state: '12345'")
                 .formatted(PROCESS_ID));
   }
@@ -508,7 +508,7 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             ("Expected to modify instance of process '%s' but it contains one or more activate"
-                    + " instructions with an an ancestor scope key that does not exist, or is not in an"
+                    + " instructions with an ancestor scope key that does not exist, or is not in an"
                     + " active state: '%d'")
                 .formatted(PROCESS_ID, subProcessKey));
   }
@@ -550,7 +550,7 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             ("Expected to modify instance of process '%s' but it contains one or more activate"
-                    + " instructions with an an ancestor scope key that does not exist, or is not in an"
+                    + " instructions with an ancestor scope key that does not exist, or is not in an"
                     + " active state: '%d'")
                 .formatted(PROCESS_ID, subProcessKey));
   }
@@ -601,7 +601,7 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             ("Expected to modify instance of process '%s' but it contains one or more activate"
-                    + " instructions with an an ancestor scope key that does not exist, or is not in an"
+                    + " instructions with an ancestor scope key that does not exist, or is not in an"
                     + " active state: '%d'")
                 .formatted(PROCESS_ID, subProcessKey));
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When a modification contains an activate instruction with an ancestor scope key, we must have an element instance for this ancestor in our state. This element instance must be in an active state. If this is not the case we cannot activate an element inside of this scope and the modification should be rejected.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9984 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
