### PR TITLE
feat(raft): only sync data for metastore file updates

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -79,7 +79,7 @@ public class MetaStore implements AutoCloseable {
             metaFile.toPath(),
             StandardOpenOption.READ,
             StandardOpenOption.WRITE,
-            StandardOpenOption.SYNC);
+            StandardOpenOption.DSYNC);
 
     confFile = new File(storage.directory(), String.format("%s.conf", storage.prefix()));
 


### PR DESCRIPTION
## Description

Meta file update is execute in the hot path of raft, and have a significant influence in performance. By switching to DSYNC, we observed a tiny bit of improvement to p50 latency. Using DSYNC is safe here as the file metadata is not relevant for us

The metrics shows slight improvement to the metastore update latency.
![image](https://user-images.githubusercontent.com/1997478/210980631-3f73559e-3c0b-4cd8-b790-70d7d3a32d11.png)
Note: This metrics is not available in this branch or main. It is WIP in #11366 

In the above benchmark, we can also see a tiny bit of improvement in p50 latency.
![image](https://user-images.githubusercontent.com/1997478/210981538-87aa6e17-3708-4bc3-ab1d-50f172d46a7b.png)

These improvements might not be significant enough to make noticeable difference in a real workload. But any small improvements will add up.

Also ran another benchmark with the medic benchmark configuration:
This PR:
![image](https://user-images.githubusercontent.com/1997478/210982384-3a2a357a-8af1-497b-99c8-e29f0112cafc.png)
medic-cw-01:
![image](https://user-images.githubusercontent.com/1997478/210982515-ac966164-c7b4-46e0-9151-74f1cc85f0fd.png)