### PR TITLE
ci(release): GHA release workflow

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -16,6 +16,12 @@ inputs:
   distball:
     description: 'The path to the Zeebe distribution TAR ball'
     required: true
+  revision:
+    description: 'The revision of the source the content of this image is based on.'
+    required: false
+  additionalTag:
+    description: 'Additional tag to be created, besides the default version tag.'
+    required: false
   push:
     description: 'If true, will push the image'
     required: false
@@ -29,7 +35,7 @@ inputs:
 outputs:
   image:
     description: "Fully qualified image name available in your local Docker daemon"
-    value: ${{ steps.get-image.outputs.result }}
+    value: ${{ steps.get-images.outputs.versionedImage }}
   date:
     description: "The ISO 8601 date at which the image was created"
     value: ${{ steps.get-date.outputs.result }}
@@ -56,16 +62,21 @@ runs:
         install: true
     - name: Set semantic version from Maven project
       id: get-version
+      if: ${{ inputs.version == ''}}
       shell: bash
-      run: echo ::set-output name=result::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+      run: echo "result=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_OUTPUT
     - name: Set image build label from ISO 8601 DATE
       id: get-date
       shell: bash
       run: echo "::set-output name=result::$(date --iso-8601=seconds)"
-    - name: Set image name from params or project version
-      id: get-image
+    - name: Set image names from params and/or project version
+      id: get-images
       shell: bash
-      run: echo "::set-output name=result::${{ inputs.repository }}:${{ inputs.version || steps.get-version.outputs.result }}"
+      run: |
+        export VERSION_TAG_IMAGE=${{ inputs.repository }}:${{ inputs.version || steps.get-version.outputs.result }}
+        export OPTIONAL_TAG_IMAGE=${{ inputs.additionalTag != '' && format('{0}:{1}', inputs.repository, inputs.additionalTag) || '' }}
+        echo "versionedImage=${VERSION_TAG_IMAGE}" >> $GITHUB_OUTPUT
+        echo "result=${VERSION_TAG_IMAGE},${OPTIONAL_TAG_IMAGE}" >> $GITHUB_OUTPUT
     - name: Set DISTBALL path relative to the build context
       id: get-distball
       shell: bash
@@ -74,7 +85,7 @@ runs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        tags: ${{ steps.get-image.outputs.result }}
+        tags: ${{ steps.get-images.outputs.result }}
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
         no-cache: true
@@ -82,6 +93,6 @@ runs:
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}
-          REVISION=${{ github.sha }}
-          VERSION=${{ steps.get-version.outputs.result }}
+          REVISION=${{ inputs.revision != '' && inputs.revision || github.sha }}
+          VERSION=${{ inputs.version != '' && inputs.version || steps.get-version.outputs.result }}
         target: app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,23 @@ jobs:
           export TAG_REVISION=$(git log -n 1 --pretty=format:'%h')
           echo "tagRevision=${TAG_REVISION}" >> $GITHUB_OUTPUT
           popd
+      - name: Update Compat Version
+        shell: bash
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Skipping updating the compat version as ${RELEASE_VERSION} is not a stable version"
+            exit 0
+          fi
+
+          pushd clients/go
+          gocompat save ./...
+          git commit -am "build(project): update go versions"
+          popd
+
+          mvn -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${RELEASE_VERSION}"
+          FILE=$(mvn -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout)
+          rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
+          git commit -am "build(project): update java compat versions"
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,9 @@ jobs:
           echo -n "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PUB }}" \
             | base64 --decode \
             | gpg -q --import --no-tty --batch --yes
-      - uses: ./.github/actions/setup-zeebe
-      - name: Go tooling setup
+      - name: Setup Zeebe Build Tooling
+        uses: ./.github/actions/setup-zeebe
+      - name: Additional Go tooling setup
         shell: bash
         run: |
           go install github.com/go-bindata/go-bindata/...@v3
@@ -82,7 +83,7 @@ jobs:
       - name: Build Go Client
         uses: ./.github/actions/build-zeebe
         with:
-          maven-extra-args: -T1C -Pprepare-offline,-PcheckFormat,-autoFormat
+          java: false
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ on:
       nextDevelopmentVersion:
         description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
         required: true
-      pushReleaseArtifacts:
-        description: 'Whether to push release commits and artifacts to remote (Git tags, Maven artifacts)'
+      pushChanges:
+        description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release)'
         default: false
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
       RELEASE_VERSION: ${{ inputs.releaseVersion }}
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
       RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
