### PR TITLE
Add new metrics for messaging service

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessagingMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessagingMetrics.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+
+final class MessagingMetrics {
+
+  private static final String NAMESPACE = "zeebe";
+  private static final String LABEL_TOPIC = "topic";
+  private static final String LABEL_ADDRESS = "address";
+  private static final String REQ_TYPE_MESSAGE = "MESSAGE";
+  private static final String REQ_TYPE_REQ_RESP = "REQ_RESP";
+
+  private static final Histogram REQUEST_RESPONSE_LATENCY =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("messaging_request_response_latency")
+          .help("The time how long it takes to retrieve a response for a request")
+          .labelNames(LABEL_TOPIC)
+          .register();
+
+  private static final Histogram REQUEST_SIZE_IN_KB =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("messaging_request_size_kb")
+          .help("The size of the request, which has been sent")
+          .labelNames(LABEL_ADDRESS, LABEL_TOPIC)
+          .buckets(.01, .1, .250, 1, 10, 100, 500, 1_000, 2_000, 4_000)
+          .register();
+  private static final Counter REQUEST_COUNT =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("messaging_request_count")
+          .help("Number of requests which has been send to a certain address")
+          .labelNames("type", LABEL_ADDRESS, LABEL_TOPIC)
+          .register();
+
+  private static final Counter RESPONSE_COUNT =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("messaging_response_count")
+          .help("Number of responses which has been received")
+          .labelNames(LABEL_ADDRESS, LABEL_TOPIC, "outcome")
+          .register();
+
+  private static final Gauge IN_FLIGHT_REQUESTS =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("messaging_inflight_requests")
+          .help("The count of inflight requests")
+          .labelNames(LABEL_ADDRESS, LABEL_TOPIC)
+          .register();
+
+  Histogram.Timer startRequestTimer(final String name) {
+    return REQUEST_RESPONSE_LATENCY.labels(name).startTimer();
+  }
+
+  void observeRequestSize(final String to, final String name, final int requestSizeInBytes) {
+    REQUEST_SIZE_IN_KB.labels(to, name).observe(requestSizeInBytes / 1_000f);
+  }
+
+  void countMessage(final String to, final String name) {
+    REQUEST_COUNT.labels(REQ_TYPE_MESSAGE, to, name).inc();
+  }
+
+  void countRequestResponse(final String to, final String name) {
+    REQUEST_COUNT.labels(REQ_TYPE_REQ_RESP, to, name).inc();
+  }
+
+  void countSuccessResponse(final String address, final String name) {
+    RESPONSE_COUNT.labels(address, name, "SUCCESS").inc();
+  }
+
+  void countFailureResponse(final String address, final String name, String error) {
+    RESPONSE_COUNT.labels(address, name, error).inc();
+  }
+
+  void incInFlightRequests(final String address, String topic) {
+    IN_FLIGHT_REQUESTS.labels(address, topic).inc();
+  }
+
+  void decInFlightRequests(final String address, String topic) {
+    IN_FLIGHT_REQUESTS.labels(address, topic).dec();
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessagingMetricsImpl.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessagingMetricsImpl.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.camunda.zeebe.util.CloseableSilently;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+
+final class MessagingMetricsImpl implements MessagingMetrics {
+
+  private static final String NAMESPACE = "zeebe";
+  private static final String LABEL_TOPIC = "topic";
+  private static final String LABEL_ADDRESS = "address";
+  private static final String REQ_TYPE_MESSAGE = "MESSAGE";
+  private static final String REQ_TYPE_REQ_RESP = "REQ_RESP";
+
+  private static final Histogram REQUEST_RESPONSE_LATENCY =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("messaging_request_response_latency")
+          .help("The time how long it takes to retrieve a response for a request")
+          .labelNames(LABEL_TOPIC)
+          .register();
+
+  private static final Histogram REQUEST_SIZE_IN_KB =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("messaging_request_size_kb")
+          .help("The size of the request, which has been sent")
+          .labelNames(LABEL_ADDRESS, LABEL_TOPIC)
+          .buckets(.01, .1, .250, 1, 10, 100, 500, 1_000, 2_000, 4_000)
+          .register();
+  private static final Counter REQUEST_COUNT =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("messaging_request_count")
+          .help("Number of requests which has been send to a certain address")
+          .labelNames("type", LABEL_ADDRESS, LABEL_TOPIC)
+          .register();
+
+  private static final Counter RESPONSE_COUNT =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("messaging_response_count")
+          .help("Number of responses which has been received")
+          .labelNames(LABEL_ADDRESS, LABEL_TOPIC, "outcome")
+          .register();
+
+  private static final Gauge IN_FLIGHT_REQUESTS =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("messaging_inflight_requests")
+          .help("The count of inflight requests")
+          .labelNames(LABEL_ADDRESS, LABEL_TOPIC)
+          .register();
+
+  @Override
+  public CloseableSilently startRequestTimer(final String name) {
+    final var timer = REQUEST_RESPONSE_LATENCY.labels(name).startTimer();
+    return timer::close;
+  }
+
+  @Override
+  public void observeRequestSize(final String to, final String name, final int requestSizeInBytes) {
+    REQUEST_SIZE_IN_KB.labels(to, name).observe(requestSizeInBytes / 1_000f);
+  }
+
+  @Override
+  public void countMessage(final String to, final String name) {
+    REQUEST_COUNT.labels(REQ_TYPE_MESSAGE, to, name).inc();
+  }
+
+  @Override
+  public void countRequestResponse(final String to, final String name) {
+    REQUEST_COUNT.labels(REQ_TYPE_REQ_RESP, to, name).inc();
+  }
+
+  @Override
+  public void countSuccessResponse(final String address, final String name) {
+    RESPONSE_COUNT.labels(address, name, "SUCCESS").inc();
+  }
+
+  @Override
+  public void countFailureResponse(final String address, final String name, String error) {
+    RESPONSE_COUNT.labels(address, name, error).inc();
+  }
+
+  @Override
+  public void incInFlightRequests(final String address, String topic) {
+    IN_FLIGHT_REQUESTS.labels(address, topic).inc();
+  }
+
+  @Override
+  public void decInFlightRequests(final String address, String topic) {
+    IN_FLIGHT_REQUESTS.labels(address, topic).dec();
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -116,7 +116,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private volatile LocalClientConnection localConnection;
   private SslContext serverSslContext;
   private SslContext clientSslContext;
-  private final MessagingMetrics messagingMetrics = new MessagingMetrics();
+  private final MessagingMetrics messagingMetrics = new MessagingMetricsImpl();
 
   public NettyMessagingService(
       final String cluster, final Address advertisedAddress, final MessagingConfig config) {

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -116,6 +116,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private volatile LocalClientConnection localConnection;
   private SslContext serverSslContext;
   private SslContext clientSslContext;
+  private final MessagingMetrics messagingMetrics = new MessagingMetrics();
 
   public NettyMessagingService(
       final String cluster, final Address advertisedAddress, final MessagingConfig config) {
@@ -652,7 +653,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private RemoteClientConnection getOrCreateClientConnection(final Channel channel) {
     RemoteClientConnection connection = connections.get(channel);
     if (connection == null) {
-      connection = connections.computeIfAbsent(channel, RemoteClientConnection::new);
+      connection = connections.computeIfAbsent(channel, c -> new RemoteClientConnection(messagingMetrics, c));
       channel
           .closeFuture()
           .addListener(

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -653,7 +653,9 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private RemoteClientConnection getOrCreateClientConnection(final Channel channel) {
     RemoteClientConnection connection = connections.get(channel);
     if (connection == null) {
-      connection = connections.computeIfAbsent(channel, c -> new RemoteClientConnection(messagingMetrics, c));
+      connection =
+          connections.computeIfAbsent(
+              channel, c -> new RemoteClientConnection(messagingMetrics, c));
       channel
           .closeFuture()
           .addListener(

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NopMessagingMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NopMessagingMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.camunda.zeebe.util.CloseableSilently;
+
+public class NopMessagingMetrics implements MessagingMetrics {
+
+  @Override
+  public CloseableSilently startRequestTimer(final String name) {
+    return () -> {};
+  }
+
+  @Override
+  public void observeRequestSize(
+      final String to, final String name, final int requestSizeInBytes) {}
+
+  @Override
+  public void countMessage(final String to, final String name) {}
+
+  @Override
+  public void countRequestResponse(final String to, final String name) {}
+
+  @Override
+  public void countSuccessResponse(final String address, final String name) {}
+
+  @Override
+  public void countFailureResponse(final String address, final String name, final String error) {}
+
+  @Override
+  public void incInFlightRequests(final String address, final String topic) {}
+
+  @Override
+  public void decInFlightRequests(final String address, final String topic) {}
+}

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteClientConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteClientConnection.java
@@ -69,8 +69,8 @@ final class RemoteClientConnection extends AbstractClientConnection {
     messagingMetrics.observeRequestSize(toAddress, subject, payload == null ? 0 : payload.length);
   }
 
-  private void countReqResponseMetrics(final ProtocolRequest message,
-      final CompletableFuture<byte[]> responseFuture) {
+  private void countReqResponseMetrics(
+      final ProtocolRequest message, final CompletableFuture<byte[]> responseFuture) {
     final String toAddress = channel.remoteAddress().toString();
     final String subject = message.subject();
     messagingMetrics.countRequestResponse(toAddress, subject);
@@ -84,13 +84,9 @@ final class RemoteClientConnection extends AbstractClientConnection {
           timer.close();
           messagingMetrics.decInFlightRequests(toAddress, subject);
           if (failure != null) {
-            messagingMetrics.countFailureResponse(
-                toAddress,
-                subject,
-                failure.getClass().getName());
+            messagingMetrics.countFailureResponse(toAddress, subject, failure.getClass().getName());
           } else {
-            messagingMetrics.countSuccessResponse(
-                toAddress, subject);
+            messagingMetrics.countSuccessResponse(toAddress, subject);
           }
         });
   }

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/RemoteClientConnectionTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/RemoteClientConnectionTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.util.CloseableSilently;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RemoteClientConnectionTest {
+
+  private SimpleMessagingMetrics simpleMetrics;
+  private Channel channel;
+  private RemoteClientConnection remoteClientConnection;
+  private InetSocketAddress toAddress;
+
+  @BeforeEach
+  public void setup() {
+    channel = mock(Channel.class);
+    toAddress = new InetSocketAddress(0);
+    when(channel.remoteAddress()).thenReturn(toAddress);
+    final ChannelFuture channelFuture = mock(ChannelFuture.class);
+    when(channel.writeAndFlush(any())).thenReturn(channelFuture);
+    simpleMetrics = new SimpleMessagingMetrics();
+    remoteClientConnection = new RemoteClientConnection(simpleMetrics, channel);
+  }
+
+  @Test
+  public void shouldCountForMessage() {
+    // given
+
+    // when
+    remoteClientConnection.sendAsync(
+        new ProtocolRequest(1, new Address("", 12345), "subj", "payload".getBytes()));
+
+    // then
+    final String expectedKey = simpleMetrics.computeKey(toAddress.toString(), "subj");
+    assertThat(simpleMetrics.messageCount.get(expectedKey)).isNotNull().isEqualTo(1);
+    assertThat(simpleMetrics.reqSize.get(expectedKey)).isEqualTo("payload".getBytes().length);
+
+    // only counted for req-resp
+    assertThat(simpleMetrics.inFlightRequestCount.size()).isEqualTo(0);
+    assertThat(simpleMetrics.reqRespCount.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldCountForRequestResponse() {
+    // given
+
+    // when
+    remoteClientConnection.sendAndReceive(
+        new ProtocolRequest(1, new Address("", 12345), "subj", "payload".getBytes()));
+
+    // then
+    final String expectedKey = simpleMetrics.computeKey(toAddress.toString(), "subj");
+    assertThat(simpleMetrics.inFlightRequestCount.get(expectedKey)).isEqualTo(1);
+    assertThat(simpleMetrics.reqRespCount.get(expectedKey)).isEqualTo(1);
+    assertThat(simpleMetrics.reqSize.get(expectedKey)).isEqualTo("payload".getBytes().length);
+
+    // only counted for message
+    assertThat(simpleMetrics.messageCount.size()).isZero();
+  }
+
+  @Test
+  public void shouldCountForResponse() {
+    // given
+    final var responseFuture =
+        remoteClientConnection.sendAndReceive(
+            new ProtocolRequest(1, new Address("", 12345), "subj", "payload".getBytes()));
+
+    // when
+    responseFuture.complete("complete".getBytes());
+
+    // then
+    final String expectedKey = simpleMetrics.computeKey(toAddress.toString(), "subj");
+    assertThat(simpleMetrics.inFlightRequestCount.get(expectedKey)).isEqualTo(0);
+    assertThat(simpleMetrics.reqRespCount.get(expectedKey)).isEqualTo(1);
+    assertThat(simpleMetrics.reqSize.get(expectedKey)).isEqualTo("payload".getBytes().length);
+    assertThat(simpleMetrics.requestResponseLatency).isGreaterThan(0);
+    assertThat(simpleMetrics.requestOutcome.get(expectedKey)).isTrue();
+
+    // only counted for message
+    assertThat(simpleMetrics.messageCount.size()).isZero();
+  }
+
+  @Test
+  public void shouldCountForFailedResponse() {
+    // given
+    final var responseFuture =
+        remoteClientConnection.sendAndReceive(
+            new ProtocolRequest(1, new Address("", 12345), "subj", "payload".getBytes()));
+
+    // when
+    responseFuture.completeExceptionally(new RuntimeException());
+
+    // then
+    final String expectedKey = simpleMetrics.computeKey(toAddress.toString(), "subj");
+    assertThat(simpleMetrics.inFlightRequestCount.get(expectedKey)).isEqualTo(0);
+    assertThat(simpleMetrics.reqRespCount.get(expectedKey)).isEqualTo(1);
+    assertThat(simpleMetrics.reqSize.get(expectedKey)).isEqualTo("payload".getBytes().length);
+    assertThat(simpleMetrics.requestResponseLatency).isGreaterThan(0);
+    assertThat(simpleMetrics.requestOutcome.get(expectedKey)).isFalse();
+
+    // only counted for message
+    assertThat(simpleMetrics.messageCount.size()).isZero();
+  }
+
+  private static final class SimpleMessagingMetrics implements MessagingMetrics {
+
+    private static final String LABEL_FORMAT = "%s-%s";
+
+    long requestResponseLatency;
+    final Map<String, Integer> messageCount = new HashMap<>();
+    final Map<String, Integer> inFlightRequestCount = new HashMap<>();
+    final Map<String, Integer> reqRespCount = new HashMap<>();
+    final Map<String, Integer> reqSize = new HashMap<>();
+    final Map<String, Boolean> requestOutcome = new HashMap<>();
+
+    @Override
+    public CloseableSilently startRequestTimer(final String name) {
+      final long start = System.nanoTime();
+      return () -> requestResponseLatency = System.nanoTime() - start;
+    }
+
+    @Override
+    public void observeRequestSize(
+        final String to, final String name, final int requestSizeInBytes) {
+      reqSize.put(computeKey(to, name), requestSizeInBytes);
+    }
+
+    @Override
+    public void countMessage(final String to, final String name) {
+      final String key = computeKey(to, name);
+      final Integer integer = messageCount.computeIfAbsent(key, s -> 0);
+      messageCount.put(key, integer + 1);
+    }
+
+    String computeKey(final String to, final String name) {
+      return String.format(LABEL_FORMAT, to, name);
+    }
+
+    @Override
+    public void countRequestResponse(final String to, final String name) {
+      final String key = computeKey(to, name);
+      final Integer integer = reqRespCount.computeIfAbsent(key, k -> 0);
+      reqRespCount.put(key, integer + 1);
+    }
+
+    @Override
+    public void countSuccessResponse(final String address, final String name) {
+      final String key = computeKey(address, name);
+      requestOutcome.put(key, true);
+    }
+
+    @Override
+    public void countFailureResponse(final String address, final String name, final String error) {
+      final String key = computeKey(address, name);
+      requestOutcome.put(key, false);
+    }
+
+    @Override
+    public void incInFlightRequests(final String address, final String topic) {
+      final String key = computeKey(address, topic);
+      final Integer integer = inFlightRequestCount.computeIfAbsent(key, k -> 0);
+      inFlightRequestCount.put(key, integer + 1);
+    }
+
+    @Override
+    public void decInFlightRequests(final String address, final String topic) {
+      final String key = computeKey(address, topic);
+      final Integer integer = inFlightRequestCount.computeIfAbsent(key, k -> 0);
+      inFlightRequestCount.put(key, integer - 1);
+    }
+  }
+}

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -178,7 +178,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 1
+            "y": 73
           },
           "id": 68,
           "links": [],
@@ -304,7 +304,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 1
+            "y": 73
           },
           "id": 243,
           "options": {
@@ -360,7 +360,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 1
+            "y": 73
           },
           "hiddenSeries": false,
           "id": 116,
@@ -475,7 +475,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 79
           },
           "hiddenSeries": false,
           "id": 58,
@@ -582,7 +582,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 79
           },
           "hiddenSeries": false,
           "id": 270,
@@ -682,7 +682,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 12
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 62,
@@ -797,7 +797,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 12
+            "y": 84
           },
           "id": 232,
           "links": [],
@@ -854,7 +854,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 12
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 74,
@@ -967,7 +967,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 14
+            "y": 86
           },
           "id": 118,
           "links": [],
@@ -1043,7 +1043,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 16
+            "y": 88
           },
           "id": 117,
           "links": [],
@@ -1098,7 +1098,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 18
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 39,
@@ -1209,7 +1209,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 18
+            "y": 90
           },
           "id": 190,
           "links": [],
@@ -1275,7 +1275,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 18
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 33,
@@ -1422,7 +1422,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 2
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 272,
@@ -1538,7 +1538,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 81
           },
           "id": 192,
           "options": {
@@ -1585,7 +1585,7 @@
             "h": 4,
             "w": 7,
             "x": 12,
-            "y": 9
+            "y": 81
           },
           "id": 196,
           "showHeader": true,
@@ -1662,7 +1662,7 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 9
+            "y": 81
           },
           "id": 200,
           "showHeader": true,
@@ -1755,7 +1755,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 13
+            "y": 85
           },
           "id": 194,
           "options": {
@@ -1801,7 +1801,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 13
+            "y": 85
           },
           "id": 199,
           "showHeader": true,
@@ -1878,7 +1878,7 @@
             "h": 12,
             "w": 5,
             "x": 12,
-            "y": 13
+            "y": 85
           },
           "id": 198,
           "showHeader": true,
@@ -1955,7 +1955,7 @@
             "h": 12,
             "w": 7,
             "x": 17,
-            "y": 13
+            "y": 85
           },
           "id": 268,
           "showHeader": true,
@@ -2048,7 +2048,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 19
+            "y": 91
           },
           "id": 189,
           "options": {
@@ -2095,7 +2095,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 19
+            "y": 91
           },
           "id": 201,
           "showHeader": true,
