### PR TITLE
feat(atomix): reduce likelihood of forced snapshot replication

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -195,7 +195,10 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
   }
 
   public void setCompactableIndex(final long index) {
-    server.getContext().getLogCompactor().setCompactableIndex(index);
+    // Don't compact everything, leave enough entries so that slow followers are not forced into
+    // snapshot replication immediately.
+    final var offset = config.getPartitionConfig().getPreferSnapshotReplicationThreshold();
+    server.getContext().getLogCompactor().setCompactableIndex(index - offset);
   }
 
   public RaftLogReader openReader() {

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -90,6 +90,10 @@ public class ZeebeTestNode {
         .build();
   }
 
+  public RaftPartitionGroup getPartitionGroup() {
+    return this.dataPartitionGroup;
+  }
+
   public MemberId getMemberId() {
     return member.id();
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -97,7 +97,13 @@ final class ClusteredSnapshotTest {
     final var adminService =
         clusteringRule.getBroker(leaderId).getBrokerContext().getBrokerAdminService();
     ControllableExporter.updatePosition(true);
-    clusteringRule.fillSegment();
+    clusteringRule.fillSegments(
+        2,
+        clusteringRule
+            .getBrokerCfg(0)
+            .getExperimental()
+            .getRaft()
+            .getPreferSnapshotReplicationThreshold());
 
     Awaitility.await("Wait until all events are exported before taking snapshot")
         .until(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -735,20 +735,46 @@ public class ClusteringRule extends ExternalResource {
   }
 
   /**
-   * Fills one segment with messages. Use {@link #runUntilSegmentsFilled} if you need more control
-   * over the content or count of segments.
+   * Writes entries until at least the given count of segments exist on all brokers. Automatically
+   * accounts for offset log compaction to ensure that at least one segment will be deleted after
+   * taking a snapshot.
    */
-  public void fillSegment() {
-    runUntilSegmentsFilled(
-        getBrokers(),
-        1,
-        () ->
-            client
-                .newPublishMessageCommand()
-                .messageName("msg")
-                .correlationKey("key")
-                .send()
-                .join());
+  public void fillSegments(final int minimumSegmentCount) {
+    fillSegments(getBrokers(), minimumSegmentCount);
+  }
+  /**
+   * Writes entries until at least the given count of segments exist on the given brokers.
+   * Automatically accounts for offset log compaction to ensure that at least one segment will be
+   * deleted after taking a snapshot.
+   */
+  public void fillSegments(final Collection<Broker> brokers, final int minimumSegmentCount) {
+    final var logCompactionOffset =
+        getBrokerCfg(0).getExperimental().getRaft().getPreferSnapshotReplicationThreshold();
+    fillSegments(brokers, minimumSegmentCount, logCompactionOffset);
+  }
+  /**
+   * Writes entries until at least the given count of segments exist on all brokers and at least the
+   * given count of entries are written.
+   */
+  public void fillSegments(final int minimumSegmentCount, final int minimumWrittenEntries) {
+    fillSegments(getBrokers(), minimumSegmentCount, minimumWrittenEntries);
+  }
+  /**
+   * Writes entries until at least the given count of segments exist on the given brokers and at
+   * least the given count of entries are written.
+   */
+  public void fillSegments(
+      final Collection<Broker> brokers,
+      final int minimumSegmentCount,
+      final int minimumWrittenEntries) {
+    var currentSegments = 0;
+    var writtenEntries = 0;
+    while (currentSegments < minimumSegmentCount || writtenEntries < minimumWrittenEntries) {
+      client.newPublishMessageCommand().messageName("msg").correlationKey("key").send().join();
+      currentSegments =
+          brokers.stream().map(this::getSegmentsCount).min(Integer::compareTo).orElse(0);
+      writtenEntries += 1;
+    }
   }
 
   /**

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -44,7 +44,13 @@ public class InstallRequestHandlingTest {
     // given
     final var followerId = clusteringRule.stopAnyFollower();
     final var jobKey = clientRule.createSingleJob("type");
-    clusteringRule.fillSegment();
+    clusteringRule.fillSegments(
+        2,
+        clusteringRule
+            .getBrokerCfg(0)
+            .getExperimental()
+            .getRaft()
+            .getPreferSnapshotReplicationThreshold());
     clusteringRule.triggerAndWaitForSnapshots();
 
     // when
@@ -70,7 +76,13 @@ public class InstallRequestHandlingTest {
                 .serviceTask("task", task -> task.zeebeJobType("type"))
                 .endEvent()
                 .done());
-    clusteringRule.fillSegment();
+    clusteringRule.fillSegments(
+        2,
+        clusteringRule
+            .getBrokerCfg(0)
+            .getExperimental()
+            .getRaft()
+            .getPreferSnapshotReplicationThreshold());
     clusteringRule.triggerAndWaitForSnapshots();
     clusteringRule.startBroker(followerId);
     clusteringRule.waitForSnapshotAtBroker(followerId);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
@@ -45,6 +45,7 @@ final class DiskSpaceRecoveryIT {
   private final ZeebeContainer container =
       new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
           .withZeebeData(volume)
+          .withEnv("ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD", "0")
           .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "1MB")
           .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "1MB")
           .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING", "10MB")


### PR DESCRIPTION
This offsets the compactable index by `preferSnapshotReplicationThreshold`.

Previously, when a leader would take a snapshot, it would immediately compact the log based on the snapshot position. This would force the leader into snapshot replication for followers which are lagging behind in replication because the would no longer contain the entries needed for normal replication.

The idea here is to truncate a little bit less to allow for normal replication even when followers are lagging behind. The offset is based on the config parameter `preferSnapshotReplicationThreshold` which is already used by the leader to decide whether to replicate events or snapshots. 

closes #8565