### PR TITLE
ci: fix benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -108,7 +108,6 @@ jobs:
           helm repo add zeebe-benchmark https://zeebe-io.github.io/benchmark-helm
           helm repo update
       - name: Helm install
-        working-directory: benchmark-helm/zeebe-benchmark
         run: >
           helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark
           --namespace ${{ inputs.name }}


### PR DESCRIPTION
The working directory doesn't exist anymore and there's no need to `cd` into it anyway because the helm chart is not local.