@@ -2195,7 +2195,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 75
           },
           "hideTimeOverride": false,
           "id": 12,
@@ -2256,7 +2256,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 75
           },
           "hideTimeOverride": false,
           "id": 13,
@@ -2328,7 +2328,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 8
+            "y": 80
           },
           "hiddenSeries": false,
           "id": 2,
@@ -2429,7 +2429,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 8
+            "y": 80
           },
           "hiddenSeries": false,
           "id": 3,
@@ -2532,7 +2532,7 @@
             "h": 6,
             "w": 9,
             "x": 0,
-            "y": 14
+            "y": 86
           },
           "hiddenSeries": false,
           "id": 4,
@@ -2626,7 +2626,7 @@
             "h": 6,
             "w": 7,
             "x": 9,
-            "y": 14
+            "y": 86
           },
           "hiddenSeries": false,
           "id": 266,
@@ -2721,7 +2721,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 14
+            "y": 86
           },
           "hiddenSeries": false,
           "id": 267,
@@ -2811,7 +2811,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 290,
@@ -2898,7 +2898,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 291,
@@ -2985,7 +2985,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 288,
@@ -3072,7 +3072,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 289,
@@ -3190,7 +3190,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4
+            "y": 76
           },
           "hiddenSeries": false,
           "id": 102,
