### PR TITLE
Fix NPE when FEEL expression results in unknown type

### DIFF
--- a/expression-language/src/main/java/io/camunda/zeebe/el/ResultType.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/ResultType.java
@@ -15,6 +15,7 @@ public enum ResultType {
   STRING,
   DURATION,
   PERIOD,
+  DATE,
   DATE_TIME,
   ARRAY,
   OBJECT

--- a/expression-language/src/main/java/io/camunda/zeebe/el/ResultType.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/ResultType.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.el;
 
 /** The possible types of an evaluation result. */
 public enum ResultType {
+  UNKNOWN,
   NULL,
   BOOLEAN,
   NUMBER,

--- a/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
+++ b/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
@@ -37,6 +37,7 @@ class FeelEvaluationResult(
     case _: ValContext => ResultType.OBJECT
     case _: ValDayTimeDuration => ResultType.DURATION
     case _: ValYearMonthDuration => ResultType.PERIOD
+    case _: ValDate => ResultType.DATE
     case _: ValDateTime => ResultType.DATE_TIME
     case _: ValLocalDateTime => ResultType.DATE_TIME
     case _ => null

--- a/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
+++ b/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
@@ -40,7 +40,7 @@ class FeelEvaluationResult(
     case _: ValDate => ResultType.DATE
     case _: ValDateTime => ResultType.DATE_TIME
     case _: ValLocalDateTime => ResultType.DATE_TIME
-    case _ => null
+    case _ => ResultType.UNKNOWN
   }
 
   override def toBuffer: DirectBuffer = messagePackTransformer(result)

--- a/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
@@ -182,7 +182,7 @@ public class EvaluationResultTest {
   public void dateExpression() {
     final var evaluationResult = evaluateExpression("=date(\"2020-04-02\")");
 
-    assertThat(evaluationResult.getType()).isNull();
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.DATE);
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
@@ -194,7 +194,7 @@ public class EvaluationResultTest {
   public void timeExpression() {
     final var evaluationResult = evaluateExpression("=time(\"14:00:00\")");
 
-    assertThat(evaluationResult.getType()).isNull();
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.UNKNOWN);
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This fixes an NPE that could occur when the result of a FEEL expression is unknown to Zeebe.

For example, when the result of a FEEL expression is a ValDate (i.e. a date without a time component) while it expects a duration, then the resulting FEEL Evaluation Result has type `null`.

> **Note** that this result type `null` differs from the `NULL` result type. The `NULL` result type means that the result has the value `null`. When the type is `null`, the result seems to have no (known) type.

This PR introduces a new `UNKNOWN` type instead of `null`. This allows the type to be used in switch statements that don't support the use of `null`.

This PR also adds the `DATE` as a known type to Zeebe, so it can be used in failure message. For example:
>Expected result of the expression 'today()' to be one of '[DURATION, PERIOD, STRING]', but was 'DATE'

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5934

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