-      PUSH_CHANGES: ${{ inputs.pushReleaseArtifacts }}
+      PUSH_CHANGES: ${{ inputs.pushChanges }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -97,9 +97,6 @@ jobs:
           go-bindata -pkg embedded -o embedded.go -prefix data data/
 
           git commit -am "build(project): update go embedded version data"
-          if [ "$PUSH_CHANGES" = "true" ]; then
-            git push origin "${RELEASE_BRANCH}"
-          fi
       - name: Build Go Client
         uses: ./.github/actions/build-zeebe
         with:
@@ -121,7 +118,7 @@ jobs:
         id: maven-release
         shell: bash
         env:
-          SKIP_REPO_DEPLOY: ${{ inputs.pushReleaseArtifacts == 'false' }}
+          SKIP_REPO_DEPLOY: ${{ inputs.pushChanges == 'false' }}
         run : |
           # This var is used to include the previously built go artifacts into the final maven release build.
           # As the maven build of the tag happens in a sub-directory to which maven checks out the release tag to build it.
@@ -135,7 +132,7 @@ jobs:
             -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
             -DpushChanges=${PUSH_CHANGES} \
             -DremoteTagging=${PUSH_CHANGES} \
-            -DlocalCheckout=${{ inputs.pushReleaseArtifacts == 'false' }} \
+            -DlocalCheckout=${{ inputs.pushChanges == 'false' }} \
             -DcompletionGoals="spotless:apply" \
             -P-autoFormat \
             -Darguments='-T1C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
@@ -218,18 +215,21 @@ jobs:
           fi
           shopt -u nocasematch # reset it
 
-          # Perform release: create draft, upload assets, etc.
-          # See https://cli.github.com/manual/gh_release_create for more
-          gh release create --repo "camunda/zeebe" --draft --notes "Release ${RELEASE_VERSION}" \
-            --title "${RELEASE_VERSION}" "${GH_OPTIONS[@]}" \
-            "${RELEASE_VERSION}" "${ASSETS[@]}"
+          if [ "$PUSH_CHANGES" = "true" ]; then
+            # Perform release: create draft, upload assets, etc.
+            # See https://cli.github.com/manual/gh_release_create for more
+            gh release create --repo "camunda/zeebe" --draft --notes "Release ${RELEASE_VERSION}" \
+              --title "${RELEASE_VERSION}" "${GH_OPTIONS[@]}" \
+              "${RELEASE_VERSION}" "${ASSETS[@]}"
+          fi
       - name: Go Post-Release
-        if: ${{ inputs.pushReleaseArtifacts == 'true' }}
         shell: bash
         run: |
           # Publish Go tag for the release
           git tag "clients/go/v${RELEASE_VERSION}"
-          git push origin "clients/go/v${RELEASE_VERSION}"
+          if [ "$PUSH_CHANGES" = "true" ]; then
+            git push origin "clients/go/v${RELEASE_VERSION}"
+          fi
 
           # Prepare Go version for the next release
           pushd "clients/go/internal/embedded" || exit $?
@@ -238,10 +238,11 @@ jobs:
           go-bindata -pkg embedded -o embedded.go -prefix data/ data/
 
           git commit -am "build(project): prepare next development version (Go client)"
-          git push origin "${RELEASE_BRANCH}"
+      - name: Push Changes to Release branch
+        if: ${{ inputs.pushChanges == 'true' }}
+        run: git push origin "${RELEASE_BRANCH}"
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
         if: always()
         shell: bash
         run: rm -rf $HOME/.gnupg
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ on:
         description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release)'
         default: false
 
+defaults:
+  run:
+    shell: bash
+
 env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
@@ -54,12 +58,10 @@ jobs:
             secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
             secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
       - name: Git User Setup
-        shell: bash
         run: |
           git config --global user.email "github-actions[release]"
           git config --global user.name "github-actions[release]@users.noreply.github.com"
       - name: Install Maven Central GPG Key
-        shell: bash
         # setup-maven supports this as well but needs the key in the armor ascii format,
         # while we only have it plain bas64 encoded
         # see https://github.com/actions/setup-java/issues/100#issuecomment-742679976
@@ -83,7 +85,6 @@ jobs:
       - name: Setup Zeebe Build Tooling
         uses: ./.github/actions/setup-zeebe
       - name: Additional Go tooling setup
-        shell: bash
         run: |
           go install github.com/go-bindata/go-bindata/...@v3
           if ! command -v go-bindata > /dev/null 2>&1; then
@@ -97,7 +98,6 @@ jobs:
             exit 1
           fi
       - name: Set and commit Go Client version
-        shell: bash
         run: |
           pushd clients/go/internal/embedded
           echo "${RELEASE_VERSION}" > data/VERSION
@@ -123,7 +123,6 @@ jobs:
             }]
       - name: Maven Release
         id: maven-release
-        shell: bash
         env:
           SKIP_REPO_DEPLOY: ${{ inputs.pushChanges == 'false' }}
         run : |
@@ -167,7 +166,6 @@ jobs:
           path: ${{ steps.release-artifacts.outputs.dir }}
           retention-days: 5
       - name: Update Compat Version
-        shell: bash
         run: |
           if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Skipping updating the compat version as ${RELEASE_VERSION} is not a stable version"
@@ -184,7 +182,6 @@ jobs:
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
           git commit -am "build(project): update java compat versions"
       - name: Go Post-Release
-        shell: bash
         run: |
           # Publish Go tag for the release
           git tag "clients/go/v${RELEASE_VERSION}"
@@ -205,7 +202,6 @@ jobs:
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
         if: always()
-        shell: bash
         run: rm -rf $HOME/.gnupg
   github:
     needs: release
@@ -219,7 +215,6 @@ jobs:
           name: release-artifacts
       - name: Create Artifact Checksums
         id: checksum
-        shell: bash
         run: |
           for filename in *; do
             checksumFile="${filename}.sha1sum"
@@ -232,7 +227,6 @@ jobs:
           done
       - name: Determine if Pre-Release
         id: pre-release
