### PR TITLE
Extract error code, error message to variables

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -214,6 +214,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.di.WaypointImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAssignmentDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledDecisionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledElementImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeErrorImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeFormDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeHeaderImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeInputImpl;
@@ -649,6 +650,7 @@ public class Bpmn {
     ZeebePropertyImpl.registerType(bpmnModelBuilder);
     ZeebePropertiesImpl.registerType(bpmnModelBuilder);
     ZeebeScriptImpl.registerType(bpmnModelBuilder);
+    ZeebeErrorImpl.registerType(bpmnModelBuilder);
   }
 
   /**

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractErrorEventDefinitionBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractErrorEventDefinitionBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Event;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeError;
 
 public abstract class AbstractErrorEventDefinitionBuilder<
         B extends AbstractErrorEventDefinitionBuilder<B>>
@@ -38,6 +39,18 @@ public abstract class AbstractErrorEventDefinitionBuilder<
   /** Sets the error attribute with errorCode. */
   public B error(final String errorCode) {
     element.setError(findErrorForNameAndCode(errorCode));
+    return myself;
+  }
+
+  public B errorCodeVariable(final String errorCodeVariable) {
+    final ZeebeError error = myself.getCreateSingleExtensionElement(ZeebeError.class);
+    error.setErrorCodeVariable(errorCodeVariable);
+    return myself;
+  }
+
+  public B errorMessageVariable(final String errorMessageVariable) {
+    final ZeebeError error = myself.getCreateSingleExtensionElement(ZeebeError.class);
+    error.setErrorMessageVariable(errorMessageVariable);
     return myself;
   }
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractErrorEventDefinitionBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractErrorEventDefinitionBuilder.java
@@ -42,12 +42,26 @@ public abstract class AbstractErrorEventDefinitionBuilder<
     return myself;
   }
 
+  /**
+   * The attribute specifies a variable that holds the error code. The specified variable will be
+   * created with error code as the value.
+   *
+   * @param errorCodeVariable the name of error code variable
+   * @return the builder object
+   */
   public B errorCodeVariable(final String errorCodeVariable) {
     final ZeebeError error = myself.getCreateSingleExtensionElement(ZeebeError.class);
     error.setErrorCodeVariable(errorCodeVariable);
     return myself;
   }
 
