### PR TITLE
[Backport stable/8.1] ci(release): github hosted runner for docker job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
   docker:
     needs: release
     name: Docker Image Release
-    runs-on: n1-standard-8-netssd-preempt
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       DOCKER_IMAGE: camunda/zeebe


### PR DESCRIPTION
# Description
Backport of #11315 to `stable/8.1`.

relates to #10992