-        shell: bash
         run: |
           shopt -s nocasematch # set matching to case insensitive
           PRE_RELEASE=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
       PUSH_CHANGES: ${{ inputs.pushChanges }}
     steps:
+      - name: Output Inputs
+        run: echo "${{ toJSON(github.event.inputs) }}"
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.RELEASE_BRANCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,12 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
+      releaseBranch:
+        description: 'The branch to perform the release on, defaults to `release-$releaseVersion`'
+        required: false
+        default: ''
       releaseVersion:
-        description: 'The version to be build and released, expecting a release branch `release-$releaseVersion` to already exist.'
+        description: 'The version to be build and released. If no releaseBranch specified, expecting `release-$releaseVersion` to already exist.'
         required: true
       nextDevelopmentVersion:
         description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
@@ -20,7 +24,7 @@ jobs:
     env:
       RELEASE_VERSION: ${{ inputs.releaseVersion }}
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
-      RELEASE_BRANCH: "release-${{ inputs.releaseVersion }}"
+      RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
       PUSH_CHANGES: ${{ inputs.pushReleaseArtifacts }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,10 @@ jobs:
           go-bindata -pkg embedded -o embedded.go -prefix data data/
 
           git commit -am "build(project): update go embedded version data"
-      - name: Build Go Client
+      - name: Build Go Client & Zeebe
         uses: ./.github/actions/build-zeebe
         with:
-          java: false
+          maven-extra-args: -T1C
       - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'The version to be build and released, expecting a release branch `release-$releaseVersion` to already exist.'
+        required: true
+      nextDevelopmentVersion:
+        description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
+        required: true
+
+jobs:
+  release:
+    name: Maven & Go Release
+    runs-on: n1-standard-16-netssd-preempt-quick
+    timeout-minutes: 30
+    env:
+      RELEASE_VERSION: ${{ inputs.releaseVersion }}
+      DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
+      RELEASE_BRANCH: "release-${{ inputs.releaseVersion }}"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.4.3
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PUB;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+      - name: Git User Setup
+        shell: bash
+        run: |
+          git config --global user.email "github-actions[release]"
+          git config --global user.name "github-actions[release]@users.noreply.github.com"
+      - name: Install Maven Central GPG Key
+        shell: bash
+        # setup-maven supports this as well but needs the key in the armor ascii format,
+        # while we only have it plain bas64 encoded
+        # see https://github.com/actions/setup-java/issues/100#issuecomment-742679976
+        run: |
+          echo -n "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}" \
+            | base64 --decode \
+            | gpg -q --allow-secret-key-import --import --no-tty --batch --yes
+          echo -n "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PUB }}" \
+            | base64 --decode \
+            | gpg -q --import --no-tty --batch --yes
+      - uses: ./.github/actions/setup-zeebe
+      - name: Go tooling setup
+        shell: bash
+        run: |
+          go install github.com/go-bindata/go-bindata/...@v3
+          if ! command -v go-bindata > /dev/null 2>&1; then
+            echo "Failed to install go-bindata, go-bindata is not available on the path"
+            exit 1
+          fi
+
+          go install github.com/smola/gocompat/...@v0.3.0
+          if ! command -v gocompat > /dev/null 2>&1; then
+            echo "Failed to install gocompat, gocompat is not available on the path"
+            exit 1
+          fi
+      - name: Set and commit Go Client version
+        shell: bash
+        run: |
+          pushd clients/go/internal/embedded
+          echo "${RELEASE_VERSION}" > data/VERSION
+          go-bindata -pkg embedded -o embedded.go -prefix data data/
+
+          git commit -am "build(project): update go embedded version data"
+          if [ "$PUSH_CHANGES" = "true" ]; then
+            git push origin "${RELEASE_BRANCH}"
+          fi
+      - name: Build Go Client
+        uses: ./.github/actions/build-zeebe
+        with:
+          maven-extra-args: -T1C -Pprepare-offline,-PcheckFormat,-autoFormat
+      - name: Cleanup Maven Central GPG Key
+        # make sure we always remove the imported signing key to avoid it leaking on runners
+        if: always()
+        shell: bash
+        run: rm -rf $HOME/.gnupg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,22 @@ jobs:
           gh release create --repo "camunda/zeebe" --draft --notes "Release ${RELEASE_VERSION}" \
             --title "${RELEASE_VERSION}" "${GH_OPTIONS[@]}" \
             "${RELEASE_VERSION}" "${ASSETS[@]}"
+      - name: Go Post-Release
+        if: ${{ inputs.pushReleaseArtifacts == 'true' }}
+        shell: bash
+        run: |
+          # Publish Go tag for the release
+          git tag "clients/go/v${RELEASE_VERSION}"
+          git push origin "clients/go/v${RELEASE_VERSION}"
+
+          # Prepare Go version for the next release
+          pushd "clients/go/internal/embedded" || exit $?
+
+          echo "${DEVELOPMENT_VERSION}" > data/VERSION
+          go-bindata -pkg embedded -o embedded.go -prefix data/ data/
+
+          git commit -am "build(project): prepare next development version (Go client)"
+          git push origin "${RELEASE_BRANCH}"
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,3 +304,37 @@ jobs:
       - name: Push Docker Image Tag latest
         if: ${{ inputs.isLatest == 'true' && inputs.pushChanges == 'true' }}
         run: docker push ${{ env.DOCKER_IMAGE }}:latest
+  notify-if-failed:
+    name: Send slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [ release, github, docker ]
+    if: failure() && github.repository == 'camunda/zeebe'
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":alarm: Release job build for ${{ inputs.releaseVersion }} failed! :alarm:\n",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: Release job build for ${{ inputs.releaseVersion }} failed! :alarm:\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related workflow execution: https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ on:
       isLatest:
         description: 'Whether this is the latest release and the docker image should be tagged as camunda/zeebe:latest'
         required: false
-      pushChanges:
-        description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release)'
-        default: false
+      dryRun:
+        description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release), defaults to true.'
+        default: true
 
 defaults:
   run:
