### PR TITLE
fix(atomix): add required argument for logging step-down decision

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -232,13 +232,12 @@ public class RaftPartition implements Partition, HealthMonitorable {
    */
   public CompletableFuture<Void> stepDownIfNotPrimary() {
     if (shouldStepDown()) {
-      LOG.atInfo()
-          .setMessage(
-              "Decided that {} should step down as {} from partition {} because {} is primary")
-          .addArgument(server.getRole())
-          .addArgument(partitionMetadata.id())
-          .addArgument(partitionMetadata.getPrimary().orElse(null))
-          .log();
+      LOG.info(
+          "Decided that {} should step down as {} from partition {} because {} is primary",
+          server.getMemberId(),
+          server.getRole(),
+          partitionMetadata.id(),
+          partitionMetadata.getPrimary().orElse(null));
       return stepDown();
     } else {
       return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
The member id was missing from the provided arguments. Since IntelliJ wasn't able to highlight this as an issue when using the SLF4J fluent API, I also reverted back to using the "normal" syntax where this issue would have been more visible.