### PR TITLE
[Backport stable/8.1] feat(raft): only sync data for metastore file updates

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -79,7 +79,7 @@ public class MetaStore implements AutoCloseable {
             metaFile.toPath(),
             StandardOpenOption.READ,
             StandardOpenOption.WRITE,
-            StandardOpenOption.SYNC);
+            StandardOpenOption.DSYNC);
 
     confFile = new File(storage.directory(), String.format("%s.conf", storage.prefix()));
 


### PR DESCRIPTION
# Description
Backport of #11373 to `stable/8.1`.

relates to #11366