### PR TITLE
ci(release): improved input descriptions

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -2,29 +2,29 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      releaseBranch:
-        description: 'The branch to perform the release on, defaults to `release-$releaseVersion`'
-        type: string
-        required: false
-        default: ''
       releaseVersion:
-        description: 'The version to be build and released. If no releaseBranch specified, expecting `release-$releaseVersion` to already exist.'
+        description: 'releaseVersion:'
         type: string
         required: true
       nextDevelopmentVersion:
-        description: 'Next development version, e.g. 8.X.X-SNAPSHOT.'
+        description: 'nextDevelopmentVersion: e.g. 8.X.X-SNAPSHOT'
         type: string
         required: true
       isLatest:
-        description: 'Whether this is the latest release and the docker image should be tagged as camunda/zeebe:latest'
+        description: 'isLatest: updates the `latest` docker tag'
         type: boolean
         required: false
         default: false
+      releaseBranch:
+        description: 'releaseBranch: defaults to `release-$releaseVersion` if not set'
+        type: string
+        required: false
+        default: ''
       dryRun:
-        description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
+        description: 'dryRun: Whether to perform a dry release where no changes/artifacts are pushed'
         type: boolean
-        default: true
-
+        required: true
+        default: false
 concurrency:
   # cannot use the inputs context here as on this level only the github context is accessible, see
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency


### PR DESCRIPTION
## Description

Improved descriptions for the Release job inputs as well as revised order and defaults (e.g. letting dryRun to default to false now, as from a release managers perspective that is the desired value). In order to make the ease of use better.

I prefixed all input descriptions with the name of the input itself, this helped to easier refer to inputs e.g. from the instructions within the release process forms.

## Related issues

closes #11303