### PR TITLE
Always activate the correct start event upon a create command

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
 import io.camunda.zeebe.model.bpmn.instance.ManualTask;
 import io.camunda.zeebe.model.bpmn.instance.ParallelGateway;
+import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.ReceiveTask;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
 import io.camunda.zeebe.model.bpmn.instance.SendTask;
@@ -436,6 +437,15 @@ public abstract class AbstractFlowNodeBuilder<
       return (T) ((Activity) instance).builder();
     } else {
       throw new BpmnModelException("Activity not found for id " + identifier);
+    }
+  }
+
+  public <T extends ProcessBuilder> T moveToProcess(final String identifier) {
+    final ModelElementInstance instance = modelInstance.getModelElementById(identifier);
+    if (instance instanceof Process) {
+      return (T) ((Process) instance).builder();
+    } else {
+      throw new BpmnModelException("Process not found for id " + identifier);
     }
   }
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -89,11 +89,20 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
   protected void setCoordinates(final BpmnShape targetBpmnShape) {
     final Bounds bounds = targetBpmnShape.getBounds();
     bounds.setX(100);
-    bounds.setY(100);
+    bounds.setY(100 + getLowestHeight());
   }
 
   protected void setEventCoordinates(final BpmnShape targetBpmnShape) {
     final Bounds targetBounds = targetBpmnShape.getBounds();
+    final double yCoord = getLowestHeight() + 50.0;
+    final double xCoord = 100.0;
+
+    // move target
+    targetBounds.setY(yCoord);
+    targetBounds.setX(xCoord);
+  }
+
+  private double getLowestHeight() {
     double lowestheight = 0;
 
     // find the lowest element in the model
@@ -105,12 +114,6 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
         lowestheight = bottom;
       }
     }
-
-    final double ycoord = lowestheight + 50.0;
-    final double xcoord = 100.0;
-
-    // move target
-    targetBounds.setY(ycoord);
-    targetBounds.setX(xcoord);
+    return lowestheight;
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -89,7 +89,9 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
   protected void setCoordinates(final BpmnShape targetBpmnShape) {
     final Bounds bounds = targetBpmnShape.getBounds();
     bounds.setX(100);
-    bounds.setY(100 + getLowestHeight());
+    // Y coordinate is 36 lower than X. This is because the start event will have a height of 36.
+    // This shape is already added to the model, so the getLowestHeight will add these 36 pixels.
+    bounds.setY(64 + getLowestHeight());
   }
 
   protected void setEventCoordinates(final BpmnShape targetBpmnShape) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -97,6 +97,10 @@ public final class ProcessProcessor
     if (element.hasMessageStartEvent() || element.hasTimerStartEvent()) {
       eventSubscriptionBehavior
           .getEventTriggerForProcessDefinition(activated.getProcessDefinitionKey())
+          .filter(
+              eventTrigger ->
+                  eventTrigger.getProcessInstanceKey() == activated.getProcessInstanceKey()
+                      || eventTrigger.getProcessInstanceKey() == -1L)
           .ifPresentOrElse(
               eventTrigger ->
                   eventSubscriptionBehavior.activateTriggeredStartEvent(activated, eventTrigger),

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringApplier.java
@@ -42,11 +42,14 @@ final class ProcessEventTriggeringApplier
 
     final var targetElementIdBuffer = value.getTargetElementIdBuffer();
     final var scopeKey = value.getScopeKey();
+    final var processInstanceKey = value.getProcessInstanceKey();
 
     if (value.getProcessDefinitionKey() == scopeKey) {
-      eventScopeState.triggerStartEvent(scopeKey, key, targetElementIdBuffer, variables);
+      eventScopeState.triggerStartEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
     } else {
-      eventScopeState.triggerEvent(scopeKey, key, targetElementIdBuffer, variables);
+      eventScopeState.triggerEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
     }
     eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
         scopeKey, value.getProcessDefinitionKey(), targetElementIdBuffer);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -105,7 +105,8 @@ final class ProcessInstanceElementActivatingApplier
           newEventScopeKey,
           eventTrigger.getEventKey(),
           eventTrigger.getElementId(),
-          eventTrigger.getVariables());
+          eventTrigger.getVariables(),
+          eventTrigger.getProcessInstanceKey());
       eventScopeInstanceState.deleteTrigger(oldEventScopeKey, eventTrigger.getEventKey());
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
@@ -92,7 +92,11 @@ final class ProcessInstanceElementCompletedApplier
         || callActivity.isPropagateAllChildVariablesEnabled()) {
       final var variables = variableState.getVariablesAsDocument(key);
       eventScopeInstanceState.triggerEvent(
-          parentElementInstanceKey, parentElementInstanceKey, elementId, variables);
+          parentElementInstanceKey,
+          parentElementInstanceKey,
+          elementId,
+          variables,
+          parentElementInstance.getValue().getProcessInstanceKey());
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -101,7 +101,8 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
       final long eventScopeKey,
       final long eventKey,
       final DirectBuffer elementId,