@@ -36,7 +36,7 @@ jobs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
-      PUSH_CHANGES: ${{ inputs.pushChanges }}
+      PUSH_CHANGES: ${{ inputs.dryRun == 'false' }}
     steps:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
@@ -126,7 +126,7 @@ jobs:
       - name: Maven Release
         id: maven-release
         env:
-          SKIP_REPO_DEPLOY: ${{ inputs.pushChanges == 'false' }}
+          SKIP_REPO_DEPLOY: ${{ inputs.dryRun == 'true' }}
         run : |
           # This var is used to include the previously built go artifacts into the final maven release build.
           # As the maven build of the tag happens in a sub-directory to which maven checks out the release tag to build it.
@@ -140,7 +140,7 @@ jobs:
             -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
             -DpushChanges=${PUSH_CHANGES} \
             -DremoteTagging=${PUSH_CHANGES} \
-            -DlocalCheckout=${{ inputs.pushChanges == 'false' }} \
+            -DlocalCheckout=${{ inputs.dryRun == 'true' }} \
             -DcompletionGoals="spotless:apply" \
             -P-autoFormat \
             -Darguments='-T1C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
@@ -199,7 +199,7 @@ jobs:
 
           git commit -am "build(project): prepare next development version (Go client)"
       - name: Push Changes to Release branch
-        if: ${{ inputs.pushChanges == 'true' }}
+        if: ${{ inputs.dryRun == 'false' }}
         run: git push origin "${RELEASE_BRANCH}"
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
@@ -237,8 +237,9 @@ jobs:
           fi
           shopt -u nocasematch # reset it
           echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
-      - uses: ncipollo/release-action@v1
-        if: ${{ inputs.pushChanges == 'true' }}
+      - name: Create Github release
+        uses: ncipollo/release-action@v1
+        if: ${{ inputs.dryRun == 'false' }}
         with:
           name: ${{ inputs.releaseVersion }}
           artifacts: "*"
@@ -301,10 +302,10 @@ jobs:
             ${PWD}/docker/test/verify.sh "${DOCKER_IMAGE}:latest"
           fi
       - name: Push Docker Image Tag ${{ inputs.releaseVersion }}
-        if: ${{ inputs.pushChanges == 'true' }}
+        if: ${{ inputs.dryRun == 'false' }}
         run: docker push ${{ env.DOCKER_IMAGE }}:${{ inputs.releaseVersion }}
       - name: Push Docker Image Tag latest
-        if: ${{ inputs.isLatest == 'true' && inputs.pushChanges == 'true' }}
+        if: ${{ inputs.isLatest == 'true' && inputs.dryRun == 'false' }}
         run: docker push ${{ env.DOCKER_IMAGE }}:latest
   notify-if-failed:
     name: Send slack notification on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       nextDevelopmentVersion:
         description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
         required: true
+      pushReleaseArtifacts:
+        description: 'Whether to push release commits and artifacts to remote (Git tags, Maven artifacts, Github Release)'
+        default: false
 
 jobs:
   release:
@@ -18,6 +21,7 @@ jobs:
       RELEASE_VERSION: ${{ inputs.releaseVersion }}
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
       RELEASE_BRANCH: "release-${{ inputs.releaseVersion }}"
