### PR TITLE
Validate ancestor key belongs to the process instance that is being modified

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -421,32 +421,6 @@ public final class ProcessInstanceModificationProcessor
         .map(valid -> VALID);
   }
 
-  private Either<Rejection, ?> validateAncestorBelongsToProcessInstance(
-      final DeployedProcess process,
-      final ProcessInstanceModificationRecord record,
-      final Map<Long, Optional<ElementInstance>> ancestorInstances) {
-    final Set<String> rejectedAncestorKeys =
-        ancestorInstances.values().stream()
-            .flatMap(Optional::stream)
-            .filter(
-                ancestorInstance ->
-                    ancestorInstance.getValue().getProcessInstanceKey()
-                        != record.getProcessInstanceKey())
-            .map(ancestorInstance -> String.valueOf(ancestorInstance.getKey()))
-            .collect(Collectors.toSet());
-
-    if (rejectedAncestorKeys.isEmpty()) {
-      return VALID;
-    }
-
-    final String reason =
-        String.format(
-            ERROR_MESSAGE_ANCESTOR_WRONG_PROCESS_INSTANCE,
-            BufferUtil.bufferAsString(process.getBpmnProcessId()),
-            String.join("', '", rejectedAncestorKeys));
-    return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
-  }
-
   private Either<Rejection, ?> validateAncestorExistsAndIsActive(
       final DeployedProcess process,
       final ProcessInstanceModificationRecord record,
@@ -474,6 +448,32 @@ public final class ProcessInstanceModificationProcessor
             ERROR_MESSAGE_ANCESTOR_NOT_FOUND,
             BufferUtil.bufferAsString(process.getBpmnProcessId()),
             String.join("', '", invalidAncestorKeys));
+    return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
+  }
+
+  private Either<Rejection, ?> validateAncestorBelongsToProcessInstance(
+      final DeployedProcess process,
+      final ProcessInstanceModificationRecord record,
+      final Map<Long, Optional<ElementInstance>> ancestorInstances) {
+    final Set<String> rejectedAncestorKeys =
+        ancestorInstances.values().stream()
+            .flatMap(Optional::stream)
+            .filter(
+                ancestorInstance ->
+                    ancestorInstance.getValue().getProcessInstanceKey()
+                        != record.getProcessInstanceKey())
+            .map(ancestorInstance -> String.valueOf(ancestorInstance.getKey()))
+            .collect(Collectors.toSet());
+
+    if (rejectedAncestorKeys.isEmpty()) {
+      return VALID;
+    }
+
+    final String reason =
+        String.format(
+            ERROR_MESSAGE_ANCESTOR_WRONG_PROCESS_INSTANCE,
+            BufferUtil.bufferAsString(process.getBpmnProcessId()),
+            String.join("', '", rejectedAncestorKeys));
     return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -298,7 +298,7 @@ public final class ProcessInstanceModificationProcessor
         .flatMap(valid -> validateElementInstanceExists(process, terminateInstructions))
         .flatMap(valid -> validateVariableScopeExists(process, activateInstructions))
         .flatMap(valid -> validateVariableScopeIsFlowScope(process, activateInstructions))
-        .flatMap(valid -> validateAncestorExistsAndIsActive(process, value))
+        .flatMap(valid -> validateAncestorKeys(process, value))
         .map(valid -> VALID);
   }
 
@@ -392,6 +392,11 @@ public final class ProcessInstanceModificationProcessor
             "The activation of elements with type '%s' is not supported. Supported element types are: %s"
                 .formatted(usedUnsupportedElementTypes, SUPPORTED_ELEMENT_TYPES));
     return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
+  }
+
+  private Either<Rejection, ?> validateAncestorKeys(
+      final DeployedProcess process, final ProcessInstanceModificationRecord record) {
+    return validateAncestorExistsAndIsActive(process, record);
   }
 
   private Either<Rejection, ?> validateAncestorExistsAndIsActive(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -112,9 +112,9 @@ public final class ProcessInstanceModificationProcessor
 
   private static final String ERROR_MESSAGE_ANCESTOR_WRONG_PROCESS_INSTANCE =
       """
-          Expected to modify instance of process '%s' but it contains one or more activate \
-          instructions with an ancestor scope key that does not belong to the modified process \
-          instance: '%s'""";
+      Expected to modify instance of process '%s' but it contains one or more activate \
+      instructions with an ancestor scope key that does not belong to the modified process \
+      instance: '%s'""";
 
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       Set.of(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -805,9 +805,10 @@ public class ModifyProcessInstanceRejectionTest {
                 + " instance is not allowed")
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            ("Expected to modify instance of process '%s' but it contains one or more activate"
-                    + " instructions with an ancestor scope key that does not belong to the "
-                    + "modified process instance: '%d'")
+            ("""
+              Expected to modify instance of process '%s' but it contains one or more \
+              activate instructions with an ancestor scope key that does not belong to the \
+              modified process instance: '%d'""")
                 .formatted(PROCESS_ID, subProcessKeyTwo));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -761,4 +761,53 @@ public class ModifyProcessInstanceRejectionTest {
                 'SubProcess', which is currently unsupported.""",
                 PROCESS_ID));
   }
+
+  @Test
+  public void shouldRejectActivationWhenAncestorBelongsToDifferentProcessInstance() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "sp", sp -> sp.embeddedSubProcess().startEvent().userTask("A").endEvent())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKeyOne = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKeyOne)
+        .withElementId("A")
+        .await();
+    final var processInstanceKeyTwo = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var subProcessKeyTwo =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKeyTwo)
+            .withElementId("A")
+            .getFirst()
+            .getKey();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKeyOne)
+            .modification()
+            .activateElement("A", subProcessKeyTwo)
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs(
+            "Expect that activating an element with ancestor key of a different process"
+                + " instance is not allowed")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            ("Expected to modify instance of process '%s' but it contains one or more activate"
+                    + " instructions with an ancestor scope key that does not belong to the "
+                    + "modified process instance: '%d'")
+                .formatted(PROCESS_ID, subProcessKeyTwo));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When activating an element using modification the user has the option to provide an ancestor key. There is no guarantee that this key is correct and that it belongs to the process instance that is being modified. We need to make sure that if the key does not belong to the modified process instance, we reject the command.

There is also some small refactoring in this PR. I recommend reviewing it by commit.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11256 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