@@ -3284,7 +3284,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4
+            "y": 76
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -3344,7 +3344,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 105,
@@ -3436,7 +3436,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 84
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -3495,7 +3495,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 182,
@@ -3601,7 +3601,6 @@
           "description": "Memory limits and requests are taken from the k8 pod metrics.",
           "fieldConfig": {
             "defaults": {
-              "custom": {},
               "links": []
             },
             "overrides": []
@@ -3612,7 +3611,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 5
+            "y": 77
           },
           "hiddenSeries": false,
           "id": 261,
@@ -3634,7 +3633,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "9.2.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -3728,19 +3727,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows the number of garbage collections (GC) per second, aggregated per pod and GC type.",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 285,
@@ -3760,7 +3753,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "9.2.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3820,19 +3813,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows the garbage collection (GC) time proportion per second. Means shows the rate which is spent in GC in a second.",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 286,
@@ -3852,7 +3839,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "9.2.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3913,7 +3900,6 @@
           },
           "fieldConfig": {
             "defaults": {
-              "custom": {},
               "links": []
             },
             "overrides": []
@@ -3924,7 +3910,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 98,
@@ -3948,7 +3934,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "9.2.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -4030,7 +4016,6 @@
           },
           "fieldConfig": {
             "defaults": {
-              "custom": {},
               "links": []
             },
             "overrides": []
@@ -4041,7 +4026,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 35,
@@ -4062,7 +4047,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "9.2.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -4158,7 +4143,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6
+            "y": 78
           },
           "hiddenSeries": false,
           "id": 64,
