### PR TITLE
Prevent NPE when terminating process instance through PI modification

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -34,9 +34,10 @@ final class ProcessInstanceModifiedEventApplier
 
   @Override
   public void applyState(final long key, final ProcessInstanceModificationRecord value) {
-    if (value.hasActivateInstructions()) {
+    final var processInstance = elementInstanceState.getInstance(value.getProcessInstanceKey());
+    if (processInstance != null && value.hasActivateInstructions()) {
       clearInterruptedState(value);
-      incrementNumberOfTakenSequenceFlows(value);
+      incrementNumberOfTakenSequenceFlows(value, processInstance);
     }
   }
 
@@ -53,9 +54,8 @@ final class ProcessInstanceModifiedEventApplier
                     instance.getKey(), ElementInstance::clearInterruptedState));
   }
 
-  private void incrementNumberOfTakenSequenceFlows(final ProcessInstanceModificationRecord value) {
-    final ElementInstance processInstance =
-        elementInstanceState.getInstance(value.getProcessInstanceKey());
+  private void incrementNumberOfTakenSequenceFlows(
+      final ProcessInstanceModificationRecord value, final ElementInstance processInstance) {
     final var process =
         processState
             .getProcessByKey(processInstance.getValue().getProcessDefinitionKey())


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Users can pass the process instance key as a terminate instruction in a modification command. If they do this, and also have an activate instruction we will run in a NPE during processing. This is because we try to find the process instance during the processing of the `MODIFIED` event. Since the process instance is terminate as a result of the instructions, this no longer exists.

We always execute the activate instructions first. The expected result in this situation would be sending the `ACTIVATE` command of the activate instruction and then terminating the process instance. This will result in a terminated process instance and a rejected activate command.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11413 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
