### PR TITLE
Flush log before committing a snapshot if raft flush is disabled

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -302,7 +302,7 @@ public interface RaftServer {
   CompletableFuture<Void> compact();
 
   /**
-   * Ensures that all records written to the log is flushed to disk
+   * Ensures that all records written to the log are flushed to disk
    *
    * @return a future which will be completed after the log is flushed to disk
    */

--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -302,6 +302,13 @@ public interface RaftServer {
   CompletableFuture<Void> compact();
 
   /**
+   * Ensures that all records written to the log is flushed to disk
+   *
+   * @return a future which will be completed after the log is flushed to disk
+   */
+  CompletableFuture<Void> flushLog();
+
+  /**
    * Shuts down the server without leaving the Raft cluster.
    *
    * @return A completable future to be completed once the server has been shutdown.

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -110,6 +110,11 @@ public class DefaultRaftServer implements RaftServer {
     return context.compact();
   }
 
+  @Override
+  public CompletableFuture<Void> flushLog() {
+    return context.flushLog();
+  }
+
   /**
    * Shuts down the server without leaving the Raft cluster.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -512,6 +512,24 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return future;
   }
 
+  /**
+   * Ensures everything written to the log until this point, is flushed to disk.
+   *
+   * @return a future to be completed once the log is flushed to disk
+   */
+  public CompletableFuture<Void> flushLog() {
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+    threadContext.execute(
+        () -> {
+          // Only flush if explicit flush is disabled
+          if (!raftLog.shouldFlushExplicitly()) {
+            raftLog.flush();
+          }
+          future.complete(null);
+        });
+    return future;
+  }
+
   /** Attempts to become the leader. */
   public CompletableFuture<Void> anoint() {
     if (role.role() == Role.LEADER) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -194,6 +194,10 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
     return server.compact();
   }
 
+  public CompletableFuture<Void> flushLog() {
+    return server.flushLog();
+  }
+
   public void setCompactableIndex(final long index) {
     server.getContext().getLogCompactor().setCompactableIndex(index);
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -169,9 +169,7 @@ public final class RaftLog implements Closeable {
   }
 
   public void flush() {
-    if (flushExplicitly) {
-      journal.flush();
-    }
+    journal.flush();
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -18,7 +18,6 @@ package io.atomix.raft.storage.log;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import io.atomix.cluster.MemberId;
@@ -227,19 +226,6 @@ class RaftLogTest {
 
     // then
     verify(journal).flush();
-  }
-
-  @Test
-  void shouldNotFlushWhenFlushExplicitlyFalse() {
-    // given
-    final Journal journal = mock(Journal.class);
-    final var log = new RaftLog(journal, false);
-
-    // when
-    log.flush();
-
-    // then
-    verify(journal, timeout(1).times(0)).flush();
   }
 
   private ApplicationEntry createApplicationEntryAfter(final ApplicationEntry applicationEntry) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 
 public final class SnapshotDirectorPartitionTransitionStep implements PartitionTransitionStep {
 
@@ -49,7 +49,7 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
     if ((context.getSnapshotDirector() == null && targetRole != Role.INACTIVE)
         || shouldInstallOnTransition(targetRole, context.getCurrentRole())) {
       final var server = context.getRaftPartition().getServer();
-      final Supplier<CompletableFuture<Void>> flushLog = server::flushLog;
+      final Callable<CompletableFuture<Void>> flushLog = server::flushLog;
 
       final Duration snapshotPeriod = context.getBrokerCfg().getData().getSnapshotPeriod();
       final AsyncSnapshotDirector director;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.test.util.AutoCloseableRule;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.Before;
@@ -102,14 +103,24 @@ public final class AsyncSnapshottingTest {
   private void createAsyncSnapshotDirectorOfProcessingMode() {
     asyncSnapshotDirector =
         AsyncSnapshotDirector.ofProcessingMode(
-            0, 1, mockStreamProcessor, snapshotController, Duration.ofMinutes(1));
+            0,
+            1,
+            mockStreamProcessor,
+            snapshotController,
+            Duration.ofMinutes(1),
+            () -> CompletableFuture.completedFuture(null));
     actorSchedulerRule.submitActor(asyncSnapshotDirector).join();
   }
 
   private void createAsyncSnapshotDirectorOfReplayMode() {
     asyncSnapshotDirector =
         AsyncSnapshotDirector.ofReplayMode(
-            0, 1, mockStreamProcessor, snapshotController, Duration.ofMinutes(1));
+            0,
+            1,
+            mockStreamProcessor,
+            snapshotController,
+            Duration.ofMinutes(1),
+            () -> CompletableFuture.completedFuture(null));
     actorSchedulerRule.submitActor(asyncSnapshotDirector).join();
   }
 


### PR DESCRIPTION
## Description

- Flush journal before committing a snapshot to ensure that the followup events required for the snapshot is persisted to the disk.
- Remove check for explicit flush in RaftLog to allow externally triggered flush even if explicit flush is disabled.

## Related issues

closes #11423

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
