### PR TITLE
ci(jenkins): disable automatic branch builds on Jenkins

### DIFF
--- a/.ci/jobs/github_camunda.dsl
+++ b/.ci/jobs/github_camunda.dsl
@@ -34,14 +34,6 @@ organizationFolder('camunda') {
         }
     }
 
-    buildStrategies {
-        // Don't auto build discovered branches for non prod envs.
-        if (ENVIRONMENT == 'prod') {
-            // Builds regular branches whenever a change is detected.
-            buildRegularBranches()
-        }
-    }
-
     orphanedItemStrategy {
         discardOldItems {
             numToKeep 10
@@ -57,9 +49,9 @@ organizationFolder('camunda') {
     properties {
         // Avoid automatically build jobs on non-prod envs by org indexing.
         // Note: The DSL name here is misleading. This config is for the branches that WILL be built automatically.
-        // So on prod env main will be built automatically but for non-prod no automatic builds.
+        // In the course of the GHA migration automatic builds on Jenkins were disabled
         noTriggerOrganizationFolderProperty {
-            branches (ENVIRONMENT == 'prod' ? 'main' : '')
+            branches ('')
         }
     }
 


### PR DESCRIPTION
## Description

Given the still active push triggered builds of the `main` as well as stable branches branch have been broken on Jenkins for a longer time already, [see](https://ci.zeebe.camunda.cloud/job/camunda/job/zeebe/job/main/), I would completely disable any automatic builds on Jenkins now. There is no benefit in investigating or running them further.

Ran the seed job with those changes [here](https://ci.zeebe.camunda.cloud/job/seed-job-zeebe/3344/console), so its at least not breaking. Have to monitor Jenkins' behaviour to be sure that this is really all that is needed to disable it ^^.

Let's check the build history once we have some merges on main https://ci.zeebe.camunda.cloud/view/all/builds

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9137