### PR TITLE
refactor(engine): fewer copies of `ElementInstance`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -183,7 +183,8 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
   @Override
   public void updateInstance(final long key, final Consumer<ElementInstance> modifier) {
-    final var scopeInstance = getInstance(key);
+    elementInstanceKey.wrapLong(key);
+    final var scopeInstance = elementInstanceColumnFamily.get(elementInstanceKey);
     modifier.accept(scopeInstance);
     updateInstance(scopeInstance);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -152,7 +152,8 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     removeNumberOfTakenSequenceFlows(key);
 
     if (parent > 0) {
-      final ElementInstance parentInstance = getInstance(parent);
+      elementInstanceKey.wrapLong(parent);
+      final var parentInstance = elementInstanceColumnFamily.get(elementInstanceKey);
       if (parentInstance == null) {
         final var errorMsg =
             "Expected to find parent instance for element instance with key %d, but none was found.";


### PR DESCRIPTION
Found during my hackday while looking at flamegraphs:
Several methods in `DbElementInstanceState` would use `getInstance` which would defensively copy the instance that is returned. In multiple places, this copy was not necessary so I've inlined the `get` call there.