### PR TITLE
[Backport 8.0]: Close channels on Timeout 

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -544,6 +544,18 @@ public final class NettyMessagingService implements ManagedMessagingService {
         .whenComplete(
             (channel, channelError) -> {
               if (channelError == null) {
+                responseFuture.whenComplete(
+                    (response, error) -> {
+                      if (error instanceof TimeoutException) {
+                        // response future has been completed exceptionally by our
+                        // timeout check, we will not receive any response on this channel
+                        // if we talk with the wrong IP or node
+                        // See https://github.com/zeebe-io/zeebe-chaos/issues/294
+                        // In order to no longer reuse a maybe broken/outdated channel we close it
+                        // On next request a new channel will be created
+                        channel.close();
+                      }
+                    });
                 final ClientConnection connection = getOrCreateClientConnection(channel);
                 callback
                     .apply(connection)

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -515,7 +515,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
    * @param type the message type to map to the connection
    * @param callback the callback to execute
    * @param executor an executor on which to complete the callback future
-   * @param future the future to be completed once the callback future is complete
+   * @param responseFuture the future to be completed once the callback future is complete
    * @param <T> the callback response type
    */
   private <T> void executeOnPooledConnection(
@@ -523,22 +523,22 @@ public final class NettyMessagingService implements ManagedMessagingService {
       final String type,
       final Function<ClientConnection, CompletableFuture<T>> callback,
       final Executor executor,
-      final CompletableFuture<T> future) {
+      final CompletableFuture<T> responseFuture) {
     if (address.equals(advertisedAddress)) {
       callback
           .apply(localConnection)
           .whenComplete(
               (result, error) -> {
                 if (error == null) {
-                  executor.execute(() -> future.complete(result));
+                  executor.execute(() -> responseFuture.complete(result));
                 } else {
-                  executor.execute(() -> future.completeExceptionally(error));
+                  executor.execute(() -> responseFuture.completeExceptionally(error));
                 }
               });
       return;
     }
 
-    openFutures.add(future);
+    openFutures.add(responseFuture);
     channelPool
         .getChannel(address, type)
         .whenComplete(
@@ -552,8 +552,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
                           if (sendError == null) {
                             executor.execute(
                                 () -> {
-                                  future.complete(result);
-                                  openFutures.remove(future);
+                                  responseFuture.complete(result);
+                                  openFutures.remove(responseFuture);
                                 });
                           } else {
                             final Throwable cause = Throwables.getRootCause(sendError);
@@ -571,16 +571,16 @@ public final class NettyMessagingService implements ManagedMessagingService {
                             }
                             executor.execute(
                                 () -> {
-                                  future.completeExceptionally(sendError);
-                                  openFutures.remove(future);
+                                  responseFuture.completeExceptionally(sendError);
+                                  openFutures.remove(responseFuture);
                                 });
                           }
                         });
               } else {
                 executor.execute(
                     () -> {
-                      future.completeExceptionally(channelError);
-                      openFutures.remove(future);
+                      responseFuture.completeExceptionally(channelError);
+                      openFutures.remove(responseFuture);
                     });
               }
             });

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -130,9 +130,27 @@ public final class NettyMessagingService implements ManagedMessagingService {
     this.advertisedAddress = advertisedAddress;
     this.protocolVersion = protocolVersion;
     this.config = config;
+    this.channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
 
     openFutures = new CopyOnWriteArrayList<>();
-    channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
+    initAddresses(config);
+  }
+
+  // duplicated for tests - to inject channel pool
+  NettyMessagingService(
+      final String cluster,
+      final Address advertisedAddress,
+      final MessagingConfig config,
+      final ProtocolVersion protocolVersion,
+      final Function<Function<Address, CompletableFuture<Channel>>, ChannelPool>
+          channelPoolFactor) {
+    preamble = cluster.hashCode();
+    this.advertisedAddress = advertisedAddress;
+    this.protocolVersion = protocolVersion;
+    this.config = config;
+    this.channelPool = channelPoolFactor.apply(this::openChannel);
+
+    openFutures = new CopyOnWriteArrayList<>();
     initAddresses(config);
   }
 


### PR DESCRIPTION
## Description

Backports #11307
<!-- Please explain the changes you made here. -->

I had to manually backport the #11307,  since the @VisibleForTesting annotation doesn't exist. I dropped these commits, I don't think it is worth to backport it.

## Related issues
closes https://github.com/zeebe-io/zeebe-chaos/issues/294
<!-- Which issues are closed by this PR or are related -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
