### PR TITLE
feat(bpmn-model): support conditional events

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -46,6 +46,12 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
     return start.builder();
   }
 
+  public StartEventBuilder startEvent(final String id, final Consumer<StartEventBuilder> consumer) {
+    final StartEventBuilder builder = startEvent(id);
+    consumer.accept(builder);
+    return builder;
+  }
+
   public EventSubProcessBuilder eventSubProcess() {
     return eventSubProcess(null);
   }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
+import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
@@ -37,7 +38,8 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
           MessageEventDefinition.class,
           ErrorEventDefinition.class,
           SignalEventDefinition.class,
-          EscalationEventDefinition.class);
+          EscalationEventDefinition.class,
+          ConditionalEventDefinition.class);
 
   @Override
   public Class<BoundaryEvent> getElementType() {
@@ -74,7 +76,8 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
         def -> {
           if (SUPPORTED_EVENT_DEFINITIONS.stream().noneMatch(type -> type.isInstance(def))) {
             validationResultCollector.addError(
-                0, "Boundary events must be one of: timer, message, error, signal, escalation");
+                0,
+                "Boundary events must be one of: timer, message, error, signal, escalation, conditional");
           }
         });
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ConditionalEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ConditionalEventDefinitionValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.Expression;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ConditionalEventDefinitionValidator
+    implements ModelElementValidator<ConditionalEventDefinition> {
+
+  @Override
+  public Class<ConditionalEventDefinition> getElementType() {
+    return ConditionalEventDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      final ConditionalEventDefinition element,
+      final ValidationResultCollector validationResultCollector) {
+
+    final Expression condition = element.getCondition();
+    if (condition == null || condition.getTextContent().isEmpty()) {
+      validationResultCollector.addError(
+          0, "Conditional event must contain an expression for evaluation");
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
+import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
@@ -38,7 +39,8 @@ public class EventDefinitionValidator implements ModelElementValidator<EventDefi
           TerminateEventDefinition.class,
           SignalEventDefinition.class,
           LinkEventDefinition.class,
-          EscalationEventDefinition.class);
+          EscalationEventDefinition.class,
+          ConditionalEventDefinition.class);
 
   @Override
   public Class<EventDefinition> getElementType() {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/IntermediateCatchEventValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/IntermediateCatchEventValidator.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
+import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
@@ -34,7 +35,8 @@ public class IntermediateCatchEventValidator
           MessageEventDefinition.class,
           TimerEventDefinition.class,
           SignalEventDefinition.class,
-          LinkEventDefinition.class);
+          LinkEventDefinition.class,
+          ConditionalEventDefinition.class);
 
   @Override
   public Class<IntermediateCatchEvent> getElementType() {
@@ -55,7 +57,7 @@ public class IntermediateCatchEventValidator
 
       if (SUPPORTED_EVENTS.stream().noneMatch(c -> c.isAssignableFrom(type))) {
         validationResultCollector.addError(
-            0, "Event definition must be one of: message, timer, signal, or link");
+            0, "Event definition must be one of: message, timer, signal, link, or conditional");
 
       } else if (eventDefinition instanceof TimerEventDefinition) {
         final TimerEventDefinition timerEventDefinition = (TimerEventDefinition) eventDefinition;

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
@@ -41,6 +41,9 @@ public class ProcessValidator implements ModelElementValidator<Process> {
       validationResultCollector.addError(0, "Multiple none start events are not allowed");
     }
 
+    ModelUtil.verifyNoDuplicatedConditionalStartEvents(
+        element, error -> validationResultCollector.addError(0, error));
+
     ModelUtil.verifyNoDuplicatedEventSubprocesses(
         element, error -> validationResultCollector.addError(0, error));
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
@@ -39,7 +40,8 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
           MessageEventDefinition.class,
           ErrorEventDefinition.class,
           SignalEventDefinition.class,
-          EscalationEventDefinition.class);
+          EscalationEventDefinition.class,
+          ConditionalEventDefinition.class);
 
   @Override
   public Class<SubProcess> getElementType() {
@@ -93,7 +95,7 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
           if (SUPPORTED_START_TYPES.stream().noneMatch(type -> type.isInstance(def))) {
             validationResultCollector.addError(
                 0,
-                "Start events in event subprocesses must be one of: message, timer, error, signal, escalation");
+                "Start events in event subprocesses must be one of: message, timer, error, signal, escalation, conditional");
           }
         });
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -46,6 +46,7 @@ public final class ZeebeDesignTimeValidators {
         ExtensionElementsValidator.verifyThat(CallActivity.class)
             .hasSingleExtensionElement(
                 ZeebeCalledElement.class, ZeebeConstants.ELEMENT_CALLED_ELEMENT));