@@ -4259,7 +4244,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6
+            "y": 78
           },
           "hiddenSeries": false,
           "id": 294,
@@ -4384,7 +4369,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 7
+            "y": 79
           },
           "hiddenSeries": false,
           "id": 260,
@@ -4485,7 +4470,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 37,
@@ -4595,7 +4580,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 40,
@@ -4689,7 +4674,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 122,
@@ -4780,7 +4765,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 124,
@@ -4871,7 +4856,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 126,
@@ -4962,7 +4947,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 127,
@@ -5045,6 +5030,885 @@
     },
     {
       "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 337,
+      "panels": [
+        {
+          "cards": {},
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Shows the general latency for request-responses in zeebe.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 339,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#ef843c",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "9.2.5",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": " Request response latency",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "format": "dtdurations",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
+        },
+        {
+          "cards": {},
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Shows the general request size distribution",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 341,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#ef843c",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "deckbytes"
+            }
+          },
+          "pluginVersion": "9.2.5",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Request size distribution",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "format": "dtdurations",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Shows the general latency for request-responses in zeebe.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 343,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "9.2.5",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (topic, le))",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "p50 {{topic}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (topic, le))",
+              "hide": false,
+              "legendFormat": "p90 {{topic}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (topic, le))",
+              "hide": false,
+              "legendFormat": "p99 {{topic}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Request response latency quantiles",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Shows the general latency for request-responses in zeebe.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "deckbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 345,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "9.2.5",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (topic, le))",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "p50 {{topic}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (topic, le))",
+              "hide": false,
+              "legendFormat": "p90 {{topic}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (topic, le))",
+              "hide": false,
+              "legendFormat": "p99 {{topic}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Request size quantiles",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 347,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(zeebe_messaging_inflight_requests) by (pod, address)",
+              "legendFormat": "{{pod}} => {{address}} ",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Inflight request count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 349,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_messaging_request_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) by (pod, address, topic)",
+              "legendFormat": "{{topic}}: {{pod}} => {{address}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Request count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 353,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_messaging_response_count_total{namespace=~\"$namespace\", pod=~\"$pod\", outcome!=\"SUCCESS\"}[1m])) by (address, topic, outcome)",
+              "legendFormat": "{{topic}} {{address}} {{outcome}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Response failure count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 0,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 351,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_messaging_request_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) by (type)",
+              "legendFormat": "{{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Request count per type",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Messaging",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
       "datasource": {
         "uid": "${DS_PROMETHEUS}"
       },
