### PR TITLE
Fix flaky ProcessScheduleServiceTest

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationWithTimeout;
 
-public class ProcessingScheduleServiceTest {
+class ProcessingScheduleServiceTest {
 
   private static final long TIMEOUT_MILLIS = 2_000L;
   private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
@@ -66,7 +66,7 @@ public class ProcessingScheduleServiceTest {
   private TestScheduleServiceActorDecorator scheduleService;
 
   @BeforeEach
-  public void before() {
+  void before() {
     clock = new ControlledActorClock();
     final var builder =
         ActorScheduler.newActorScheduler()
@@ -89,7 +89,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @AfterEach
-  public void clean() {
+  void clean() {
     try {
       actorScheduler.close();
     } catch (final Exception e) {
@@ -100,7 +100,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldExecuteScheduledTask() {
+  void shouldExecuteScheduledTask() {
     // given
     final var mockedTask = spy(new DummyTask());
 
@@ -112,7 +112,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldExecuteScheduledTaskInRightOrder() {
+  void shouldExecuteScheduledTaskInRightOrder() {
     // given
     final var mockedTask = spy(new DummyTask());
     final var mockedTask2 = spy(new DummyTask());
@@ -129,7 +129,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldNotExecuteScheduledTaskIfNotInProcessingPhase() {
+  void shouldNotExecuteScheduledTaskIfNotInProcessingPhase() {
     // given
     lifecycleSupplier.currentPhase = Phase.INITIAL;
     final var mockedTask = spy(new DummyTask());
@@ -142,7 +142,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldNotExecuteScheduledTaskIfAborted() {
+  void shouldNotExecuteScheduledTaskIfAborted() {
     // given
     lifecycleSupplier.isAborted = true;
     final var mockedTask = spy(new DummyTask());
@@ -155,7 +155,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldExecuteScheduledTaskInProcessing() {
+  void shouldExecuteScheduledTaskInProcessing() {
     // given
     lifecycleSupplier.currentPhase = Phase.PAUSED;
     final var mockedTask = spy(new DummyTask());
@@ -170,7 +170,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldNotExecuteTasksWhenScheduledOnClosedActor() {
+  void shouldNotExecuteTasksWhenScheduledOnClosedActor() {
     // given
     lifecycleSupplier.currentPhase = Phase.PAUSED;
     final var notOpenScheduleService =
@@ -186,7 +186,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldFailActorIfWriterCantBeRetrieved() {
+  void shouldFailActorIfWriterCantBeRetrieved() {
     // given
     writerAsyncSupplier.writerFutureRef.set(
         CompletableActorFuture.completedExceptionally(new RuntimeException("expected")));
@@ -203,7 +203,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldWriteRecordAfterTaskWasExecuted() {
+  void shouldWriteRecordAfterTaskWasExecuted() {
     // given
     final var batchWriter = writerAsyncSupplier.get().join();
     when(batchWriter.canWriteAdditionalEvent(anyInt(), anyInt())).thenReturn(true);
@@ -225,7 +225,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @RegressionTest("https://github.com/camunda/zeebe/issues/10240")
-  public void shouldPreserveOrderingOfWritesEvenWithRetries() throws InterruptedException {
+  void shouldPreserveOrderingOfWritesEvenWithRetries() throws InterruptedException {
     // given
     final var batchWriter = writerAsyncSupplier.get().join();
     when(batchWriter.canWriteAdditionalEvent(anyInt(), anyInt())).thenReturn(true);
@@ -289,7 +289,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldScheduleOnFixedRate() {
+  void shouldScheduleOnFixedRate() {
     // given
     final var mockedTask = spy(new DummyTask());
 
@@ -301,7 +301,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldNotRunScheduledTasksAfterClosed() {
+  void shouldNotRunScheduledTasksAfterClosed() {
     // given
     final var mockedTask = spy(new DummyTask());
     scheduleService.runDelayed(Duration.ofMillis(200), mockedTask);


### PR DESCRIPTION
## Description

Increased timeout to prevent flaky test. 
In the `main` branch, the timeout is already 10 seconds as the test was rewritten to use new logstream api and `Awaitility`.

## Related issues

closes #10887 

