### PR TITLE
Reject modification with selected ancestor that is not an ancestor of element to activate

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -492,6 +492,7 @@ public final class ProcessInstanceModificationProcessor
 
     final String invalidInstructionMessages =
         record.getActivateInstructions().stream()
+            .filter(instruction -> instruction.getAncestorScopeKey() > 0)
             .map(
                 instruction -> {
                   final var ancestorId =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -608,6 +608,69 @@ public class ModifyProcessInstanceRejectionTest {
   }
 
   @Test
+  public void shouldRejectActivationWhenAncestorScopeIsNotFlowScope() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .parallelGateway("split")
+                .subProcess(
+                    "subProcess1",
+                    sp -> sp.embeddedSubProcess().startEvent().manualTask("A").endEvent())
+                .parallelGateway("join")
+                .moveToLastGateway()
+                .subProcess(
+                    "subProcess2",
+                    sp2 -> sp2.embeddedSubProcess().startEvent().userTask("B").endEvent())
+                .connectTo("join")
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("subProcess1")
+        .await();
+
+    // when
+    final var subProcess2 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("subProcess2")
+            .getFirst();
+    final var taskB =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("B")
+            .getFirst();
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("A", subProcess2.getKey())
+            .activateElement("B", subProcess2.getKey())
+            .activateElement("A", taskB.getKey())
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs("Expect that subProcess2 cannot be selected as ancestor of task A")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to modify instance of process '%s' \
+            but it contains one or more activate instructions with an ancestor scope key \
+            that is not an ancestor of the element to activate:
+            - instance '%s' of element 'subProcess2' is not an ancestor of element 'A'
+            - instance '%s' of element 'B' is not an ancestor of element 'A'"""
+                .formatted(PROCESS_ID, subProcess2.getKey(), taskB.getKey()));
+  }
+
+  @Test
   public void shouldRejectActivationOfMultiInstanceInstance() {
     // given
     ENGINE


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This adds an additional validation to the ProcessInstanceModification command, where the command is rejection if:
- it contains an activation instruction with a selected ancestor that is not an ancestor of the element to activate

For example, in the process below:
- `subProcess1` is an ancestor of `A`, but it is not an ancestor of `B`
- `subProcess2` is not an ancestor of `A`, but it is an ancestor of `B`
- `A` is not an ancestor of `B`, and `B` is not an ancestor of `A`
- `subProcess1` is not an ancestor of `subProcess2`, and `subProcess2` is not an ancestor of `subProcess1`

![Screen Shot 2022-12-20 at 14 33 54](https://user-images.githubusercontent.com/3511026/208679213-796346fa-aae4-429a-9cc7-2c7552103a1c.png)

The rejection may read something like:
```
Expected to modify instance of process 'process' but it contains one or more activate instructions with an ancestor scope key that is not an ancestor of the element to activate:
- instance '2251799813685257' of element 'subProcess2' is not an ancestor of element 'A'
- instance '2251799813685263' of element 'B' is not an ancestor of element 'A'
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9990

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
