### PR TITLE
Add AdHocSubProcess to the BPMN Model and fix validations

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.model.bpmn.impl.BpmnImpl;
 import io.camunda.zeebe.model.bpmn.impl.BpmnParser;
 import io.camunda.zeebe.model.bpmn.impl.instance.ActivationConditionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.ActivityImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.AdHocSubProcessImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.ArtifactImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.AssignmentImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.AssociationImpl;
@@ -435,6 +436,7 @@ public class Bpmn {
   protected void doRegisterTypes(final ModelBuilder bpmnModelBuilder) {
     ActivationConditionImpl.registerType(bpmnModelBuilder);
     ActivityImpl.registerType(bpmnModelBuilder);
+    AdHocSubProcessImpl.registerType(bpmnModelBuilder);
     ArtifactImpl.registerType(bpmnModelBuilder);
     AssignmentImpl.registerType(bpmnModelBuilder);
     AssociationImpl.registerType(bpmnModelBuilder);

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/BpmnModelConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/BpmnModelConstants.java
@@ -231,6 +231,7 @@ public final class BpmnModelConstants {
   public static final String BPMN_ELEMENT_NONE_BEHAVIOR_EVENT_REF = "noneBehaviorEventRef";
   public static final String BPMN_ELEMENT_GROUP = "group";
   public static final String BPMN_ELEMENT_CATEGORY = "category";
+  public static final String BPMN_ELEMENT_AD_HOC_SUB_PROCESS = "adHocSubProcess";
 
   /** DC */
   public static final String DC_ELEMENT_FONT = "Font";

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/AdHocSubProcessImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/AdHocSubProcessImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance;
+
+import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
+import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ELEMENT_AD_HOC_SUB_PROCESS;
+
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.SubProcess;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder.ModelTypeInstanceProvider;
+
+public class AdHocSubProcessImpl extends SubProcessImpl implements AdHocSubProcess {
+
+  public AdHocSubProcessImpl(final ModelTypeInstanceContext context) {
+    super(context);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(AdHocSubProcess.class, BPMN_ELEMENT_AD_HOC_SUB_PROCESS)
+            .namespaceUri(BPMN20_NS)
+            .extendsType(SubProcess.class)
+            .instanceProvider(
+                new ModelTypeInstanceProvider<ModelElementInstance>() {
+                  @Override
+                  public ModelElementInstance newInstance(
+                      final ModelTypeInstanceContext instanceContext) {
+                    return new AdHocSubProcessImpl(instanceContext);
+                  }
+                });
+
+    typeBuilder.build();
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/AdHocSubProcess.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/AdHocSubProcess.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance;
+
+public interface AdHocSubProcess extends SubProcess {}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -94,7 +94,7 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
           String.format(
               "Elements of type '%s' are currently not supported. Please refer "
                   + "to the documentation for a list of supported elements: "
-                  + "https://docs.camunda.io/docs/reference/bpmn-processes/bpmn-coverage",
+                  + "https://docs.camunda.io/docs/components/modeler/bpmn/bpmn-coverage/",
               elementType.getSimpleName()));
     }
   }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
@@ -50,7 +51,7 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
       final SubProcess element, final ValidationResultCollector validationResultCollector) {
     final Collection<StartEvent> startEvents = element.getChildElementsByType(StartEvent.class);
 
-    if (startEvents.size() != 1) {
+    if (startEvents.size() != 1 && !(element instanceof AdHocSubProcess)) {
       validationResultCollector.addError(0, "Must have exactly one start event");
     }
 

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/UnsupportedElementTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/UnsupportedElementTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+import static java.util.Collections.singletonList;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class UnsupportedElementTest extends AbstractZeebeValidationTest {
+
+  @Parameters(name = "{index}: {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        "AdHocSubProcess.bpmn",
+        singletonList(
+            expect(
+                "adhocsubprocess",
+                "Elements of type 'AdHocSubProcess' are currently not supported."))
+      }
+    };
+  }
+}

--- a/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcess.bpmn
+++ b/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/AdHocSubProcess.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1birbky" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.7.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:process id="Process_053jrwn" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1hqnq4r</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1hqnq4r" sourceRef="StartEvent_1" targetRef="adhocsubprocess" />
+    <bpmn:endEvent id="Event_1m5imql">
+      <bpmn:incoming>Flow_1kvf2rt</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1kvf2rt" sourceRef="adhocsubprocess" targetRef="Event_1m5imql" />
+    <bpmn:adHocSubProcess id="adhocsubprocess">
+      <bpmn:incoming>Flow_1hqnq4r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1kvf2rt</bpmn:outgoing>
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_053jrwn">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1m5imql_di" bpmnElement="Event_1m5imql">
+        <dc:Bounds x="492" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xtkag0_di" bpmnElement="adhocsubprocess" isExpanded="true">
+        <dc:Bounds x="240" y="77" width="220" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1hqnq4r_di" bpmnElement="Flow_1hqnq4r">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="240" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kvf2rt_di" bpmnElement="Flow_1kvf2rt">
+        <di:waypoint x="460" y="177" />
+        <di:waypoint x="492" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
`AdHocSubProcess` is an element that is part of the BPMN specification. It was not part of our BPMN Model.
Recently the Modeler had an update which allows users to model `AdHocSubProcesses`. They would show an error in the Modeler that this element is not supported. However, upon deploying the model Zeebe ran into a `ClassCastException`, since the BPMN Model didn't know this element.

I have introduced this element to the BPMN Model in its most minimal form. We can extend this once we support this element. This resolves the `ClassCastException` and results in a proper rejection of the deployment with the message that this element is not supported.
I had to make a small modification to the `SubProcessValidator` so we didn't show a second ERROR about start events.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11343 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