+      PUSH_CHANGES: ${{ inputs.pushReleaseArtifacts }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -36,6 +40,8 @@ jobs:
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PUB;
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
+            secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
       - name: Git User Setup
         shell: bash
         run: |
@@ -84,6 +90,48 @@ jobs:
         uses: ./.github/actions/build-zeebe
         with:
           java: false
+      - uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: |
+            [{
+                "id": "camunda-nexus",
+                "username": "${{ steps.secrets.outputs.ARTIFACTS_USR }}",
+                "password": "${{ steps.secrets.outputs.ARTIFACTS_PSW }}"
+            },
+            {
+                "id": "central",
+                "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
+                "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+            }]
+      - name: Maven Release
+        id: maven-release
+        shell: bash
+        env:
+          SKIP_REPO_DEPLOY: ${{ inputs.pushReleaseArtifacts == 'false' }}
+        run : |
+          # This var is used to include the previously built go artifacts into the final maven release build.
+          # As the maven build of the tag happens in a sub-directory to which maven checks out the release tag to build it.
+          # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
+          export ZBCTL_ROOT_DIR=${PWD}
+          mvn release:prepare release:perform -B \
+            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
+            -Dresume=false \
+            -Dtag=${RELEASE_VERSION} \
+            -DreleaseVersion=${RELEASE_VERSION} \
+            -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
+            -DpushChanges=${PUSH_CHANGES} \
+            -DremoteTagging=${PUSH_CHANGES} \
+            -DlocalCheckout=${{ inputs.pushReleaseArtifacts == 'false' }} \
+            -DcompletionGoals="spotless:apply" \
+            -P-autoFormat \
+            -Darguments='-T1C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+
+          # switch to the directory to which maven checks out the release tag
+          # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
+          pushd target/checkout
+          export TAG_REVISION=$(git log -n 1 --pretty=format:'%h')
+          echo "tagRevision=${TAG_REVISION}" >> $GITHUB_OUTPUT
+          popd
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,19 +12,26 @@ on:
       nextDevelopmentVersion:
         description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
         required: true
+      isLatest:
+        description: 'Whether this is the latest release and the docker image should be tagged as camunda/zeebe:latest'
+        required: false
       pushChanges:
         description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release)'
         default: false
+
+env:
+  RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
+  RELEASE_VERSION: ${{ inputs.releaseVersion }}
 
 jobs:
   release:
     name: Maven & Go Release
     runs-on: n1-standard-16-netssd-preempt-quick
     timeout-minutes: 30
+    outputs:
+      releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}
     env:
-      RELEASE_VERSION: ${{ inputs.releaseVersion }}
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
-      RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
       PUSH_CHANGES: ${{ inputs.pushChanges }}
     steps:
       - uses: actions/checkout@v3
@@ -140,9 +147,18 @@ jobs:
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
           pushd target/checkout
+          export BUILD_DIR=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.directory -q -DforceStdout)
+          export ARTIFACT=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+          echo "distball=${BUILD_DIR}/${ARTIFACT}.tar.gz" >> $GITHUB_OUTPUT
           export TAG_REVISION=$(git log -n 1 --pretty=format:'%h')
           echo "tagRevision=${TAG_REVISION}" >> $GITHUB_OUTPUT
           popd
+      - name: Upload Zeebe Release Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: camunda-zeebe.tar.gz
+          path: ${{ steps.maven-release.outputs.distball }}
+          retention-days: 5
       - name: Update Compat Version
         shell: bash
         run: |
@@ -246,3 +262,62 @@ jobs:
         if: always()
         shell: bash
         run: rm -rf $HOME/.gnupg
