### PR TITLE
ci(release): nightly release dry run from main

### DIFF
--- a/.github/workflows/release-main-dry-run.yml
+++ b/.github/workflows/release-main-dry-run.yml
@@ -1,0 +1,61 @@
+name: Release Dry Run from main
+on:
+  workflow_dispatch: { }
+  schedule:
+    # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
+    - cron: '0 1 * * 1-5'
+
+jobs:
+  dry-run-release:
+    name: "${{ matrix.version }} from main"
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ 0.8.2, 0.8.2-alpha1 ]
+        include:
+          - version: 0.8.2
+            latest: true
+          - version: 0.8.2-alpha1
+            latest: false
+    with:
+      releaseBranch: main
+      releaseVersion: ${{ matrix.version }}
+      nextDevelopmentVersion: 0.0.0-SNAPSHOT
+      isLatest: ${{ matrix.latest }}
+      dryRun: true
+  notify-if-failed:
+    name: Send slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [ dry-run-release ]
+    if: ${{ failure() }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":alarm: *Release Dry Run* from `main` failed! :alarm:\n",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Release Dry Run* from `main` failed! :alarm:\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related workflow execution: https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,0 +1,80 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseBranch:
+        description: 'The branch to perform the release on, defaults to `release-$releaseVersion`'
+        type: string
+        required: false
+        default: ''
+      releaseVersion:
+        description: 'The version to be build and released. If no releaseBranch specified, expecting `release-$releaseVersion` to already exist.'
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
+        type: string
+        required: true
+      isLatest:
+        description: 'Whether this is the latest release and the docker image should be tagged as camunda/zeebe:latest'
+        type: boolean
+        required: false
+        default: false
+      dryRun:
+        description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release), defaults to true.'
+        type: boolean
+        default: true
+
+concurrency:
+  # cannot use the inputs context here as on this level only the github context is accessible, see
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.event.inputs.releaseBranch != '' && github.event.inputs.releaseBranch || format('release-{0}', github.event.inputs.releaseVersion) }}
+  cancel-in-progress: true
+
+jobs:
+  run-release:
+    name: "Release ${{ inputs.releaseVersion }} from ${{ inputs.releaseBranch }}"
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    with:
+      releaseBranch: ${{ inputs.releaseBranch }}
+      releaseVersion: ${{ inputs.releaseVersion }}
+      nextDevelopmentVersion: ${{ inputs.nextDevelopmentVersion }}
+      isLatest: ${{ inputs.isLatest }}
+      dryRun: ${{ inputs.dryRun }}
+  notify-if-failed:
+    name: Send slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
+    # else => send slack notification as an actual release failed
+    if: ${{ failure() && inputs.dryRun == false }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":alarm: Release job for ${{ inputs.releaseVersion }} failed! :alarm:\n",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: Release job for ${{ inputs.releaseVersion }} failed! :alarm:\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related workflow execution: https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
-name: Release
+name: Release Workflow
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       releaseBranch:
         description: 'The branch to perform the release on, defaults to `release-$releaseVersion`'
@@ -24,12 +24,6 @@ on:
         description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release), defaults to true.'
         type: boolean
         default: true
-
-concurrency:
-  # cannot use the inputs context here as on this level only the github context is accessible, see
-  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
-  group: ${{ github.event.inputs.releaseBranch != '' && github.event.inputs.releaseBranch || format('release-{0}', github.event.inputs.releaseVersion) }}
-  cancel-in-progress: true
 
 defaults:
   run:
@@ -176,7 +170,7 @@ jobs:
       - name: Upload Zeebe Release Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: release-artifacts
+          name: release-artifacts-${{ inputs.releaseVersion }}
           path: ${{ steps.release-artifacts.outputs.dir }}
           retention-days: 5
       - name: Update Compat Version
@@ -226,7 +220,7 @@ jobs:
       - name: Download Release Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: release-artifacts
+          name: release-artifacts-${{ inputs.releaseVersion }}
       - name: Create Artifact Checksums
         id: checksum
         run: |
@@ -292,7 +286,7 @@ jobs:
       - name: Download Zeebe Release Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: release-artifacts
+          name: release-artifacts-${{ inputs.releaseVersion }}
       - name: Build Docker Image
         uses: ./.github/actions/build-docker
         id: build-docker
@@ -319,37 +313,3 @@ jobs:
       - name: Push Docker Image Tag latest
         if: ${{ inputs.isLatest && inputs.dryRun == false }}
         run: docker push ${{ env.DOCKER_IMAGE }}:latest
-  notify-if-failed:
-    name: Send slack notification on failure
-    runs-on: ubuntu-latest
-    needs: [ release, github, docker ]
-    if: failure() && github.repository == 'camunda/zeebe'
-    steps:
-      - id: slack-notify
-        name: Send slack notification
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          # For posting a rich message using Block Kit
-          payload: |
-            {
-              "text": ":alarm: Release job build for ${{ inputs.releaseVersion }} failed! :alarm:\n",
-             	"blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: Release job build for ${{ inputs.releaseVersion }} failed! :alarm:\n"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Please check the related workflow execution: https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Description

This adds a nightly dry run of the release from the `main` branch, thus ensures our release workflow is functional if we would create a new alpha or minor release.

As the `releaseVersion` as well as the `isLatest` input of the release workflow result in slightly different behaviour of the release workflow it tests the two relevant combinations being:
- release a stable release as latest
- release an alpha release, not as latest

In order to setup a scheduled dry run as well as the workflow to be used manually during a release, the former `release.yml` workflow was converted to be only triggerable via `workflow_call`. A separate workflow for the manual execution as well as the scheduled dry run execution (without inputs) was added.

To differentiate failures of dry runs and actual release runs the slack notification job was moved to the corresponding invoking workflows. Also the manual release workflow will not send a slack notification if it was a manual dry run (Assuming if someone triggers it manually they will look for the result anyway and to not cause noise in #zeebe-ci in such a case)

Test runs:

- [Run of the new manual/workflow_dispatch release workflow](https://github.com/camunda/zeebe/actions/runs/3702215073)
- [Run of the main dry run release workflow, testing relevant scenarios](https://github.com/camunda/zeebe/actions/runs/3705080683)

## Related issues

This puts focus only on the main branch in relation to the following issue.
Dry runs for stable branches will be covered with a separate workflow and PR.

relates to #11259 