### PR TITLE
refactor: no intermediate batch serialization

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -45,6 +45,7 @@ import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.raft.zeebe.EntryValidator.ValidationResult;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
@@ -305,7 +306,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   }
 
   /** Commits the given configuration. */
-  protected CompletableFuture<Long> configure(final Collection<RaftMember> members) {
+  private CompletableFuture<Long> configure(final Collection<RaftMember> members) {
     raft.checkThread();
 
     final long term = raft.getTerm();
@@ -548,7 +549,8 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       final AppendListener appendListener) {
     raft.checkThread();
 
-    final ApplicationEntry entry = new ApplicationEntry(lowestPosition, highestPosition, data);
+    final ApplicationEntry entry =
+        new SerializedApplicationEntry(lowestPosition, highestPosition, data);
 
     if (!isRunning()) {
       appendListener.onWriteError(

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -535,6 +535,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   }
 
   @Override
+  public void appendEntry(final ApplicationEntry entry, final AppendListener appendListener) {
+    raft.getThreadContext().execute(() -> safeAppendEntry(entry, appendListener));
+  }
+
+  @Override
   public void appendEntry(
       final long lowestPosition,
       final long highestPosition,

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/ApplicationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/ApplicationEntry.java
@@ -1,44 +1,15 @@
 /*
- * Copyright © 2020 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.atomix.raft.storage.log.entry;
 
-import io.atomix.raft.storage.serializer.RaftEntrySerializer;
-import io.atomix.raft.storage.serializer.RaftEntrySerializer.SerializedBufferWriterAdapter;
-import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.nio.ByteBuffer;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
+public interface ApplicationEntry extends RaftEntry {
 
-/**
- * Stores an entry that contains serialized records, ordered by their position; the lowestPosition
- * and highestPosition metadata allow for fast binary search over a collection of entries to quickly
- * find a particular record.
- */
-public record ApplicationEntry(long lowestPosition, long highestPosition, DirectBuffer data)
-    implements RaftEntry {
+  long lowestPosition();
 
-  public ApplicationEntry(
-      final long lowestPosition, final long highestPosition, final ByteBuffer data) {
-    this(lowestPosition, highestPosition, new UnsafeBuffer(data));
-  }
-
-  @Override
-  public BufferWriter toSerializable(final long term, final RaftEntrySerializer serializer) {
-    return new SerializedBufferWriterAdapter(
-        () -> serializer.getApplicationEntrySerializedLength(this),
-        (buffer, offset) -> serializer.writeApplicationEntry(term, this, buffer, offset));
-  }
+  long highestPosition();
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/ApplicationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/ApplicationEntry.java
@@ -7,9 +7,13 @@
  */
 package io.atomix.raft.storage.log.entry;
 
+import io.camunda.zeebe.util.buffer.BufferWriter;
+
 public interface ApplicationEntry extends RaftEntry {
 
   long lowestPosition();
 
   long highestPosition();
+
+  BufferWriter dataWriter();
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/SerializedApplicationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/SerializedApplicationEntry.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.log.entry;
+
+import io.atomix.raft.storage.serializer.RaftEntrySerializer;
+import io.atomix.raft.storage.serializer.RaftEntrySerializer.SerializedBufferWriterAdapter;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.nio.ByteBuffer;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * Stores an entry that contains serialized records, ordered by their position; the lowestPosition
+ * and highestPosition metadata allow for fast binary search over a collection of entries to quickly
+ * find a particular record.
+ */
+public record SerializedApplicationEntry(
+    long lowestPosition, long highestPosition, DirectBuffer data) implements ApplicationEntry {
+
+  public SerializedApplicationEntry(
+      final long lowestPosition, final long highestPosition, final ByteBuffer data) {
+    this(lowestPosition, highestPosition, new UnsafeBuffer(data));
+  }
+
+  @Override
+  public BufferWriter toSerializable(final long term, final RaftEntrySerializer serializer) {
+    return new SerializedBufferWriterAdapter(
+        () -> serializer.getApplicationEntrySerializedLength(this),
+        (buffer, offset) -> serializer.writeApplicationEntry(term, this, buffer, offset));
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/SerializedApplicationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/SerializedApplicationEntry.java
@@ -18,6 +18,7 @@ package io.atomix.raft.storage.log.entry;
 import io.atomix.raft.storage.serializer.RaftEntrySerializer;
 import io.atomix.raft.storage.serializer.RaftEntrySerializer.SerializedBufferWriterAdapter;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.nio.ByteBuffer;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -40,5 +41,10 @@ public record SerializedApplicationEntry(
     return new SerializedBufferWriterAdapter(
         () -> serializer.getApplicationEntrySerializedLength(this),
         (buffer, offset) -> serializer.writeApplicationEntry(term, this, buffer, offset));
+  }
+
+  @Override
+  public BufferWriter dataWriter() {
+    return new DirectBufferWriter().wrap(data);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/UnserializedApplicationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/UnserializedApplicationEntry.java
@@ -16,17 +16,13 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
  * the log.
  */
 public record UnserializedApplicationEntry(
-    long lowestPosition, long highestPosition, BufferWriter writer) implements ApplicationEntry {
+    long lowestPosition, long highestPosition, BufferWriter dataWriter)
+    implements ApplicationEntry {
 
   @Override
   public BufferWriter toSerializable(final long term, final RaftEntrySerializer serializer) {
     return new SerializedBufferWriterAdapter(
         () -> serializer.getApplicationEntrySerializedLength(this),
         (buffer, offset) -> serializer.writeApplicationEntry(term, this, buffer, offset));
-  }
-
-  @Override
-  public BufferWriter dataWriter() {
-    return writer;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/UnserializedApplicationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/UnserializedApplicationEntry.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.storage.log.entry;
+
+import io.atomix.raft.storage.serializer.RaftEntrySerializer;
+import io.atomix.raft.storage.serializer.RaftEntrySerializer.SerializedBufferWriterAdapter;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+
+public record UnserializedApplicationEntry(
+    long lowestPosition, long highestPosition, BufferWriter writer) implements ApplicationEntry {
+
+  @Override
+  public BufferWriter toSerializable(final long term, final RaftEntrySerializer serializer) {
+    return new SerializedBufferWriterAdapter(
+        () -> serializer.getApplicationEntrySerializedLength(this),
+        (buffer, offset) -> serializer.writeApplicationEntry(term, this, buffer, offset));
+  }
+
+  @Override
+  public BufferWriter dataWriter() {
+    return writer;
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/UnserializedApplicationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/UnserializedApplicationEntry.java
@@ -11,6 +11,10 @@ import io.atomix.raft.storage.serializer.RaftEntrySerializer;
 import io.atomix.raft.storage.serializer.RaftEntrySerializer.SerializedBufferWriterAdapter;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 
+/**
+ * An {@link ApplicationEntry} with unserialized application data. Used for writing new entries to
+ * the log.
+ */
 public record UnserializedApplicationEntry(
     long lowestPosition, long highestPosition, BufferWriter writer) implements ApplicationEntry {
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializer.java
@@ -27,6 +27,7 @@ import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.atomix.raft.storage.serializer.ConfigurationEntryDecoder.RaftMemberDecoder;
 import io.camunda.zeebe.journal.file.RecordDataEncoder;
 import java.time.Instant;
@@ -46,7 +47,7 @@ public class RaftEntrySBESerializer implements RaftEntrySerializer {
   final ConfigurationEntryDecoder configurationEntryDecoder = new ConfigurationEntryDecoder();
 
   @Override
-  public int getApplicationEntrySerializedLength(final ApplicationEntry entry) {
+  public int getApplicationEntrySerializedLength(final SerializedApplicationEntry entry) {
     // raft frame length
     return headerEncoder.encodedLength()
         + raftLogEntryEncoder.sbeBlockLength()
@@ -83,7 +84,7 @@ public class RaftEntrySBESerializer implements RaftEntrySerializer {
   @Override
   public int writeApplicationEntry(
       final long term,
-      final ApplicationEntry entry,
+      final SerializedApplicationEntry entry,
       final MutableDirectBuffer buffer,
       final int offset) {
 
@@ -214,7 +215,7 @@ public class RaftEntrySBESerializer implements RaftEntrySerializer {
     final DirectBuffer data = new UnsafeBuffer();
     applicationEntryDecoder.wrapApplicationData(data);
 
-    return new ApplicationEntry(
+    return new SerializedApplicationEntry(
         applicationEntryDecoder.lowestAsqn(), applicationEntryDecoder.highestAsqn(), data);
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySerializer.java
@@ -15,10 +15,10 @@
  */
 package io.atomix.raft.storage.serializer;
 
-import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -33,7 +33,7 @@ public interface RaftEntrySerializer {
    * @param entry to determine the length in bytes for
    * @return the length in bytes when the entry gets serialized
    */
-  int getApplicationEntrySerializedLength(ApplicationEntry entry);
+  int getApplicationEntrySerializedLength(SerializedApplicationEntry entry);
 
   /**
    * Determines the length in bytes of a serialized initial entry.
@@ -60,7 +60,7 @@ public interface RaftEntrySerializer {
    * @return the number of bytes written
    */
   int writeApplicationEntry(
-      long term, ApplicationEntry entry, MutableDirectBuffer buffer, int offset);
+      long term, SerializedApplicationEntry entry, MutableDirectBuffer buffer, int offset);
 
   /**
    * Writes the term and entry into given buffer at the given offset

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySerializer.java
@@ -15,10 +15,10 @@
  */
 package io.atomix.raft.storage.serializer;
 
+import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
-import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -33,7 +33,7 @@ public interface RaftEntrySerializer {
    * @param entry to determine the length in bytes for
    * @return the length in bytes when the entry gets serialized
    */
-  int getApplicationEntrySerializedLength(SerializedApplicationEntry entry);
+  int getApplicationEntrySerializedLength(ApplicationEntry entry);
 
   /**
    * Determines the length in bytes of a serialized initial entry.
@@ -60,7 +60,7 @@ public interface RaftEntrySerializer {
    * @return the number of bytes written
    */
   int writeApplicationEntry(
-      long term, SerializedApplicationEntry entry, MutableDirectBuffer buffer, int offset);
+      long term, ApplicationEntry entry, MutableDirectBuffer buffer, int offset);
 
   /**
    * Writes the term and entry into given buffer at the given offset

--- a/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
@@ -16,6 +16,7 @@
 package io.atomix.raft.zeebe;
 
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.nio.ByteBuffer;
 
 /**
@@ -23,9 +24,7 @@ import java.nio.ByteBuffer;
  * automatically replicated and eventually committed, and the ability for callers to be notified of
  * various events, e.g. {@link AppendListener#onCommit(IndexedRaftLogEntry)}.
  */
-@FunctionalInterface
 public interface ZeebeLogAppender {
-
   /**
    * Appends an entry to the local Raft log and schedules replication to each follower.
    *
@@ -35,6 +34,16 @@ public interface ZeebeLogAppender {
    */
   void appendEntry(
       long lowestPosition, long highestPosition, ByteBuffer data, AppendListener appendListener);
+
+  /**
+   * Appends an entry to the local Raft log and schedules replication to each follower.
+   *
+   * @param lowestPosition lowest record position in the data buffer
+   * @param highestPosition highest record position in the data buffer
+   * @param data data to store in the entry
+   */
+  void appendEntry(
+      long lowestPosition, long highestPosition, BufferWriter data, AppendListener appendListener);
 
   /**
    * An append listener can observe and be notified of different events related to the append

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -36,6 +36,7 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
@@ -670,9 +671,9 @@ public final class RaftRule extends ExternalResource {
     private static CopiedRaftLogEntry of(final IndexedRaftLogEntry entry) {
       final RaftEntry copiedEntry;
 
-      if (entry.entry() instanceof ApplicationEntry app) {
+      if (entry.entry() instanceof SerializedApplicationEntry app) {
         copiedEntry =
-            new ApplicationEntry(
+            new SerializedApplicationEntry(
                 app.lowestPosition(), app.highestPosition(), BufferUtil.cloneBuffer(app.data()));
       } else {
         copiedEntry = entry.entry();

--- a/atomix/cluster/src/test/java/io/atomix/raft/SingleRaftEntryValidationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/SingleRaftEntryValidationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.EntryValidator.ValidationResult;
 import io.camunda.zeebe.test.util.TestUtil;
@@ -56,7 +57,7 @@ public class SingleRaftEntryValidationTest {
     raftRule.appendEntry();
 
     // then
-    assertThat(getEntryTypeCount(ApplicationEntry.class)).isOne();
+    assertThat(getEntryTypeCount(SerializedApplicationEntry.class)).isOne();
   }
 
   private int getEntryTypeCount(final Class type) {

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogCommittedReaderTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogCommittedReaderTest.java
@@ -17,8 +17,8 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -141,8 +141,8 @@ class RaftLogCommittedReaderTest {
 
   private void appendEntries(final int count) {
     for (int i = 0; i < count; i++) {
-      final ApplicationEntry applicationEntry = new ApplicationEntry(i + 1, i + 1, data);
-      final RaftLogEntry entry = new RaftLogEntry(1, applicationEntry);
+      final var applicationEntry = new SerializedApplicationEntry(i + 1, i + 1, data);
+      final var entry = new RaftLogEntry(1, applicationEntry);
       raftlog.append(entry);
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -28,6 +28,7 @@ import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.camunda.zeebe.journal.Journal;
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -114,7 +115,8 @@ class RaftLogTest {
     assertThat(entryRead.isApplicationEntry()).isTrue();
     assertThat(entryRead.getApplicationEntry().lowestPosition()).isEqualTo(1);
     assertThat(entryRead.getApplicationEntry().highestPosition()).isEqualTo(2);
-    assertThat(entryRead.getApplicationEntry().data()).isEqualTo(new UnsafeBuffer(data));
+    assertThat(((SerializedApplicationEntry) entryRead.getApplicationEntry()).data())
+        .isEqualTo(new UnsafeBuffer(data));
     assertThat(appended).isEqualTo(entryRead);
   }
 
@@ -246,7 +248,7 @@ class RaftLogTest {
 
   private ApplicationEntry createApplicationEntry(final long lowestPosition) {
     // -1 on highest position as the lowestPosition is inclusive
-    return new ApplicationEntry(
+    return new SerializedApplicationEntry(
         lowestPosition, lowestPosition + DEFAULT_APPLICATION_ENTRY_LENGTH - 1, data);
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -136,7 +137,7 @@ class RaftLogUncommittedReaderTest {
 
   private void appendEntries(final int count) {
     for (int i = 0; i < count; i++) {
-      final ApplicationEntry applicationEntry = new ApplicationEntry(i + 1, i + 1, data);
+      final ApplicationEntry applicationEntry = new SerializedApplicationEntry(i + 1, i + 1, data);
       final RaftLogEntry entry = new RaftLogEntry(1, applicationEntry);
       raftlog.append(entry);
     }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializerTest.java
@@ -25,6 +25,7 @@ import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import java.time.Instant;
 import java.util.Set;
 import org.agrona.ExpandableArrayBuffer;
@@ -41,7 +42,8 @@ public class RaftEntrySBESerializerTest {
   public void shouldCalculateActualApplicationEntrySize() {
     // given
     final byte[] data = "Test".getBytes();
-    final ApplicationEntry applicationEntry = new ApplicationEntry(1, 2, new UnsafeBuffer(data));
+    final SerializedApplicationEntry applicationEntry =
+        new SerializedApplicationEntry(1, 2, new UnsafeBuffer(data));
 
     // when
     final int writtenBytes = serializer.writeApplicationEntry(5, applicationEntry, buffer, 0);
@@ -55,8 +57,8 @@ public class RaftEntrySBESerializerTest {
   public void shouldWriteApplicationEntry() {
     // given
     final byte[] data = "Test".getBytes();
-    final ApplicationEntry applicationEntryWritten =
-        new ApplicationEntry(1, 2, new UnsafeBuffer(data));
+    final SerializedApplicationEntry applicationEntryWritten =
+        new SerializedApplicationEntry(1, 2, new UnsafeBuffer(data));
     final RaftLogEntry raftLogEntryExpected = new RaftLogEntry(5, applicationEntryWritten);
 
     // when
@@ -77,8 +79,8 @@ public class RaftEntrySBESerializerTest {
     // given
     final int offset = 10;
     final byte[] data = "Test".getBytes();
-    final ApplicationEntry applicationEntryWritten =
-        new ApplicationEntry(1, 2, new UnsafeBuffer(data));
+    final SerializedApplicationEntry applicationEntryWritten =
+        new SerializedApplicationEntry(1, 2, new UnsafeBuffer(data));
     final RaftLogEntry raftLogEntryExpected = new RaftLogEntry(5, applicationEntryWritten);
 
     // when

--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
@@ -11,7 +11,6 @@ import io.atomix.raft.RaftCommitListener;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -52,16 +51,6 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
       final AppendListener listener) {
     final var adapter = new AtomixAppendListenerAdapter(lowestPosition, highestPosition, listener);
     logAppender.appendEntry(lowestPosition, highestPosition, bufferWriter, adapter);
-  }
-
-  @Override
-  public void append(
-      final long lowestPosition,
-      final long highestPosition,
-      final ByteBuffer buffer,
-      final AppendListener listener) {
-    final var adapter = new AtomixAppendListenerAdapter(lowestPosition, highestPosition, listener);
-    logAppender.appendEntry(lowestPosition, highestPosition, buffer, adapter);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.logstreams;
 import io.atomix.raft.RaftCommitListener;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -41,6 +42,16 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
   @Override
   public AtomixLogStorageReader newReader() {
     return new AtomixLogStorageReader(readerFactory.create());
+  }
+
+  @Override
+  public void append(
+      final long lowestPosition,
+      final long highestPosition,
+      final BufferWriter bufferWriter,
+      final AppendListener listener) {
+    final var adapter = new AtomixAppendListenerAdapter(lowestPosition, highestPosition, listener);
+    logAppender.appendEntry(lowestPosition, highestPosition, bufferWriter, adapter);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReader.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.logstreams;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import java.util.NoSuchElementException;
 import org.agrona.DirectBuffer;
@@ -91,7 +92,9 @@ public final class AtomixLogStorageReader implements LogStorageReader {
     while (reader.hasNext()) {
       final IndexedRaftLogEntry entry = reader.next();
       if (entry.isApplicationEntry()) {
-        final ApplicationEntry nextEntry = entry.getApplicationEntry();
+        // application entries read from the log should always be `SerializedApplicationEntry`
+        final SerializedApplicationEntry nextEntry =
+            (SerializedApplicationEntry) entry.getApplicationEntry();
 
         nextBlockBuffer.wrap(nextEntry.data());
         return true;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransi
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.nio.ByteBuffer;
 
 public final class LogStoragePartitionTransitionStep implements PartitionTransitionStep {
@@ -141,6 +142,18 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
         final long lowestPosition,
         final long highestPosition,
         final ByteBuffer data,
+        final AppendListener appendListener) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Expect to append entry (positions %d - %d), but was in Follower role. Followers must not append entries to the log storage",
+              lowestPosition, highestPosition));
+    }
+
+    @Override
+    public void appendEntry(
+        final long lowestPosition,
+        final long highestPosition,
+        final BufferWriter data,
         final AppendListener appendListener) {
       throw new UnsupportedOperationException(
           String.format(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.Either.right;
 
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
@@ -20,8 +21,6 @@ import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransi
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.nio.ByteBuffer;
 
 public final class LogStoragePartitionTransitionStep implements PartitionTransitionStep {
   private static final String WRONG_TERM_ERROR_MSG =
@@ -137,28 +136,13 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
   }
 
   private static class LogAppenderForReadOnlyStorage implements ZeebeLogAppender {
-    @Override
-    public void appendEntry(
-        final long lowestPosition,
-        final long highestPosition,
-        final ByteBuffer data,
-        final AppendListener appendListener) {
-      throw new UnsupportedOperationException(
-          String.format(
-              "Expect to append entry (positions %d - %d), but was in Follower role. Followers must not append entries to the log storage",
-              lowestPosition, highestPosition));
-    }
 
     @Override
-    public void appendEntry(
-        final long lowestPosition,
-        final long highestPosition,
-        final BufferWriter data,
-        final AppendListener appendListener) {
+    public void appendEntry(final ApplicationEntry entry, final AppendListener appendListener) {
       throw new UnsupportedOperationException(
           String.format(
               "Expect to append entry (positions %d - %d), but was in Follower role. Followers must not append entries to the log storage",
-              lowestPosition, highestPosition));
+              entry.lowestPosition(), entry.highestPosition()));
     }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
@@ -15,6 +15,7 @@ import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.io.File;
 import java.nio.ByteBuffer;
 import org.agrona.CloseHelper;
@@ -177,6 +178,15 @@ final class AtomixLogStorageReaderTest {
       appendListener.onWrite(indexedEntry);
       log.setCommitIndex(indexedEntry.index());
       appendListener.onCommit(indexedEntry);
+    }
+
+    @Override
+    public void appendEntry(
+        final long lowestPosition,
+        final long highestPosition,
+        final BufferWriter data,
+        final AppendListener appendListener) {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
-import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
 import java.io.File;
@@ -32,7 +32,7 @@ final class AtomixLogStorageReaderTest {
   private AtomixLogStorageReader reader;
 
   @BeforeEach
-  void beforeEach(final @TempDir File tempDir) {
+  void beforeEach(@TempDir final File tempDir) {
     log = RaftLog.builder().withDirectory(tempDir).build();
     final Appender appender = new Appender();
     logStorage = new AtomixLogStorage(log::openUncommittedReader, appender);
@@ -171,7 +171,7 @@ final class AtomixLogStorageReaderTest {
         final long highestPosition,
         final ByteBuffer data,
         final AppendListener appendListener) {
-      final ApplicationEntry entry = new ApplicationEntry(lowestPosition, highestPosition, data);
+      final var entry = new SerializedApplicationEntry(lowestPosition, highestPosition, data);
       final IndexedRaftLogEntry indexedEntry = log.append(new RaftLogEntry(1, entry));
 
       appendListener.onWrite(indexedEntry);

--- a/broker/src/test/java/io/camunda/zeebe/broker/raft/ZeebeEntryValidatorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/raft/ZeebeEntryValidatorTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.broker.raft;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.atomix.raft.zeebe.EntryValidator.ValidationResult;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
@@ -23,8 +23,8 @@ final class ZeebeEntryValidatorTest {
   @Test
   void shouldRejectEntryWithGapInPosition() {
     // given
-    final var lastEntry = new ApplicationEntry(1, 1, new UnsafeBuffer());
-    final var entry = new ApplicationEntry(3, 3, new UnsafeBuffer());
+    final var lastEntry = new SerializedApplicationEntry(1, 1, new UnsafeBuffer());
+    final var entry = new SerializedApplicationEntry(3, 3, new UnsafeBuffer());
 
     // when
     final ValidationResult result = validator.validateEntry(lastEntry, entry);
@@ -36,8 +36,8 @@ final class ZeebeEntryValidatorTest {
   @Test
   void shouldAcceptEntryWithoutGapInPosition() {
     // given
-    final var lastEntry = new ApplicationEntry(1, 2, new UnsafeBuffer());
-    final var entry = new ApplicationEntry(3, 3, new UnsafeBuffer());
+    final var lastEntry = new SerializedApplicationEntry(1, 2, new UnsafeBuffer());
+    final var entry = new SerializedApplicationEntry(3, 3, new UnsafeBuffer());
 
     // when
     final ValidationResult result = validator.validateEntry(lastEntry, entry);
@@ -49,7 +49,7 @@ final class ZeebeEntryValidatorTest {
   @Test
   void shouldAcceptEntryWhenNoLastKnownEntry() {
     // given
-    final var entry = new ApplicationEntry(3, 3, new UnsafeBuffer());
+    final var entry = new SerializedApplicationEntry(3, 3, new UnsafeBuffer());
 
     // when
     final ValidationResult result = validator.validateEntry(null, entry);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
@@ -71,7 +71,7 @@ public final class AsyncSnapshottingTest {
             l ->
                 Optional.of(
                     new TestIndexedRaftLogEntry(
-                        l + 100, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
+                        l + 100, 1, new SerializedApplicationEntry(1, 10, new UnsafeBuffer()))),
             db -> Long.MAX_VALUE,
             new TestConcurrencyControl());
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
@@ -11,6 +11,7 @@ import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 
 public class TestIndexedRaftLogEntry implements IndexedRaftLogEntry {
 
@@ -41,7 +42,7 @@ public class TestIndexedRaftLogEntry implements IndexedRaftLogEntry {
 
   @Override
   public boolean isApplicationEntry() {
-    return entry instanceof ApplicationEntry;
+    return entry instanceof SerializedApplicationEntry;
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.camunda.zeebe.broker.system.partitions.AtomixRecordEntrySupplier;
 import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.TestIndexedRaftLogEntry;
@@ -52,7 +52,8 @@ public final class StateControllerImplTest {
   private final AtomixRecordEntrySupplier indexedRaftLogEntry =
       l ->
           Optional.of(
-              new TestIndexedRaftLogEntry(l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer())));
+              new TestIndexedRaftLogEntry(
+                  l, 1, new SerializedApplicationEntry(1, 10, new UnsafeBuffer())));
   private final AtomixRecordEntrySupplier emptyEntrySupplier = l -> Optional.empty();
   private final AtomicReference<AtomixRecordEntrySupplier> atomixRecordEntrySupplier =
       new AtomicReference<>(indexedRaftLogEntry);

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -243,7 +243,8 @@ public final class StreamProcessorRule implements TestRule {
       }
 
       streamProcessingComposite =
-          new StreamProcessingComposite(streams, startPartitionId, zeebeDbFactory);
+          new StreamProcessingComposite(
+              streams, startPartitionId, zeebeDbFactory, actorSchedulerRule.get());
     }
 
     @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.AppendErrorHandler;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.AppenderFlowControl;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.InFlightAppend;
-import io.camunda.zeebe.logstreams.impl.serializer.SequencedBatchSerializer;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -126,9 +125,8 @@ final class LogStorageAppender extends Actor implements HealthMonitorable, Appen
     final var lowestPosition = sequencedBatch.firstPosition();
     final var highestPosition =
         sequencedBatch.firstPosition() + sequencedBatch.entries().size() - 1;
-    final var serialized = SequencedBatchSerializer.serializeBatch(sequencedBatch);
     append.start(highestPosition);
-    logStorage.append(lowestPosition, highestPosition, serialized, append);
+    logStorage.append(lowestPosition, highestPosition, sequencedBatch, append);
     actor.submit(this::tryWriteBatch);
   }
 

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -30,7 +30,6 @@ final class LogStorageAppender extends Actor implements HealthMonitorable, Appen
   private final String name;
   private final AppenderFlowControl flowControl;
   private final Sequencer sequencer;
-  private final SequencedBatchSerializer serializer = new SequencedBatchSerializer();
   private final LogStorage logStorage;
   private final Set<FailureListener> failureListeners = new HashSet<>();
   private final ActorFuture<Void> closeFuture;
@@ -127,7 +126,7 @@ final class LogStorageAppender extends Actor implements HealthMonitorable, Appen
     final var lowestPosition = sequencedBatch.firstPosition();
     final var highestPosition =
         sequencedBatch.firstPosition() + sequencedBatch.entries().size() - 1;
-    final var serialized = serializer.serializeBatch(sequencedBatch);
+    final var serialized = SequencedBatchSerializer.serializeBatch(sequencedBatch);
     append.start(highestPosition);
     logStorage.append(lowestPosition, highestPosition, serialized, append);
     actor.submit(this::tryWriteBatch);

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
@@ -13,7 +13,8 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.List;
 import org.agrona.MutableDirectBuffer;
 
-public record SequencedBatch(long firstPosition, long sourcePosition, List<LogAppendEntry> entries)
+public record SequencedBatch(
+    long timestamp, long firstPosition, long sourcePosition, List<LogAppendEntry> entries)
     implements BufferWriter {
 
   @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
@@ -7,8 +7,22 @@
  */
 package io.camunda.zeebe.logstreams.impl.log;
 
+import io.camunda.zeebe.logstreams.impl.serializer.SequencedBatchSerializer;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.List;
+import org.agrona.MutableDirectBuffer;
 
-public record SequencedBatch(
-    long firstPosition, long sourcePosition, List<LogAppendEntry> entries) {}
+public record SequencedBatch(long firstPosition, long sourcePosition, List<LogAppendEntry> entries)
+    implements BufferWriter {
+
+  @Override
+  public int getLength() {
+    return SequencedBatchSerializer.calculateBatchSize(this);
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    SequencedBatchSerializer.serializeBatch(buffer, offset, this);
+  }
+}

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.scheduler.ActorCondition;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Queue;
@@ -85,7 +86,10 @@ final class Sequencer implements LogStreamWriter, Closeable {
     lock.lock();
     try {
       currentPosition = position;
-      isEnqueued = queue.offer(new SequencedBatch(currentPosition, sourcePosition, appendEntries));
+      isEnqueued =
+          queue.offer(
+              new SequencedBatch(
+                  ActorClock.currentTimeMillis(), currentPosition, sourcePosition, appendEntries));
       if (isEnqueued) {
         position = currentPosition + batchSize;
       }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
@@ -36,7 +36,7 @@ final class LogAppendEntrySerializer {
    * @return the length of the serialized entry, with dispatcher framing but not aligned
    * @throws IllegalArgumentException if the entry's value is empty, i.e. has a length of 0
    */
-  int serialize(
+  static int serialize(
       final MutableDirectBuffer writeBuffer,
       final int writeBufferOffset,
       final LogAppendEntry entry,
@@ -99,7 +99,7 @@ final class LogAppendEntrySerializer {
     return framedEntryLength;
   }
 
-  int framedLength(final LogAppendEntry entry) {
+  static int framedLength(final LogAppendEntry entry) {
     return DataFrameDescriptor.framedLength(
         LogEntryDescriptor.headerLength(entry.recordMetadata().getLength())
             + entry.recordValue().getLength());

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/SequencedBatchSerializer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/SequencedBatchSerializer.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.logstreams.impl.serializer;
 import io.camunda.zeebe.logstreams.impl.log.SequencedBatch;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.Protocol;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import org.agrona.MutableDirectBuffer;
@@ -43,7 +42,7 @@ public final class SequencedBatchSerializer {
               entry,
               batch.firstPosition() + i,
               getSourcePosition(batch, i, entry),
-              ActorClock.currentTimeMillis());
+              batch.timestamp());
       currentOffset += DataFrameDescriptor.alignedLength(framedLength);
     }
   }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.logstreams.storage;
 
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.nio.ByteBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * Storage abstraction for the log stream API. The storage is expected to store the given blocks of
@@ -64,8 +66,17 @@ public interface LogStorage {
    * @param highestPosition the highest record position of all records in the block buffer
    * @param blockBuffer the buffer containing a block of log entries to be written into storage
    */
-  void append(
-      long lowestPosition, long highestPosition, ByteBuffer blockBuffer, AppendListener listener);
+  default void append(
+      final long lowestPosition,
+      final long highestPosition,
+      final ByteBuffer blockBuffer,
+      final AppendListener listener) {
+    append(
+        lowestPosition,
+        highestPosition,
+        new DirectBufferWriter().wrap(new UnsafeBuffer(blockBuffer)),
+        listener);
+  }
 
   /**
    * Register a commit listener

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.logstreams.storage;
 
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.nio.ByteBuffer;
 
 /**
@@ -28,6 +29,26 @@ public interface LogStorage {
    * @return a new stateful storage reader
    */
   LogStorageReader newReader();
+
+  /**
+   * Writes a block containing one or multiple log entries in the storage and returns the address at
+   * which the block has been written.
+   *
+   * <p>Storage implementations must guarantee eventually atomicity. When this method completes,
+   * either all the bytes must be written or none at all.
+   *
+   * <p>The caller of this method must guarantee that the provided block contains unfragmented log
+   * entries.
+   *
+   * @param lowestPosition the lowest record position of all records in the block buffer
+   * @param highestPosition the highest record position of all records in the block buffer
+   * @param bufferWriter the buffer containing a block of log entries to be written into storage
+   */
+  void append(
+      long lowestPosition,
+      long highestPosition,
+      BufferWriter bufferWriter,
+      AppendListener listener);
 
   /**
    * Writes a block containing one or multiple log entries in the storage and returns the address at

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.health.HealthStatus;
-import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.BiConsumer;
 import org.junit.After;
@@ -112,15 +111,6 @@ public final class LogStorageAppenderHealthTest {
     @Override
     public LogStorageReader newReader() {
       return null;
-    }
-
-    @Override
-    public void append(
-        final long lowestPosition,
-        final long highestPosition,
-        final ByteBuffer blockBuffer,
-        final AppendListener listener) {
-      actor.run(() -> onAppend.accept(highestPosition, listener));
     }
 
     @Override

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import io.camunda.zeebe.logstreams.util.TestEntry;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
@@ -118,6 +119,15 @@ public final class LogStorageAppenderHealthTest {
         final long lowestPosition,
         final long highestPosition,
         final ByteBuffer blockBuffer,
+        final AppendListener listener) {
+      actor.run(() -> onAppend.accept(highestPosition, listener));
+    }
+
+    @Override
+    public void append(
+        final long lowestPosition,
+        final long highestPosition,
+        final BufferWriter blockBuffer,
         final AppendListener listener) {
       actor.run(() -> onAppend.accept(highestPosition, listener));
     }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/SequencedBatchSerializerTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/SequencedBatchSerializerTest.java
@@ -22,10 +22,10 @@ final class SequencedBatchSerializerTest {
   void serializedBatchIsReadableAsLoggedEvents() {
     // given
     final var entries = List.of(TestEntry.ofKey(1), TestEntry.ofKey(2));
-    final var batch = new SequencedBatch(1, -1, entries);
+    final var batch = new SequencedBatch(0, 1, -1, entries);
 
     // when
-    final var serialized = serializer.serializeBatch(batch);
+    final var serialized = SequencedBatchSerializer.serializeBatch(batch);
 
     // then
     final var firstEvent = new LoggedEventImpl();

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/SequencedBatchSerializerTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/SequencedBatchSerializerTest.java
@@ -21,7 +21,6 @@ final class SequencedBatchSerializerTest {
   @Test
   void serializedBatchIsReadableAsLoggedEvents() {
     // given
-    final var serializer = new SequencedBatchSerializer();
     final var entries = List.of(TestEntry.ofKey(1), TestEntry.ofKey(2));
     final var batch = new SequencedBatch(1, -1, entries);
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.logstreams.util;
 
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.List;
@@ -65,6 +66,17 @@ public class ListLogStorage implements LogStorage {
     } catch (final Exception e) {
       listener.onWriteError(e);
     }
+  }
+
+  @Override
+  public void append(
+      final long lowestPosition,
+      final long highestPosition,
+      final BufferWriter bufferWriter,
+      final AppendListener listener) {
+    final var buffer = ByteBuffer.allocate(bufferWriter.getLength());
+    bufferWriter.write(new UnsafeBuffer(buffer), 0);
+    append(lowestPosition, highestPosition, buffer, listener);
   }
 
   @Override

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -89,17 +89,7 @@ public class ListLogStorage implements LogStorage {
     commitListeners.remove(listener);
   }
 
-  private static final class Entry {
-    private final ByteBuffer data;
-
-    public Entry(final ByteBuffer data) {
-      this.data = data;
-    }
-
-    public ByteBuffer getData() {
-      return data;
-    }
-  }
+  private record Entry(ByteBuffer data) {}
 
   private class ListLogStorageReader implements LogStorageReader {
     int currentIndex;


### PR DESCRIPTION
Previously, record batches were serialized before handing them off to raft and the journal. This wasn't really necessary and it is better to serialize directly to the mapped byte buffer from the journal segment to prevent another copy of the record batch data on the heap.

The log storage now supports appending entries that carry a `BufferWriter` instead of `ByteBuffer`. On raft's side, `ApplicationEntry` is no longer exposing the buffer, only positions are available for entry validation. This allows for two `ApplicationEntry` implementations, one carrying `ByteBuffer` that is used while reading from the log and one holding `BufferWriter` used when writing to the log.

closes #11264