-      final DirectBuffer variables) {
+      final DirectBuffer variables,
+      final long processInstanceKey) {
     this.eventScopeKey.wrapLong(eventScopeKey);
     final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
 
@@ -118,7 +119,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
       }
       eventScopeInstanceColumnFamily.update(this.eventScopeKey, instance);
 
-      createTrigger(eventScopeKey, eventKey, elementId, variables);
+      createTrigger(eventScopeKey, eventKey, elementId, variables, processInstanceKey);
     }
   }
 
@@ -127,8 +128,9 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
       final long processDefinitionKey,
       final long eventKey,
       final DirectBuffer elementId,
-      final DirectBuffer variables) {
-    createTrigger(processDefinitionKey, eventKey, elementId, variables);
+      final DirectBuffer variables,
+      final long processInstanceKey) {
+    createTrigger(processDefinitionKey, eventKey, elementId, variables, processInstanceKey);
   }
 
   @Override
@@ -183,11 +185,16 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
       final long eventScopeKey,
       final long eventKey,
       final DirectBuffer elementId,
-      final DirectBuffer variables) {
+      final DirectBuffer variables,
+      final long processInstanceKey) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
     eventTriggerEventKey.wrapLong(eventKey);
 
-    eventTrigger.setElementId(elementId).setVariables(variables).setEventKey(eventKey);
+    eventTrigger
+        .setElementId(elementId)
+        .setVariables(variables)
+        .setEventKey(eventKey)
+        .setProcessInstanceKey(processInstanceKey);
 
     eventTriggerColumnFamily.insert(eventTriggerKey, eventTrigger);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventTrigger.java
