### PR TITLE
ci(release): release multi-arch docker images

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -26,11 +26,11 @@ inputs:
     description: 'If true, will push the image'
     required: false
     default: 'false'
-  platforms:
+  architectures:
     # See https://docs.docker.com/build/ci/github-actions/examples/#multi-platform-images
-    description: 'Comma separated-list of platforms to build the image for; defaults to linux/amd64'
+    description: 'Comma separated-list of linux architectures to build the image for; defaults to amd64'
     required: false
-    default: 'linux/amd64'
+    default: 'amd64'
 
 outputs:
   image:
@@ -68,7 +68,7 @@ runs:
     - name: Set image build label from ISO 8601 DATE
       id: get-date
       shell: bash
-      run: echo "::set-output name=result::$(date --iso-8601=seconds)"
+      run: echo "result=$(date --iso-8601=seconds)" >> $GITHUB_OUTPUT
     - name: Set image names from params and/or project version
       id: get-images
       shell: bash
@@ -80,7 +80,20 @@ runs:
     - name: Set DISTBALL path relative to the build context
       id: get-distball
       shell: bash
-      run: echo "::set-output name=result::$(realpath --relative-to="${PWD}" ${{ inputs.distball }})"
+      run: echo "result=$(realpath --relative-to="${PWD}" ${{ inputs.distball }})" >> $GITHUB_OUTPUT
+    - name: Set Platforms
+      id: get-platforms
+      shell: bash
+      env:
+        ARCHS_RAW: ${{ inputs.architectures }}
+      # prefix architectures with `linux/` as this is the format needed by the build-push-action
+      run: |
+        declare -a archs=(${ARCHS_RAW//,/ })
+        declare -a platforms=()
+        for arch in "${archs[@]}"; do
+          platforms+=("linux/$arch")
+        done
+        echo "result=$( IFS=','; echo "${platforms[*]}" )" >> $GITHUB_OUTPUT
     - name: Build Docker image
       uses: docker/build-push-action@v3
       with:
@@ -89,7 +102,7 @@ runs:
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
         no-cache: true
-        platforms: ${{ inputs.platforms }}
+        platforms: ${{ steps.get-platforms.outputs.result }}
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -23,11 +23,11 @@ inputs:
     description: 'If true, will push the image'
     required: false
     default: 'false'
-  architectures:
+  platforms:
     # See https://docs.docker.com/build/ci/github-actions/examples/#multi-platform-images
-    description: 'Comma separated-list of linux architectures to build the image for; defaults to amd64'
+    description: 'Comma separated-list of platforms to build the image for; defaults to linux/amd64'
     required: false
-    default: 'amd64'
+    default: 'linux/amd64'
 
 outputs:
   image:
@@ -74,19 +74,6 @@ runs:
       id: get-distball
       shell: bash
       run: echo "result=$(realpath --relative-to="${PWD}" ${{ inputs.distball }})" >> $GITHUB_OUTPUT
-    - name: Set Platforms
-      id: get-platforms
-      shell: bash
-      env:
-        ARCHS_RAW: ${{ inputs.architectures }}
-      # prefix architectures with `linux/` as this is the format needed by the build-push-action
-      run: |
-        declare -a archs=(${ARCHS_RAW//,/ })
-        declare -a platforms=()
-        for arch in "${archs[@]}"; do
-          platforms+=("linux/$arch")
-        done
-        echo "result=$( IFS=','; echo "${platforms[*]}" )" >> $GITHUB_OUTPUT
     - name: Build Docker image
       uses: docker/build-push-action@v3
       with:
@@ -95,7 +82,7 @@ runs:
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
         no-cache: true
-        platforms: ${{ steps.get-platforms.outputs.result }}
+        platforms: ${{ inputs.platforms }}
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -19,9 +19,6 @@ inputs:
   revision:
     description: 'The revision of the source the content of this image is based on.'
     required: false
-  additionalTag:
-    description: 'Additional tag to be created, besides the default version tag.'
-    required: false
   push:
     description: 'If true, will push the image'
     required: false
@@ -35,7 +32,7 @@ inputs:
 outputs:
   image:
     description: "Fully qualified image name available in your local Docker daemon"
-    value: ${{ steps.get-images.outputs.versionedImage }}
+    value: ${{ steps.get-image.outputs.result }}
   date:
     description: "The ISO 8601 date at which the image was created"
     value: ${{ steps.get-date.outputs.result }}
@@ -69,14 +66,10 @@ runs:
       id: get-date
       shell: bash
       run: echo "result=$(date --iso-8601=seconds)" >> $GITHUB_OUTPUT
-    - name: Set image names from params and/or project version
-      id: get-images
+    - name: Set image name from params and/or project version
+      id: get-image
       shell: bash
-      run: |
-        export VERSION_TAG_IMAGE=${{ inputs.repository }}:${{ inputs.version || steps.get-version.outputs.result }}
-        export OPTIONAL_TAG_IMAGE=${{ inputs.additionalTag != '' && format('{0}:{1}', inputs.repository, inputs.additionalTag) || '' }}
-        echo "versionedImage=${VERSION_TAG_IMAGE}" >> $GITHUB_OUTPUT
-        echo "result=${VERSION_TAG_IMAGE},${OPTIONAL_TAG_IMAGE}" >> $GITHUB_OUTPUT
+      run: echo "result=${{ inputs.repository }}:${{ inputs.version || steps.get-version.outputs.result }}" >> $GITHUB_OUTPUT
     - name: Set DISTBALL path relative to the build context
       id: get-distball
       shell: bash
@@ -98,7 +91,7 @@ runs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        tags: ${{ steps.get-images.outputs.result }}
+        tags: ${{ steps.get-image.outputs.result }}
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
         no-cache: true

--- a/.github/actions/verify-zeebe-docker/action.yml
+++ b/.github/actions/verify-zeebe-docker/action.yml
@@ -16,10 +16,6 @@ inputs:
   revision:
     description: 'Revision from which the image to verify was built, used to verify the date label of the image.'
     required: true
-  verifyLatestTag:
-    description: 'Whether to also verify the image tagged as latest.'
-    required: false
-    default: 'false'
   architectures:
     # See https://docs.docker.com/build/ci/github-actions/examples/#multi-platform-images
     description: 'Comma separated-list of linux architectures to verify (linux/${arch}), defaults to `amd64`.'
@@ -37,15 +33,10 @@ runs:
         REVISION: ${{ inputs.revision }}
         VERSION: ${{ inputs.version }}
         ARCHS_RAW: ${{ inputs.architectures }}
-        VERIFY_LATEST: ${{ inputs.verifyLatestTag }}
       run: |
         declare -a archs=(${ARCHS_RAW//,/ })
 
         for arch in "${archs[@]}"; do
           docker pull --platform "linux/$arch" "${{ inputs.imageName }}:${VERSION}"
           ${PWD}/docker/test/verify.sh "${{ inputs.imageName }}:${VERSION}" "$arch"
-          if [ "$VERIFY_LATEST" = "true" ]; then
-            docker pull --platform "linux/$arch" "${{ inputs.imageName }}:latest"
-            ${PWD}/docker/test/verify.sh "${{ inputs.imageName }}:latest" "$arch"
-          fi
         done

--- a/.github/actions/verify-zeebe-docker/action.yml
+++ b/.github/actions/verify-zeebe-docker/action.yml
@@ -1,0 +1,51 @@
+# This action expects the docker to be setup beforehand
+---
+name: Verify Zeebe Docker Image
+description: Verifies metadata of the Zeebe Docker image
+
+inputs:
+  imageName:
+    description: 'Full name of the image, without the tag.'
+    required: true
+  date:
+    description: 'Date when the image to verify was built, used to verify the date label of the image.'
+    required: true
+  version:
+    description: 'Version tag of the image to verify.'
+    required: true
+  revision:
+    description: 'Revision from which the image to verify was built, used to verify the date label of the image.'
+    required: true
+  verifyLatestTag:
+    description: 'Whether to also verify the image tagged as latest.'
+    required: false
+    default: 'false'
+  architectures:
+    # See https://docs.docker.com/build/ci/github-actions/examples/#multi-platform-images
+    description: 'Comma separated-list of linux architectures to verify (linux/${arch}), defaults to `amd64`.'
+    required: false
+    default: 'amd64'
+
+runs:
+  using: composite
+  steps:
+    - name: Verify Docker image
+      id: verify-docker-image
+      shell: bash
+      env:
+        DATE: ${{ inputs.date }}
+        REVISION: ${{ inputs.revision }}
+        VERSION: ${{ inputs.version }}
+        ARCHS_RAW: ${{ inputs.architectures }}
+        VERIFY_LATEST: ${{ inputs.verifyLatestTag }}
+      run: |
+        declare -a archs=(${ARCHS_RAW//,/ })
+
+        for arch in "${archs[@]}"; do
+          docker pull --platform "linux/$arch" "${{ inputs.imageName }}:${VERSION}"
+          ${PWD}/docker/test/verify.sh "${{ inputs.imageName }}:${VERSION}" "$arch"
+          if [ "$VERIFY_LATEST" = "true" ]; then
+            docker pull --platform "linux/$arch" "${{ inputs.imageName }}:latest"
+            ${PWD}/docker/test/verify.sh "${{ inputs.imageName }}:latest" "$arch"
+          fi
+        done

--- a/.github/actions/verify-zeebe-docker/action.yml
+++ b/.github/actions/verify-zeebe-docker/action.yml
@@ -16,11 +16,11 @@ inputs:
   revision:
     description: 'Revision from which the image to verify was built, used to verify the date label of the image.'
     required: true
-  architectures:
+  platforms:
     # See https://docs.docker.com/build/ci/github-actions/examples/#multi-platform-images
-    description: 'Comma separated-list of linux architectures to verify (linux/${arch}), defaults to `amd64`.'
+    description: 'Comma separated-list of platforms to verify the image for; defaults to linux/amd64'
     required: false
-    default: 'amd64'
+    default: 'linux/amd64'
 
 runs:
   using: composite
@@ -32,11 +32,11 @@ runs:
         DATE: ${{ inputs.date }}
         REVISION: ${{ inputs.revision }}
         VERSION: ${{ inputs.version }}
-        ARCHS_RAW: ${{ inputs.architectures }}
+        PLATFORMS_RAW: ${{ inputs.platforms }}
       run: |
-        declare -a archs=(${ARCHS_RAW//,/ })
+        declare -a platforms=(${PLATFORMS_RAW//,/ })
 
-        for arch in "${archs[@]}"; do
-          docker pull --platform "linux/$arch" "${{ inputs.imageName }}:${VERSION}"
-          ${PWD}/docker/test/verify.sh "${{ inputs.imageName }}:${VERSION}" "$arch"
+        for platform in "${platforms[@]}"; do
+          docker pull --platform "$platform" "${{ inputs.imageName }}:${VERSION}"
+          ${PWD}/docker/test/verify.sh "${{ inputs.imageName }}:${VERSION}" "$(echo $platform | cut -d '/' -f 2)"
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  DOCKER_ARCHITECTURES: "amd64,arm64"
+  DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
   integration-tests:
@@ -214,7 +214,7 @@ jobs:
         with:
           version: current-test
           distball: ${{ steps.build-zeebe.outputs.distball }}
-          architectures: ${{ matrix.arch }}
+          platforms: linux/${{ matrix.arch }}
           push: false
       - name: Run smoke test on ${{ matrix.arch }}
         env:
@@ -433,7 +433,7 @@ jobs:
           # we use a local registry for pushing
           repository: ${{ env.LOCAL_DOCKER_IMAGE }}
           distball: ${{ steps.build-zeebe.outputs.distball }}
-          architectures: ${{ env.DOCKER_ARCHITECTURES }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           # push is needed for multi-arch images as buildkit does not support loading them locally
           push: true
       - name: Verify Docker image
@@ -443,7 +443,7 @@ jobs:
           date: ${{ steps.build-docker.outputs.date }}
           revision: ${{ github.sha }}
           version: ${{ steps.build-docker.outputs.version }}
-          architectures: ${{ env.DOCKER_ARCHITECTURES }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
   test-summary:
     # Used by bors to check all tests, including the unit test matrix.
     # New test jobs must be added to the `needs` lists!
@@ -555,7 +555,7 @@ jobs:
         with:
           repository: camunda/zeebe
           version: SNAPSHOT
-          architectures: ${{ env.DOCKER_ARCHITECTURES }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
   notify-if-failed:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+  DOCKER_ARCHITECTURES: "amd64,arm64"
 
 jobs:
   integration-tests:
@@ -214,7 +214,7 @@ jobs:
         with:
           version: current-test
           distball: ${{ steps.build-zeebe.outputs.distball }}
-          platforms: linux/${{ matrix.arch }}
+          architectures: ${{ matrix.arch }}
           push: false
       - name: Run smoke test on ${{ matrix.arch }}
         env:
@@ -408,6 +408,8 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+    env:
+      LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
     steps:
       - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v3.0.0
@@ -429,21 +431,19 @@ jobs:
         id: build-docker
         with:
           # we use a local registry for pushing
-          repository: localhost:5000/camunda/zeebe
+          repository: ${{ env.LOCAL_DOCKER_IMAGE }}
           distball: ${{ steps.build-zeebe.outputs.distball }}
-          platforms: ${{ env.BUILD_DOCKER_PLATFORMS }}
+          architectures: ${{ env.DOCKER_ARCHITECTURES }}
           # push is needed for multi-arch images as buildkit does not support loading them locally
           push: true
-      - name: Verify Docker images
-        env:
-          DATE: ${{ steps.build-docker.outputs.date }}
-          REVISION: ${{ github.sha }}
-          VERSION: ${{ steps.build-docker.outputs.version }}
-        run: |
-          docker pull --platform linux/amd64 ${{ steps.build-docker.outputs.image }}
-          ${PWD}/docker/test/verify.sh '${{ steps.build-docker.outputs.image }}' amd64
-          docker pull --platform linux/arm64 ${{ steps.build-docker.outputs.image }}
-          ${PWD}/docker/test/verify.sh '${{ steps.build-docker.outputs.image }}' arm64
+      - name: Verify Docker image
+        uses: ./.github/actions/verify-zeebe-docker
+        with:
+          imageName: ${{ env.LOCAL_DOCKER_IMAGE }}
+          date: ${{ steps.build-docker.outputs.date }}
+          revision: ${{ github.sha }}
+          version: ${{ steps.build-docker.outputs.version }}
+          architectures: ${{ env.DOCKER_ARCHITECTURES }}
   test-summary:
     # Used by bors to check all tests, including the unit test matrix.
     # New test jobs must be added to the `needs` lists!
@@ -555,7 +555,7 @@ jobs:
         with:
           repository: camunda/zeebe
           version: SNAPSHOT
-          platforms: ${{ env.BUILD_DOCKER_PLATFORMS }}
+          architectures: ${{ env.DOCKER_ARCHITECTURES }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
   notify-if-failed:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
         ports:
           - 5000:5000
     env:
-      BUILD_DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+      ARCHITECTURES: "amd64,arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
       DOCKER_IMAGE: camunda/zeebe
       TAG_LATEST: ${{ inputs.isLatest }}
@@ -315,36 +315,25 @@ jobs:
           version: ${{ inputs.releaseVersion }}
           additionalTag: ${{ inputs.isLatest && 'latest' || '' }}
           revision: ${{ needs.release.outputs.releaseTagRevision }}
-          # pushes to local registry
+          # pushes to local registry for verification prior pushing to remote
           push: true
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
-          platforms: ${{ env.BUILD_DOCKER_PLATFORMS }}
+          architectures: ${{ env.ARCHITECTURES }}
       - name: Verify Docker image
-        env:
-          DATE: ${{ steps.build-docker.outputs.date }}
-          REVISION: ${{ needs.release.outputs.releaseTagRevision }}
-          VERSION: ${{ inputs.releaseVersion }}
-        # FIXME consider extraction to an action, also used in ci workflow
-        run: |
-          docker pull --platform linux/amd64 "${{ steps.build-docker.outputs.image }}"
-          ${PWD}/docker/test/verify.sh "${{ steps.build-docker.outputs.image }}" amd64
-          if [ "$TAG_LATEST" = "true" ]; then
-            docker pull --platform linux/amd64 "${LOCAL_DOCKER_IMAGE}:latest" amd64
-            ${PWD}/docker/test/verify.sh "${LOCAL_DOCKER_IMAGE}:latest"
-          fi
-
-          docker pull --platform linux/arm64 "${{ steps.build-docker.outputs.image }}"
-          ${PWD}/docker/test/verify.sh "${{ steps.build-docker.outputs.image }}" arm64
-          if [ "$TAG_LATEST" = "true" ]; then
-            docker pull --platform linux/arm64 "${LOCAL_DOCKER_IMAGE}:latest" arm64
-            ${PWD}/docker/test/verify.sh "${LOCAL_DOCKER_IMAGE}:latest"
-          fi
+        uses: ./.github/actions/verify-zeebe-docker
+        with:
+          imageName: ${{ env.LOCAL_DOCKER_IMAGE }}
+          date: ${{ steps.build-docker.outputs.date }}
+          revision: ${{ needs.release.outputs.releaseTagRevision }}
+          version: ${{ inputs.releaseVersion }}
+          verifyLatestTag: ${{ inputs.isLatest }}
+          architectures: ${{ env.ARCHITECTURES }}
       - name: Sync Docker Image to DockerHub
         id: push-docker
-        # FIXME enable condition
-#        if: ${{ inputs.dryRun == false }}
+        if: ${{ inputs.dryRun == false }}
         # see step `setup-regclient` on why regctl is used
         run: |
+          # disable usage of https for the local registry, it is only served via http
           regctl registry set --tls=disabled localhost:5000
 
           regctl image copy ${{ steps.build-docker.outputs.image }} ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,16 +293,6 @@ jobs:
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
-      - name: Setup regclient
-        id: setup-regclient
-        # To sync the multi-arch image from the local to the remote registry regctl is used.
-        # This is due to the docker client always dereferencing multi-arch images.
-        # See https://stackoverflow.com/a/68576882
-        uses: supplypike/setup-bin@v1
-        with:
-          uri: https://github.com/regclient/regclient/releases/download/v0.4.5/regctl-linux-amd64
-          name: regctl
-          version: v0.4.5
       - name: Download Zeebe Release Artifacts
         uses: actions/download-artifact@v3
         with:
@@ -331,12 +321,9 @@ jobs:
       - name: Sync Docker Image to DockerHub
         id: push-docker
         if: ${{ inputs.dryRun == false }}
-        # see step `setup-regclient` on why regctl is used
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
-          # disable usage of https for the local registry, it is only served via http
-          regctl registry set --tls=disabled localhost:5000
-
-          regctl image copy ${{ steps.build-docker.outputs.image }} ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}
-          if [ "$TAG_LATEST" = "true" ]; then
-            regctl image copy ${{ env.LOCAL_DOCKER_IMAGE }}:latest ${{ env.DOCKER_IMAGE }}:latest
-          fi
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
+            ${{ inputs.isLatest && format('--tag {0}:latest', env.DOCKER_IMAGE) || '' }} \
+            ${{ steps.build-docker.outputs.image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,17 @@ jobs:
     name: Docker Image Release
     runs-on: n1-standard-8-netssd-preempt
     timeout-minutes: 15
+    services:
+      # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
+      # registry. As we want to verify the images first before pushing them to dockerhub though,
+      # a local registry is used and if verification passes images are pushed to the remote registry.
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     env:
+      BUILD_DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+      LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
       DOCKER_IMAGE: camunda/zeebe
       TAG_LATEST: ${{ inputs.isLatest }}
     steps:
@@ -283,6 +293,16 @@ jobs:
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Setup regclient
+        id: setup-regclient
+        # To sync the multi-arch image from the local to the remote registry regctl is used.
+        # This is due to the docker client always dereferencing multi-arch images.
+        # See https://stackoverflow.com/a/68576882
+        uses: supplypike/setup-bin@v1
+        with:
+          uri: https://github.com/regclient/regclient/releases/download/v0.4.5/regctl-linux-amd64
+          name: regctl
+          version: v0.4.5
       - name: Download Zeebe Release Artifacts
         uses: actions/download-artifact@v3
         with:
@@ -291,25 +311,43 @@ jobs:
         uses: ./.github/actions/build-docker
         id: build-docker
         with:
-          repository: ${{ env.DOCKER_IMAGE }}
+          repository: ${{ env.LOCAL_DOCKER_IMAGE }}
           version: ${{ inputs.releaseVersion }}
           additionalTag: ${{ inputs.isLatest && 'latest' || '' }}
           revision: ${{ needs.release.outputs.releaseTagRevision }}
-          push: false
+          # pushes to local registry
+          push: true
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
+          platforms: ${{ env.BUILD_DOCKER_PLATFORMS }}
       - name: Verify Docker image
         env:
           DATE: ${{ steps.build-docker.outputs.date }}
           REVISION: ${{ needs.release.outputs.releaseTagRevision }}
           VERSION: ${{ inputs.releaseVersion }}
+        # FIXME consider extraction to an action, also used in ci workflow
         run: |
-          ${PWD}/docker/test/verify.sh "${DOCKER_IMAGE}:${RELEASE_VERSION}"
+          docker pull --platform linux/amd64 "${{ steps.build-docker.outputs.image }}"
+          ${PWD}/docker/test/verify.sh "${{ steps.build-docker.outputs.image }}" amd64
           if [ "$TAG_LATEST" = "true" ]; then
-            ${PWD}/docker/test/verify.sh "${DOCKER_IMAGE}:latest"
+            docker pull --platform linux/amd64 "${LOCAL_DOCKER_IMAGE}:latest" amd64
+            ${PWD}/docker/test/verify.sh "${LOCAL_DOCKER_IMAGE}:latest"
           fi
-      - name: Push Docker Image Tag ${{ inputs.releaseVersion }}
-        if: ${{ inputs.dryRun == false }}
-        run: docker push ${{ env.DOCKER_IMAGE }}:${{ inputs.releaseVersion }}
-      - name: Push Docker Image Tag latest
-        if: ${{ inputs.isLatest && inputs.dryRun == false }}
-        run: docker push ${{ env.DOCKER_IMAGE }}:latest
+
+          docker pull --platform linux/arm64 "${{ steps.build-docker.outputs.image }}"
+          ${PWD}/docker/test/verify.sh "${{ steps.build-docker.outputs.image }}" arm64
+          if [ "$TAG_LATEST" = "true" ]; then
+            docker pull --platform linux/arm64 "${LOCAL_DOCKER_IMAGE}:latest" arm64
+            ${PWD}/docker/test/verify.sh "${LOCAL_DOCKER_IMAGE}:latest"
+          fi
+      - name: Sync Docker Image to DockerHub
+        id: push-docker
+        # FIXME enable condition
+#        if: ${{ inputs.dryRun == false }}
+        # see step `setup-regclient` on why regctl is used
+        run: |
+          regctl registry set --tls=disabled localhost:5000
+
+          regctl image copy ${{ steps.build-docker.outputs.image }} ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}
+          if [ "$TAG_LATEST" = "true" ]; then
+            regctl image copy ${{ env.LOCAL_DOCKER_IMAGE }}:latest ${{ env.DOCKER_IMAGE }}:latest
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,6 @@ jobs:
       ARCHITECTURES: "amd64,arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
       DOCKER_IMAGE: camunda/zeebe
-      TAG_LATEST: ${{ inputs.isLatest }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -303,7 +302,6 @@ jobs:
         with:
           repository: ${{ env.LOCAL_DOCKER_IMAGE }}
           version: ${{ inputs.releaseVersion }}
-          additionalTag: ${{ inputs.isLatest && 'latest' || '' }}
           revision: ${{ needs.release.outputs.releaseTagRevision }}
           # pushes to local registry for verification prior pushing to remote
           push: true
@@ -316,7 +314,6 @@ jobs:
           date: ${{ steps.build-docker.outputs.date }}
           revision: ${{ needs.release.outputs.releaseTagRevision }}
           version: ${{ inputs.releaseVersion }}
-          verifyLatestTag: ${{ inputs.isLatest }}
           architectures: ${{ env.ARCHITECTURES }}
       - name: Sync Docker Image to DockerHub
         id: push-docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
         ports:
           - 5000:5000
     env:
-      ARCHITECTURES: "amd64,arm64"
+      PLATFORMS: "linux/amd64,linux/arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
       DOCKER_IMAGE: camunda/zeebe
     steps:
@@ -306,7 +306,7 @@ jobs:
           # pushes to local registry for verification prior pushing to remote
           push: true
           distball: camunda-zeebe-${{ inputs.releaseVersion }}.tar.gz
-          architectures: ${{ env.ARCHITECTURES }}
+          platforms: ${{ env.PLATFORMS }}
       - name: Verify Docker image
         uses: ./.github/actions/verify-zeebe-docker
         with:
@@ -314,7 +314,7 @@ jobs:
           date: ${{ steps.build-docker.outputs.date }}
           revision: ${{ needs.release.outputs.releaseTagRevision }}
           version: ${{ inputs.releaseVersion }}
-          architectures: ${{ env.ARCHITECTURES }}
+          platforms: ${{ env.PLATFORMS }}
       - name: Sync Docker Image to DockerHub
         id: push-docker
         if: ${{ inputs.dryRun == false }}


### PR DESCRIPTION
## Description

Extends the release workflow to build multi arch linux images for amd64 and arm64.

As unfortunately you can't load multi arch images locally as the local docker client only supports a single arch at a time,
a local repository is used to push the multi-arch image to it.
Afterwards the verification script runs for each architecture. To deduplicate a similar inline bash step in the ci workflow, a new verify-zeebe-docker action was added, which takes the architectures to verify as an input and iterates through them.

If all was fine the multi-arch image from the local registry is copied to dockerhub by making use of `regctl`, as the [docker cli lacks such a functionality](https://stackoverflow.com/a/68576882). A successful sync invocation was tested [here](https://github.com/camunda/zeebe/actions/runs/3713604241/jobs/6296577815) and resulted in [this image synced to dockerhub](https://hub.docker.com/layers/camunda/zeebe/0.0.4/images/sha256-6b921ddc3b16db325844ad26a7c6ae901368471ad44607abf42185f393faafe4?context=explore),

In all workflows and actions multi-platform variables were also simplified to be just multi-arch variables, removing the `linux/` platform prefix which is only needed for the `build-push-action` encapsulated within the local `build-docker` action. I don't see us building non linux images anytime.

Test Run:
- [Release dry run, building and verifying multi-arch images](https://github.com/camunda/zeebe/actions/runs/3714661996/jobs/6299030996)
- [a WIP hot test-run that synced an image to docker-hub](https://github.com/camunda/zeebe/actions/runs/3713604241/jobs/6296577815)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11286