### PR TITLE
Backport 8726 to stable 8.0

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -239,6 +239,7 @@ public final class EngineProcessors {
       final Writers writers) {
     MessageEventProcessors.addMessageProcessors(
         eventTriggerBehavior,
+        bpmnBehaviors.stateBehavior(),
         typedRecordProcessors,
         zeebeState,
         subscriptionCommandSender,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -238,11 +238,6 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers) {
     MessageEventProcessors.addMessageProcessors(
-        eventTriggerBehavior,
-        bpmnBehaviors.stateBehavior(),
-        typedRecordProcessors,
-        zeebeState,
-        subscriptionCommandSender,
-        writers);
+        bpmnBehaviors, typedRecordProcessors, zeebeState, subscriptionCommandSender, writers);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationController;
@@ -89,9 +91,15 @@ public final class EngineProcessors {
         new EventTriggerBehavior(
             zeebeState.getKeyGenerator(), catchEventBehavior, writers, zeebeState);
 
+    final VariableBehavior variableBehavior =
+        new VariableBehavior(
+            zeebeState.getVariableState(), writers.state(), zeebeState.getKeyGenerator());
+
+    final BpmnStateBehavior stateBehavior = new BpmnStateBehavior(zeebeState, variableBehavior);
+
     final var eventPublicationBehavior =
         new BpmnEventPublicationBehavior(
-            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);
+            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, stateBehavior, writers);
 
     addDeploymentRelatedProcessorAndServices(
         catchEventBehavior,
@@ -107,6 +115,7 @@ public final class EngineProcessors {
         zeebeState.getKeyGenerator());
     addMessageProcessors(
         eventTriggerBehavior,
+        stateBehavior,
         subscriptionCommandSender,
         zeebeState,
         typedRecordProcessors,
@@ -122,6 +131,7 @@ public final class EngineProcessors {
             subscriptionCommandSender,
             catchEventBehavior,
             eventTriggerBehavior,
+            stateBehavior,
             writers,
             timerChecker,
             jobMetrics);
@@ -133,7 +143,8 @@ public final class EngineProcessors {
         eventPublicationBehavior,
         writers,
         jobMetrics,
-        eventTriggerBehavior);
+        eventTriggerBehavior,
+        stateBehavior);
 
     addIncidentProcessors(
         zeebeState,
@@ -152,6 +163,7 @@ public final class EngineProcessors {
       final SubscriptionCommandSender subscriptionCommandSender,
       final CatchEventBehavior catchEventBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final Writers writers,
       final DueDateTimerChecker timerChecker,
       final JobMetrics jobMetrics) {
@@ -163,6 +175,7 @@ public final class EngineProcessors {
         catchEventBehavior,
         timerChecker,
         eventTriggerBehavior,
+        stateBehavior,
         writers,
         jobMetrics);
   }
@@ -233,11 +246,17 @@ public final class EngineProcessors {
 
   private static void addMessageProcessors(
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableZeebeState zeebeState,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers) {
     MessageEventProcessors.addMessageProcessors(
-        bpmnBehaviors, typedRecordProcessors, zeebeState, subscriptionCommandSender, writers);
+        eventTriggerBehavior,
+        stateBehavior,
+        typedRecordProcessors,
+        zeebeState,
+        subscriptionCommandSender,
+        writers);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -145,12 +145,7 @@ public final class ProcessEventProcessors {
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.CORRELATE,
             new ProcessMessageSubscriptionCorrelateProcessor(
-                subscriptionState,
-                subscriptionCommandSender,
-                zeebeState,
-                eventTriggerBehavior,
-                bpmnBehaviors.stateBehavior(),
-                writers))
+                subscriptionState, subscriptionCommandSender, zeebeState, bpmnBehaviors, writers))
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.DELETE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -53,6 +54,7 @@ public final class ProcessEventProcessors {
       final CatchEventBehavior catchEventBehavior,
       final DueDateTimerChecker timerChecker,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final Writers writers,
       final JobMetrics jobMetrics) {
     final MutableProcessMessageSubscriptionState subscriptionState =
@@ -79,6 +81,7 @@ public final class ProcessEventProcessors {
         subscriptionState,
         subscriptionCommandSender,
         eventTriggerBehavior,
+        stateBehavior,
         zeebeState,
         writers);
     addTimerStreamProcessors(
@@ -87,6 +90,7 @@ public final class ProcessEventProcessors {
         zeebeState,
         catchEventBehavior,
         eventTriggerBehavior,
+        stateBehavior,
         expressionProcessor,
         writers);
     addVariableDocumentStreamProcessors(
@@ -133,6 +137,7 @@ public final class ProcessEventProcessors {
       final MutableProcessMessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final MutableZeebeState zeebeState,
       final Writers writers) {
     typedRecordProcessors
@@ -145,7 +150,12 @@ public final class ProcessEventProcessors {
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.CORRELATE,
             new ProcessMessageSubscriptionCorrelateProcessor(
-                subscriptionState, subscriptionCommandSender, zeebeState, bpmnBehaviors, writers))
+                subscriptionState,
+                subscriptionCommandSender,
+                zeebeState,
+                eventTriggerBehavior,
+                stateBehavior,
+                writers))
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.DELETE,
@@ -161,6 +171,7 @@ public final class ProcessEventProcessors {
       final MutableZeebeState zeebeState,
       final CatchEventBehavior catchEventOutput,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final ExpressionProcessor expressionProcessor,
       final Writers writers) {
     typedRecordProcessors
@@ -168,7 +179,12 @@ public final class ProcessEventProcessors {
             ValueType.TIMER,
             TimerIntent.TRIGGER,
             new TriggerTimerProcessor(
-                zeebeState, catchEventOutput, eventTriggerBehavior, expressionProcessor, writers))
+                zeebeState,
+                catchEventOutput,
+                eventTriggerBehavior,
+                stateBehavior,
+                expressionProcessor,
+                writers))
         .onCommand(
             ValueType.TIMER,
             TimerIntent.CANCEL,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -149,6 +149,7 @@ public final class ProcessEventProcessors {
                 subscriptionCommandSender,
                 zeebeState,
                 eventTriggerBehavior,
+                bpmnBehaviors.stateBehavior(),
                 writers))
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -92,12 +92,12 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new BpmnIncidentBehavior(zeebeState, zeebeState.getKeyGenerator(), stateWriter);
     eventPublicationBehavior =
         new BpmnEventPublicationBehavior(
-            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);
+            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, stateBehavior, writers);
     processResultSenderBehavior =
         new BpmnProcessResultSenderBehavior(zeebeState, writers.response());
     bufferedMessageStartEventBehavior =
         new BpmnBufferedMessageStartEventBehavior(
-            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);
+            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, stateBehavior, writers);
     jobBehavior =
         new BpmnJobBehavior(
             zeebeState.getKeyGenerator(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -34,6 +34,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
       final ZeebeState zeebeState,
       final KeyGenerator keyGenerator,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final Writers writers) {
     messageState = zeebeState.getMessageState();
     processState = zeebeState.getProcessState();
@@ -45,7 +46,8 @@ public final class BpmnBufferedMessageStartEventBehavior {
             zeebeState.getEventScopeInstanceState(),
             writers,
             processState,
-            eventTriggerBehavior);
+            eventTriggerBehavior,
+            stateBehavior);
   }
 
   public Optional<DirectBuffer> findCorrelationKey(final BpmnElementContext context) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -33,6 +33,7 @@ public final class BpmnEventPublicationBehavior {
       final ZeebeState zeebeState,
       final KeyGenerator keyGenerator,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final Writers writers) {
     elementInstanceState = zeebeState.getElementInstanceState();
     eventHandle =
@@ -41,7 +42,8 @@ public final class BpmnEventPublicationBehavior {
             zeebeState.getEventScopeInstanceState(),
             writers,
             zeebeState.getProcessState(),
-            eventTriggerBehavior);
+            eventTriggerBehavior,
+            stateBehavior);
     catchEventAnalyzer = new CatchEventAnalyzer(zeebeState.getProcessState(), elementInstanceState);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -140,6 +140,7 @@ public final class CallActivityProcessor
     eventSubscriptionBehavior
         .findEventTrigger(context)
         .filter(eventTrigger -> flowScopeInstance.isActive())
+        .filter(eventTrigger -> !flowScopeInstance.isInterrupted())
         .ifPresentOrElse(
             eventTrigger -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -273,6 +273,7 @@ public final class MultiInstanceBodyProcessor
     eventSubscriptionBehavior
         .findEventTrigger(flowScopeContext)
         .filter(eventTrigger -> flowScopeInstance.isActive())
+        .filter(eventTrigger -> !flowScopeInstance.isInterrupted())
         .ifPresentOrElse(
             eventTrigger -> {
               final var terminated =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -126,6 +126,7 @@ public final class SubProcessProcessor
       eventSubscriptionBehavior
           .findEventTrigger(subProcessContext)
           .filter(eventTrigger -> flowScopeInstance.isActive())
+          .filter(eventTrigger -> !flowScopeInstance.isInterrupted())
           .ifPresentOrElse(
               eventTrigger -> {
                 final var terminated =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
@@ -119,6 +119,7 @@ public final class BusinessRuleTaskProcessor
       eventSubscriptionBehavior
           .findEventTrigger(context)
           .filter(eventTrigger -> flowScopeInstance.isActive())
+          .filter(eventTrigger -> !flowScopeInstance.isInterrupted())
           .ifPresentOrElse(
               eventTrigger -> {
                 final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -81,6 +81,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
     eventSubscriptionBehavior
         .findEventTrigger(context)
         .filter(eventTrigger -> flowScopeInstance.isActive())
+        .filter(eventTrigger -> !flowScopeInstance.isInterrupted())
         .ifPresentOrElse(
             eventTrigger -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -74,6 +74,7 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
     eventSubscriptionBehavior
         .findEventTrigger(context)
         .filter(eventTrigger -> flowScopeInstance.isActive())
+        .filter(eventTrigger -> !flowScopeInstance.isInterrupted())
         .ifPresentOrElse(
             eventTrigger -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -41,7 +41,8 @@ public final class JobEventProcessors {
             zeebeState.getEventScopeInstanceState(),
             writers,
             zeebeState.getProcessState(),
-            eventTriggerBehavior);
+            bpmnBehaviors.eventTriggerBehavior(),
+            bpmnBehaviors.stateBehavior());
 
     final var jobBackoffChecker = new JobBackoffChecker(jobState);
     typedRecordProcessors

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
@@ -30,7 +31,8 @@ public final class JobEventProcessors {
       final BpmnEventPublicationBehavior eventPublicationBehavior,
       final Writers writers,
       final JobMetrics jobMetrics,
-      final EventTriggerBehavior eventTriggerBehavior) {
+      final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior) {
 
     final var jobState = zeebeState.getJobState();
     final var keyGenerator = zeebeState.getKeyGenerator();
@@ -41,8 +43,8 @@ public final class JobEventProcessors {
             zeebeState.getEventScopeInstanceState(),
             writers,
             zeebeState.getProcessState(),
-            bpmnBehaviors.eventTriggerBehavior(),
-            bpmnBehaviors.stateBehavior());
+            eventTriggerBehavior,
+            stateBehavior);
 
     final var jobBackoffChecker = new JobBackoffChecker(jobState);
     typedRecordProcessors

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -24,7 +25,8 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 public final class MessageEventProcessors {
 
   public static void addMessageProcessors(
-      final BpmnBehaviors bpmnBehaviors,
+      final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableZeebeState zeebeState,
       final SubscriptionCommandSender subscriptionCommandSender,
@@ -53,8 +55,8 @@ public final class MessageEventProcessors {
                 keyGenerator,
                 writers,
                 processState,
-                bpmnBehaviors.eventTriggerBehavior(),
-                bpmnBehaviors.stateBehavior()))
+                eventTriggerBehavior,
+                stateBehavior))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -25,6 +26,7 @@ public final class MessageEventProcessors {
 
   public static void addMessageProcessors(
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableZeebeState zeebeState,
       final SubscriptionCommandSender subscriptionCommandSender,
@@ -53,7 +55,8 @@ public final class MessageEventProcessors {
                 keyGenerator,
                 writers,
                 processState,
-                eventTriggerBehavior))
+                eventTriggerBehavior,
+                stateBehavior))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -7,8 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
-import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -25,8 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 public final class MessageEventProcessors {
 
   public static void addMessageProcessors(
-      final EventTriggerBehavior eventTriggerBehavior,
-      final BpmnStateBehavior stateBehavior,
+      final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableZeebeState zeebeState,
       final SubscriptionCommandSender subscriptionCommandSender,
@@ -55,8 +53,8 @@ public final class MessageEventProcessors {
                 keyGenerator,
                 writers,
                 processState,
-                eventTriggerBehavior,
-                stateBehavior))
+                bpmnBehaviors.eventTriggerBehavior(),
+                bpmnBehaviors.stateBehavior()))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
@@ -59,7 +60,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
       final KeyGenerator keyGenerator,
       final Writers writers,
       final ProcessState processState,
-      final EventTriggerBehavior eventTriggerBehavior) {
+      final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior) {
     this.messageState = messageState;
     this.subscriptionState = subscriptionState;
     this.startEventSubscriptionState = startEventSubscriptionState;
@@ -68,7 +70,12 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     stateWriter = writers.state();
     eventHandle =
         new EventHandle(
-            keyGenerator, eventScopeInstanceState, writers, processState, eventTriggerBehavior);
+            keyGenerator,
+            eventScopeInstanceState,
+            writers,
+            processState,
+            eventTriggerBehavior,
+            stateBehavior);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -9,9 +9,8 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
-import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
@@ -59,8 +58,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
       final ProcessMessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableZeebeState zeebeState,
-      final EventTriggerBehavior eventTriggerBehavior,
-      final BpmnStateBehavior stateBehavior,
+      final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {
     this.subscriptionState = subscriptionState;
     this.subscriptionCommandSender = subscriptionCommandSender;
@@ -75,8 +73,8 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
             zeebeState.getEventScopeInstanceState(),
             writers,
             processState,
-            eventTriggerBehavior,
-            stateBehavior);
+            bpmnBehaviors.eventTriggerBehavior(),
+            bpmnBehaviors.stateBehavior());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -9,8 +9,9 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
@@ -58,7 +59,8 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
       final ProcessMessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableZeebeState zeebeState,
-      final BpmnBehaviors bpmnBehaviors,
+      final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final Writers writers) {
     this.subscriptionState = subscriptionState;
     this.subscriptionCommandSender = subscriptionCommandSender;
@@ -73,8 +75,8 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
             zeebeState.getEventScopeInstanceState(),
             writers,
             processState,
-            bpmnBehaviors.eventTriggerBehavior(),
-            bpmnBehaviors.stateBehavior());
+            eventTriggerBehavior,
+            stateBehavior);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
@@ -59,6 +60,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableZeebeState zeebeState,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final Writers writers) {
     this.subscriptionState = subscriptionState;
     this.subscriptionCommandSender = subscriptionCommandSender;
@@ -73,7 +75,8 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
             zeebeState.getEventScopeInstanceState(),
             writers,
             processState,
-            eventTriggerBehavior);
+            eventTriggerBehavior,
+            stateBehavior);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -81,7 +81,8 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
             zeebeState.getEventScopeInstanceState(),
             writers,
             processState,
