### PR TITLE
feat(clients/java): add evaluateDecision command

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1;
+import io.camunda.zeebe.client.api.command.EvaluateDecisionCommandStep1;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
@@ -194,6 +195,21 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   SetVariablesCommandStep1 newSetVariablesCommand(long elementInstanceKey);
+
+  /**
+   * Command to evaluate a decision.
+   *
+   * <pre>
+   * zeebeClient
+   *  .newEvaluateDecisionCommand()
+   *  .decisionKey("my-decision")
+   *  .variables(json)
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the command
+   */
+  EvaluateDecisionCommandStep1 newEvaluateDecisionCommand();
 
   /**
    * Command to publish a message which can be correlated to a process instance.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/EvaluateDecisionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/EvaluateDecisionCommandStep1.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
+import java.io.InputStream;
+import java.util.Map;
+
+public interface EvaluateDecisionCommandStep1 {
+
+  /**
+   * Set the id of the decision to evaluate. This is the static id of the decision in the DMN XML
+   * (i.e. "&#60;decision id='my-decision'&#62;").
+   *
+   * @param decisionId the DMN id of the decision
+   * @return the builder for this command
+   */
+  EvaluateDecisionCommandStep2 decisionId(String decisionId);
+
+  /**
+   * Set the key of the decision to evaluate. The key is assigned by the broker while deploying the
+   * decision. It can be picked from the deployment.
+   *
+   * @param decisionKey the key of the decision
+   * @return the builder for this command
+   */
+  EvaluateDecisionCommandStep2 decisionKey(long decisionKey);
+
+  interface EvaluateDecisionCommandStep2 extends FinalCommandStep<EvaluateDecisionResponse> {
+
+    /**
+     * Set the variables for the decision evaluation.
+     *
+     * @param variables the variables JSON document as stream
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    EvaluateDecisionCommandStep2 variables(InputStream variables);
+
+    /**
+     * Set the variables for the decision evaluation.
+     *
+     * @param variables the variables JSON document as String
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    EvaluateDecisionCommandStep2 variables(String variables);
+
+    /**
+     * Set the variables for the decision evaluation.
+     *
+     * @param variables the variables document as map
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    EvaluateDecisionCommandStep2 variables(Map<String, Object> variables);
+
+    /**
+     * Set the variables for the decision evaluation.
+     *
+     * @param variables the variables document as object to be serialized to JSON
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    EvaluateDecisionCommandStep2 variables(Object variables);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+import java.util.List;
+
+public interface EvaluateDecisionResponse {
+
+  /**
+   * @return the decision ID, as parsed during deployment; together with the versions forms a unique
+   *     identifier for a specific decision
+   */
+  String getDecisionId();
+
+  /**
+   * @return the assigned decision version
+   */
+  int getDecisionVersion();
+
+  /**
+   * @return the assigned decision key, which acts as a unique identifier for this decision
+   */
+  long getDecisionKey();
+
+  /**
+   * @return the name of the decision, as parsed during deployment
+   */
+  String getDecisionName();
+
+  /**
+   * @return the ID of the decision requirements graph that this decision is part of, as parsed
+   *     during deployment
+   */
+  String getDecisionRequirementsId();
+
+  /**
+   * @return the assigned key of the decision requirements graph that this decision is part of
+   */
+  long getDecisionRequirementsKey();
+
+  /**
+   * @return the output of the evaluated decision
+   */
+  String getDecisionOutput();
+
+  /**
+   * @return a list of decisions that were evaluated within the requested decision evaluation
+   */
+  List<EvaluatedDecision> getEvaluatedDecisions();
+
+  /**
+   * @return a string indicating the ID of the decision which failed during evaluation
+   */
+  String getFailedDecisionId();
+
+  /**
+   * @return a message describing why the decision which was evaluated failed
+   */
+  String getFailureMessage();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecision.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecision.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+import java.util.List;
+
+public interface EvaluatedDecision {
+
+  /**
+   * @return the decision ID, as parsed during deployment; together with the versions forms a unique
+   *     identifier for a specific decision
+   */
+  String getDecisionId();
+
+  /**
+   * @return the assigned decision version
+   */
+  int getDecisionVersion();
+
+  /**
+   * @return the assigned decision key, which acts as a unique identifier for this decision
+   */
+  long getDecisionKey();
+
+  /**
+   * @return the name of the decision, as parsed during deployment
+   */
+  String getDecisionName();
+
+  /**
+   * @return the type of the evaluated decision
+   */
+  String getDecisionType();
+
+  /**
+   * @return the output of the evaluated decision
+   */
+  String getDecisionOutput();
+
+  /**
+   * @return the decision inputs that were evaluated within this decision evaluation
+   */
+  List<EvaluatedDecisionInput> getEvaluatedInputs();
+
+  /**
+   * @return the decision rules that matched within this decision evaluation
+   */
+  List<MatchedDecisionRule> getMatchedRules();
+
+  /**
+   * @return the record encoded as JSON
+   */
+  String toJson();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionInput.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionInput.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface EvaluatedDecisionInput {
+
+  /**
+   * @return the id of the evaluated decision input
+   */
+  String getInputId();
+
+  /**
+   * @return the name of the evaluated decision input
+   */
+  String getInputName();
+
+  /**
+   * @return the value of the evaluated decision input
+   */
+  String getInputValue();
+
+  /**
+   * @return the record encoded as JSON
+   */
+  String toJson();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionOutput.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionOutput.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface EvaluatedDecisionOutput {
+
+  /**
+   * @return the id of the evaluated decision output
+   */
+  String getOutputId();
+
+  /**
+   * @return the name of the evaluated decision output
+   */
+  String getOutputName();
+
+  /**
+   * @return the value of the evaluated decision output
+   */
+  String getOutputValue();
+
+  /**
+   * @return the record encoded as JSON
+   */
+  String toJson();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MatchedDecisionRule.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MatchedDecisionRule.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+import java.util.List;
+
+public interface MatchedDecisionRule {
+
+  /**
+   * @return the id of the matched rule
+   */
+  String getRuleId();
+
+  /**
+   * @return the index of the matched rule
+   */
+  int getRuleIndex();
+
+  /**
+   * @return the evaluated decision outputs
+   */
+  List<EvaluatedDecisionOutput> getEvaluatedOutputs();
+
+  /**
+   * @return the record encoded as JSON
+   */
+  String toJson();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1;
+import io.camunda.zeebe.client.api.command.EvaluateDecisionCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
@@ -43,6 +44,7 @@ import io.camunda.zeebe.client.impl.command.CancelProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.CreateProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeployProcessCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeployResourceCommandImpl;
+import io.camunda.zeebe.client.impl.command.EvaluateDecisionCommandImpl;
 import io.camunda.zeebe.client.impl.command.JobUpdateRetriesCommandImpl;
 import io.camunda.zeebe.client.impl.command.ModifyProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.PublishMessageCommandImpl;
@@ -284,6 +286,15 @@ public final class ZeebeClientImpl implements ZeebeClient {
         asyncStub,
         jsonMapper,
         elementInstanceKey,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest);
+  }
+
+  @Override
+  public EvaluateDecisionCommandStep1 newEvaluateDecisionCommand() {
+    return new EvaluateDecisionCommandImpl(
+        asyncStub,
+        jsonMapper,
         config.getDefaultRequestTimeout(),
         credentialsProvider::shouldRetryRequest);
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/EvaluateDecisionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/EvaluateDecisionCommandImpl.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.EvaluateDecisionCommandStep1;
+import io.camunda.zeebe.client.api.command.EvaluateDecisionCommandStep1.EvaluateDecisionCommandStep2;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
+import io.camunda.zeebe.client.impl.RetriableClientFutureImpl;
+import io.camunda.zeebe.client.impl.response.EvaluateDecisionResponseImpl;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest.Builder;
+import io.grpc.stub.StreamObserver;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+public class EvaluateDecisionCommandImpl
+    implements EvaluateDecisionCommandStep1, EvaluateDecisionCommandStep2 {
+
+  private final GatewayStub asyncStub;
+  private final Builder builder;
+  private final Predicate<Throwable> retryPredicate;
+  private final JsonMapper jsonMapper;
+  private Duration requestTimeout;
+
+  public EvaluateDecisionCommandImpl(
+      final GatewayStub asyncStub,
+      final JsonMapper jsonMapper,
+      final Duration requestTimeout,
+      final Predicate<Throwable> retryPredicate) {
+    this.asyncStub = asyncStub;
+    this.retryPredicate = retryPredicate;
+    this.jsonMapper = jsonMapper;
+    this.requestTimeout = requestTimeout;
+    builder = EvaluateDecisionRequest.newBuilder();
+  }
+
+  @Override
+  public EvaluateDecisionCommandStep2 decisionId(final String decisionId) {
+    builder.setDecisionId(decisionId);
+    return this;
+  }
+
+  @Override
+  public EvaluateDecisionCommandStep2 decisionKey(final long decisionKey) {
+    builder.setDecisionKey(decisionKey);
+    return this;
+  }
+
+  @Override
+  public EvaluateDecisionCommandStep2 variables(final InputStream variables) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    return setVariables(jsonMapper.validateJson("variables", variables));
+  }
+
+  @Override
+  public EvaluateDecisionCommandStep2 variables(final String variables) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    return setVariables(variables);
+  }
+
+  @Override
+  public EvaluateDecisionCommandStep2 variables(final Map<String, Object> variables) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    return setVariables(jsonMapper.toJson(variables));
+  }
+
+  @Override
+  public EvaluateDecisionCommandStep2 variables(final Object variables) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    return setVariables(jsonMapper.toJson(variables));
+  }
+
+  @Override
+  public FinalCommandStep<EvaluateDecisionResponse> requestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<EvaluateDecisionResponse> send() {
+    final EvaluateDecisionRequest request = builder.build();
+
+    final RetriableClientFutureImpl<
+            EvaluateDecisionResponse, GatewayOuterClass.EvaluateDecisionResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                gatewayResponse -> new EvaluateDecisionResponseImpl(jsonMapper, gatewayResponse),
+                retryPredicate,
+                streamObserver -> send(request, streamObserver));
+
+    send(request, future);
+
+    return future;
+  }
+
+  private void send(
+      final EvaluateDecisionRequest request,
+      final StreamObserver<GatewayOuterClass.EvaluateDecisionResponse> streamObserver) {
+    asyncStub
+        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .evaluateDecision(request, streamObserver);
+  }
+
+  private EvaluateDecisionCommandStep2 setVariables(final String jsonDocument) {
+    builder.setVariables(jsonDocument);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluateDecisionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluateDecisionResponseImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
+import io.camunda.zeebe.client.api.response.EvaluatedDecision;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
+
+  @JsonIgnore private final JsonMapper jsonMapper;
+  private final String decisionId;
+  private final long decisionKey;
+  private final int decisionVersion;
+  private final String decisionName;
+  private final String decisionRequirementsId;
+  private final long decisionRequirementsKey;
+  private final String decisionOutput;
+  private final List<EvaluatedDecision> evaluatedDecisions = new ArrayList<>();
+  private final String failedDecisionId;
+  private final String failureMessage;
+
+  public EvaluateDecisionResponseImpl(
+      final JsonMapper jsonMapper, final GatewayOuterClass.EvaluateDecisionResponse response) {
+    this.jsonMapper = jsonMapper;
+
+    decisionId = response.getDecisionId();
+    decisionKey = response.getDecisionKey();
+    decisionVersion = response.getDecisionVersion();
+    decisionName = response.getDecisionName();
+    decisionRequirementsId = response.getDecisionRequirementsId();
+    decisionRequirementsKey = response.getDecisionRequirementsKey();
+    decisionOutput = response.getDecisionOutput();
+    failedDecisionId = response.getFailedDecisionId();
+    failureMessage = response.getFailureMessage();
+
+    response.getEvaluatedDecisionsList().stream()
+        .map(evaluatedDecision -> new EvaluatedDecisionImpl(jsonMapper, evaluatedDecision))
+        .forEach(evaluatedDecisions::add);
+  }
+
+  @Override
+  public String getDecisionId() {
+    return decisionId;
+  }
+
+  @Override
+  public int getDecisionVersion() {
+    return decisionVersion;
+  }
+
+  @Override
+  public long getDecisionKey() {
+    return decisionKey;
+  }
+
+  @Override
+  public String getDecisionName() {
+    return decisionName;
+  }
+
+  @Override
+  public String getDecisionRequirementsId() {
+    return decisionRequirementsId;
+  }
+
+  @Override
+  public long getDecisionRequirementsKey() {
+    return decisionRequirementsKey;
+  }
+
+  @Override
+  public String getDecisionOutput() {
+    return decisionOutput;
+  }
+
+  @Override
+  public List<EvaluatedDecision> getEvaluatedDecisions() {
+    return evaluatedDecisions;
+  }
+
+  @Override
+  public String getFailedDecisionId() {
+    return failedDecisionId;
+  }
+
+  @Override
+  public String getFailureMessage() {
+    return failureMessage;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluatedDecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluatedDecisionImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.response.EvaluatedDecision;
+import io.camunda.zeebe.client.api.response.EvaluatedDecisionInput;
+import io.camunda.zeebe.client.api.response.MatchedDecisionRule;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EvaluatedDecisionImpl implements EvaluatedDecision {
+
+  @JsonIgnore private final JsonMapper jsonMapper;
+  private final String decisionId;
+  private final long decisionKey;
+  private final int decisionVersion;
+  private final String decisionName;
+  private final String decisionType;
+  private final String decisionOutput;
+  private final List<MatchedDecisionRule> matchedRules = new ArrayList<>();
+  private final List<EvaluatedDecisionInput> evaluatedInputs = new ArrayList<>();
+
+  public EvaluatedDecisionImpl(
+      final JsonMapper jsonMapper, final GatewayOuterClass.EvaluatedDecision evaluatedDecision) {
+    this.jsonMapper = jsonMapper;
+
+    decisionId = evaluatedDecision.getDecisionId();
+    decisionKey = evaluatedDecision.getDecisionKey();
+    decisionName = evaluatedDecision.getDecisionName();
+    decisionVersion = evaluatedDecision.getDecisionVersion();
+    decisionType = evaluatedDecision.getDecisionType();
+    decisionOutput = evaluatedDecision.getDecisionOutput();
+
+    evaluatedDecision.getEvaluatedInputsList().stream()
+        .map(evaluatedInput -> new EvaluatedDecisionInputImpl(jsonMapper, evaluatedInput))
+        .forEach(evaluatedInputs::add);
+
+    evaluatedDecision.getMatchedRulesList().stream()
+        .map(matchedRule -> new MatchedDecisionRuleImpl(jsonMapper, matchedRule))
+        .forEach(matchedRules::add);
+  }
+
+  @Override
+  public String getDecisionId() {
+    return decisionId;
+  }
+
+  @Override
+  public int getDecisionVersion() {
+    return decisionVersion;
+  }
+
+  @Override
+  public long getDecisionKey() {
+    return decisionKey;
+  }
+
+  @Override
+  public String getDecisionName() {
+    return decisionName;
+  }
+
+  @Override
+  public String getDecisionType() {
+    return decisionType;
+  }
+
+  @Override
+  public String getDecisionOutput() {
+    return decisionOutput;
+  }
+
+  @Override
+  public List<EvaluatedDecisionInput> getEvaluatedInputs() {
+    return evaluatedInputs;
+  }
+
+  @Override
+  public List<MatchedDecisionRule> getMatchedRules() {
+    return matchedRules;
+  }
+
+  @Override
+  public String toJson() {
+    return jsonMapper.toJson(this);
+  }
+
+  @Override
+  public String toString() {
+    return toJson();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluatedDecisionInputImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluatedDecisionInputImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.response.EvaluatedDecisionInput;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+
+public class EvaluatedDecisionInputImpl implements EvaluatedDecisionInput {
+
+  @JsonIgnore private final JsonMapper jsonMapper;
+  private final String inputId;
+  private final String inputName;
+  private final String inputValue;
+
+  public EvaluatedDecisionInputImpl(
+      final JsonMapper jsonMapper, final GatewayOuterClass.EvaluatedDecisionInput evaluatedInput) {
+    this.jsonMapper = jsonMapper;
+
+    inputId = evaluatedInput.getInputId();
+    inputName = evaluatedInput.getInputName();
+    inputValue = evaluatedInput.getInputValue();
+  }
+
+  @Override
+  public String getInputId() {
+    return inputId;
+  }
+
+  @Override
+  public String getInputName() {
+    return inputName;
+  }
+
+  @Override
+  public String getInputValue() {
+    return inputValue;
+  }
+
+  @Override
+  public String toJson() {
+    return jsonMapper.toJson(this);
+  }
+
+  @Override
+  public String toString() {
+    return toJson();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluatedDecisionOutputImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluatedDecisionOutputImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.response.EvaluatedDecisionOutput;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+
+public class EvaluatedDecisionOutputImpl implements EvaluatedDecisionOutput {
+
+  @JsonIgnore private final JsonMapper jsonMapper;
+  private final String outputId;
+  private final String outputName;
+  private final String outputValue;
+
+  public EvaluatedDecisionOutputImpl(
+      final JsonMapper jsonMapper,
+      final GatewayOuterClass.EvaluatedDecisionOutput evaluatedOutput) {
+    this.jsonMapper = jsonMapper;
+
+    outputId = evaluatedOutput.getOutputId();
+    outputName = evaluatedOutput.getOutputName();
+    outputValue = evaluatedOutput.getOutputValue();
+  }
+
+  @Override
+  public String getOutputId() {
+    return outputId;
+  }
+
+  @Override
+  public String getOutputName() {
+    return outputName;
+  }
+
+  @Override
+  public String getOutputValue() {
+    return outputValue;
+  }
+
+  @Override
+  public String toJson() {
+    return jsonMapper.toJson(this);
+  }
+
+  @Override
+  public String toString() {
+    return toJson();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/MatchedDecisionRuleImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/MatchedDecisionRuleImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.response.EvaluatedDecisionOutput;
+import io.camunda.zeebe.client.api.response.MatchedDecisionRule;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MatchedDecisionRuleImpl implements MatchedDecisionRule {
+
+  @JsonIgnore private final JsonMapper jsonMapper;
+  private final String ruleId;
+  private final int ruleIndex;
+  private final List<EvaluatedDecisionOutput> evaluatedOutputs = new ArrayList<>();
+
+  public MatchedDecisionRuleImpl(
+      final JsonMapper jsonMapper, final GatewayOuterClass.MatchedDecisionRule matchedRule) {
+    this.jsonMapper = jsonMapper;
+
+    ruleId = matchedRule.getRuleId();
+    ruleIndex = matchedRule.getRuleIndex();
+
+    matchedRule.getEvaluatedOutputsList().stream()
+        .map(evaluatedOutput -> new EvaluatedDecisionOutputImpl(jsonMapper, evaluatedOutput))
+        .forEach(evaluatedOutputs::add);
+  }
+
+  @Override
+  public String getRuleId() {
+    return ruleId;
+  }
+
+  @Override
+  public int getRuleIndex() {
+    return ruleIndex;
+  }
+
+  @Override
+  public List<EvaluatedDecisionOutput> getEvaluatedOutputs() {
+    return evaluatedOutputs;
+  }
+
+  @Override
+  public String toJson() {
+    return jsonMapper.toJson(this);
+  }
+
+  @Override
+  public String toString() {
+    return toJson();
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.decision;
+
+import static io.camunda.zeebe.client.util.JsonUtil.fromJsonAsMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
+import io.camunda.zeebe.client.api.response.EvaluatedDecision;
+import io.camunda.zeebe.client.api.response.EvaluatedDecisionInput;
+import io.camunda.zeebe.client.api.response.EvaluatedDecisionOutput;
+import io.camunda.zeebe.client.api.response.MatchedDecisionRule;
+import io.camunda.zeebe.client.util.ClientTest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StandaloneDecisionEvaluationTest extends ClientTest {
+
+  private static GatewayOuterClass.EvaluatedDecisionOutput evaluatedOutput;
+  private static GatewayOuterClass.MatchedDecisionRule matchedRule;
+  private static GatewayOuterClass.EvaluatedDecisionInput evaluatedInput;
+  private static GatewayOuterClass.EvaluatedDecision evaluatedDecision;
+  private static GatewayOuterClass.EvaluateDecisionResponse evaluateDecisionResponse;
+
+  @BeforeClass
+  public static void setUpAll() {
+    evaluatedOutput =
+        GatewayOuterClass.EvaluatedDecisionOutput.newBuilder()
+            .setOutputId("output-id")
+            .setOutputName("output-name")
+            .setOutputValue("output-value")
+            .build();
+
+    matchedRule =
+        GatewayOuterClass.MatchedDecisionRule.newBuilder()
+            .setRuleId("rule-id")
+            .setRuleIndex(1)
+            .addEvaluatedOutputs(evaluatedOutput)
+            .build();
+
+    evaluatedInput =
+        GatewayOuterClass.EvaluatedDecisionInput.newBuilder()
+            .setInputId("input-id")
+            .setInputName("input-name")
+            .setInputValue("input-value")
+            .build();
+
+    evaluatedDecision =
+        GatewayOuterClass.EvaluatedDecision.newBuilder()
+            .setDecisionId("my-decision")
+            .setDecisionKey(123L)
+            .setDecisionName("My Decision")
+            .setDecisionVersion(1)
+            .setDecisionType("TABLE")
+            .setDecisionOutput("testOutput")
+            .addEvaluatedInputs(evaluatedInput)
+            .addMatchedRules(matchedRule)
+            .build();
+
+    evaluateDecisionResponse =
+        GatewayOuterClass.EvaluateDecisionResponse.newBuilder()
+            .setDecisionKey(123L)
+            .setDecisionId("my-decision")
+            .setDecisionName("My Decision")
+            .setDecisionVersion(1)
+            .setDecisionOutput("testOutput")
+            .setDecisionRequirementsId("decision-requirements-id")
+            .setDecisionRequirementsKey(124L)
+            .setFailedDecisionId("my-decision")
+            .setFailureMessage("decision-evaluation-failure")
+            .addEvaluatedDecisions(evaluatedDecision)
+            .build();
+  }
+
+  @Test
+  public void shouldEvaluateStandaloneDecisionWithDecisionKey() {
+    // given
+    gatewayService.onEvaluateDecisionRequest(evaluateDecisionResponse);
+
+    // when
+    final EvaluateDecisionResponse response =
+        client.newEvaluateDecisionCommand().decisionKey(123L).send().join();
+
+    // then
+    assertResponse(response);
+  }
+
+  @Test
+  public void shouldEvaluateStandaloneDecisionWithDecisionId() {
+    // given
+    gatewayService.onEvaluateDecisionRequest(evaluateDecisionResponse);
+
+    // when
+    final EvaluateDecisionResponse response =
+        client.newEvaluateDecisionCommand().decisionId("my-decision").send().join();
+
+    // then
+    assertResponse(response);
+  }
+
+  @Test
+  public void shouldEvaluateStandaloneDecisionWithStringVariables() {
+    // given
+    client
+        .newEvaluateDecisionCommand()
+        .decisionKey(123L)
+        .variables("{\"foo\": \"bar\"}")
+        .send()
+        .join();
+
+    // when
+    final EvaluateDecisionRequest request = gatewayService.getLastRequest();
+
+    // then
+    assertThat(fromJsonAsMap(request.getVariables())).containsOnly(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldEvaluateStandaloneDecisionWithInputStreamVariables() {
+    // given
+    final String variables = "{\"foo\": \"bar\"}";
+    final InputStream inputStream =
+        new ByteArrayInputStream(variables.getBytes(StandardCharsets.UTF_8));
+    client.newEvaluateDecisionCommand().decisionKey(123L).variables(inputStream).send().join();
+
+    // when
+    final EvaluateDecisionRequest request = gatewayService.getLastRequest();
+
+    // then
+    assertThat(fromJsonAsMap(request.getVariables())).containsOnly(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldEvaluateStandaloneDecisionWithMapVariables() {
+    // given
+    client
+        .newEvaluateDecisionCommand()
+        .decisionKey(123L)
+        .variables(Collections.singletonMap("foo", "bar"))
+        .send()
+        .join();
+
+    // when
+    final EvaluateDecisionRequest request = gatewayService.getLastRequest();
+
+    // then
+    assertThat(fromJsonAsMap(request.getVariables())).containsOnly(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldEvaluateStandaloneDecisionWithObjectVariables() {
+    // given
+    client
+        .newEvaluateDecisionCommand()
+        .decisionKey(123L)
+        .variables(new VariableDocument())
+        .send()
+        .join();
+
+    // when
+    final EvaluateDecisionRequest request = gatewayService.getLastRequest();
+
+    // then
+    assertThat(fromJsonAsMap(request.getVariables())).containsOnly(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldRaise() {
+    // when
+    gatewayService.errorOnRequest(
+        EvaluateDecisionRequest.class, () -> new ClientException("Invalid request"));
+
+    // then
+    assertThatThrownBy(() -> client.newEvaluateDecisionCommand().decisionKey(123).send().join())
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("Invalid request");
+  }
+
+  @Test
+  public void shouldSetRequestTimeout() {
+    // given
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client
+        .newEvaluateDecisionCommand()
+        .decisionKey(123)
+        .requestTimeout(requestTimeout)
+        .send()
+        .join();
+
+    // then
+    rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  private void assertResponse(final EvaluateDecisionResponse response) {
+    // assert EvaluateDecisionResponse properties
+    assertThat(response.getDecisionKey()).isEqualTo(evaluateDecisionResponse.getDecisionKey());
+    assertThat(response.getDecisionId()).isEqualTo(evaluateDecisionResponse.getDecisionId());
+    assertThat(response.getDecisionVersion())
+        .isEqualTo(evaluateDecisionResponse.getDecisionVersion());
+    assertThat(response.getDecisionName()).isEqualTo(evaluateDecisionResponse.getDecisionName());
+    assertThat(response.getDecisionOutput())
+        .isEqualTo(evaluateDecisionResponse.getDecisionOutput());
+    assertThat(response.getDecisionRequirementsId())
+        .isEqualTo(evaluateDecisionResponse.getDecisionRequirementsId());
+    assertThat(response.getDecisionRequirementsKey())
+        .isEqualTo(evaluateDecisionResponse.getDecisionRequirementsKey());
+    assertThat(response.getFailedDecisionId())
+        .isEqualTo(evaluateDecisionResponse.getFailedDecisionId());
+    assertThat(response.getFailureMessage())
+        .isEqualTo(evaluateDecisionResponse.getFailureMessage());
+
+    // assert EvaluatedDecision
+    assertThat(response.getEvaluatedDecisions()).hasSize(1);
+    final EvaluatedDecision evaluatedDecisionResponse = response.getEvaluatedDecisions().get(0);
+    assertThat(evaluatedDecisionResponse.getDecisionId())
+        .isEqualTo(evaluatedDecision.getDecisionId());
+    assertThat(evaluatedDecisionResponse.getDecisionKey())
+        .isEqualTo(evaluatedDecision.getDecisionKey());
+    assertThat(evaluatedDecisionResponse.getDecisionName())
+        .isEqualTo(evaluatedDecision.getDecisionName());
+    assertThat(evaluatedDecisionResponse.getDecisionVersion())
+        .isEqualTo(evaluatedDecision.getDecisionVersion());
+    assertThat(evaluatedDecisionResponse.getDecisionType())
+        .isEqualTo(evaluatedDecision.getDecisionType());
+    assertThat(evaluatedDecisionResponse.getDecisionOutput())
+        .isEqualTo(evaluatedDecision.getDecisionOutput());
+
+    // assert EvaluatedDecisionInput
+    assertThat(evaluatedDecisionResponse.getEvaluatedInputs()).hasSize(1);
+    final EvaluatedDecisionInput evaluatedDecisionInput =
+        evaluatedDecisionResponse.getEvaluatedInputs().get(0);
+    assertThat(evaluatedDecisionInput.getInputId()).isEqualTo(evaluatedInput.getInputId());
+    assertThat(evaluatedDecisionInput.getInputName()).isEqualTo(evaluatedInput.getInputName());
+    assertThat(evaluatedDecisionInput.getInputValue()).isEqualTo(evaluatedInput.getInputValue());
+
+    // assert MatchedRule
+    assertThat(evaluatedDecisionResponse.getMatchedRules()).hasSize(1);
+    final MatchedDecisionRule matchedDecisionRule =
+        evaluatedDecisionResponse.getMatchedRules().get(0);
+    assertThat(matchedDecisionRule.getRuleId()).isEqualTo(matchedRule.getRuleId());
+    assertThat(matchedDecisionRule.getRuleIndex()).isEqualTo(matchedRule.getRuleIndex());
+
+    // assert EvaluatedDecisionOutput
+    assertThat(matchedDecisionRule.getEvaluatedOutputs()).hasSize(1);
+    final EvaluatedDecisionOutput evaluatedDecisionOutput =
+        matchedDecisionRule.getEvaluatedOutputs().get(0);
+    assertThat(evaluatedDecisionOutput.getOutputId()).isEqualTo(evaluatedOutput.getOutputId());
+    assertThat(evaluatedDecisionOutput.getOutputName()).isEqualTo(evaluatedOutput.getOutputName());
+    assertThat(evaluatedDecisionOutput.getOutputValue())
+        .isEqualTo(evaluatedOutput.getOutputValue());
+  }
+
+  public static class VariableDocument {
+
+    private final String foo = "bar";
+
+    VariableDocument() {}
+
+    public String getFoo() {
+      return foo;
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.util;
 
 import com.google.protobuf.GeneratedMessageV3;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
@@ -36,6 +37,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Deployment;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest;
@@ -104,6 +107,8 @@ public final class RecordingGatewayService extends GatewayImplBase {
     addRequestHandler(
         ModifyProcessInstanceRequest.class,
         r -> ModifyProcessInstanceResponse.getDefaultInstance());
+    addRequestHandler(
+        EvaluateDecisionRequest.class, r -> EvaluateDecisionResponse.getDefaultInstance());
   }
 
   public static Partition partition(
@@ -235,6 +240,13 @@ public final class RecordingGatewayService extends GatewayImplBase {
   }
 
   @Override
+  public void evaluateDecision(
+      final EvaluateDecisionRequest request,
+      final StreamObserver<EvaluateDecisionResponse> responseObserver) {
+    handle(request, responseObserver);
+  }
+
+  @Override
   public void deployProcess(
       final DeployProcessRequest request,
       final StreamObserver<DeployProcessResponse> responseObserver) {
@@ -353,6 +365,11 @@ public final class RecordingGatewayService extends GatewayImplBase {
                 .setVersion(version)
                 .setProcessInstanceKey(processInstanceKey)
                 .build());
+  }
+
+  public void onEvaluateDecisionRequest(
+      final GatewayOuterClass.EvaluateDecisionResponse evaluateDecisionResponse) {
+    addRequestHandler(EvaluateDecisionRequest.class, request -> evaluateDecisionResponse);
   }
 
   public void onPublishMessageRequest(final long key) {


### PR DESCRIPTION
## Description

Enable standalone decision evaluation in the Java client. The response from the standalone decision evaluation provides the full data contained by the DecisionEvaluationRecord. It provides the final decisionOutput. For audit and debugging reasons, it also provides all the evaluatedDecisions that were triggered by the request. Users can access the evaluatedInputs, matchedRules, and evaluatedOutputs.

## Related issues

closes #11048 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
