### PR TITLE
[Backport stable/8.0] fix(broker): transition to inactive before stopping raft partition

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -364,7 +364,7 @@ public final class ZeebePartition extends Actor
           context.getPartitionId(),
           context.getCurrentRole(),
           context.getCurrentTerm());
-      context.getRaftPartition().stop();
+      stopPartitionOnError();
     }
   }
 
@@ -372,9 +372,21 @@ public final class ZeebePartition extends Actor
     final var report = HealthReport.dead(this).withIssue(error);
     healthMetrics.setDead();
     zeebePartitionHealth.onUnrecoverableFailure(error);
-    context.getRaftPartition().stop();
-    failureListeners.forEach((l) -> l.onUnrecoverableFailure(report));
-    context.notifyListenersOfBecomingInactive();
+    stopPartitionOnError();
+    failureListeners.forEach(l -> l.onUnrecoverableFailure(report));
+  }
+
+  private void stopPartitionOnError() {
+    context.getRaftPartition().removeRoleChangeListener(this);
+    transitionToInactive()
+        .onComplete(
+            (ignore, e) -> {
+              if (e != null) {
+                LOG.warn("Failed to transition to inactive. Stopping raft partition anyway.");
+              }
+              context.notifyListenersOfBecomingInactive();
+              context.getRaftPartition().stop();
+            });
   }
 
   private void onRecoveredInternal() {


### PR DESCRIPTION
# Description
Backport of #11445 to `stable/8.0`.

relates to #11070