### PR TITLE
Add new configuration for disk watermarks

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStep.java
@@ -29,7 +29,7 @@ class DiskSpaceUsageMonitorStep extends AbstractBrokerStartupStep {
 
     final var data = brokerStartupContext.getBrokerConfiguration().getData();
 
-    if (!data.isDiskUsageMonitoringEnabled()) {
+    if (!data.getDisk().isEnableMonitoring()) {
       brokerStartupContext.setDiskSpaceUsageMonitor(new DisabledDiskUsageMonitor());
       startupFuture.complete(brokerStartupContext);
       return;

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -67,11 +67,7 @@ public final class RaftPartitionGroupFactory {
             .withMaxAppendsPerFollower(experimentalCfg.getMaxAppendsPerFollower())
             .withEntryValidator(new ZeebeEntryValidator())
             .withFlushExplicitly(!experimentalCfg.isDisableExplicitRaftFlush())
-            .withFreeDiskSpace(
-                dataCfg
-                    .getDisk()
-                    .getFreeSpace()
-                    .getMinFreeSpaceForReplication(dataCfg.getDirectory()))
+            .withFreeDiskSpace(dataCfg.getDisk().getFreeSpace().getReplication().toBytes())
             .withJournalIndexDensity(dataCfg.getLogIndexDensity())
             .withPriorityElection(clusterCfg.getRaft().isEnablePriorityElection())
             .withPartitionDistributor(partitionDistributor)

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -67,7 +67,11 @@ public final class RaftPartitionGroupFactory {
             .withMaxAppendsPerFollower(experimentalCfg.getMaxAppendsPerFollower())
             .withEntryValidator(new ZeebeEntryValidator())
             .withFlushExplicitly(!experimentalCfg.isDisableExplicitRaftFlush())
-            .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())
+            .withFreeDiskSpace(
+                dataCfg
+                    .getDisk()
+                    .getFreeSpace()
+                    .getMinFreeSpaceForReplication(dataCfg.getDirectory()))
             .withJournalIndexDensity(dataCfg.getLogIndexDensity())
             .withPriorityElection(clusterCfg.getRaft().isEnablePriorityElection())
             .withPartitionDistributor(partitionDistributor)

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -145,28 +145,19 @@ public final class SystemContext {
       throw new IllegalArgumentException(String.format(SNAPSHOT_PERIOD_ERROR_MSG, snapshotPeriod));
     }
 
-    final var diskUsageCommandWatermark = dataCfg.getDiskUsageCommandWatermark();
-    if (!(diskUsageCommandWatermark > 0 && diskUsageCommandWatermark <= 1)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Expected diskUsageCommandWatermark to be in the range (0,1], but found %f",
-              diskUsageCommandWatermark));
-    }
-
-    final var diskUsageReplicationWatermark = dataCfg.getDiskUsageReplicationWatermark();
-    if (!(diskUsageReplicationWatermark > 0 && diskUsageReplicationWatermark <= 1)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Expected diskUsageReplicationWatermark to be in the range (0,1], but found %f",
-              diskUsageReplicationWatermark));
-    }
-
-    if (dataCfg.isDiskUsageMonitoringEnabled()
-        && diskUsageCommandWatermark >= diskUsageReplicationWatermark) {
-      throw new IllegalArgumentException(
-          String.format(
-              "diskUsageCommandWatermark (%f) must be less than diskUsageReplicationWatermark (%f)",
-              diskUsageCommandWatermark, diskUsageReplicationWatermark));
+    if (dataCfg.isDiskUsageMonitoringEnabled()) {
+      try {
+        final var processingFreeSpace = dataCfg.getFreeDiskSpaceCommandWatermark();
+        final var replicationFreeSpace = dataCfg.getFreeDiskSpaceReplicationWatermark();
+        if (processingFreeSpace <= replicationFreeSpace) {
+          throw new IllegalArgumentException(
+              "Minimum free space for processing (%d) must be greater than minimum free space for replication (%d). Configured values are %s"
+                  .formatted(
+                      processingFreeSpace, replicationFreeSpace, dataCfg.getDisk().getFreeSpace()));
+        }
+      } catch (final Exception e) {
+        throw new InvalidConfigurationException("Failed to parse disk monitoring configuration", e);
+      }
     }
 
     if (backupFeatureEnabled) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -145,7 +145,7 @@ public final class SystemContext {
       throw new IllegalArgumentException(String.format(SNAPSHOT_PERIOD_ERROR_MSG, snapshotPeriod));
     }
 
-    if (dataCfg.isDiskUsageMonitoringEnabled()) {
+    if (dataCfg.getDisk().isEnableMonitoring()) {
       try {
         final long processingFreeSpace =
             dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing(dataCfg.getDirectory());

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -150,7 +150,7 @@ public final class SystemContext {
         final long processingFreeSpace =
             dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing(dataCfg.getDirectory());
         final long replicationFreeSpace =
-            dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing(dataCfg.getDirectory());
+            dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForReplication(dataCfg.getDirectory());
         if (processingFreeSpace <= replicationFreeSpace) {
           throw new IllegalArgumentException(
               "Minimum free space for processing (%d) must be greater than minimum free space for replication (%d). Configured values are %s"

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
+import io.camunda.zeebe.broker.system.configuration.DiskCfg.FreeSpaceCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.SecurityCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
@@ -147,15 +148,13 @@ public final class SystemContext {
 
     if (dataCfg.getDisk().isEnableMonitoring()) {
       try {
-        final long processingFreeSpace =
-            dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing(dataCfg.getDirectory());
-        final long replicationFreeSpace =
-            dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForReplication(dataCfg.getDirectory());
+        final FreeSpaceCfg freeSpaceCfg = dataCfg.getDisk().getFreeSpace();
+        final var processingFreeSpace = freeSpaceCfg.getProcessing().toBytes();
+        final var replicationFreeSpace = freeSpaceCfg.getReplication().toBytes();
         if (processingFreeSpace <= replicationFreeSpace) {
           throw new IllegalArgumentException(
               "Minimum free space for processing (%d) must be greater than minimum free space for replication (%d). Configured values are %s"
-                  .formatted(
-                      processingFreeSpace, replicationFreeSpace, dataCfg.getDisk().getFreeSpace()));
+                  .formatted(processingFreeSpace, replicationFreeSpace, freeSpaceCfg));
         }
       } catch (final Exception e) {
         throw new InvalidConfigurationException("Failed to parse disk monitoring configuration", e);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -147,8 +147,10 @@ public final class SystemContext {
 
     if (dataCfg.isDiskUsageMonitoringEnabled()) {
       try {
-        final var processingFreeSpace = dataCfg.getFreeDiskSpaceCommandWatermark();
-        final var replicationFreeSpace = dataCfg.getFreeDiskSpaceReplicationWatermark();
+        final long processingFreeSpace =
+            dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing(dataCfg.getDirectory());
+        final long replicationFreeSpace =
+            dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing(dataCfg.getDirectory());
         if (processingFreeSpace <= replicationFreeSpace) {
           throw new IllegalArgumentException(
               "Minimum free space for processing (%d) must be greater than minimum free space for replication (%d). Configured values are %s"

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import java.io.File;
 import java.time.Duration;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -18,15 +17,12 @@ import org.springframework.util.unit.DataSize;
 public final class DataCfg implements ConfigurationEntry {
 
   public static final String DEFAULT_DIRECTORY = "data";
-
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
-
   private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(128);
   private static final boolean DEFAULT_DISK_USAGE_MONITORING_ENABLED = true;
   private static final double DEFAULT_DISK_USAGE_REPLICATION_WATERMARK = 0.99;
   private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.97;
   private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
-  private static final double DISABLED_DISK_USAGE_WATERMARK = 1.0;
 
   private String directory = DEFAULT_DIRECTORY;
 
@@ -40,22 +36,42 @@ public final class DataCfg implements ConfigurationEntry {
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
   private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
-
+  private DiskCfg disk = new DiskCfg();
   private BackupStoreCfg backup = new BackupStoreCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     directory = ConfigurationUtil.toAbsolutePath(directory, brokerBase);
 
-    if (!diskUsageMonitoringEnabled) {
-      LOG.info(
-          "Disk usage watermarks are disabled, setting all watermarks to {}",
-          DISABLED_DISK_USAGE_WATERMARK);
-      diskUsageReplicationWatermark = DISABLED_DISK_USAGE_WATERMARK;
-      diskUsageCommandWatermark = DISABLED_DISK_USAGE_WATERMARK;
-    }
-
     backup.init(globalConfig, brokerBase);
+
+    overrideDiskConfig();
+    disk.init(globalConfig, brokerBase);
+  }
+
+  private void overrideDiskConfig() {
+    // For backward compatibility, if the old disk watermarks are configured use those values
+    // instead of the new ones
+    if (diskUsageMonitoringEnabled != DEFAULT_DISK_USAGE_MONITORING_ENABLED) {
+      LOG.warn(
+          "Configuration parameter data.diskUsageMonitoringEnabled is deprecated. Use data.disk.enableMonitoring instead.");
+      disk.setEnableMonitoring(diskUsageMonitoringEnabled);
+    }
+    if (!diskUsageMonitoringInterval.equals(DEFAULT_DISK_USAGE_MONITORING_DELAY)) {
+      LOG.warn(
+          "Configuration parameter data.diskUsageMonitoringInterval is deprecated. Use data.disk.monitoringInterval instead.");
+      disk.setMonitoringInterval(diskUsageMonitoringInterval);
+    }
+    if (diskUsageCommandWatermark != DEFAULT_DISK_USAGE_COMMAND_WATERMARK) {
+      LOG.warn(
+          "Configuration parameter data.diskUsageCommandWatermark is deprecated. Use data.disk.freeSpace.processing instead.");
+      disk.getFreeSpace().setProcessing((1 - diskUsageCommandWatermark) * 100 + "%");
+    }
+    if (diskUsageReplicationWatermark != DEFAULT_DISK_USAGE_REPLICATION_WATERMARK) {
+      LOG.warn(
+          "Configuration parameter data.diskUsageReplicationWatermark is deprecated. Use data.disk.freeSpace.replication instead.");
+      disk.getFreeSpace().setReplication((1 - diskUsageReplicationWatermark) * 100 + "%");
+    }
   }
 
   public String getDirectory() {
@@ -95,15 +111,11 @@ public final class DataCfg implements ConfigurationEntry {
   }
 
   public boolean isDiskUsageMonitoringEnabled() {
-    return diskUsageMonitoringEnabled;
+    return disk.isEnableMonitoring();
   }
 
   public void setDiskUsageMonitoringEnabled(final boolean diskUsageMonitoringEnabled) {
     this.diskUsageMonitoringEnabled = diskUsageMonitoringEnabled;
-  }
-
-  public double getDiskUsageCommandWatermark() {
-    return diskUsageCommandWatermark;
   }
 
   public void setDiskUsageCommandWatermark(final double diskUsageCommandWatermark) {
@@ -111,12 +123,7 @@ public final class DataCfg implements ConfigurationEntry {
   }
 
   public long getFreeDiskSpaceCommandWatermark() {
-    final var directoryFile = new File(getDirectory());
-    return Math.round(directoryFile.getTotalSpace() * (1 - diskUsageCommandWatermark));
-  }
-
-  public double getDiskUsageReplicationWatermark() {
-    return diskUsageReplicationWatermark;
+    return disk.getFreeSpace().getMinFreeSpaceForProcessing(getDirectory());
   }
 
   public void setDiskUsageReplicationWatermark(final double diskUsageReplicationWatermark) {
@@ -124,16 +131,23 @@ public final class DataCfg implements ConfigurationEntry {
   }
 
   public long getFreeDiskSpaceReplicationWatermark() {
-    final var directoryFile = new File(getDirectory());
-    return Math.round(directoryFile.getTotalSpace() * (1 - diskUsageReplicationWatermark));
+    return disk.getFreeSpace().getMinFreeSpaceForReplication(getDirectory());
   }
 
   public Duration getDiskUsageMonitoringInterval() {
-    return diskUsageMonitoringInterval;
+    return disk.getMonitoringInterval();
   }
 
   public void setDiskUsageMonitoringInterval(final Duration diskUsageMonitoringInterval) {
     this.diskUsageMonitoringInterval = diskUsageMonitoringInterval;
+  }
+
+  public DiskCfg getDisk() {
+    return disk;
+  }
+
+  public void setDisk(final DiskCfg disk) {
+    this.disk = disk;
   }
 
   public BackupStoreCfg getBackup() {
@@ -164,6 +178,8 @@ public final class DataCfg implements ConfigurationEntry {
         + diskUsageCommandWatermark
         + ", diskUsageMonitoringInterval="
         + diskUsageMonitoringInterval
+        + ", disk="
+        + disk
         + ", backup="
         + backup
         + '}';

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -32,6 +32,7 @@ public final class DataCfg implements ConfigurationEntry {
 
   private int logIndexDensity = 100;
 
+  // diskUsageMonitoring and watermark configs are deprecated and replaced by DiskCfg
   private boolean diskUsageMonitoringEnabled = DEFAULT_DISK_USAGE_MONITORING_ENABLED;
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
@@ -108,10 +109,6 @@ public final class DataCfg implements ConfigurationEntry {
 
   public void setLogIndexDensity(final int logIndexDensity) {
     this.logIndexDensity = logIndexDensity;
-  }
-
-  public boolean isDiskUsageMonitoringEnabled() {
-    return disk.isEnableMonitoring();
   }
 
   public void setDiskUsageMonitoringEnabled(final boolean diskUsageMonitoringEnabled) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -19,10 +19,6 @@ public final class DataCfg implements ConfigurationEntry {
   public static final String DEFAULT_DIRECTORY = "data";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(128);
-  private static final boolean DEFAULT_DISK_USAGE_MONITORING_ENABLED = true;
-  private static final double DEFAULT_DISK_USAGE_REPLICATION_WATERMARK = 0.99;
-  private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.97;
-  private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
 
   private String directory = DEFAULT_DIRECTORY;
 
@@ -33,10 +29,10 @@ public final class DataCfg implements ConfigurationEntry {
   private int logIndexDensity = 100;
 
   // diskUsageMonitoring and watermark configs are deprecated and replaced by DiskCfg
-  private boolean diskUsageMonitoringEnabled = DEFAULT_DISK_USAGE_MONITORING_ENABLED;
-  private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
-  private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
-  private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
+  private Boolean diskUsageMonitoringEnabled;
+  private Double diskUsageReplicationWatermark;
+  private Double diskUsageCommandWatermark;
+  private Duration diskUsageMonitoringInterval;
   private DiskCfg disk = new DiskCfg();
   private BackupStoreCfg backup = new BackupStoreCfg();
 
@@ -53,22 +49,22 @@ public final class DataCfg implements ConfigurationEntry {
   private void overrideDiskConfig() {
     // For backward compatibility, if the old disk watermarks are configured use those values
     // instead of the new ones
-    if (diskUsageMonitoringEnabled != DEFAULT_DISK_USAGE_MONITORING_ENABLED) {
+    if (diskUsageMonitoringEnabled != null) {
       LOG.warn(
           "Configuration parameter data.diskUsageMonitoringEnabled is deprecated. Use data.disk.enableMonitoring instead.");
       disk.setEnableMonitoring(diskUsageMonitoringEnabled);
     }
-    if (!diskUsageMonitoringInterval.equals(DEFAULT_DISK_USAGE_MONITORING_DELAY)) {
+    if (diskUsageMonitoringInterval != null) {
       LOG.warn(
           "Configuration parameter data.diskUsageMonitoringInterval is deprecated. Use data.disk.monitoringInterval instead.");
       disk.setMonitoringInterval(diskUsageMonitoringInterval);
     }
-    if (diskUsageCommandWatermark != DEFAULT_DISK_USAGE_COMMAND_WATERMARK) {
+    if (diskUsageCommandWatermark != null) {
       LOG.warn(
           "Configuration parameter data.diskUsageCommandWatermark is deprecated. Use data.disk.freeSpace.processing instead.");
       disk.getFreeSpace().setProcessing((1 - diskUsageCommandWatermark) * 100 + "%");
     }
-    if (diskUsageReplicationWatermark != DEFAULT_DISK_USAGE_REPLICATION_WATERMARK) {
+    if (diskUsageReplicationWatermark != null) {
       LOG.warn(
           "Configuration parameter data.diskUsageReplicationWatermark is deprecated. Use data.disk.freeSpace.replication instead.");
       disk.getFreeSpace().setReplication((1 - diskUsageReplicationWatermark) * 100 + "%");

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -122,20 +122,12 @@ public final class DataCfg implements ConfigurationEntry {
     this.diskUsageCommandWatermark = diskUsageCommandWatermark;
   }
 
-  public long getFreeDiskSpaceCommandWatermark() {
-    return disk.getFreeSpace().getMinFreeSpaceForProcessing(getDirectory());
-  }
-
   public void setDiskUsageReplicationWatermark(final double diskUsageReplicationWatermark) {
     this.diskUsageReplicationWatermark = diskUsageReplicationWatermark;
   }
 
   public long getFreeDiskSpaceReplicationWatermark() {
     return disk.getFreeSpace().getMinFreeSpaceForReplication(getDirectory());
-  }
-
-  public Duration getDiskUsageMonitoringInterval() {
-    return disk.getMonitoringInterval();
   }
 
   public void setDiskUsageMonitoringInterval(final Duration diskUsageMonitoringInterval) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -126,10 +126,6 @@ public final class DataCfg implements ConfigurationEntry {
     this.diskUsageReplicationWatermark = diskUsageReplicationWatermark;
   }
 
-  public long getFreeDiskSpaceReplicationWatermark() {
-    return disk.getFreeSpace().getMinFreeSpaceForReplication(getDirectory());
-  }
-
   public void setDiskUsageMonitoringInterval(final Duration diskUsageMonitoringInterval) {
     this.diskUsageMonitoringInterval = diskUsageMonitoringInterval;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DiskCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DiskCfg.java
@@ -68,7 +68,7 @@ public class DiskCfg implements ConfigurationEntry {
     return "DiskCfg{" + "enableMonitoring=" + enableMonitoring + ", freeSpace=" + freeSpace + '}';
   }
 
-  static class FreeSpaceCfg implements ConfigurationEntry {
+  public static class FreeSpaceCfg implements ConfigurationEntry {
 
     private static final String DEFAULT_PROCESSING_FREESPACE = "2GB";
     private static final String DEFAULT_REPLICATION_FREESPACE = "1GB";

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DiskCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DiskCfg.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import io.camunda.zeebe.broker.Loggers;
+import java.io.File;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.springframework.util.unit.DataSize;
+
+public class DiskCfg implements ConfigurationEntry {
+
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+
+  private static final boolean DEFAULT_DISK_MONITORING_ENABLED = true;
+  private static final String DISABLED_DISK_FREESPACE = "0%";
+  private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
+  private boolean enableMonitoring = DEFAULT_DISK_MONITORING_ENABLED;
+  private Duration monitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
+  private FreeSpaceCfg freeSpace = new FreeSpaceCfg();
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    freeSpace.init(globalConfig, brokerBase);
+
+    if (!enableMonitoring) {
+      LOG.info(
+          "Disk usage monitoring is disabled, setting required freespace to {}",
+          DISABLED_DISK_FREESPACE);
+      freeSpace.setReplication(DISABLED_DISK_FREESPACE);
+      freeSpace.setProcessing(DISABLED_DISK_FREESPACE);
+    }
+  }
+
+  public boolean isEnableMonitoring() {
+    return enableMonitoring;
+  }
+
+  public void setEnableMonitoring(final boolean enableMonitoring) {
+    this.enableMonitoring = enableMonitoring;
+  }
+
+  public Duration getMonitoringInterval() {
+    return monitoringInterval;
+  }
+
+  public void setMonitoringInterval(final Duration monitoringInterval) {
+    this.monitoringInterval = monitoringInterval;
+  }
+
+  public FreeSpaceCfg getFreeSpace() {
+    return freeSpace;
+  }
+
+  public void setFreeSpace(final FreeSpaceCfg freeSpace) {
+    this.freeSpace = freeSpace;
+  }
+
+  @Override
+  public String toString() {
+    return "DiskCfg{" + "enableMonitoring=" + enableMonitoring + ", freeSpace=" + freeSpace + '}';
+  }
+
+  static class FreeSpaceCfg implements ConfigurationEntry {
+
+    private static final String DEFAULT_PROCESSING_FREESPACE = "2GB";
+    private static final String DEFAULT_REPLICATION_FREESPACE = "1GB";
+    private String processing = DEFAULT_PROCESSING_FREESPACE;
+    private String replication = DEFAULT_REPLICATION_FREESPACE;
+
+    public String getProcessing() {
+      return processing;
+    }
+
+    public void setProcessing(final String processing) {
+      this.processing = processing;
+    }
+
+    public String getReplication() {
+      return replication;
+    }
+
+    public void setReplication(final String replication) {
+      this.replication = replication;
+    }
+
+    public long getMinFreeSpaceForProcessing(final String dataDirectory) {
+      return parse(dataDirectory, processing);
+    }
+
+    public long getMinFreeSpaceForReplication(final String dataDirectory) {
+      return parse(dataDirectory, replication);
+    }
+
+    private long parse(final String dataDirectory, final String watermark) {
+      if (watermark.endsWith("%")) {
+        final NumberFormat defaultFormat = NumberFormat.getPercentInstance();
+        try {
+          final Number minFreeRatio = defaultFormat.parse(watermark);
+          final var directoryFile = new File(dataDirectory);
+          return Math.round(minFreeRatio.doubleValue() * directoryFile.getTotalSpace());
+        } catch (final ParseException e) {
+          throw new IllegalArgumentException(e);
+        }
+      } else {
+        return DataSize.parse(watermark).toBytes();
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "FreeSpaceCfg{"
+          + "processing='"
+          + processing
+          + '\''
+          + ", replication='"
+          + replication
+          + '\''
+          + '}';
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DiskCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DiskCfg.java
@@ -8,9 +8,6 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import io.camunda.zeebe.broker.Loggers;
-import java.io.File;
-import java.text.NumberFormat;
-import java.text.ParseException;
 import java.time.Duration;
 import org.slf4j.Logger;
 import org.springframework.util.unit.DataSize;
@@ -20,7 +17,7 @@ public class DiskCfg implements ConfigurationEntry {
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   private static final boolean DEFAULT_DISK_MONITORING_ENABLED = true;
-  private static final String DISABLED_DISK_FREESPACE = "0%";
+  private static final DataSize DISABLED_DISK_FREESPACE = DataSize.ofBytes(0);
   private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
   private boolean enableMonitoring = DEFAULT_DISK_MONITORING_ENABLED;
   private Duration monitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
@@ -70,48 +67,25 @@ public class DiskCfg implements ConfigurationEntry {
 
   public static class FreeSpaceCfg implements ConfigurationEntry {
 
-    private static final String DEFAULT_PROCESSING_FREESPACE = "2GB";
-    private static final String DEFAULT_REPLICATION_FREESPACE = "1GB";
-    private String processing = DEFAULT_PROCESSING_FREESPACE;
-    private String replication = DEFAULT_REPLICATION_FREESPACE;
+    private static final DataSize DEFAULT_PROCESSING_FREESPACE = DataSize.ofGigabytes(2);
+    private static final DataSize DEFAULT_REPLICATION_FREESPACE = DataSize.ofGigabytes(1);
+    private DataSize processing = DEFAULT_PROCESSING_FREESPACE;
+    private DataSize replication = DEFAULT_REPLICATION_FREESPACE;
 
-    public String getProcessing() {
+    public DataSize getProcessing() {
       return processing;
     }
 
-    public void setProcessing(final String processing) {
+    public void setProcessing(final DataSize processing) {
       this.processing = processing;
     }
 
-    public String getReplication() {
+    public DataSize getReplication() {
       return replication;
     }
 
-    public void setReplication(final String replication) {
+    public void setReplication(final DataSize replication) {
       this.replication = replication;
-    }
-
-    public long getMinFreeSpaceForProcessing(final String dataDirectory) {
-      return parse(dataDirectory, processing);
-    }
-
-    public long getMinFreeSpaceForReplication(final String dataDirectory) {
-      return parse(dataDirectory, replication);
-    }
-
-    private long parse(final String dataDirectory, final String watermark) {
-      if (watermark.endsWith("%")) {
-        final NumberFormat defaultFormat = NumberFormat.getPercentInstance();
-        try {
-          final Number minFreeRatio = defaultFormat.parse(watermark);
-          final var directoryFile = new File(dataDirectory);
-          return Math.round(minFreeRatio.doubleValue() * directoryFile.getTotalSpace());
-        } catch (final ParseException e) {
-          throw new IllegalArgumentException(e);
-        }
-      } else {
-        return DataSize.parse(watermark).toBytes();
-      }
     }
 
     @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorActor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorActor.java
@@ -28,13 +28,14 @@ public class DiskSpaceUsageMonitorActor extends Actor implements DiskSpaceUsageM
   private final long minFreeDiskSpaceRequired;
 
   public DiskSpaceUsageMonitorActor(final DataCfg dataCfg) {
-    monitoringDelay = dataCfg.getDiskUsageMonitoringInterval();
-    minFreeDiskSpaceRequired = dataCfg.getFreeDiskSpaceCommandWatermark();
+    final var diskCfg = dataCfg.getDisk();
+    monitoringDelay = diskCfg.getMonitoringInterval();
     final var directory = new File(dataCfg.getDirectory());
-
     if (!directory.exists()) {
       throw new UncheckedIOException(new IOException("Folder '" + directory + "' does not exist."));
     }
+    minFreeDiskSpaceRequired =
+        diskCfg.getFreeSpace().getMinFreeSpaceForProcessing(dataCfg.getDirectory());
     freeDiskSpaceSupplier = directory::getUsableSpace;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorActor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorActor.java
@@ -34,8 +34,7 @@ public class DiskSpaceUsageMonitorActor extends Actor implements DiskSpaceUsageM
     if (!directory.exists()) {
       throw new UncheckedIOException(new IOException("Folder '" + directory + "' does not exist."));
     }
-    minFreeDiskSpaceRequired =
-        diskCfg.getFreeSpace().getMinFreeSpaceForProcessing(dataCfg.getDirectory());
+    minFreeDiskSpaceRequired = diskCfg.getFreeSpace().getProcessing().toBytes();
     freeDiskSpaceSupplier = directory::getUsableSpace;
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/DataCfgTest.java
@@ -8,11 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
-import io.camunda.zeebe.broker.system.configuration.DiskCfg.FreeSpaceCfg;
 import java.time.Duration;
 import org.junit.Test;
 import org.springframework.util.unit.DataSize;
@@ -26,28 +22,21 @@ public class DataCfgTest {
     dataCfg.init(new BrokerCfg(), "/base");
 
     // then
-    assertThat(dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing("ignore"))
-        .isEqualTo(DataSize.ofGigabytes(2).toBytes());
-    assertThat(dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForReplication("ignore"))
-        .isEqualTo(DataSize.ofGigabytes(1).toBytes());
+    assertThat(dataCfg.getDisk().getFreeSpace().getProcessing()).isEqualTo(DataSize.ofGigabytes(2));
+    assertThat(dataCfg.getDisk().getFreeSpace().getReplication())
+        .isEqualTo(DataSize.ofGigabytes(1));
   }
 
   @Test
   public void shouldOverrideWhenOldWatermarksConfigProvided() {
     // when
     final DataCfg dataCfg = new DataCfg();
-    final FreeSpaceCfg mockFreeSpaceCfg = mock(FreeSpaceCfg.class);
-    dataCfg.getDisk().setFreeSpace(mockFreeSpaceCfg);
     dataCfg.setDiskUsageMonitoringInterval(Duration.ofMinutes(5));
     dataCfg.setDiskUsageMonitoringEnabled(false);
-    dataCfg.setDiskUsageCommandWatermark(0.1);
-    dataCfg.setDiskUsageReplicationWatermark(0.2);
     dataCfg.init(new BrokerCfg(), "/base");
 
     // then
-    verify(mockFreeSpaceCfg, times(1)).setProcessing("90.0%");
-    verify(mockFreeSpaceCfg, times(1)).setReplication("80.0%");
-    assertThat(dataCfg.getDisk().isEnableMonitoring()).isFalse();
     assertThat(dataCfg.getDisk().getMonitoringInterval()).isEqualTo(Duration.ofMinutes(5));
+    assertThat(dataCfg.getDisk().isEnableMonitoring()).isFalse();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/DataCfgTest.java
@@ -8,25 +8,46 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import io.camunda.zeebe.broker.system.configuration.DiskCfg.FreeSpaceCfg;
+import java.time.Duration;
 import org.junit.Test;
+import org.springframework.util.unit.DataSize;
 
 public class DataCfgTest {
 
   @Test
-  public void shouldSetWatermarksTo1IfDisabled() {
-    // given
-    final DataCfg dataCfg = new DataCfg();
-    dataCfg.setDiskUsageCommandWatermark(0.1);
-    dataCfg.setDiskUsageReplicationWatermark(0.2);
-    dataCfg.setDiskUsageMonitoringEnabled(false);
-
+  public void shouldUseDefaultFreeSpaceConfig() {
     // when
+    final DataCfg dataCfg = new DataCfg();
     dataCfg.init(new BrokerCfg(), "/base");
 
     // then
-    assertThat(dataCfg.isDiskUsageMonitoringEnabled()).isFalse();
-    assertThat(dataCfg.getDiskUsageCommandWatermark()).isEqualTo(1.0);
-    assertThat(dataCfg.getDiskUsageReplicationWatermark()).isEqualTo(1.0);
+    assertThat(dataCfg.getFreeDiskSpaceReplicationWatermark())
+        .isEqualTo(DataSize.ofGigabytes(1).toBytes());
+    assertThat(dataCfg.getFreeDiskSpaceCommandWatermark())
+        .isEqualTo(DataSize.ofGigabytes(2).toBytes());
+  }
+
+  @Test
+  public void shouldOverrideWhenOldWatermarksConfigProvided() {
+    // when
+    final DataCfg dataCfg = new DataCfg();
+    final FreeSpaceCfg mockFreeSpaceCfg = mock(FreeSpaceCfg.class);
+    dataCfg.getDisk().setFreeSpace(mockFreeSpaceCfg);
+    dataCfg.setDiskUsageMonitoringInterval(Duration.ofMinutes(5));
+    dataCfg.setDiskUsageMonitoringEnabled(false);
+    dataCfg.setDiskUsageCommandWatermark(0.1);
+    dataCfg.setDiskUsageReplicationWatermark(0.2);
+    dataCfg.init(new BrokerCfg(), "/base");
+
+    // then
+    verify(mockFreeSpaceCfg, times(1)).setProcessing("90.0%");
+    verify(mockFreeSpaceCfg, times(1)).setReplication("80.0%");
+    assertThat(dataCfg.getDisk().isEnableMonitoring()).isFalse();
+    assertThat(dataCfg.getDisk().getMonitoringInterval()).isEqualTo(Duration.ofMinutes(5));
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/DataCfgTest.java
@@ -26,9 +26,9 @@ public class DataCfgTest {
     dataCfg.init(new BrokerCfg(), "/base");
 
     // then
-    assertThat(dataCfg.getFreeDiskSpaceReplicationWatermark())
+    assertThat(dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing("ignore"))
         .isEqualTo(DataSize.ofGigabytes(1).toBytes());
-    assertThat(dataCfg.getFreeDiskSpaceCommandWatermark())
+    assertThat(dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForReplication("ignore"))
         .isEqualTo(DataSize.ofGigabytes(2).toBytes());
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/DataCfgTest.java
@@ -27,9 +27,9 @@ public class DataCfgTest {
 
     // then
     assertThat(dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForProcessing("ignore"))
-        .isEqualTo(DataSize.ofGigabytes(1).toBytes());
-    assertThat(dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForReplication("ignore"))
         .isEqualTo(DataSize.ofGigabytes(2).toBytes());
+    assertThat(dataCfg.getDisk().getFreeSpace().getMinFreeSpaceForReplication("ignore"))
+        .isEqualTo(DataSize.ofGigabytes(1).toBytes());
   }
 
   @Test

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -213,22 +213,56 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       # snapshotPeriod: 15m
 
+      # Configure whether to monitor disk usage to prevent out of disk space issues.
+      # If set to false the broker might run out of disk space and end in a non recoverable state.
+      # If set to true the disk space will be monitored and the broker will reject commands and pause replication
+      # if the thresholds of diskUsageCommandWatermark and diskUsageReplicationWatermark are reached.
+      #
+      # DEPRECATED. Use zeebe.broker.data.disk.enableMonitoring
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGENABLED
+      # diskUsageMonitoringEnabled = true
+
+      # DEPRECATED. Use zeebe.broker.data.disk.freeSpace.processing
       # When the disk usage is above this value all client commands will be rejected.
       # The value is specified as a percentage of the total disk space.
-      # The value should be in the range (0, 1).
+      # The value should be in the range (0, 1].
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
       # diskUsageCommandWatermark = 0.97
 
+      # DEPRECATED. Use zeebe.broker.data.disk.freeSpace.replication
       # When the disk usage is above this value, this broker will stop writing replicated events it receives from other brokers.
       # The value is specified as a percentage of the total disk space.
-      # The value should be in the range (0, 1).
+      # The value should be in the range (0, 1].
       # It is recommended that diskUsageReplicationWatermark > diskUsageCommandWatermark
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
       # diskUsageReplicationWatermark = 0.99
 
+      # DEPRECATED. Use zeebe.broker.data.disk.monitoringInterval.
       # Sets the interval at which the disk usage is monitored
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
       # diskUsageMonitoringInterval = 1s
+
+      # disk:
+        # Configure disk monitoring to prevent getting into a non-recoverable state due to out of disk space.
+        # When monitoring is enabled, the broker rejects commands and pause replication when the required freeSpace is not available.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_ENABLEMONITORING
+        # enableMonitoring: true
+
+        # Sets the interval at which the disk usage is monitored
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_MONITORINGINTERVAL
+        # monitoringInterval: 1s
+
+        # freeSpace:
+          # When the free space available is less than this value, this broker rejects all client commands and pause processing.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING
+          # processing: 2GB
+
+          # When the free space available is less than this value, broker stops receiving replicated events.
+          # This value must be less than freeSpace.processing. It is recommended to configure free space
+          # large enough for at least one log segment and one snapshot. This is because a partition needs
+          # enough space to take a new snapshot to be able to compact the log segments to make disk space available again.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION
+          # replication: 1GB
 
       # backup:
         # Configure backup store. NOTE:- Use the same configuration on all brokers of this cluster.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -186,12 +186,10 @@
 
         # freeSpace:
           # When the free space available is less than this value, this broker rejects all client commands and pause processing.
-          # The value can be absolute data size or a percentage such as 10%.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING
           # processing: 2GB
 
           # When the free space available is less than this value, broker stops receiving replicated events.
-          # The value can be absolute data size or a percentage such as 10%.
           # This value must be less than freeSpace.processing. It is recommended to configure free space
           # large enough for at least one log segment and one snapshot. This is because a partition needs
           # enough space to take a new snapshot to be able to compact the log segments to make disk space available again.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -150,15 +150,18 @@
       # If set to true the disk space will be monitored and the broker will reject commands and pause replication
       # if the thresholds of diskUsageCommandWatermark and diskUsageReplicationWatermark are reached.
       #
+      # DEPRECATED. Use zeebe.broker.data.disk.enableMonitoring
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGENABLED
       # diskUsageMonitoringEnabled = true
 
+      # DEPRECATED. Use zeebe.broker.data.disk.freeSpace.processing
       # When the disk usage is above this value all client commands will be rejected.
       # The value is specified as a percentage of the total disk space.
       # The value should be in the range (0, 1].
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
       # diskUsageCommandWatermark = 0.97
 
+      # DEPRECATED. Use zeebe.broker.data.disk.freeSpace.replication
       # When the disk usage is above this value, this broker will stop writing replicated events it receives from other brokers.
       # The value is specified as a percentage of the total disk space.
       # The value should be in the range (0, 1].
@@ -166,9 +169,34 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
       # diskUsageReplicationWatermark = 0.99
 
+      # DEPRECATED. Use zeebe.broker.data.disk.monitoringInterval.
       # Sets the interval at which the disk usage is monitored
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
       # diskUsageMonitoringInterval = 1s
+
+      # disk:
+        # Configure disk monitoring to prevent getting into a non-recoverable state due to out of disk space.
+        # When monitoring is enabled, the broker rejects commands and pause replication when the required freeSpace is not available.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_ENABLEMONITORING
+        # enableMonitoring: true
+
+        # Sets the interval at which the disk usage is monitored
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_MONITORINGINTERVAL
+        # monitoringInterval: 1s
+
+        # freeSpace:
+          # When the free space available is less than this value, this broker rejects all client commands and pause processing.
+          # The value can be absolute data size or a percentage such as 10%.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING
+          # processing: 2GB
+
+          # When the free space available is less than this value, broker stops receiving replicated events.
+          # The value can be absolute data size or a percentage such as 10%.
+          # This value must be less than freeSpace.processing. It is recommended to configure free space
+          # large enough for at least one log segment and one snapshot. This is because a partition needs
+          # enough space to take a new snapshot to be able to compact the log segments to make disk space available again.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION
+          # replication: 1GB
 
       # backup:
         # Configure backup store. NOTE:- Use the same configuration on all brokers of this cluster.

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
@@ -47,7 +47,8 @@ final class DiskSpaceRecoveryIT {
           .withZeebeData(volume)
           .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "1MB")
           .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "1MB")
-          .withEnv("ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK", "0.5");
+          .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING", "10MB")
+          .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION", "1MB");
 
   private ZeebeClient client;
 
@@ -127,7 +128,9 @@ final class DiskSpaceRecoveryIT {
         ContainerEngine.builder()
             .withDebugReceiverPort(SocketUtil.getNextAddress().getPort())
             .withContainer(
-                container.withEnv("ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK", "0.0001"))
+                container
+                    .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING", "16MB")
+                    .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION", "10MB"))
             .build();
 
     @BeforeEach


### PR DESCRIPTION
## Description

Specify new configuration parameters for disk watermarks.
```
zeebe:
  broker:
    data:
      disk: 
          enableMonitoring : true
          monitoringInterval: 1s
          freespace: 
              processing: 2GB
              replication: 1GB
```
Previously watermarks were provided as maximum disk space we can use as percentage values. This is changed now. We specify minimum required freespace. Also we now specify them as absolute values. So instead of 10%, we specify as 5GB for example.

To make it backward compatible, if the old watermarks config is provided we use them instead. The old watermarks are deprecated and will be eventually removed. 

## Related issues

closes #8149 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
