### PR TITLE
ci: use stable branch for benchmark helm charts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -110,6 +110,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: zeebe-io/benchmark-helm
+          ref: stable
           path: benchmark-helm
       - name: Helm dependency build
         working-directory: benchmark-helm/zeebe-benchmark


### PR DESCRIPTION
To prepare for changes in https://github.com/zeebe-io/benchmark-helm/pull/2, switch to the stable branch of the helm charts. This way, the benchmark workflows continue to work, even if we break the release or make incompatible changes.