### PR TITLE
Adjust modification rejection message to suggest ancestor selection

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -91,7 +91,8 @@ public final class ProcessInstanceModificationProcessor
       """
       Expected to modify instance of process '%s' but it contains one or more activate instructions \
       for an element that has a flow scope with more than one active instance: '%s'. Can't decide \
-      in which instance of the flow scope the element should be activated.""";
+      in which instance of the flow scope the element should be activated. Please specify an \
+      ancestor element instance key for this activate instruction.""";
 
   private static final String ERROR_MESSAGE_CHILD_PROCESS_INSTANCE_TERMINATED =
       """

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -375,7 +375,8 @@ public class ModifyProcessInstanceRejectionTest {
                 Expected to modify instance of process '%s' but it contains one or more activate \
                 instructions for an element that has a flow scope with more than one active \
                 instance: 'event-subprocess'. Can't decide in which instance of the flow scope the \
-                element should be activated.""",
+                element should be activated. Please specify an ancestor element instance key for \
+                this activate instruction.""",
                 PROCESS_ID));
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Originally, this part of the rejection message was left out because ancestor selection was unavailable. 

Now that an ancestor can be selected (with #9646 and related issues), we should inform users that they can resolve this rejection by selecting an ancestor.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11032 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