@@ -23,9 +23,13 @@ public final class EventTrigger extends UnpackedObject implements DbValue {
   private final StringProperty elementIdProp = new StringProperty("elementId");
   private final BinaryProperty variablesProp = new BinaryProperty("variables");
   private final LongProperty eventKeyProp = new LongProperty("eventKey");
+  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
 
   public EventTrigger() {
-    declareProperty(elementIdProp).declareProperty(variablesProp).declareProperty(eventKeyProp);
+    declareProperty(elementIdProp)
+        .declareProperty(variablesProp)
+        .declareProperty(eventKeyProp)
+        .declareProperty(processInstanceKeyProp);
   }
 
   // Copies over the previous event
@@ -62,6 +66,15 @@ public final class EventTrigger extends UnpackedObject implements DbValue {
 
   public EventTrigger setEventKey(final long eventKey) {
     eventKeyProp.setValue(eventKey);
+    return this;
+  }
+
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public EventTrigger setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
     return this;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -186,7 +186,11 @@ public class DbMigrationState implements MutableMigrationState {
             // trigger with the passed parameters without doing any checks beforehand. This is
             // sufficient for this migration.
             eventScopeInstanceState.triggerStartEvent(
-                flowScopeKey, eventKey, elementIdBuffer, value.get());
+                flowScopeKey,
+                eventKey,
+                elementIdBuffer,
+                value.get(),
+                elementInstance.getValue().getProcessInstanceKey());
             while (eventScopeInstanceState.pollEventTrigger(key.getValue()) != null) {
               // We don't need to do anything because we want to delete the event trigger, which is
               // what the pollEventTrigger does
@@ -196,7 +200,7 @@ public class DbMigrationState implements MutableMigrationState {
             // trigger with the passed parameters without doing any checks beforehand. This is
             // sufficient for this migration.
             eventScopeInstanceState.triggerStartEvent(
-                key.getValue(), eventKey, elementIdBuffer, value.get());
+                key.getValue(), eventKey, elementIdBuffer, value.get(), -1L);
           }
 
           temporaryVariableColumnFamily.deleteExisting(key);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
@@ -56,9 +56,14 @@ public interface MutableEventScopeInstanceState extends EventScopeInstanceState 
    * @param eventKey the key of the event record (used for ordering)
    * @param elementId the id of the element which should be triggered, e.g. boundary event
    * @param variables the variables of the occurred event, i.e. message variables
+   * @param processInstanceKey the key of the process instance this event is a part of
    */
   void triggerEvent(
-      long eventScopeKey, long eventKey, DirectBuffer elementId, DirectBuffer variables);
+      long eventScopeKey,
+      long eventKey,
+      DirectBuffer elementId,
+      DirectBuffer variables,
+      long processInstanceKey);
 
   /**
    * Creates an event trigger for a process start event. Uses the process definition key as the
@@ -69,9 +74,14 @@ public interface MutableEventScopeInstanceState extends EventScopeInstanceState 
    * @param eventKey the key of the event record (used for ordering)
    * @param elementId the id of the start event which should be triggered
    * @param variables the variables of the occurred event, i.e. message variables
+   * @param processInstanceKey the key of the process instance this event is a part of
    */
   void triggerStartEvent(
-      long processDefinitionKey, long eventKey, DirectBuffer elementId, DirectBuffer variables);
+      long processDefinitionKey,
+      long eventKey,
+      DirectBuffer elementId,
+      DirectBuffer variables,
+      long processInstanceKey);
 
   /**
    * Deletes an event trigger by key and scope key. Does not fail if the trigger does not exist.

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -11,13 +11,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Map;
@@ -32,6 +38,8 @@ public final class CreateProcessInstanceTest {
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
   @Test
   public void shouldActivateProcess() {
@@ -221,5 +229,90 @@ public final class CreateProcessInstanceTest {
             tuple(BpmnElementType.TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  // Regression test for https://github.com/camunda/zeebe/issues/10536
+  @Test
+  public void shouldActivateNoneStartEventWhenEventTriggerIsAvailableInState() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent("noneStart")
+            .endEvent()
+            .moveToProcess(processId)
+            .startEvent("msgStart")
+            .message("msg")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstanceCreation(
+                ProcessInstanceCreationIntent.CREATE,
+                new ProcessInstanceCreationRecord().setBpmnProcessId(processId).setVersion(1)),
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord().setName("msg").setCorrelationKey("").setTimeToLive(0)));
+
+    final var processInstanceKey =
+        RecordingExporter.processInstanceCreationRecords()
+            .withBpmnProcessId(processId)
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            r -> r.getValue().getElementId(),
+            Record::getIntent)
+        .containsSequence(
+            tuple(BpmnElementType.PROCESS, processId, ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(BpmnElementType.PROCESS, processId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, processId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, "noneStart", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(
+                BpmnElementType.START_EVENT, "noneStart", ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(
+                BpmnElementType.START_EVENT, "noneStart", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .doesNotContain(
+            tuple(BpmnElementType.START_EVENT, "msgStart", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(
+                BpmnElementType.START_EVENT, "msgStart", ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(
+                BpmnElementType.START_EVENT, "msgStart", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withBpmnProcessId(processId)
+                .filter(r -> r.getValue().getProcessInstanceKey() != processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            r -> r.getValue().getElementId(),
+            Record::getIntent)
+        .containsSequence(
+            tuple(BpmnElementType.PROCESS, processId, ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(BpmnElementType.PROCESS, processId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, processId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.START_EVENT, "msgStart", ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.START_EVENT, "msgStart", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .doesNotContain(
+            tuple(BpmnElementType.START_EVENT, "noneStart", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(
+                BpmnElementType.START_EVENT, "noneStart", ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(
+                BpmnElementType.START_EVENT, "noneStart", ProcessInstanceIntent.ELEMENT_ACTIVATED));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
@@ -460,6 +460,20 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
+  void shouldStoreProcessInstanceKeyInEventTrigger() {
+    // given
+    final EventTrigger eventTrigger = createEventTrigger();
+    final long processInstanceKey = 12345L;
+    triggerStartEvent(SCOPE_KEY, 1, eventTrigger, processInstanceKey);
+
+    // when
+    final EventTrigger stateEventTrigger = state.peekEventTrigger(SCOPE_KEY);
+
+    // then
+    assertThat(stateEventTrigger.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
   void shouldDeleteTrigger() {
     // given
     final long eventKey = 456;

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
@@ -139,7 +139,7 @@ public final class EventScopeInstanceStateTest {
     assertThat(canInterruptScope).isTrue();
 
     final var eventTrigger = createEventTrigger(bufferAsString(interruptingElementId), "");
-    triggerEvent(SCOPE_KEY, 123, eventTrigger);
+    triggerEvent(SCOPE_KEY, 123, eventTrigger, -1L);
 
     // when
     final var canTriggerEventAgain = state.canTriggerEvent(SCOPE_KEY, interruptingElementId);
@@ -166,7 +166,7 @@ public final class EventScopeInstanceStateTest {
     assertThat(canInterruptScope).isTrue();
 
     final var eventTrigger = createEventTrigger(bufferAsString(interruptingElementId), "");
-    triggerEvent(SCOPE_KEY, 123, eventTrigger);
+    triggerEvent(SCOPE_KEY, 123, eventTrigger, -1L);
 
     // when
     final var canTriggerInterruptingBoundaryEvent =
@@ -196,7 +196,7 @@ public final class EventScopeInstanceStateTest {
 
     final var eventTrigger =
         createEventTrigger(bufferAsString(nonInterruptingBoundaryElementId), "");
-    triggerEvent(SCOPE_KEY, 123, eventTrigger);
+    triggerEvent(SCOPE_KEY, 123, eventTrigger, -1L);
 
     // when
     final var canTriggerInterruptingBoundaryEvent =
@@ -230,7 +230,7 @@ public final class EventScopeInstanceStateTest {
     assertThat(canTriggerBoundaryEvent).isTrue();
 
     final var eventTrigger = createEventTrigger(bufferAsString(interruptingBoundaryElementId), "");
-    triggerEvent(SCOPE_KEY, 123, eventTrigger);
+    triggerEvent(SCOPE_KEY, 123, eventTrigger, -1L);
 
     // when
     final var canTriggerInterruptingBoundaryEventAgain =
@@ -258,7 +258,7 @@ public final class EventScopeInstanceStateTest {
     state.createInstance(SCOPE_KEY, interruptingElementIds, NO_BOUNDARY_ELEMENT_IDS);
 
     // when
-    triggerEvent(SCOPE_KEY, eventKey, eventTrigger);
+    triggerEvent(SCOPE_KEY, eventKey, eventTrigger, -1L);
 
     // then
     assertThat(state.pollEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger);
@@ -281,8 +281,8 @@ public final class EventScopeInstanceStateTest {
     state.createInstance(SCOPE_KEY, interruptingElementIds, NO_BOUNDARY_ELEMENT_IDS);
 
     // when
-    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1);
-    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2);
+    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1, -1L);
+    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2, -1L);
 
     // then
     assertThat(state.pollEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger1);
@@ -304,8 +304,8 @@ public final class EventScopeInstanceStateTest {
     state.createInstance(SCOPE_KEY, NO_INTERRUPTING_ELEMENT_IDS, NO_BOUNDARY_ELEMENT_IDS);
 
     // when
-    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1);
-    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2);
+    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1, -1L);
+    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2, -1L);
 
     // then
     assertThat(state.pollEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger1);
@@ -330,8 +330,8 @@ public final class EventScopeInstanceStateTest {
     state.createInstance(SCOPE_KEY, interruptingIds, boundaryElementIds);
 
     // when
-    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1);
-    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2);
+    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1, -1L);
+    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2, -1L);
 
     // then
     assertThat(state.pollEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger1);
@@ -356,8 +356,8 @@ public final class EventScopeInstanceStateTest {
     state.createInstance(SCOPE_KEY, interruptingIds, boundaryElementIds);
 
     // when
-    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1);
-    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2);
+    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1, -1L);
+    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2, -1L);
 
     // then
     assertThat(state.pollEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger1);
@@ -385,9 +385,9 @@ public final class EventScopeInstanceStateTest {
     state.createInstance(SCOPE_KEY, interruptingIds, boundaryElementIds);
 
     // when
-    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1);
-    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2);
-    triggerEvent(SCOPE_KEY, eventKey3, eventTrigger3);
+    triggerEvent(SCOPE_KEY, eventKey1, eventTrigger1, -1L);
+    triggerEvent(SCOPE_KEY, eventKey2, eventTrigger2, -1L);
+    triggerEvent(SCOPE_KEY, eventKey3, eventTrigger3, -1L);
 
     // then
     assertThat(state.pollEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger1);
@@ -404,7 +404,7 @@ public final class EventScopeInstanceStateTest {
     final EventTrigger eventTrigger = createEventTrigger();
 
     // when
-    triggerStartEvent(SCOPE_KEY, 456, eventTrigger);
+    triggerStartEvent(SCOPE_KEY, 456, eventTrigger, -1L);
 
     // then
     assertThat(state.peekEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger);
@@ -418,7 +418,7 @@ public final class EventScopeInstanceStateTest {
     state.createInstance(SCOPE_KEY, NO_INTERRUPTING_ELEMENT_IDS, NO_BOUNDARY_ELEMENT_IDS);
 
     // when
-    triggerEvent(SCOPE_KEY, 1, eventTrigger);
+    triggerEvent(SCOPE_KEY, 1, eventTrigger, -1L);
 
     // then
     assertThat(state.peekEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger);
@@ -434,8 +434,8 @@ public final class EventScopeInstanceStateTest {
     state.createInstance(SCOPE_KEY, NO_INTERRUPTING_ELEMENT_IDS, NO_INTERRUPTING_ELEMENT_IDS);
 
     // when
-    triggerEvent(SCOPE_KEY, 1, eventTrigger1);
-    triggerEvent(SCOPE_KEY, 2, eventTrigger2);
+    triggerEvent(SCOPE_KEY, 1, eventTrigger1, -1L);
+    triggerEvent(SCOPE_KEY, 2, eventTrigger2, -1L);
 
     // then
     assertThat(state.pollEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger1);
@@ -450,8 +450,8 @@ public final class EventScopeInstanceStateTest {
     final EventTrigger eventTrigger2 = createEventTrigger();
 
     // when
-    triggerStartEvent(SCOPE_KEY, 1, eventTrigger1);
-    triggerStartEvent(SCOPE_KEY, 2, eventTrigger2);
+    triggerStartEvent(SCOPE_KEY, 1, eventTrigger1, -1L);
+    triggerStartEvent(SCOPE_KEY, 2, eventTrigger2, -1L);
 
     // then
     assertThat(state.pollEventTrigger(SCOPE_KEY)).isEqualTo(eventTrigger1);
@@ -465,7 +465,7 @@ public final class EventScopeInstanceStateTest {
     final long eventKey = 456;
 
     state.createInstance(SCOPE_KEY, NO_INTERRUPTING_ELEMENT_IDS, NO_BOUNDARY_ELEMENT_IDS);
-    triggerEvent(SCOPE_KEY, eventKey, createEventTrigger());
+    triggerEvent(SCOPE_KEY, eventKey, createEventTrigger(), -1L);
 
     // when
     state.deleteTrigger(SCOPE_KEY, eventKey);
@@ -478,7 +478,7 @@ public final class EventScopeInstanceStateTest {
   void shouldDeleteStartEventTrigger() {
     // given
     final EventTrigger eventTrigger1 = createEventTrigger();
-    triggerStartEvent(SCOPE_KEY, 1, eventTrigger1);
+    triggerStartEvent(SCOPE_KEY, 1, eventTrigger1, -1L);
 
     // when
     state.deleteTrigger(SCOPE_KEY, 1);
@@ -491,9 +491,9 @@ public final class EventScopeInstanceStateTest {
   void shouldDeleteEventScopeAndTriggers() {
     // given
     state.createInstance(SCOPE_KEY, NO_INTERRUPTING_ELEMENT_IDS, NO_BOUNDARY_ELEMENT_IDS);
-    triggerEvent(SCOPE_KEY, 1, createEventTrigger());
-    triggerEvent(SCOPE_KEY, 2, createEventTrigger());
-    triggerEvent(SCOPE_KEY, 3, createEventTrigger());
+    triggerEvent(SCOPE_KEY, 1, createEventTrigger(), -1L);
+    triggerEvent(SCOPE_KEY, 2, createEventTrigger(), -1L);
+    triggerEvent(SCOPE_KEY, 3, createEventTrigger(), -1L);
 
     // when
     state.deleteInstance(SCOPE_KEY);
@@ -507,7 +507,7 @@ public final class EventScopeInstanceStateTest {
   void shouldDeleteStartEventTriggerOnDeletionOfInstance() {
     // given
     final EventTrigger eventTrigger1 = createEventTrigger();
-    triggerStartEvent(SCOPE_KEY, 1, eventTrigger1);
+    triggerStartEvent(SCOPE_KEY, 1, eventTrigger1, -1L);
 
     // when
     state.deleteInstance(SCOPE_KEY);
@@ -546,15 +546,29 @@ public final class EventScopeInstanceStateTest {
   }
 
   private void triggerEvent(
-      final long eventScopeKey, final long eventKey, final EventTrigger eventTrigger) {
+      final long eventScopeKey,
+      final long eventKey,
+      final EventTrigger eventTrigger,
+      final long processInstanceKey) {
     state.triggerEvent(
-        eventScopeKey, eventKey, eventTrigger.getElementId(), eventTrigger.getVariables());
+        eventScopeKey,
+        eventKey,
+        eventTrigger.getElementId(),
+        eventTrigger.getVariables(),
+        processInstanceKey);
   }
 
   private void triggerStartEvent(
-      final long eventScopeKey, final long eventKey, final EventTrigger eventTrigger) {
+      final long eventScopeKey,
+      final long eventKey,
+      final EventTrigger eventTrigger,
+      final long processInstanceKey) {
     state.triggerStartEvent(
-        eventScopeKey, eventKey, eventTrigger.getElementId(), eventTrigger.getVariables());
+        eventScopeKey,
+        eventKey,
+        eventTrigger.getElementId(),
+        eventTrigger.getVariables(),
+        processInstanceKey);
   }
 
   private EventTrigger createEventTrigger() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -30,6 +32,7 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
@@ -113,6 +116,13 @@ public final class RecordToWrite implements LogAppendEntry {
       final ProcessInstanceIntent intent, final ProcessInstanceRecordValue value) {
     recordMetadata.valueType(ValueType.PROCESS_INSTANCE).intent(intent);
     unifiedRecordValue = (ProcessInstanceRecord) value;
+    return this;
+  }
+
+  public RecordToWrite processInstanceCreation(
+      final ProcessInstanceCreationIntent intent, final ProcessInstanceCreationRecordValue value) {
+    recordMetadata.valueType(ValueType.PROCESS_INSTANCE_CREATION).intent(intent);
+    unifiedRecordValue = (ProcessInstanceCreationRecord) value;
     return this;
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
A process could contain multiple start events. Depending on whether we can find an EventTrigger we activate the triggered start event, or the none start event. If we want to activate the none start event, but we already have an EventTrigger in the state we will trigger the wrong one.

By using the process instance key in the EventTrigger we can determine whether this activation relates to the EventTrigger in the state. If this is the case we should activate this triggered start event. Otherwise we should activate the none start event.

For backwards compatibility's sake, if the process instance key is not available in the EventTrigger, we should still activate the triggered start event. This way behavior does not change.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10536 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
