### PR TITLE
ci(release): github hosted runner for docker job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
   docker:
     needs: release
     name: Docker Image Release
-    runs-on: n1-standard-8-netssd-preempt
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
       # Local registry is used as multi arch images cannot be loaded locally but only pushed to a


### PR DESCRIPTION
## Description

I experienced some scheduling delays with the pool used for the docker job (the known hiccups that lead to the zeebe-io self-hosted runners and the new *-quick pool provided by infra). As the docker build is not that demanding I figured we can just make use of github hosted runners for it.

Dry run: [here](https://github.com/camunda/zeebe/actions/runs/3748237847)

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #10992