### PR TITLE
Fix flaky exporter test

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -350,12 +350,19 @@ public final class ExporterDirectorTest {
     // then
     doRepeatedly(() -> rule.getClock().addTime(Duration.ofSeconds(1)))
         .until((r) -> failCount.get() <= -2);
-    assertThat(exporters.get(0).getExportedRecords())
-        .extracting(Record::getPosition)
-        .containsExactly(eventPosition1, eventPosition2);
-    assertThat(exporters.get(1).getExportedRecords())
-        .extracting(Record::getPosition)
-        .containsExactly(eventPosition1, eventPosition2);
+
+    Awaitility.await("Exporter %s has exported all records".formatted(EXPORTER_ID_1))
+        .untilAsserted(
+            () ->
+                assertThat(exporters.get(0).getExportedRecords())
+                    .extracting(Record::getPosition)
+                    .containsExactly(eventPosition1, eventPosition2));
+    Awaitility.await("Exporter %s has exported all records".formatted(EXPORTER_ID_2))
+        .untilAsserted(
+            () ->
+                assertThat(exporters.get(1).getExportedRecords())
+                    .extracting(Record::getPosition)
+                    .containsExactly(eventPosition1, eventPosition2));
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -522,12 +522,8 @@ public final class ExporterDirectorTest {
         .until(() -> exporters.get(1).getExportedRecords().size() >= 1);
 
     // then
-    assertThat(exporters.get(0).getController().readMetadata())
-        .isPresent()
-        .hasValue(exporterMetadata1);
-    assertThat(exporters.get(1).getController().readMetadata())
-        .isPresent()
-        .hasValue(exporterMetadata2);
+    assertThat(exporters.get(0).getController().readMetadata()).hasValue(exporterMetadata1);
+    assertThat(exporters.get(1).getController().readMetadata()).hasValue(exporterMetadata2);
   }
 
   @Test


### PR DESCRIPTION
## Description

The flaky test failure was not reproducible. But by the failure description, it seems to be a race condition between updating the exported records and verifying the properties. The test was flaky because exporter 1 did not have all expected records. `failCount` is updated before the record is added to the `exportedRecords`. So it is possible that the property is asserted too early. To prevent it, wait until the condition is satisfied.

## Related issues

closes #11078 

