### PR TITLE
fix(release): use github context for concurrency variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ on:
 concurrency:
   # cannot use the inputs context here as on this level only the github context is accessible, see
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
-  group: ${{ github.event.inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
+  group: ${{ github.event.inputs.releaseBranch != '' && github.event.inputs.releaseBranch || format('release-{0}', github.event.inputs.releaseVersion) }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
## Description

As documented the inputs context is not available for workflow concurrency.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates #11142