+  /**
+   * The attribute specifies a variable that holds the error message. The specified variable will be
+   * created with error message as the value.
+   *
+   * @param errorMessageVariable the name of error message variable
+   * @return the builder object
+   */
   public B errorMessageVariable(final String errorMessageVariable) {
     final ZeebeError error = myself.getCreateSingleExtensionElement(ZeebeError.class);
     error.setErrorMessageVariable(errorMessageVariable);

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -45,9 +45,14 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_DECISION_ID = "decisionId";
 
+  public static final String ATTRIBUTE_ERROR_CODE_VARIABLE = "errorCodeVariable";
+  public static final String ATTRIBUTE_ERROR_MESSAGE_VARIABLE = "errorMessageVariable";
+
   public static final String ATTRIBUTE_EXPRESSION = "expression";
 
   public static final String ATTRIBUTE_RESULT_VARIABLE = "resultVariable";
+
+  public static final String ELEMENT_ERROR = "error";
 
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeErrorImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeErrorImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.ZEEBE_NS;
+import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.ATTRIBUTE_ERROR_CODE_VARIABLE;
+import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.ATTRIBUTE_ERROR_MESSAGE_VARIABLE;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeError;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeErrorImpl extends BpmnModelElementInstanceImpl implements ZeebeError {
+
+  protected static Attribute<String> errorCodeVariableAttribute;
+
+  protected static Attribute<String> errorMessageVariableAttribute;
+
+  public ZeebeErrorImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  @Override
+  public String getErrorCodeVariable() {
+    return errorCodeVariableAttribute.getValue(this);
+  }
+
+  @Override
+  public void setErrorCodeVariable(final String errorCodeVariable) {
+    errorCodeVariableAttribute.setValue(this, errorCodeVariable);
+  }
+
+  @Override
+  public String getErrorMessageVariable() {
+    return errorMessageVariableAttribute.getValue(this);
+  }
+
+  @Override
+  public void setErrorMessageVariable(final String errorMessageVariable) {
+    errorMessageVariableAttribute.setValue(this, errorMessageVariable);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeError.class, ZeebeConstants.ELEMENT_ERROR)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeErrorImpl::new);
+
+    errorCodeVariableAttribute =
+        typeBuilder.stringAttribute(ATTRIBUTE_ERROR_CODE_VARIABLE).namespace(ZEEBE_NS).build();
+
+    errorMessageVariableAttribute =
+        typeBuilder.stringAttribute(ATTRIBUTE_ERROR_MESSAGE_VARIABLE).namespace(ZEEBE_NS).build();
+
+    typeBuilder.build();
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeError.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeError.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+public interface ZeebeError extends BpmnModelElementInstance {
+
+  String getErrorCodeVariable();
+
+  void setErrorCodeVariable(String errorCodeVariable);
+
+  String getErrorMessageVariable();
+
+  void setErrorMessageVariable(String errorMessageVariable);
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BoundaryEventBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BoundaryEventBuilderTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeError;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.jupiter.api.Test;
+
+class BoundaryEventBuilderTest {
+
+  private static final String PROCESS_ID = "wf";
+  private static final String JOB_TYPE = "test";
+  private static final String ERROR_CODE = "ERROR";
+
+  @Test
+  void testErrorBoundaryEventErrorCodeVariableCanBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .boundaryEvent(
+                "error-boundary-event",
+                b -> b.errorEventDefinition().error(ERROR_CODE).errorCodeVariable("errorCode"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance errorEventDefinition =
+        instance.getModelElementsByType(ErrorEventDefinition.class).iterator().next();
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            errorEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebeError.class))
+        .hasSize(1)
+        .extracting(ZeebeError::getErrorCodeVariable)
+        .containsExactly("errorCode");
+  }
+
+  @Test
+  void testErrorBoundaryEventErrorMessageVariableCanBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .boundaryEvent(
+                "error-boundary-event",
+                b ->
+                    b.errorEventDefinition().error(ERROR_CODE).errorMessageVariable("errorMessage"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance errorEventDefinition =
+        instance.getModelElementsByType(ErrorEventDefinition.class).iterator().next();
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            errorEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebeError.class))
+        .hasSize(1)
+        .extracting(ZeebeError::getErrorMessageVariable)
+        .containsExactly("errorMessage");
+  }
+
+  @Test
+  void testErrorBoundaryEventErrorCodeVariableAndErrorMessageVariableCanAllBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .boundaryEvent(
+                "error-boundary-event",
+                b ->
+                    b.errorEventDefinition()
+                        .error(ERROR_CODE)
+                        .errorCodeVariable("errorCode")
+                        .errorMessageVariable("errorMessage"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance errorEventDefinition =
+        instance.getModelElementsByType(ErrorEventDefinition.class).iterator().next();
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            errorEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebeError.class))
+        .hasSize(1)
+        .extracting(ZeebeError::getErrorCodeVariable, ZeebeError::getErrorMessageVariable)
+        .containsExactly(tuple("errorCode", "errorMessage"));
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BoundaryEventBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BoundaryEventBuilderTest.java
@@ -108,4 +108,23 @@ class BoundaryEventBuilderTest {
         .extracting(ZeebeError::getErrorCodeVariable, ZeebeError::getErrorMessageVariable)
         .containsExactly(tuple("errorCode", "errorMessage"));
   }
+
+  @Test
+  void testErrorBoundaryEventDoesNotContainZeebeErrorExtensionElement() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .boundaryEvent("error-boundary-event", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance errorEventDefinition =
+        instance.getModelElementsByType(ErrorEventDefinition.class).iterator().next();
+
+    assertThat(errorEventDefinition.getUniqueChildElementByType(ExtensionElements.class))
+        .describedAs(
+            "Expect that ZeebeError extension element is not added to error event definition")
+        .isNull();
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableError;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer;
@@ -21,16 +22,19 @@ import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTupl
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.apache.commons.lang3.StringUtils;
 
 public final class BpmnEventPublicationBehavior {
-
   private final ElementInstanceState elementInstanceState;
   private final EventHandle eventHandle;
   private final CatchEventAnalyzer catchEventAnalyzer;
@@ -63,32 +67,37 @@ public final class BpmnEventPublicationBehavior {
    * interrupted, etc.
    *
    * @param catchEventTuple a tuple representing a catch event and its current instance
-   */
-  public void throwErrorEvent(final CatchEventAnalyzer.CatchEventTuple catchEventTuple) {
-    final ElementInstance eventScopeInstance = catchEventTuple.getElementInstance();
-    final ExecutableCatchEvent catchEvent = catchEventTuple.getCatchEvent();
-
-    if (eventHandle.canTriggerElement(eventScopeInstance, catchEvent.getId())) {
-      eventHandle.activateElement(
-          catchEvent, eventScopeInstance.getKey(), eventScopeInstance.getValue());
-    }
-  }
-
-  /**
-   * Throws an error event to the given element instance/catch event pair. Only throws the event if
-   * the given element instance is exists and is accepting events, e.g. isn't terminating, wasn't
-   * interrupted, etc.
-   *
-   * @param catchEventTuple a tuple representing a catch event and its current instance
+   * @param variables the variables/payload that the event can propagate (can be empty)
+   * @param errorMessage the error message that the event can propagate (can be empty)
    */
   public void throwErrorEvent(
-      final CatchEventAnalyzer.CatchEventTuple catchEventTuple, final DirectBuffer variables) {
+      final CatchEventAnalyzer.CatchEventTuple catchEventTuple,
+      final Map<String, Object> variables,
+      final String errorMessage) {
     final ElementInstance eventScopeInstance = catchEventTuple.getElementInstance();
     final ExecutableCatchEvent catchEvent = catchEventTuple.getCatchEvent();
+    final ExecutableError error = catchEvent.getError();
+    final Optional<String> errorCodeOptional = error.getErrorCode().map(BufferUtil::bufferAsString);
+
+    error
+        .getErrorCodeVariable()
+        .filter(StringUtils::isNotBlank)
+        .ifPresent(
+            errorCodeVariable ->
+                errorCodeOptional.ifPresent(
+                    errorCode -> variables.put(errorCodeVariable, errorCode)));
+
+    error
+        .getErrorMessageVariable()
+        .filter(StringUtils::isNotBlank)
+        .ifPresent(errorMessageVariable -> variables.put(errorMessageVariable, errorMessage));
 
     if (eventHandle.canTriggerElement(eventScopeInstance, catchEvent.getId())) {
       eventHandle.activateElement(
-          catchEvent, eventScopeInstance.getKey(), eventScopeInstance.getValue(), variables);
+          catchEvent,
+          eventScopeInstance.getKey(),
+          eventScopeInstance.getValue(),
+          new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variables)));
     }
   }
 
@@ -98,7 +107,7 @@ public final class BpmnEventPublicationBehavior {
    * returned.
    *
    * <p>The returned {@link CatchEventTuple} can be used to throw the event via {@link
-   * #throwErrorEvent(CatchEventTuple)}.
+   * #throwErrorEvent(CatchEventTuple, Map, String)}.
    *
    * @param errorCode the error code of the error event
    * @param context the current element context

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -22,7 +22,9 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.util.Either;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 
 public final class EndEventProcessor implements BpmnElementProcessor<ExecutableEndEvent> {
@@ -125,6 +127,8 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
 
   private class ErrorEndEventBehavior implements EndEventBehavior {
 
+    private static final Map<String, Object> EMPTY_VARIABLES = new HashMap<>();
+
     @Override
     public boolean isSuitableForEvent(final ExecutableEndEvent element) {
       return element.isErrorEndEvent();
@@ -142,7 +146,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
           .ifRightOrLeft(
               catchEvent -> {
                 stateTransitionBehavior.transitionToActivated(activating);
-                eventPublicationBehavior.throwErrorEvent(catchEvent);
+                eventPublicationBehavior.throwErrorEvent(catchEvent, EMPTY_VARIABLES, "");
               },
               failure -> incidentBehavior.createIncident(failure, activating));
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableError.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableError.java
@@ -16,6 +16,8 @@ public class ExecutableError extends AbstractFlowElement {
 
   private DirectBuffer errorCode;
   private Expression errorCodeExpression;
+  private String errorCodeVariable;
+  private String errorMessageVariable;
 
   public ExecutableError(final String id) {
     super(id);
@@ -43,5 +45,21 @@ public class ExecutableError extends AbstractFlowElement {
 
   public void setErrorCodeExpression(final Expression errorCodeExpression) {
     this.errorCodeExpression = errorCodeExpression;
+  }
+
+  public Optional<String> getErrorCodeVariable() {
+    return Optional.ofNullable(errorCodeVariable);
+  }
+
+  public void setErrorCodeVariable(final String errorCodeVariable) {
+    this.errorCodeVariable = errorCodeVariable;
+  }
+
+  public Optional<String> getErrorMessageVariable() {
+    return Optional.ofNullable(errorMessageVariable);
+  }
+
+  public void setErrorMessageVariable(final String errorMessageVariable) {
+    this.errorMessageVariable = errorMessageVariable;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ErrorTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ErrorTransformer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableError;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeError;
+
+public class ErrorTransformer {
+
+  public void transform(final ExecutableError executableElement, final ZeebeError zeebeError) {
+
+    if (zeebeError == null) {
+      return;
+    }
+
+    executableElement.setErrorCodeVariable(zeebeError.getErrorCodeVariable());
+    executableElement.setErrorMessageVariable(zeebeError.getErrorMessageVariable());
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -96,7 +96,8 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       return;
     }
 
-    eventPublicationBehavior.throwErrorEvent(foundCatchEvent.get(), job.getVariablesBuffer());
+    eventPublicationBehavior.throwErrorEvent(
+        foundCatchEvent.get(), job.getVariables(), job.getErrorMessage());
   }
 
   private void acceptCommand(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
@@ -16,10 +16,12 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractStartEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
@@ -618,5 +620,183 @@ public class ErrorEventTest {
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldPropagateErrorCodeVariable() {
+    // Given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .boundaryEvent(
+                "error-boundary-event",
+                b -> b.errorEventDefinition().error(ERROR_CODE).errorCodeVariable("errorCode"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // Then
+    final long scopeKey =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.BOUNDARY_EVENT)
+            .getFirst()
+            .getKey();
+
+    final Record<VariableRecordValue> variableRecords =
+        RecordingExporter.variableRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(scopeKey)
+            .withName("errorCode")
+            .getFirst();
+
+    Assertions.assertThat(variableRecords.getValue()).hasValue("\"ERROR\"");
+  }
+
+  @Test
+  public void shouldPropagateErrorMessageVariable() {
+    // Given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .boundaryEvent(
+                "error-boundary-event",
+                b ->
+                    b.errorEventDefinition().error(ERROR_CODE).errorMessageVariable("errorMessage"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .withErrorMessage("error-message")
+        .throwError();
+
+    // Then
+    final long scopeKey =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.BOUNDARY_EVENT)
+            .getFirst()
+            .getKey();
+
+    final Record<VariableRecordValue> variableRecords =
+        RecordingExporter.variableRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(scopeKey)
+            .withName("errorMessage")
+            .getFirst();
+
+    Assertions.assertThat(variableRecords.getValue()).hasValue("\"error-message\"");
+  }
+
+  @Test
+  public void shouldPropagateEmptyErrorMessageVariable() {
+    // Given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .boundaryEvent(
+                "error-boundary-event",
+                b ->
+                    b.errorEventDefinition().error(ERROR_CODE).errorMessageVariable("errorMessage"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // Then
+    final long scopeKey =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.BOUNDARY_EVENT)
+            .getFirst()
+            .getKey();
+
+    final Record<VariableRecordValue> variableRecords =
+        RecordingExporter.variableRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(scopeKey)
+            .withName("errorMessage")
+            .getFirst();
+
+    Assertions.assertThat(variableRecords.getValue())
+        .describedAs(
+            "Expect that errorMessage variable has an empty string as value because no error message was provided with the thrown error")
+        .hasValue("\"\"");
+  }
+
+  @Test
+  public void shouldPropagateEmptyErrorMessageVariableFromErrorEndEvent() {
+    // Given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "sub",
+                s ->
+                    s.embeddedSubProcess().startEvent().endEvent("error", e -> e.error(ERROR_CODE)))
+            .boundaryEvent(
+                "error-boundary-event",
+                b ->
+                    b.errorEventDefinition().error(ERROR_CODE).errorMessageVariable("errorMessage"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // Then
+    final long scopeKey =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.BOUNDARY_EVENT)
+            .getFirst()
+            .getKey();
+
+    final Record<VariableRecordValue> variableRecords =
+        RecordingExporter.variableRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(scopeKey)
+            .withName("errorMessage")
+            .getFirst();
+
+    Assertions.assertThat(variableRecords.getValue())
+        .describedAs(
+            "Expect that errorMessage variable has an empty string as value because no error message was provided with the thrown error")
+        .hasValue("\"\"");
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
@@ -799,4 +799,47 @@ public class ErrorEventTest {
             "Expect that errorMessage variable has an empty string as value because no error message was provided with the thrown error")
         .hasValue("\"\"");
   }
+
+  @Test
+  public void shouldApplyOutputMappingsWithErrorCodeAndErrorMessage() {
+    // Given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .boundaryEvent(
+                "error-boundary-event",
+                b ->
+                    b.errorEventDefinition()
+                        .error(ERROR_CODE)
+                        .errorCodeVariable("errorCode")
+                        .errorMessageVariable("errorMessage"))
+            .zeebeOutputExpression("errorCode", "errCode")
+            .zeebeOutputExpression("errorMessage", "errMsg")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .withErrorMessage("error-message")
+        .throwError();
+
+    // Then
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withScopeKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(VariableRecordValue::getName, VariableRecordValue::getValue)
+        .containsSequence(tuple("errCode", "\"ERROR\""), tuple("errMsg", "\"error-message\""));
+  }
 }


### PR DESCRIPTION
## Description
Allow specifying specific variable names for the `errorCode` and `errorMessage` in the process model (BPMN). The specified variables will be created with as values the error code and error message provided along with the thrown error, respectively. For example, `errorCodeVariable: 'errCode'` would end up creating a process variable named `errCode` with as value the thrown error's error code. `errorMessageVariable` will allow specifying the variable that will contain the error message.

## Related issues
closes #4337
closes #9473

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
