### PR TITLE
Create ResourceDeletionRecord

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -654,6 +654,7 @@
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
+        #     resourceDeletion: true
         #     signal: true
         #     signalSubscription: true
         #     timer: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -584,6 +584,7 @@
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
+        #     resourceDeletion: true
         #     signal: true
         #     signalSubscription: true
         #     timer: true

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -99,6 +99,7 @@ exporters:
         processInstanceCreation: false
         processInstanceModification: false
         processMessageSubscription: false
+        resourceDeletion: false
         signal: false
         signalSubscription: false
         variable: false
@@ -149,6 +150,7 @@ More specifically, each option configures the following:
   be exported; if false, ignored.
 * `processMessageSubscription` (`boolean`): if true, records related to process message
   subscriptions will be exported; if false, ignored.
+* `resourceDeletion` (`boolean`): if true, records related to resource deletions will be exported; if false, ignored.
 * `signal` (`boolean`): if true, records related to signals will be exported; if false, ignored.
 * `signalSubscription` (`boolean`): if true, records related to signal subscription will be exported; if false, ignored.
 * `timer` (`boolean`): if true, records related to timers will be exported; if false, ignored.
@@ -212,6 +214,7 @@ exporters:
         processInstanceCreation: true
         processInstanceModification: true
         processMessageSubscription: true
+        resourceDeletion: true
         signal: true
         signalSubscription: true
         timer: true

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -269,6 +269,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.signalSubscription) {
         createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION);
       }
+      if (index.resourceDeletion) {
+        createValueIndexTemplate(ValueType.RESOURCE_DELETION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -103,6 +103,8 @@ public class ElasticsearchExporterConfiguration {
         return index.signal;
       case SIGNAL_SUBSCRIPTION:
         return index.signalSubscription;
+      case RESOURCE_DELETION:
+        return index.resourceDeletion;
       default:
         return false;
     }
@@ -160,6 +162,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean escalation = true;
     public boolean signal = true;
     public boolean signalSubscription = true;
+    public boolean resourceDeletion = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -243,6 +246,8 @@ public class ElasticsearchExporterConfiguration {
           + signal
           + ", signalSubscription="
           + signalSubscription
+          + ", resourceDeletion="
+          + resourceDeletion
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
@@ -1,0 +1,30 @@
+{
+  "index_patterns": [
+    "zeebe-record_resource-deletion_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-resource-deletion": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "resourceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -74,6 +74,7 @@ final class TestSupport {
       case ESCALATION -> config.escalation = value;
       case SIGNAL -> config.signal = value;
       case SIGNAL_SUBSCRIPTION -> config.signalSubscription = value;
+      case RESOURCE_DELETION -> config.resourceDeletion = value;
       default -> throw new IllegalArgumentException(
           "No known indexing configuration option for value type " + valueType);
     }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.resource;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+
+public class ResourceDeletionRecord extends UnifiedRecordValue
+    implements ResourceDeletionRecordValue {
+
+  private final LongProperty resourceKeyProp = new LongProperty("resourceKey");
+
+  public ResourceDeletionRecord() {
+    declareProperty(resourceKeyProp);
+  }
+
+  public void wrap(final ResourceDeletionRecord record) {
+    resourceKeyProp.setValue(record.getResourceKey());
+  }
+
+  @Override
+  public long getResourceKey() {
+    return resourceKeyProp.getValue();
+  }
+
+  public ResourceDeletionRecord setResourceKey(final long resourceKey) {
+    resourceKeyProp.setValue(resourceKey);
+    return this;
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
@@ -1171,6 +1172,23 @@ final class JsonSerializableToJsonTest {
           }
           """
       },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////// ResourceDeletionRecord ///////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ResourceDeletionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var resourceKey = 1L;
+
+              return new ResourceDeletionRecord().setResourceKey(resourceKey);
+            },
+        """
+          {
+            "resourceKey":1
+          }
+          """
+      }
     };
   }
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -59,6 +60,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
@@ -184,6 +186,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.SIGNAL_SUBSCRIPTION,
         new Mapping<>(SignalSubscriptionRecordValue.class, SignalSubscriptionIntent.class));
+    mapping.put(
+        ValueType.RESOURCE_DELETION,
+        new Mapping<>(ResourceDeletionRecordValue.class, ResourceDeletionIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -123,6 +123,8 @@ public interface Intent {
         return SignalIntent.from(intent);
       case SIGNAL_SUBSCRIPTION:
         return SignalSubscriptionIntent.from(intent);
+      case RESOURCE_DELETION:
+        return ResourceDeletionIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -186,6 +188,8 @@ public interface Intent {
         return SignalIntent.valueOf(intent);
       case SIGNAL_SUBSCRIPTION:
         return SignalSubscriptionIntent.valueOf(intent);
+      case RESOURCE_DELETION:
+        return ResourceDeletionIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ResourceDeletionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ResourceDeletionRecordValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import org.immutables.value.Value;
+
+/**
+ * Represents a resource deletion event
+ *
+ * <p>See {@link ResourceDeletionIntent} for intents.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableResourceDeletionRecordValue.Builder.class)
+public interface ResourceDeletionRecordValue extends RecordValue {
+
+  /**
+   * @return the key of the resource that will be deleted
+   */
+  long getResourceKey();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -46,6 +46,7 @@
       <validValue name="ESCALATION">29</validValue>
       <validValue name="SIGNAL_SUBSCRIPTION">30</validValue>
       <validValue name="SIGNAL">31</validValue>
+      <validValue name="RESOURCE_DELETION">32</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds the `ResourceDeletionRecord`. It also makes sure the record is exported by the `ElasticSearchExporter`

## Related issues

<!-- Which issues are closed by this PR or are related -->

Can be merged after #11477 is merged.
closes #9766 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
