### PR TITLE
feat(engine): support catch-all and code-specific escalation catch events

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
@@ -252,13 +252,6 @@ public class ModelUtil {
             .map(escalation -> Optional.ofNullable(escalation.getEscalationCode()))
             .collect(groupingBy(escalationCode -> escalationCode, counting()));
 
-    if (definitionWithoutEscalationCount >= 1 && !escalationCodeOccurrences.isEmpty()) {
-      errorCollector.accept(
-          "The same scope can not contain an escalation catch event without escalation code "
-              + "and another one with escalation code. An escalation catch event without "
-              + "escalation code catches all escalations.");
-    }
-
     escalationCodeOccurrences.forEach(
         (escalationCode, occurrences) -> {
           if (occurrences > 1) {

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEscalationValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEscalationValidationTest.java
@@ -143,30 +143,6 @@ class ZeebeEscalationValidationTest {
   }
 
   @Test
-  @DisplayName(
-      "The same scope can not contains an escalation boundary event without escalation code and another one with escalation code.")
-  void verifyMultipleEscalationBoundaryEventsWithAndWithOutEscalationCode() {
-    // given
-    final BpmnModelInstance process =
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .callActivity("call", c -> c.zeebeProcessId("child"))
-            .boundaryEvent("catch-1", b -> b.escalation().endEvent())
-            .moveToActivity("call")
-            .boundaryEvent("catch-2", b -> b.escalation("escalation").endEvent())
-            .moveToNode("call")
-            .endEvent()
-            .done();
-
-    // when/then
-    ProcessValidationUtil.assertThatProcessHasViolations(
-        process,
-        expect(
-            CallActivity.class,
-            "The same scope can not contain an escalation catch event without escalation code and another one with escalation code. An escalation catch event without escalation code catches all escalations."));
-  }
-
-  @Test
   @DisplayName("A sub-process with multiple escalation start event definitions are not allowed")
   void verifyMultipleEscalationEventSubprocessWithoutEscalationCode() {
     // given
@@ -194,36 +170,6 @@ class ZeebeEscalationValidationTest {
         expect(
             SubProcess.class,
             "The same scope can not contain more than one escalation catch event without escalation code. An escalation catch event without escalation code catches all escalations."));
-  }
-
-  @Test
-  @DisplayName("A sub-process with multiple escalation start event definitions are not allowed")
-  void verifyMultipleEscalationEventSubprocessWithAndWithoutEscalationCode() {
-    // given
-    final BpmnModelInstance process =
-        process(
-            sp -> {
-              sp.embeddedSubProcess()
-                  .eventSubProcess()
-                  .startEvent()
-                  .interrupting(false)
-                  .escalation()
-                  .endEvent();
-              sp.embeddedSubProcess()
-                  .eventSubProcess()
-                  .startEvent()
-                  .interrupting(false)
-                  .escalation("escalation")
-                  .endEvent();
-              sp.embeddedSubProcess().startEvent().endEvent();
-            });
-
-    // when/then
-    ProcessValidationUtil.assertThatProcessHasViolations(
-        process,
-        expect(
-            SubProcess.class,
-            "The same scope can not contain an escalation catch event without escalation code and another one with escalation code. An escalation catch event without escalation code catches all escalations."));
   }
 
   @Test


### PR DESCRIPTION
## Description
As a user, in a given scope, I can define:

* A single Escalation catch event with no escalation code defined (a catch-all Escalation event).
* Multiple Escalation catch events with a defined escalation code.

## Related issues
closes #11265

## Definition of Done
Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