@@ -5052,7 +5916,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 8
       },
       "id": 46,
       "panels": [
@@ -5089,7 +5953,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 8
+            "y": 80
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5189,7 +6053,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 8
+            "y": 80
           },
           "hiddenSeries": false,
           "id": 222,
@@ -5308,7 +6172,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 88
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5419,7 +6283,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 88
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5530,7 +6394,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 24
+            "y": 96
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5641,7 +6505,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 103
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5752,7 +6616,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 103
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5845,7 +6709,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 110
           },
           "hiddenSeries": false,
           "id": 310,
@@ -5962,7 +6826,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 110
           },
           "hiddenSeries": false,
           "id": 311,
@@ -6097,7 +6961,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 117
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6208,7 +7072,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 117
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6307,7 +7171,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 48,
       "panels": [
@@ -6333,7 +7197,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 8
+            "y": 80
           },
           "hiddenSeries": false,
           "id": 26,
@@ -6426,7 +7290,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 8
+            "y": 80
           },
           "hiddenSeries": false,
           "id": 27,
@@ -6531,7 +7395,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 15
+            "y": 87
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6594,7 +7458,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 15
+            "y": 87
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6657,7 +7521,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 15
+            "y": 87
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6718,7 +7582,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 10
       },
       "id": 162,
       "panels": [
@@ -6746,7 +7610,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 9
+            "y": 81
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6805,7 +7669,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 89
           },
           "hiddenSeries": false,
           "id": 166,