+    validators.add(new ConditionalEventDefinitionValidator());
     validators.add(new DefinitionsValidator());
     validators.add(new EndEventValidator());
     validators.add(new EventDefinitionValidator());

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeConditionalEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeConditionalEventValidationTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ZeebeConditionalEventValidationTest {
+
+  private static final String CONDITION = "= true";
+
+  @Test
+  @DisplayName("A conditional start event contain a valid expression for evaluation")
+  void verifyValidConditionOfConditionalStartEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start", s -> s.condition(CONDITION))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName("A conditional start event must contain a valid expression for evaluation")
+  void verifyInvalidConditionOfConditionalStartEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start", s -> s.condition(""))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ConditionalEventDefinition.class,
+            "Conditional event must contain an expression for evaluation"));
+  }
+
+  @Test
+  @DisplayName(
+      "Cannot have more than one conditional event subscription with the same condition for conditional start events")
+  void verifyNoDuplicatedConditionOfConditionalStartEvents() {
+    // given
+    final ProcessBuilder processBuilder = Bpmn.createExecutableProcess("process");
+    processBuilder.startEvent("start-1", s -> s.condition(CONDITION)).endEvent();
+
+    final BpmnModelInstance process =
+        processBuilder.startEvent("start-2", s -> s.condition(CONDITION)).endEvent().done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            Process.class,
+            "Cannot have more than one conditional event subscription with the same condition '= true'"));
+  }
+
+  @Test
+  @DisplayName("A boundary conditional event contain a valid expression for evaluation")
+  void verifyValidConditionOfBoundaryConditionalEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .boundaryEvent("catch", b -> b.condition(CONDITION))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(process);
+  }
+
+  @Test
+  @DisplayName("A boundary conditional event must contain a valid expression for evaluation")
+  void verifyInvalidConditionOfBoundaryConditionalEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .boundaryEvent("catch", b -> b.condition(""))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ConditionalEventDefinition.class,
+            "Conditional event must contain an expression for evaluation"));
+  }
+
+  @Test
+  @DisplayName("A intermediate conditional event contain a valid expression for evaluation")
+  void verifyValidConditionOfIntermediateConditionalEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .intermediateCatchEvent("catch", i -> i.condition(CONDITION))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName("A intermediate conditional event must contain a valid expression for evaluation")
+  void verifyInvalidConditionOfIntermediateConditionalEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .intermediateCatchEvent("catch", i -> i.condition(""))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ConditionalEventDefinition.class,
+            "Conditional event must contain an expression for evaluation"));
+  }
+
+  @Test
+  @DisplayName(
+      "An event subprocess conditional start event contain a valid expression for evaluation")
+  void verifyValidConditionOfEventSubprocessConditionalStartEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess(
+                "sub", e -> e.startEvent("start", s -> s.condition(CONDITION).endEvent()))
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName(
+      "An event subprocess conditional start event must contain a valid expression for evaluation")
+  void verifyInvalidConditionOfEventSubprocessConditionalStartEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess("sub", e -> e.startEvent("start", s -> s.condition("").endEvent()))
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ConditionalEventDefinition.class,
+            "Conditional event must contain an expression for evaluation"));
+  }
+
+  @Test
+  @DisplayName(
+      "Cannot have more than one conditional event subscription with the same condition for event subprocess conditional start events")
+  void verifyNoDuplicatedConditionOfEventSubprocessConditionalStartEvents() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess(
+                "sub-1", e -> e.startEvent("start-1", s -> s.condition(CONDITION).endEvent()))
+            .eventSubProcess(
+                "sub-2", e -> e.startEvent("start-2", s -> s.condition(CONDITION).endEvent()))
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            Process.class,
+            "Cannot have more than one conditional event subscription with the same condition '= true'"));
+  }
+}


### PR DESCRIPTION
## Description
As a user, I can deploy a process definition with conditional events.

<img width="699" alt="image" src="https://user-images.githubusercontent.com/24605947/206225501-4ee20ec4-a278-4b95-a712-3fdb78ec6a46.png">


## Related issues
closes #11340

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
