### PR TITLE
refactor(monitoring): adjust FNI and PI targets of throughput benchmark

### DIFF
--- a/monitor/grafana/medic-benchmark-dashboard.json
+++ b/monitor/grafana/medic-benchmark-dashboard.json
@@ -117,7 +117,7 @@
               },
               {
                 "color": "green",
-                "value": 145
+                "value": 290
               }
             ]
           },
@@ -201,7 +201,7 @@
               },
               {
                 "color": "green",
-                "value": 49
+                "value": 100
               }
             ]
           },


### PR DESCRIPTION
This doubles both values since we increased the target PI/s from 75 to
150. Other benchmark types were not modified.

depends on https://github.com/zeebe-io/benchmark-helm/pull/9