@@ -6897,7 +7761,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 89
           },
           "hiddenSeries": false,
           "id": 168,
@@ -6989,7 +7853,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 11
       },
       "id": 76,
       "panels": [
@@ -7003,13 +7867,19 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows the rate of different raft requests send from the leader to different followers",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 11
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 278,
@@ -7031,7 +7901,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7098,16 +7968,7 @@
           },
           "fieldConfig": {
             "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
+              "custom": {}
             },
             "overrides": []
           },
@@ -7115,7 +7976,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 91
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7125,44 +7986,6 @@
             "show": false
           },
           "links": [],
-          "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#b4ff00",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Spectral",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
-            "legend": {
-              "show": false
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "show": true,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "dtdurations"
-            }
-          },
-          "pluginVersion": "9.2.5",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7207,16 +8030,7 @@
           },
           "fieldConfig": {
             "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
+              "custom": {}
             },
             "overrides": []
           },
@@ -7224,7 +8038,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 91
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7234,44 +8048,6 @@
             "show": false
           },
           "links": [],
-          "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#b4ff00",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Spectral",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
-            "legend": {
-              "show": false
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "show": true,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "dtdurations"
-            }
-          },
-          "pluginVersion": "9.2.5",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7311,13 +8087,19 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows the total count of send install requests from the leader to the followers",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 24
+            "y": 97
           },
           "hiddenSeries": false,
           "id": 283,
