### PR TITLE
ci(release): manual release workflow for 8.0

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,0 +1,80 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseBranch:
+        description: 'The branch to perform the release on, defaults to `release-$releaseVersion`'
+        type: string
+        required: false
+        default: ''
+      releaseVersion:
+        description: 'The version to be build and released. If no releaseBranch specified, expecting `release-$releaseVersion` to already exist.'
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
+        type: string
+        required: true
+      isLatest:
+        description: 'Whether this is the latest release and the docker image should be tagged as camunda/zeebe:latest'
+        type: boolean
+        required: false
+        default: false
+      dryRun:
+        description: 'Whether to push release commits and artifacts to remote (Git commits & tags, Maven artifacts, Github Release), defaults to true.'
+        type: boolean
+        default: true
+
+concurrency:
+  # cannot use the inputs context here as on this level only the github context is accessible, see
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.event.inputs.releaseBranch != '' && github.event.inputs.releaseBranch || format('release-{0}', github.event.inputs.releaseVersion) }}
+  cancel-in-progress: true
+
+jobs:
+  run-release:
+    name: "Release ${{ inputs.releaseVersion }} from ${{ inputs.releaseBranch }}"
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    with:
+      releaseBranch: ${{ inputs.releaseBranch }}
+      releaseVersion: ${{ inputs.releaseVersion }}
+      nextDevelopmentVersion: ${{ inputs.nextDevelopmentVersion }}
+      isLatest: ${{ inputs.isLatest }}
+      dryRun: ${{ inputs.dryRun }}
+  notify-if-failed:
+    name: Send slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
+    # else => send slack notification as an actual release failed
+    if: ${{ failure() && inputs.dryRun == false }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":alarm: Release job for ${{ inputs.releaseVersion }} failed! :alarm:\n",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: Release job for ${{ inputs.releaseVersion }} failed! :alarm:\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related workflow execution: https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Description

Adds the manual release workflow file to the stable branch so it can be invoked directly.

- [dry run](https://github.com/camunda/zeebe/actions/runs/3739014790)

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates #11259 
