### PR TITLE
ci(release): success notification on release dry run

### DIFF
--- a/.github/workflows/release-main-dry-run.yml
+++ b/.github/workflows/release-main-dry-run.yml
@@ -25,21 +25,24 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: ${{ matrix.latest }}
       dryRun: true
-  notify-if-failed:
-    name: Send slack notification on failure
+  notify:
+    name: Send slack notification
     runs-on: ubuntu-latest
     needs: [ dry-run-release ]
-    if: ${{ failure() }}
+    if: ${{ always() }}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-      - id: slack-notify
-        name: Send slack notification
+      - id: slack-notify-failure
+        name: Send failure slack notification
         uses: slackapi/slack-github-action@v1.23.0
+        if: ${{ always() && needs.dry-run-release.result != 'success' }}
         with:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": ":alarm: *Release Dry Run* from `main` failed! :alarm:\n",
-             	"blocks": [
+              "blocks": [
                 {
                   "type": "section",
                   "text": {
@@ -56,6 +59,29 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - id: slack-notify-success
+        name: Send success slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        if: ${{ always() && needs.dry-run-release.result == 'success' }}
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":tada: *Release Dry Run* from `main` succeeded! :tada:\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Nothing to check today. Good job! :clap:\n"
+                  }
+                }
+              ]
+            }
+

--- a/.github/workflows/release-stable-dry-run.yml
+++ b/.github/workflows/release-stable-dry-run.yml
@@ -30,26 +30,29 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: false
       dryRun: true
-  notify-if-failed:
-    name: Send slack notification on failure
+  notify:
+    name: Send slack notification
     runs-on: ubuntu-latest
     needs: [ dry-run-release-80, dry-run-release-81 ]
-    if: ${{ failure() }}
+    if: ${{ always() }}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-      - id: slack-notify
-        name: Send slack notification
+      - id: slack-notify-failure
+        name: Send failure slack notification
         uses: slackapi/slack-github-action@v1.23.0
+        if: ${{ always() && (needs.dry-run-release-80.result != 'success' || needs.dry-run-release-81.result != 'success') }}
         with:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": ":alarm: *Release Dry Run* from stable branches failed! :alarm:\n",
-             	"blocks": [
+              "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alarm: *Release Dry Run* from stable branches failed! :alarm:\n"
+                    "text": ":alarm: *Release Dry Run* from `stable/*` failed! :alarm:\n"
                   }
                 },
                 {
@@ -61,6 +64,28 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - id: slack-notify-success
+        name: Send success slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        if: ${{ always() && needs.dry-run-release-80.result == 'success' && needs.dry-run-release-81.result == 'success' }}
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":tada: *Release Dry Run* from `stable/*` succeeded! :tada:\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Nothing to check today. Good job! :clap:\n"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Description

Adds a success notification of release dry runs to assure dry runs were indeed executed.
Medic duties will be adjusted to daily check for these.

Success Tests:
- [main](https://github.com/camunda/zeebe/actions/runs/3749875838) and [slack message](https://camunda.slack.com/archives/C013MEVQ4M9/p1671631547703939)  
- [stable](https://github.com/camunda/zeebe/actions/runs/3750158798) and [slack message](https://camunda.slack.com/archives/C013MEVQ4M9/p1671633745569909)  

Failure Tests:
- [main](https://github.com/camunda/zeebe/actions/runs/3750393040) and [slack message](https://camunda.slack.com/archives/C013MEVQ4M9/p1671634905674859)
- [stable](https://github.com/camunda/zeebe/actions/runs/3750710575) and [slack message](https://camunda.slack.com/archives/C013MEVQ4M9/p1671638060989509)

## Related issues

closes #11320 