-            eventTriggerBehavior);
+            bpmnBehaviors.eventTriggerBehavior(),
+            bpmnBehaviors.stateBehavior());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.timer;
 
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
@@ -63,6 +64,7 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
       final MutableZeebeState zeebeState,
       final CatchEventBehavior catchEventBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnStateBehavior stateBehavior,
       final ExpressionProcessor expressionProcessor,
       final Writers writers) {
     this.catchEventBehavior = catchEventBehavior;
@@ -81,8 +83,8 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
             zeebeState.getEventScopeInstanceState(),
             writers,
             processState,
-            bpmnBehaviors.eventTriggerBehavior(),
-            bpmnBehaviors.stateBehavior());
+            eventTriggerBehavior,
+            stateBehavior);
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
@@ -11,20 +11,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.EmbeddedSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.util.function.Consumer;
 import org.junit.ClassRule;
@@ -563,5 +571,124 @@ public final class EmbeddedSubProcessTest {
                 .withScopeKey(processInstanceKey))
         .extracting(var -> tuple(var.getIntent(), var.getValue().getValue()))
         .containsExactly(tuple(VariableIntent.CREATED, "1"), tuple(VariableIntent.UPDATED, "2"));
+  }
+
+  @Test
+  public void shouldNotTriggerBoundaryEventWhenFlowscopeIsInterrupted() {
+    // given
+    final Consumer<EmbeddedSubProcessBuilder> subProcessBuilder =
+        subprocess ->
+            subprocess
+                .startEvent()
+                .serviceTask("task", b -> b.zeebeJobType("task"))
+                .endEvent()
+                .moveToActivity("subProcess")
+                .boundaryEvent(
+                    "msgBoundary",
+                    boundary ->
+                        boundary
+                            .cancelActivity(true)
+                            .message(
+                                msg ->
+                                    msg.name("boundary")
+                                        .zeebeCorrelationKeyExpression("correlationKey")))
+                .endEvent()
+                .done();
+
+    final Consumer<EventSubProcessBuilder> eventSubProcessBuilder =
+        eventSubProcess ->
+            eventSubProcess
+                .startEvent("eventSubProcessStartEvent")
+                .message(
+                    m -> m.name("eventSubProcess").zeebeCorrelationKeyExpression("correlationKey"))
+                .endEvent();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess("eventSubProcess", eventSubProcessBuilder)
+                .startEvent()
+                .subProcess(
+                    "subProcess",
+                    subProcess -> subProcessBuilder.accept(subProcess.embeddedSubProcess()))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("correlationKey", "correlationKey")
+            .create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("task")
+        .await();
+
+    // when
+    // We need to make sure no records are written in between the publish commands. This could
+    // cause the test to become flaky.
+    ENGINE.writeRecords(
+        // First we publish a message to try and trigger the boundary event
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord()
+                    .setName("boundary")
+                    .setTimeToLive(0L)
+                    .setCorrelationKey("correlationKey")
+                    .setVariables(BufferUtil.wrapString(""))),
+        // Next we publish a message to trigger the event sub process. This will interrupt the
+        // flow scope of the sub process, whilst the subprocess is being terminated because of the
+        // boundary event
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord()
+                    .setName("eventSubProcess")
+                    .setTimeToLive(0L)
+                    .setCorrelationKey("correlationKey")
+                    .setVariables(BufferUtil.wrapString(""))));
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .filter(r -> r.getValueType() == ValueType.PROCESS_EVENT)
+                .withIntent(ProcessEventIntent.TRIGGERING))
+        .extracting(r -> ((ProcessEventRecordValue) r.getValue()).getTargetElementId())
+        .containsExactly("msgBoundary", "eventSubProcessStartEvent");
+
+    // No event should be TRIGGERED. We don't want to trigger the boundary event.
+    // The event sub process does not write a TRIGGERED event.
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .withIntent(ProcessEventIntent.TRIGGERED))
+        .isEmpty();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .onlyEvents()
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .contains(
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.util.StreamProcessorRule;
@@ -64,6 +65,7 @@ public final class MessageStreamProcessorTest {
           final var zeebeState = processingContext.getZeebeState();
           MessageEventProcessors.addMessageProcessors(
               mock(EventTriggerBehavior.class),
+              mock(BpmnStateBehavior.class),
               typedRecordProcessors,
               zeebeState,
               mockSubscriptionCommandSender,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -20,8 +20,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
-import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.util.StreamProcessorRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -64,8 +63,7 @@ public final class MessageStreamProcessorTest {
         (typedRecordProcessors, processingContext) -> {
           final var zeebeState = processingContext.getZeebeState();
           MessageEventProcessors.addMessageProcessors(
-              mock(EventTriggerBehavior.class),
-              mock(BpmnStateBehavior.class),
+              mock(BpmnBehaviors.class),
               typedRecordProcessors,
               zeebeState,
               mockSubscriptionCommandSender,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -20,7 +20,8 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.util.StreamProcessorRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -63,7 +64,8 @@ public final class MessageStreamProcessorTest {
         (typedRecordProcessors, processingContext) -> {
           final var zeebeState = processingContext.getZeebeState();
           MessageEventProcessors.addMessageProcessors(
-              mock(BpmnBehaviors.class),
+              mock(EventTriggerBehavior.class),
+              mock(BpmnStateBehavior.class),
               typedRecordProcessors,
               zeebeState,
               mockSubscriptionCommandSender,


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR could not be automatically back ported because of merge conflicts. They originate from a refactoring that we have done, where we pass around the `BpmnBehaviors` to processors. We don't have this refactoring on the 8.0 branch. Because of this I had to make a new `BpmnStateBehavior` object to pass around to the processors that need it to fix this bug.

Original PR: #11216 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
