### PR TITLE
[Backport stable/8.1] fix(gateway): don't log IllegalArgumentException as errors

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -187,8 +187,7 @@ public final class RequestMapper {
         return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value));
       } catch (final RuntimeException e) {
         final var cause = e.getCause();
-        if (cause instanceof JsonParseException) {
-          final var parseException = (JsonParseException) cause;
+        if (cause instanceof final JsonParseException parseException) {
 
           final var descriptiveException =
               new JsonParseException(
@@ -199,6 +198,9 @@ public final class RequestMapper {
 
           rethrowUnchecked(descriptiveException);
           return DocumentValue.EMPTY_DOCUMENT; // bogus return statement
+        } else if (cause instanceof IllegalArgumentException) {
+          rethrowUnchecked(cause);
+          return DocumentValue.EMPTY_DOCUMENT;
         } else {
           throw e;
         }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -76,6 +76,9 @@ public final class GrpcErrorMapper {
     } else if (error instanceof JsonParseException) {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
       logger.debug("Expected to handle gRPC request, but JSON property was invalid", rootError);
+    } else if (error instanceof IllegalArgumentException) {
+      builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
+      logger.debug("Expected to handle gRPC request, but JSON property was invalid 123", rootError);
     } else if (error instanceof PartitionNotFoundException) {
       builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
       logger.debug(

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -18,6 +18,10 @@ public class RequestMapperTest {
   private static final String INVALID_VARIABLES =
       "{ \"test\": \"value\", \"error\": \"errorrvalue }";
 
+  // BigInteger larger than 2^64-1
+  private static final String BIG_INTEGER =
+      "{\"mybigintistoolong\": 123456789012345678901234567890}";
+
   @Test
   public void shouldThrowHelpfulExceptionIfJsonIsInvalid() {
     // when + then
@@ -26,5 +30,13 @@ public class RequestMapperTest {
         .hasMessageContaining("Invalid JSON", INVALID_VARIABLES)
         .cause()
         .isInstanceOf(JsonParseException.class);
+  }
+
+  @Test
+  public void shouldThrowHelpfulExceptionIfJsonHasBigInteger() {
+    // when + then
+    assertThatThrownBy(() -> RequestMapper.ensureJsonSet(BIG_INTEGER))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("MessagePack cannot serialize BigInteger larger than 2^64-1");
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -143,4 +143,27 @@ final class GrpcErrorMapperTest {
       assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
     }
   }
+
+  @Test
+  void shouldLogIllegalArgumentExceptionOnDebugWithBigIntTooLong() {
+    // given
+    try {
+      MsgPackConverter.convertToMsgPack("{\"mybigintistoolong\":123456789012345678901234567890}");
+      fail("Expected to throw exception");
+    } catch (final RuntimeException runtimeException) {
+      assertThat(runtimeException.getCause()).isInstanceOf(IllegalArgumentException.class);
+      final IllegalArgumentException exception =
+          (IllegalArgumentException) runtimeException.getCause();
+
+      // when
+      log.setLevel(Level.DEBUG);
+      final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+      // then
+      assertThat(statusException.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+      assertThat(recorder.getAppendedEvents()).hasSize(1);
+      final LogEvent event = recorder.getAppendedEvents().get(0);
+      assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+    }
+  }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -77,7 +77,11 @@ public final class MsgPackConverter {
 
       return outputStream.toByteArray();
     } catch (final Exception e) {
-      throw new RuntimeException("Failed to convert JSON to MessagePack", e);
+      if (e instanceof IllegalArgumentException) {
+        throw new IllegalArgumentException("Failed to convert JSON to MessagePack", e);
+      } else {
+        throw new RuntimeException("Failed to convert JSON to MessagePack", e);
+      }
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
@@ -94,6 +94,21 @@ public final class CompleteJobTest {
   }
 
   @Test
+  public void shouldRejectIfVariableIsBigIntTooLong() {
+    // when
+    assertThatThrownBy(
+            () ->
+                CLIENT_RULE
+                    .getClient()
+                    .newCompleteCommand(jobKey)
+                    .variables("{\"mybigintistoolong\":123456789012345678901234567890}")
+                    .send()
+                    .join())
+        .isInstanceOf(ClientStatusException.class)
+        .hasMessageContaining("MessagePack cannot serialize BigInteger larger than 2^64-1");
+  }
+
+  @Test
   public void shouldRejectIfJobIsAlreadyCompleted() {
     // given
     CLIENT_RULE.getClient().newCompleteCommand(jobKey).send().join();


### PR DESCRIPTION
# Description
Backport of #11169 to `stable/8.1`.

relates to #9832