### PR TITLE
ci(release): nightly release dry run from stable branches

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -21,7 +21,7 @@ on:
         required: false
         default: false
       dryRun:
-        description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release), defaults to true.'
+        description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
         type: boolean
         default: true
 

--- a/.github/workflows/release-stable-dry-run.yml
+++ b/.github/workflows/release-stable-dry-run.yml
@@ -1,0 +1,66 @@
+name: Release Dry Run from stable branches
+on:
+  workflow_dispatch: { }
+  schedule:
+    # Runs at 02:00 every week day; see this link for more: https://crontab.guru/#0_2_*_*_1-5
+    - cron: '0 2 * * 1-5'
+
+jobs:
+  dry-run-release-81:
+    name: "Release from stable/8.1"
+    uses: camunda/zeebe/.github/workflows/release.yml@stable/8.1
+    secrets: inherit
+    strategy:
+      fail-fast: false
+    with:
+      releaseBranch: stable/8.1
+      releaseVersion: 0.8.1
+      nextDevelopmentVersion: 0.0.0-SNAPSHOT
+      isLatest: true
+      dryRun: true
+  dry-run-release-80:
+    name: "Release from stable/8.0"
+    uses: camunda/zeebe/.github/workflows/release.yml@stable/8.0
+    secrets: inherit
+    strategy:
+      fail-fast: false
+    with:
+      releaseBranch: stable/8.0
+      releaseVersion: 0.8.0
+      nextDevelopmentVersion: 0.0.0-SNAPSHOT
+      isLatest: false
+      dryRun: true
+  notify-if-failed:
+    name: Send slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [ dry-run-release-80, dry-run-release-81 ]
+    if: ${{ failure() }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":alarm: *Release Dry Run* from stable branches failed! :alarm:\n",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Release Dry Run* from stable branches failed! :alarm:\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related workflow execution: https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
         required: false
         default: false
       dryRun:
-        description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release), defaults to true.'
+        description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
         type: boolean
         default: true
 


### PR DESCRIPTION
## Description

Adds a nightly dry run referencing the release workflows from stable branches, to ensure they are functional, sends a [slack notification to #zeebe-ci else for the medic to check](https://camunda.slack.com/archives/C013MEVQ4M9/p1671183699739009). The dry run tests relevant inputs being latest:true for the most recent stable branch (8.1) as well as latest:false for previous stable branche(s).

With every minor release the stable dry run workflow needs to be updated, release guide/process will get adjusted with a separate sub-task listed in https://github.com/camunda/zeebe/issues/10992.

Manual Tests:
- [Run of the scheduled dry run for all stable branches](https://github.com/camunda/zeebe/actions/runs/3739887730)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11259 