### PR TITLE
[Backport stable/8.0] ci(release): github hosted runner for docker job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
   docker:
     needs: release
     name: Docker Image Release
-    runs-on: n1-standard-8-netssd-preempt
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       DOCKER_IMAGE: camunda/zeebe


### PR DESCRIPTION
# Description
Backport of #11315 to `stable/8.0`.

relates to #10992