@@ -7339,7 +8121,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7402,6 +8184,7 @@
           "description": "Approximate Install RPC as measured by the follower.",
           "fieldConfig": {
             "defaults": {
+              "custom": {},
               "links": []
             },
             "overrides": []
@@ -7412,7 +8195,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 104
           },
           "hiddenSeries": false,
           "id": 79,
@@ -7433,7 +8216,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7495,6 +8278,7 @@
           "description": "Ongoing snapshot replications per partition, from the follower point-of-view.",
           "fieldConfig": {
             "defaults": {
+              "custom": {},
               "links": []
             },
             "overrides": []
@@ -7505,7 +8289,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 104
           },
           "hiddenSeries": false,
           "id": 114,
@@ -7525,7 +8309,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7589,16 +8373,7 @@
           },
           "fieldConfig": {
             "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
+              "custom": {}
             },
             "overrides": []
           },
@@ -7606,7 +8381,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 111
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7616,44 +8391,6 @@
             "show": false
           },
           "links": [],
-          "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#b4ff00",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Spectral",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
-            "legend": {
-              "show": false
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "show": true,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "dtdurations"
-            }
-          },
-          "pluginVersion": "9.2.5",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7692,13 +8429,19 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 111
           },
           "hiddenSeries": false,
           "id": 300,
@@ -7718,7 +8461,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7742,26 +8485,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "editorMode": "code",
               "expr": "histogram_quantile(0.50, sum(rate(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le))",
               "hide": false,
               "interval": "",
-              "legendFormat": "p50",
-              "range": true,
+              "legendFormat": "Median",
               "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "p99",
-              "range": true,
-              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -7809,16 +8537,7 @@
           },
           "fieldConfig": {
             "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
+              "custom": {}
             },
             "overrides": []
           },
@@ -7826,7 +8545,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 118
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7836,44 +8555,6 @@
             "show": false
           },
           "links": [],
-          "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#b4ff00",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Spectral",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
-            "legend": {
-              "show": false
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "show": true,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "dtdurations"
-            }
-          },
-          "pluginVersion": "9.2.5",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7913,13 +8594,19 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 118
           },
           "hiddenSeries": false,
           "id": 305,
@@ -7939,7 +8626,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7953,26 +8640,21 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le))",
-              "hide": false,
+              "expr": "sum(rate(atomix_append_entries_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) / sum(rate(atomix_append_entries_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m]))",
               "interval": "",
-              "legendFormat": "p50",
-              "range": true,
-              "refId": "C"
+              "legendFormat": "Avg",
+              "refId": "A"
             },
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le))",
               "hide": false,
               "interval": "",
-              "legendFormat": "p99",
-              "range": true,
-              "refId": "A"
+              "legendFormat": "Median",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -8020,16 +8702,7 @@
           },
           "fieldConfig": {
             "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
+              "custom": {}
             },
             "overrides": []
           },
@@ -8037,7 +8710,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 125
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8047,44 +8720,6 @@
             "show": true
           },
           "links": [],
-          "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#b4ff00",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Spectral",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
-            "legend": {
-              "show": true
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "show": true,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "dtdurations"
-            }
-          },
-          "pluginVersion": "9.2.5",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -8126,6 +8761,7 @@
           },
           "fieldConfig": {
             "defaults": {
+              "custom": {},
               "links": []
             },
             "overrides": []
@@ -8136,7 +8772,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 125
           },
           "hiddenSeries": false,
           "id": 72,
@@ -8159,7 +8795,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -8222,6 +8858,7 @@
           "description": "Shows when a role change has happened. \n1 = Follower\n2 = Candidate\n3 = Leader\n2 - ",
           "fieldConfig": {
             "defaults": {
+              "custom": {},
               "links": []
             },
             "overrides": []
@@ -8232,7 +8869,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 133
           },
           "hiddenSeries": false,
           "id": 95,
@@ -8259,7 +8896,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -8330,6 +8967,7 @@
           "description": "",
           "fieldConfig": {
             "defaults": {
+              "custom": {},
               "links": []
             },
             "overrides": []
@@ -8340,7 +8978,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 133
           },
           "hiddenSeries": false,
           "id": 180,
@@ -8360,7 +8998,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "7.4.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -8431,7 +9069,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 68
+            "y": 141
           },
           "id": 205,
           "maxPerRow": 6,
