### PR TITLE
[Backport stable/8.0] Fix NPE when FEEL expression results in unknown type

### DIFF
--- a/expression-language/src/main/java/io/camunda/zeebe/el/ResultType.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/ResultType.java
@@ -15,6 +15,7 @@ public enum ResultType {
   STRING,
   DURATION,
   PERIOD,
+  DATE,
   DATE_TIME,
   ARRAY,
   OBJECT

--- a/expression-language/src/main/java/io/camunda/zeebe/el/ResultType.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/ResultType.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.el;
 
 /** The possible types of an evaluation result. */
 public enum ResultType {
+  UNKNOWN,
   NULL,
   BOOLEAN,
   NUMBER,

--- a/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
+++ b/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
@@ -37,6 +37,7 @@ class FeelEvaluationResult(
     case _: ValContext => ResultType.OBJECT
     case _: ValDayTimeDuration => ResultType.DURATION
     case _: ValYearMonthDuration => ResultType.PERIOD
+    case _: ValDate => ResultType.DATE
     case _: ValDateTime => ResultType.DATE_TIME
     case _: ValLocalDateTime => ResultType.DATE_TIME
     case _ => null

--- a/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
+++ b/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
@@ -40,7 +40,7 @@ class FeelEvaluationResult(
     case _: ValDate => ResultType.DATE
     case _: ValDateTime => ResultType.DATE_TIME
     case _: ValLocalDateTime => ResultType.DATE_TIME
-    case _ => null
+    case _ => ResultType.UNKNOWN
   }
 
   override def toBuffer: DirectBuffer = messagePackTransformer(result)

--- a/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
@@ -182,7 +182,7 @@ public class EvaluationResultTest {
   public void dateExpression() {
     final var evaluationResult = evaluateExpression("=date(\"2020-04-02\")");
 
-    assertThat(evaluationResult.getType()).isNull();
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.DATE);
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
@@ -194,7 +194,7 @@ public class EvaluationResultTest {
   public void timeExpression() {
     final var evaluationResult = evaluateExpression("=time(\"14:00:00\")");
 
-    assertThat(evaluationResult.getType()).isNull();
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.UNKNOWN);
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();


### PR DESCRIPTION
# Description
Backport of #11354 to `stable/8.0`.

relates to #5934