+  docker:
+    needs: release
+    name: Docker Image Release
+    runs-on: n1-standard-8-netssd-preempt
+    timeout-minutes: 15
+    env:
+      DOCKER_IMAGE: camunda/zeebe
+      TAG_LATEST: ${{ inputs.isLatest == 'true' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.4.3
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW;
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
+          password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Download Zeebe Release Archive
+        uses: actions/download-artifact@v3
+        with:
+          name: camunda-zeebe.tar.gz
+      - name: Build Docker Image
+        uses: ./.github/actions/build-docker
+        id: build-docker
+        with:
+          repository: ${{ env.DOCKER_IMAGE }}
+          version: ${{ inputs.releaseVersion }}
+          additionalTag: ${{ inputs.isLatest == 'true' && 'latest' || '' }}
+          revision: ${{ needs.release.outputs.releaseTagRevision }}
+          push: false
+          distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
+      - name: Verify Docker image
+        env:
+          DATE: ${{ steps.build-docker.outputs.date }}
+          REVISION: ${{ needs.release.outputs.releaseTagRevision }}
+          VERSION: ${{ inputs.releaseVersion }}
+        run: |
+          ${PWD}/docker/test/verify.sh "${DOCKER_IMAGE}:${RELEASE_VERSION}"
+          if [ "$TAG_LATEST" = "true" ]; then
+            ${PWD}/docker/test/verify.sh "${DOCKER_IMAGE}:latest"
+          fi
+      - name: Push Docker Image Tag ${{ inputs.releaseVersion }}
+        if: ${{ inputs.pushChanges == 'true' }}
+        run: docker push ${{ env.DOCKER_IMAGE }}:${{ inputs.releaseVersion }}
+      - name: Push Docker Image Tag latest
+        if: ${{ inputs.isLatest == 'true' && inputs.pushChanges == 'true' }}
+        run: docker push ${{ env.DOCKER_IMAGE }}:latest
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,25 @@ on:
     inputs:
       releaseBranch:
         description: 'The branch to perform the release on, defaults to `release-$releaseVersion`'
+        type: string
         required: false
         default: ''
       releaseVersion:
         description: 'The version to be build and released. If no releaseBranch specified, expecting `release-$releaseVersion` to already exist.'
+        type: string
         required: true
       nextDevelopmentVersion:
         description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
+        type: string
         required: true
       isLatest:
         description: 'Whether this is the latest release and the docker image should be tagged as camunda/zeebe:latest'
+        type: boolean
         required: false
+        default: false
       dryRun:
         description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release), defaults to true.'
+        type: boolean
         default: true
 
 concurrency:
@@ -42,7 +48,7 @@ jobs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
-      PUSH_CHANGES: ${{ inputs.dryRun == 'false' }}
+      PUSH_CHANGES: ${{ inputs.dryRun == false }}
     steps:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
@@ -132,7 +138,7 @@ jobs:
       - name: Maven Release
         id: maven-release
         env:
-          SKIP_REPO_DEPLOY: ${{ inputs.dryRun == 'true' }}
+          SKIP_REPO_DEPLOY: ${{ inputs.dryRun }}
         run : |
           # This var is used to include the previously built go artifacts into the final maven release build.
           # As the maven build of the tag happens in a sub-directory to which maven checks out the release tag to build it.
@@ -146,7 +152,7 @@ jobs:
             -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
             -DpushChanges=${PUSH_CHANGES} \
             -DremoteTagging=${PUSH_CHANGES} \
-            -DlocalCheckout=${{ inputs.dryRun == 'true' }} \
+            -DlocalCheckout=${{ inputs.dryRun }} \
             -DcompletionGoals="spotless:apply" \
             -P-autoFormat \
             -Darguments='-T1C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
@@ -205,7 +211,7 @@ jobs:
 
           git commit -am "build(project): prepare next development version (Go client)"
       - name: Push Changes to Release branch
-        if: ${{ inputs.dryRun == 'false' }}
+        if: ${{ inputs.dryRun == false }}
         run: git push origin "${RELEASE_BRANCH}"
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
@@ -245,7 +251,7 @@ jobs:
           echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
       - name: Create Github release
         uses: ncipollo/release-action@v1
-        if: ${{ inputs.dryRun == 'false' }}
+        if: ${{ inputs.dryRun == false }}
         with:
           name: ${{ inputs.releaseVersion }}
           artifacts: "*"
@@ -262,7 +268,7 @@ jobs:
     timeout-minutes: 15
     env:
       DOCKER_IMAGE: camunda/zeebe
-      TAG_LATEST: ${{ inputs.isLatest == 'true' }}
+      TAG_LATEST: ${{ inputs.isLatest }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -293,7 +299,7 @@ jobs:
         with:
           repository: ${{ env.DOCKER_IMAGE }}
           version: ${{ inputs.releaseVersion }}
-          additionalTag: ${{ inputs.isLatest == 'true' && 'latest' || '' }}
+          additionalTag: ${{ inputs.isLatest && 'latest' || '' }}
           revision: ${{ needs.release.outputs.releaseTagRevision }}
           push: false
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
@@ -308,10 +314,10 @@ jobs:
             ${PWD}/docker/test/verify.sh "${DOCKER_IMAGE}:latest"
           fi
       - name: Push Docker Image Tag ${{ inputs.releaseVersion }}
-        if: ${{ inputs.dryRun == 'false' }}
+        if: ${{ inputs.dryRun == false }}
         run: docker push ${{ env.DOCKER_IMAGE }}:${{ inputs.releaseVersion }}
       - name: Push Docker Image Tag latest
-        if: ${{ inputs.isLatest == 'true' && inputs.dryRun == 'false' }}
+        if: ${{ inputs.isLatest && inputs.dryRun == false }}
         run: docker push ${{ env.DOCKER_IMAGE }}:latest
   notify-if-failed:
     name: Send slack notification on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ on:
         description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release), defaults to true.'
         default: true
 
+concurrency:
+  # cannot use the inputs context here as on this level only the github context is accessible, see
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.event.inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
         required: true
       pushReleaseArtifacts:
-        description: 'Whether to push release commits and artifacts to remote (Git tags, Maven artifacts, Github Release)'
+        description: 'Whether to push release commits and artifacts to remote (Git tags, Maven artifacts)'
         default: false
 
 jobs:
@@ -63,6 +63,16 @@ jobs:
           echo -n "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PUB }}" \
             | base64 --decode \
             | gpg -q --import --no-tty --batch --yes
+      - name: Setup Github cli
+        # On non-Github hosted runners it may be missing
+        # https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
+        run: |
+          type -p curl >/dev/null || sudo apt install curl -y
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && sudo apt update \
+          && sudo apt install gh -y
       - name: Setup Zeebe Build Tooling
         uses: ./.github/actions/setup-zeebe
       - name: Additional Go tooling setup
@@ -153,8 +163,69 @@ jobs:
           FILE=$(mvn -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
           git commit -am "build(project): update java compat versions"
+      - name: Github Release
+        shell: bash
+        # FIXME check if we can simplify it composing it with actions
+        # e.g. checksums https://github.com/marketplace/actions/generate-release-hashes
+        # https://github.com/actions/upload-release-asset
+        # https://github.com/actions/create-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          declare -a ASSETS=()
+          declare -a GH_OPTIONS=()
+
+          # This is the list of base artifacts that we expect to upload as part of the release; we'll also
+          # compute their sha1 sum and upload those as well, but no need to list that here. If there are new
+          # binaries to ship with a Zeebe release, add them here.
+          declare -a ARTIFACTS=( \
+            "dist/target/camunda-zeebe-${RELEASE_VERSION}.tar.gz" \
+            "dist/target/camunda-zeebe-${RELEASE_VERSION}.zip" \
+            "clients/go/cmd/zbctl/dist/zbctl" \
+            "clients/go/cmd/zbctl/dist/zbctl.exe" \
+            "clients/go/cmd/zbctl/dist/zbctl.darwin" \
+          )
+
+          # Prepare assets
+          CHECKSUM_DIR=$(mktemp -d)
+          if [ ! -e "${CHECKSUM_DIR}" ]; then
+            >&2 echo "Failed to create temporary assets directory directory"
+            exit 1
+          fi
+          for artifact in "${ARTIFACTS[@]}"; do
+            filename=$(basename "${artifact}")
+            checksum="${CHECKSUM_DIR}/${filename}.sha1sum"
+
+            if [ ! -f "${artifact}" ]; then
+              echo "Expected to upload asset ${artifact} as part of the GitHub release, but no such file was found; are you sure the release went through correctly?"
+              exit 1
+            fi
+
+            sha1sum "${artifact}" > "${checksum}"
+            sha1sumResult=$?
+            if [ ! -f "${checksum}" ]; then
+              echo "Failed to created checksum of artifact ${artifact} at ${checksum}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
+              exit 1
+            fi
+
+            ASSETS+=("${artifact}" "${checksum}")
+          done
+
+          # Mark as pre-release already if it's an alpha or rc
+          shopt -s nocasematch # set matching to case insensitive
+          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
+            GH_OPTIONS+=(--prerelease)
+          fi
+          shopt -u nocasematch # reset it
+
+          # Perform release: create draft, upload assets, etc.
+          # See https://cli.github.com/manual/gh_release_create for more
+          gh release create --repo "camunda/zeebe" --draft --notes "Release ${RELEASE_VERSION}" \
+            --title "${RELEASE_VERSION}" "${GH_OPTIONS[@]}" \
+            "${RELEASE_VERSION}" "${ASSETS[@]}"
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
         if: always()
         shell: bash
         run: rm -rf $HOME/.gnupg
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,17 +147,24 @@ jobs:
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
           pushd target/checkout
-          export BUILD_DIR=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.directory -q -DforceStdout)
-          export ARTIFACT=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
-          echo "distball=${BUILD_DIR}/${ARTIFACT}.tar.gz" >> $GITHUB_OUTPUT
           export TAG_REVISION=$(git log -n 1 --pretty=format:'%h')
           echo "tagRevision=${TAG_REVISION}" >> $GITHUB_OUTPUT
           popd
-      - name: Upload Zeebe Release Archive
+      - name: Collect Release artifacts
+        id: release-artifacts
+        run: |
+          ARTIFACT_DIR=$(mktemp -d)
+          cp target/checkout/dist/target/camunda-zeebe-${RELEASE_VERSION}.tar.gz "${ARTIFACT_DIR}/"
+          cp target/checkout/dist/target/camunda-zeebe-${RELEASE_VERSION}.zip "${ARTIFACT_DIR}/"
+          cp clients/go/cmd/zbctl/dist/zbctl "${ARTIFACT_DIR}/"
+          cp clients/go/cmd/zbctl/dist/zbctl.exe "${ARTIFACT_DIR}/"
+          cp clients/go/cmd/zbctl/dist/zbctl.darwin "${ARTIFACT_DIR}/"
+          echo "dir=${ARTIFACT_DIR}" >> $GITHUB_OUTPUT
+      - name: Upload Zeebe Release Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: camunda-zeebe.tar.gz
-          path: ${{ steps.maven-release.outputs.distball }}
+          name: release-artifacts
+          path: ${{ steps.release-artifacts.outputs.dir }}
           retention-days: 5
       - name: Update Compat Version
         shell: bash
@@ -176,68 +183,6 @@ jobs:
           FILE=$(mvn -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
           git commit -am "build(project): update java compat versions"
-      - name: Github Release
-        shell: bash
-        # FIXME check if we can simplify it composing it with actions
-        # e.g. checksums https://github.com/marketplace/actions/generate-release-hashes
-        # https://github.com/actions/upload-release-asset
-        # https://github.com/actions/create-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          declare -a ASSETS=()
-          declare -a GH_OPTIONS=()
-
-          # This is the list of base artifacts that we expect to upload as part of the release; we'll also
-          # compute their sha1 sum and upload those as well, but no need to list that here. If there are new
-          # binaries to ship with a Zeebe release, add them here.
-          declare -a ARTIFACTS=( \
-            "dist/target/camunda-zeebe-${RELEASE_VERSION}.tar.gz" \
-            "dist/target/camunda-zeebe-${RELEASE_VERSION}.zip" \
-            "clients/go/cmd/zbctl/dist/zbctl" \
-            "clients/go/cmd/zbctl/dist/zbctl.exe" \
-            "clients/go/cmd/zbctl/dist/zbctl.darwin" \
-          )
-
-          # Prepare assets
-          CHECKSUM_DIR=$(mktemp -d)
-          if [ ! -e "${CHECKSUM_DIR}" ]; then
-            >&2 echo "Failed to create temporary assets directory directory"
-            exit 1
-          fi
-          for artifact in "${ARTIFACTS[@]}"; do
-            filename=$(basename "${artifact}")
-            checksum="${CHECKSUM_DIR}/${filename}.sha1sum"
-
-            if [ ! -f "${artifact}" ]; then
-              echo "Expected to upload asset ${artifact} as part of the GitHub release, but no such file was found; are you sure the release went through correctly?"
-              exit 1
-            fi
-
-            sha1sum "${artifact}" > "${checksum}"
-            sha1sumResult=$?
-            if [ ! -f "${checksum}" ]; then
-              echo "Failed to created checksum of artifact ${artifact} at ${checksum}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
-              exit 1
-            fi
-
-            ASSETS+=("${artifact}" "${checksum}")
-          done
-
-          # Mark as pre-release already if it's an alpha or rc
-          shopt -s nocasematch # set matching to case insensitive
-          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
-            GH_OPTIONS+=(--prerelease)
-          fi
-          shopt -u nocasematch # reset it
-
-          if [ "$PUSH_CHANGES" = "true" ]; then
-            # Perform release: create draft, upload assets, etc.
-            # See https://cli.github.com/manual/gh_release_create for more
-            gh release create --repo "camunda/zeebe" --draft --notes "Release ${RELEASE_VERSION}" \
-              --title "${RELEASE_VERSION}" "${GH_OPTIONS[@]}" \
-              "${RELEASE_VERSION}" "${ASSETS[@]}"
-          fi
       - name: Go Post-Release
         shell: bash
         run: |
@@ -262,6 +207,51 @@ jobs:
         if: always()
         shell: bash
         run: rm -rf $HOME/.gnupg
+  github:
+    needs: release
+    name: Github Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: release-artifacts
+      - name: Create Artifact Checksums
+        id: checksum
+        shell: bash
+        run: |
+          for filename in *; do
+            checksumFile="${filename}.sha1sum"
+            sha1sum "${filename}" > "${checksumFile}"
+            sha1sumResult=$?
+            if [ ! -f "${checksumFile}" ]; then
+              echo "Failed to created checksum of ${filename} at ${checksumFile}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
+              exit 1
+            fi
+          done
+      - name: Determine if Pre-Release
+        id: pre-release
+        shell: bash
+        run: |
+          shopt -s nocasematch # set matching to case insensitive
+          PRE_RELEASE=false
+          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
+            PRE_RELEASE=true
+          fi
+          shopt -u nocasematch # reset it
+          echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
+      - uses: ncipollo/release-action@v1
+        if: ${{ inputs.pushChanges == 'true' }}
+        with:
+          name: ${{ inputs.releaseVersion }}
+          artifacts: "*"
+          artifactErrorsFailBuild: true
+          draft: true
+          body: Release ${{ inputs.releaseVersion }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ steps.pre-release.result }}
+          tag: ${{ inputs.releaseVersion }}
   docker:
     needs: release
     name: Docker Image Release
@@ -290,10 +280,10 @@ jobs:
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
-      - name: Download Zeebe Release Archive
+      - name: Download Zeebe Release Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: camunda-zeebe.tar.gz
+          name: release-artifacts
       - name: Build Docker Image
         uses: ./.github/actions/build-docker
         id: build-docker
@@ -320,4 +310,3 @@ jobs:
       - name: Push Docker Image Tag latest
         if: ${{ inputs.isLatest == 'true' && inputs.pushChanges == 'true' }}
         run: docker push ${{ env.DOCKER_IMAGE }}:latest
-


### PR DESCRIPTION
## Description

This introduces a new GHA release workflow, replicating all steps of the previous jenkins release job as defined in #11142.

Functional changes in comparison to previous Jenkins job:
- a new optional input parameter `releaseBranch` was added which allows to release from an arbitrary branch, I decided to add this to make testing easier
- the `PUSH_DOCKER` input parameter was omitted, instead all write behavior to "remote" is controlled with a single input being `dryRun` that defaults to true

I split the release into three jobs:
- first being the intertwined Maven & Go release (might be worth a follow-up to decouple if feasible) producing the release artifacts and attaching them to the workflow run
- second, depending on the release job, being the creation of the Github release, also generating the checksum files
- third, depending on the release job, being the docker image build, verification & push

I would like to perform some more "hot" releases (pushChanges=true) before we merge, but would like to get review feedback first.

Dry Test runs:

- [alpha release `0.0.4-alpha5`](https://github.com/camunda/zeebe/actions/runs/3677179115)
- [stable release `0.0.4` without tagging of latest image](https://github.com/camunda/zeebe/actions/runs/3677286634)
- [stable release `0.0.4` with tagging of latest image](https://github.com/camunda/zeebe/actions/runs/3677185231)
- [failed release job, sending a slack notification](https://github.com/camunda/zeebe/actions/runs/3677141190) and the [corresponding slack message](https://camunda.slack.com/archives/C013MEVQ4M9/p1670858299585059)

**Hot test runs** before merge (using a `meg-release-test` branch based on this branch):

- [x] release an alpha version `0.0.4-alpha1`: [job](https://github.com/camunda/zeebe/actions/runs/3683289329/jobs/6231911360), [release notes](https://github.com/camunda/zeebe/releases/tag/untagged-605833993b331e117379), [tag](https://github.com/camunda/zeebe/releases/tag/0.0.4-alpha1) , [docker image](https://hub.docker.com/layers/camunda/zeebe/0.0.4-alpha1/images/sha256-dec341e8ee187c994fa186b458e43d5383f09fbbc3df2dd075762a64885be189?context=explore)
- [x] release a stable version `0.0.4`: [job](https://github.com/camunda/zeebe/actions/runs/3683416289), [release notes](https://github.com/camunda/zeebe/releases/tag/untagged-108ebe3275f619f8d3cc), [tag](https://github.com/camunda/zeebe/releases/tag/0.0.4), [docker image](https://hub.docker.com/layers/camunda/zeebe/0.0.4/images/sha256-60ed0640f53b65c241a75dc22d08309b4b7f04d12333d418b9e7f74327c5795e?context=explore)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11142

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