@@ -8505,7 +9143,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 73
+            "y": 146
           },
           "id": 209,
           "maxPerRow": 6,
@@ -8585,7 +9223,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 151
           },
           "id": 215,
           "options": {
@@ -8643,7 +9281,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 151
           },
           "id": 217,
           "options": {
@@ -8696,7 +9334,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 140,
       "panels": [
@@ -8722,7 +9360,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 83
           },
           "hiddenSeries": false,
           "id": 154,
@@ -8815,7 +9453,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 83
           },
           "hiddenSeries": false,
           "id": 144,
@@ -8906,7 +9544,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 89
           },
           "hiddenSeries": false,
           "id": 142,
@@ -8997,7 +9635,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 95
           },
           "hiddenSeries": false,
           "id": 151,
@@ -9089,7 +9727,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 95
           },
           "hiddenSeries": false,
           "id": 152,
@@ -9181,7 +9819,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 101
           },
           "hiddenSeries": false,
           "id": 150,
@@ -9273,7 +9911,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 107
           },
           "hiddenSeries": false,
           "id": 147,
@@ -9365,7 +10003,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 107
           },
           "hiddenSeries": false,
           "id": 149,
@@ -9458,7 +10096,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 114
           },
           "hiddenSeries": false,
           "id": 148,
@@ -9549,7 +10187,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 120
           },
           "hiddenSeries": false,
           "id": 155,
@@ -9640,7 +10278,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 120
           },
           "hiddenSeries": false,
           "id": 156,
@@ -9732,7 +10370,7 @@
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 56
+            "y": 128
           },
           "id": 158,
           "pluginVersion": "6.7.1",
@@ -9842,7 +10480,7 @@
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 56
+            "y": 128
           },
           "hiddenSeries": false,
           "id": 157,
@@ -9933,7 +10571,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 128
           },
           "hiddenSeries": false,
           "id": 146,
@@ -10024,7 +10662,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 62
+            "y": 134
           },
           "hiddenSeries": false,
           "id": 159,
@@ -10115,7 +10753,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 62
+            "y": 134
           },
           "hiddenSeries": false,
           "id": 160,
@@ -10206,7 +10844,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 134
           },
           "hiddenSeries": false,
           "id": 153,
@@ -10297,7 +10935,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 50,
       "panels": [
@@ -10324,7 +10962,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 84
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -10385,7 +11023,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 255,
@@ -10479,7 +11117,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 94
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -10539,7 +11177,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 94
           },
           "hiddenSeries": false,
           "id": 185,
@@ -10635,7 +11273,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 32
+            "y": 104
           },
           "height": "400",
           "hiddenSeries": false,
@@ -10750,7 +11388,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 176,
       "panels": [
@@ -10788,7 +11426,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 14
+            "y": 86
           },
           "id": 170,
           "maxPerRow": 6,
@@ -10868,7 +11506,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 92
           },
           "id": 174,
           "options": {
@@ -10934,7 +11572,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 92
           },
           "id": 265,
           "options": {
@@ -10989,7 +11627,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 315,
       "panels": [
@@ -11016,7 +11654,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 87
           },
           "id": 329,
           "options": {
@@ -11082,7 +11720,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 15
+            "y": 87
           },
           "id": 319,
           "options": {
@@ -11140,7 +11778,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 95
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -11214,7 +11852,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 95
           },
           "id": 325,
           "options": {
@@ -11298,7 +11936,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 103
           },
           "id": 313,
           "options": {
@@ -11358,7 +11996,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 103
           },
           "id": 321,
           "options": {
@@ -11440,7 +12078,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 111
           },
           "id": 335,
           "options": {
@@ -11498,7 +12136,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 111
           },
           "id": 317,
           "options": {
@@ -11560,7 +12198,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 47
+            "y": 119
           },
           "id": 327,
           "options": {


### PR DESCRIPTION
## Description

![msg](https://user-images.githubusercontent.com/2758593/210272810-15290730-4e40-4378-8ac3-ea2a6603c291.png)
![msg2](https://user-images.githubusercontent.com/2758593/210272813-cacb59b7-7c39-40ca-9bd0-f65b1fe3650e.png)


Add new metrics for the MessagingService, the metrics allow to observe:

 * request count, grouped by subject, address, and if necessary by type (req-resp + message)
 * response count, failures on responses
 * req-response latency
 * size of requests in KB
 * in flight requests


Added tests to verify that there are called. Add new feature flag to disable them, in gateway they are currently hard coded since here we have no experimental config.


Based on the metrics we can already had some interesting insights, like the spike of Req-Response latency because of the InstallRequests, or how many data is sent for this req.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
