### PR TITLE
fix(ZeebeObjectMapper): added JavaTimeModule to ObjectMapper

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -49,6 +49,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-gateway-protocol-impl</artifactId>
     </dependency>

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.InternalClientException;
 import java.io.IOException;
@@ -37,7 +38,7 @@ public final class ZeebeObjectMapper implements JsonMapper {
   private final ObjectMapper objectMapper;
 
   public ZeebeObjectMapper() {
-    this(new ObjectMapper());
+    this(new ObjectMapper().registerModule(new JavaTimeModule()));
   }
 
   public ZeebeObjectMapper(ObjectMapper objectMapper) {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/ZeebeObjectMapperTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/ZeebeObjectMapperTest.java
@@ -18,6 +18,8 @@ package io.camunda.zeebe.client.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.util.ClientTest;
+import java.time.ZoneOffset;
+import java.util.Date;
 import org.junit.Test;
 
 public class ZeebeObjectMapperTest extends ClientTest {
@@ -32,6 +34,18 @@ public class ZeebeObjectMapperTest extends ClientTest {
     final String actual = zeebeObjectMapper.toJson(testObject);
     // Then
     assertThat(actual).isEqualTo("{\"object\":{}}");
+  }
+
+  @Test
+  public void shouldParseOffsetDateTimeWithoutException() {
+    // Given
+    final ZeebeObjectMapper zeebeObjectMapper = new ZeebeObjectMapper();
+    final TestObject testObject = new TestObject();
+    testObject.setObject(new Date().toInstant().atOffset(ZoneOffset.UTC));
+    // When
+    final String actual = zeebeObjectMapper.toJson(testObject);
+    // Then object not null and parsed without exception
+    assertThat(actual).isNotEmpty();
   }
 
   public static final class TestObject {


### PR DESCRIPTION
## Description
Added JavaTimeModule to ObjectMapper
<!-- Please explain the changes you made here. -->

Microsoft teams connector return Graph API response with OffsetDate : 
<img width="1164" alt="Screenshot 2022-12-12 at 16 37 38" src="https://user-images.githubusercontent.com/108869886/207084215-be6f936e-a492-496b-aed6-16b22718f5e5.png">



<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
