### PR TITLE
Backport 11169 to stable 8.0

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -175,8 +175,7 @@ public final class RequestMapper {
         return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value));
       } catch (final RuntimeException e) {
         final var cause = e.getCause();
-        if (cause instanceof JsonParseException) {
-          final var parseException = (JsonParseException) cause;
+        if (cause instanceof final JsonParseException parseException) {
 
           final var descriptiveException =
               new JsonParseException(
@@ -187,6 +186,9 @@ public final class RequestMapper {
 
           rethrowUnchecked(descriptiveException);
           return DocumentValue.EMPTY_DOCUMENT; // bogus return statement
+        } else if (cause instanceof IllegalArgumentException) {
+          rethrowUnchecked(cause);
+          return DocumentValue.EMPTY_DOCUMENT;
         } else {
           throw e;
         }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -76,6 +76,9 @@ public final class GrpcErrorMapper {
     } else if (error instanceof JsonParseException) {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
       logger.debug("Expected to handle gRPC request, but JSON property was invalid", rootError);
+    } else if (error instanceof IllegalArgumentException) {
+      builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
+      logger.debug("Expected to handle gRPC request, but JSON property was invalid 123", rootError);
     } else if (error instanceof PartitionNotFoundException) {
       builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
       logger.debug(

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -14,17 +14,29 @@ import org.junit.jupiter.api.Test;
 
 public class RequestMapperTest {
 
+  // missing closing quote in second variable
+  private static final String INVALID_VARIABLES =
+      "{ \"test\": \"value\", \"error\": \"errorrvalue }";
+
+  // BigInteger larger than 2^64-1
+  private static final String BIG_INTEGER =
+      "{\"mybigintistoolong\": 123456789012345678901234567890}";
+
   @Test
   public void shouldThrowHelpfulExceptionIfJsonIsInvalid() {
-    // given
-    final var invalidJson = "{ \"test\": \"value\", \"error\": \"errorrvalue }";
-    // closing quote missing in second value
-
     // when + then
-    assertThatThrownBy(() -> RequestMapper.ensureJsonSet(invalidJson))
+    assertThatThrownBy(() -> RequestMapper.ensureJsonSet(INVALID_VARIABLES))
         .isInstanceOf(JsonParseException.class)
-        .hasMessageContaining("Invalid JSON", invalidJson)
+        .hasMessageContaining("Invalid JSON", INVALID_VARIABLES)
         .getCause()
         .isInstanceOf(JsonParseException.class);
+  }
+
+  @Test
+  public void shouldThrowHelpfulExceptionIfJsonHasBigInteger() {
+    // when + then
+    assertThatThrownBy(() -> RequestMapper.ensureJsonSet(BIG_INTEGER))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("MessagePack cannot serialize BigInteger larger than 2^64-1");
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -143,4 +143,27 @@ final class GrpcErrorMapperTest {
       assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
     }
   }
+
+  @Test
+  void shouldLogIllegalArgumentExceptionOnDebugWithBigIntTooLong() {
+    // given
+    try {
+      MsgPackConverter.convertToMsgPack("{\"mybigintistoolong\":123456789012345678901234567890}");
+      fail("Expected to throw exception");
+    } catch (final RuntimeException runtimeException) {
+      assertThat(runtimeException.getCause()).isInstanceOf(IllegalArgumentException.class);
+      final IllegalArgumentException exception =
+          (IllegalArgumentException) runtimeException.getCause();
+
+      // when
+      log.setLevel(Level.DEBUG);
+      final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+      // then
+      assertThat(statusException.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+      assertThat(recorder.getAppendedEvents()).hasSize(1);
+      final LogEvent event = recorder.getAppendedEvents().get(0);
+      assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+    }
+  }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -77,7 +77,11 @@ public final class MsgPackConverter {
 
       return outputStream.toByteArray();
     } catch (final Exception e) {
-      throw new RuntimeException("Failed to convert JSON to MessagePack", e);
+      if (e instanceof IllegalArgumentException) {
+        throw new IllegalArgumentException("Failed to convert JSON to MessagePack", e);
+      } else {
+        throw new RuntimeException("Failed to convert JSON to MessagePack", e);
+      }
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
@@ -94,6 +94,21 @@ public final class CompleteJobTest {
   }
 
   @Test
+  public void shouldRejectIfVariableIsBigIntTooLong() {
+    // when
+    assertThatThrownBy(
+            () ->
+                CLIENT_RULE
+                    .getClient()
+                    .newCompleteCommand(jobKey)
+                    .variables("{\"mybigintistoolong\":123456789012345678901234567890}")
+                    .send()
+                    .join())
+        .isInstanceOf(ClientStatusException.class)
+        .hasMessageContaining("MessagePack cannot serialize BigInteger larger than 2^64-1");
+  }
+
+  @Test
   public void shouldRejectIfJobIsAlreadyCompleted() {
     // given
     CLIENT_RULE.getClient().newCompleteCommand(jobKey).send().join();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Manual backport of #11169 to stable 8.0 because of a merge conflicts in the `RequestMapperTest`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
