### PR TITLE
Add Intents for resource deletion

### DIFF
--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
@@ -16,7 +16,8 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum DecisionIntent implements Intent {
-  CREATED(0);
+  CREATED(0),
+  DELETED(1);
 
   private final short value;
 
@@ -32,6 +33,8 @@ public enum DecisionIntent implements Intent {
     switch (value) {
       case 0:
         return CREATED;
+      case 1:
+        return DELETED;
       default:
         return UNKNOWN;
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
@@ -16,7 +16,8 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum DecisionRequirementsIntent implements Intent {
-  CREATED(0);
+  CREATED(0),
+  DELETED(1);
 
   private final short value;
 
@@ -32,6 +33,8 @@ public enum DecisionRequirementsIntent implements Intent {
     switch (value) {
       case 0:
         return CREATED;
+      case 1:
+        return DELETED;
       default:
         return UNKNOWN;
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -48,7 +48,8 @@ public interface Intent {
           CheckpointIntent.class,
           ProcessInstanceModificationIntent.class,
           SignalIntent.class,
-          SignalSubscriptionIntent.class);
+          SignalSubscriptionIntent.class,
+          ResourceDeletionIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
@@ -16,7 +16,8 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum ProcessIntent implements Intent {
-  CREATED((short) 0);
+  CREATED((short) 0),
+  DELETED((short) 1);
 
   private final short value;
 
@@ -32,6 +33,8 @@ public enum ProcessIntent implements Intent {
     switch (value) {
       case 0:
         return CREATED;
+      case 1:
+        return DELETED;
       default:
         return UNKNOWN;
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceDeletionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceDeletionIntent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ResourceDeletionIntent implements Intent {
+  DELETE(0),
+  DELETED(1);
+
+  private final short value;
+
+  ResourceDeletionIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return DELETE;
+      case 1:
+        return DELETED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Introduces the `ResourceDeletionIntent`. This enum contains 2 intents, `DELETE` and `DELETED`. The `DELETE` intent is the command that gets written. When he command has been fully processed we will write an event with the `DELETED` intent to signal that the command has been processed.

This PR also adds the `DELETED` intent to the `ProcessIntent`, `DecisionRequirementsIntent` and the `DecisionIntent`. Events with these intents will be written during the processing of the `ResourceDeletion DELETE` command. The appliers of these intents will be responsible to remove the related resource from the state.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9767 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
