### PR TITLE
Allow activate instructions to target elements inside existing multi-instances

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -193,6 +193,16 @@ public final class ElementActivationBehavior {
       createVariablesCallback.accept(nextSubprocess.getId(), activatedInstanceKey);
     } else {
       // no subprocess instance found, let's create a new one
+
+      if (nextSubprocess.getElementType() == BpmnElementType.MULTI_INSTANCE_BODY
+          || (nextSubprocess.getFlowScope() != null
+              && nextSubprocess.getFlowScope().getElementType()
+                  == BpmnElementType.MULTI_INSTANCE_BODY)) {
+        // unsupported scenario, attempting to activate a multi-instance body or an inner instance
+        throw new UnsupportedMultiInstanceBodyActivationException(
+            BufferUtil.bufferAsString(nextSubprocess.getId()), bpmnProcessId);
+      }
+
       activatedInstanceKey =
           activateFlowScope(
               processInstanceRecord, flowScopeKey, nextSubprocess, createVariablesCallback);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/UnsupportedMultiInstanceBodyActivationException.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/UnsupportedMultiInstanceBodyActivationException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+/**
+ * Exception that can be thrown during processing of a command, in case the engine attempts to
+ * directly activate a multi-instance body, which is not supported at this time.
+ *
+ * <p>This exception can be handled by the processor in {@link
+ * io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor#tryHandleError(TypedRecord,
+ * Throwable)}.
+ */
+public class UnsupportedMultiInstanceBodyActivationException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE =
+      """
+      Expected to activate element '%s', but it is a multi-instance element, \
+      which is not supported at this time.""";
+
+  private final String bpmnProcessId;
+  private final String multiInstanceId;
+
+  /**
+   * Constructs a new exception for the case that a multi-instance body is activated directly by
+   * engine, which is not supported at this time.
+   *
+   * @param multiInstanceId the element id of the multi-instance
+   * @param bpmnProcessId the BPMN process id
+   */
+  UnsupportedMultiInstanceBodyActivationException(
+      final String multiInstanceId, final String bpmnProcessId) {
+    super(ERROR_MESSAGE.formatted(multiInstanceId));
+    this.bpmnProcessId = bpmnProcessId;
+    this.multiInstanceId = multiInstanceId;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public String getMultiInstanceId() {
+    return multiInstanceId;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -262,14 +262,10 @@ public final class ProcessInstanceModificationProcessor
       return ProcessingError.EXPECTED_ERROR;
 
     } else if (error instanceof ExceededBatchRecordSizeException) {
-      rejectionWriter.appendRejection(
-          typedCommand,
-          RejectionType.INVALID_ARGUMENT,
-          ERROR_COMMAND_TOO_LARGE.formatted(typedCommand.getValue().getProcessInstanceKey()));
-      responseWriter.writeRejectionOnCommand(
-          typedCommand,
-          RejectionType.INVALID_ARGUMENT,
-          ERROR_COMMAND_TOO_LARGE.formatted(typedCommand.getValue().getProcessInstanceKey()));
+      final var message =
+          ERROR_COMMAND_TOO_LARGE.formatted(typedCommand.getValue().getProcessInstanceKey());
+      rejectionWriter.appendRejection(typedCommand, RejectionType.INVALID_ARGUMENT, message);
+      responseWriter.writeRejectionOnCommand(typedCommand, RejectionType.INVALID_ARGUMENT, message);
       return ProcessingError.EXPECTED_ERROR;
 
     } else if (error instanceof TerminatedChildProcessException exception) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -663,9 +663,8 @@ public class ModifyProcessInstanceRejectionTest {
             String.format(
                 """
                 Expected to modify instance of process '%s' but it contains one or more activate \
-                instructions for elements that are unsupported: 'A'. The activate instruction \
-                would result in the activation of a new instance of a multi-instance marked \
-                element.""",
+                instructions that would result in the activation of multi-instance element \
+                'SubProcess', which is currently unsupported.""",
                 PROCESS_ID));
   }
 
@@ -715,9 +714,8 @@ public class ModifyProcessInstanceRejectionTest {
             String.format(
                 """
                 Expected to modify instance of process '%s' but it contains one or more activate \
-                instructions for elements that are unsupported: 'A'. The activate instruction \
-                would result in the activation of a new instance of a multi-instance marked \
-                element.""",
+                instructions that would result in the activation of multi-instance element \
+                'SubProcess', which is currently unsupported.""",
                 PROCESS_ID));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceUnsupportedElementsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceUnsupportedElementsTest.java
@@ -45,24 +45,6 @@ public class ModifyProcessInstanceUnsupportedElementsTest {
   public static Collection<Object> scenarios() {
     return List.of(
         new Scenario(
-            "Activate element inside multi-instance sub-process",
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .userTask("A")
-                .subProcess(
-                    "subprocess",
-                    s -> s.embeddedSubProcess().startEvent().manualTask("B").manualTask("C").done())
-                .multiInstance(m -> m.zeebeInputCollectionExpression("[1,2,3]"))
-                .manualTask("D")
-                .endEvent()
-                .done(),
-            instructionBuilder ->
-                instructionBuilder.activateElement("B").activateElement("C").activateElement("D"),
-            new Rejection(
-                RejectionType.INVALID_ARGUMENT,
-                "'B', 'C'",
-                "The activation of elements inside a multi-instance subprocess is not supported")),
-        new Scenario(
             "Activate element that belongs to an event-based gateway",
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This pull request lifts part of the restriction for [Process Instance Modification](https://docs.camunda.io/docs/components/concepts/process-instance-modification/) related to multi-instances:
- https://github.com/camunda/zeebe/issues/9977
- Most modifications with activate instructions targeting an element inside a multi-instance are now allowed.

We can lift this restriction because we can now use ancestor selection to activate elements inside existing multi-instance instances.

The restriction is only lifted as long as the modification:
- does NOT NEED to activate a multi-instance as part of the flow scope activations.
- does NOT attempt to activate a new instance of the multi-instance

Generally, we can consider that there are 3 cases where this can happen:
- there is no instance of a multi-instance yet, and a task inside is targetted
- an ancestor is selected to activate a task inside a newly activated multi-instance marked element
- an ancestor is selected to activate a task inside a new instance of an existing multi-instance marked element

You can review this pull request per commit to see the individual reasons for the implementation.
You can also review this pull request in one go, as most of the changes are just the new test cases.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11031 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [x] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
