### PR TITLE
Add year to weekly medic benchmark name

### DIFF
--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
         id: data
         run: |
           # Get all namespaces, filter for medic benchmarks and select the oldest one
-          echo "normal=$(kubectl get ns -o name | grep -E namespace/medic-cw-[0-9]+-[a-z0-9]+-benchmark$ | sort -V | head -n1)" >> $GITHUB_OUTPUT
+          echo "normal=$(kubectl get ns -o name | grep -E namespace/medic-y-[0-9]+-cw-[0-9]+-[a-z0-9]+-benchmark$ | sort -V | head -n1)" >> $GITHUB_OUTPUT
       - name: Delete benchmarks
         run: |
           kubectl delete ${{ steps.data.outputs.normal }}
@@ -35,16 +35,14 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       full-ref: ${{ steps.data.outputs.full-ref }}
-      ref: ${{ steps.data.outputs.ref }}
-      cw: ${{ steps.data.outputs.cw }}
+      benchmark: ${{ steps.data.outputs.benchmark }}
     steps:
       - uses: actions/checkout@v3
       - name: Collect benchmark data
         id: data
         run: |
           echo "full-ref"=$(git rev-parse HEAD) >> $GITHUB_OUTPUT
-          echo "ref=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "cw=$(date +%V)" >> $GITHUB_OUTPUT
+          echo "benchmark=medic-y-$(date +%Y)-cw-$(date +%V)-$(git rev-parse --short HEAD)-benchmark" >> $GITHUB_OUTPUT
 
   setup-normal-benchmark:
     name: Setup normal benchmark
@@ -54,7 +52,7 @@ jobs:
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
     with:
-      name: medic-cw-${{ needs.benchmark-data.outputs.cw }}-${{ needs.benchmark-data.outputs.ref }}-benchmark
+      name: ${{ needs.benchmark-data.outputs.benchmark }}
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
@@ -66,7 +64,7 @@ jobs:
       - benchmark-data
       - delete-old-benchmarks
     with:
-      name: medic-cw-${{ needs.benchmark-data.outputs.cw }}-${{ needs.benchmark-data.outputs.ref }}-benchmark-mixed
+      name: ${{ needs.benchmark-data.outputs.benchmark }}-mixed
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
@@ -84,7 +82,7 @@ jobs:
       - benchmark-data
       - delete-old-benchmarks
     with:
-      name: medic-cw-${{ needs.benchmark-data.outputs.cw }}-${{ needs.benchmark-data.outputs.ref }}-benchmark-latency
+      name: ${{ needs.benchmark-data.outputs.benchmark }}-latency
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}

--- a/createMedicCWBenchmark.sh
+++ b/createMedicCWBenchmark.sh
@@ -35,7 +35,7 @@ cd benchmarks/setup/
 cw=$(date +%V)
 if [ $cw -gt 4 ]
 then
-  nameOfOldestBenchmark=$(ls | grep medic-cw- | sort | head -n 1)
+  nameOfOldestBenchmark=$(ls | grep medic-y- | sort | head -n 1)
   ./deleteBenchmark.sh $nameOfOldestBenchmark
 
   # commit that change
@@ -52,5 +52,5 @@ fi
 
 
 # print out the name of the new benchmark so it can be easily copied
-nameOfNewestBenchmark=$(ls | grep medic-cw- | sort | tail -n 1)
+nameOfNewestBenchmark=$(ls | grep medic-y- | sort | tail -n 1)
 echo "Finished creating new medic benchmark: $nameOfNewestBenchmark"


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The medic benchmark workflow deletes the oldest benchmark. It does this by sorting the name of benchmarks and picking the first ones. When we transition to the next year this means we consider the benchmark from week 1 to be older than the benchmark from week 51. Because of this we delete the wrong benchmark.

Introducing the year in benchmark name is an easy way to circumvent this problem.


⚠️ After this is merged the current medic benchmarks need to be recreated to adhere to the new naming. Otherwise they will not get deleted, since this now checks for a different name.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11379 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
