### PR TITLE
fix(logstreams): include header length on canWrite for batchSize

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/api/records/RecordBatch.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/records/RecordBatch.java
@@ -54,7 +54,10 @@ public final class RecordBatch implements MutableRecordBatch {
             rejectionReason,
             valueType,
             valueWriter);
-    final var entryLength = recordBatchEntry.getLength();
+    // Can't use RecordBatchEntry.getLength here, as it includes the key and source index length
+    // The to be called recordBatchSizePredicate expects only metadata and value length to be passed
+    final var entryLength =
+        recordBatchEntry.getMetadataLength() + recordBatchEntry.getValueLength();
 
     if (!recordBatchSizePredicate.test(recordBatchEntries.size() + 1, batchSize + entryLength)) {
       return Either.left(

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/records/RecordBatchEntry.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/records/RecordBatchEntry.java
@@ -38,6 +38,14 @@ public record RecordBatchEntry(
         + unifiedRecordValue.getLength();
   }
 
+  public int getMetadataLength() {
+    return recordMetadata.getLength();
+  }
+
+  public int getValueLength() {
+    return unifiedRecordValue.getLength();
+  }
+
   public static RecordBatchEntry createEntry(
       final long key,
       final int sourceIndex,

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/RecordBatchTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/RecordBatchTest.java
@@ -205,7 +205,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 249]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 237]");
   }
 
   @Test

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImpl.java
@@ -103,7 +103,8 @@ final class LogStreamBatchWriterImpl implements LogStreamBatchWriter, LogEntryBu
 
   @Override
   public boolean canWriteAdditionalEvent(final int eventCount, final int batchSize) {
-    return logWriteBuffer.canClaimFragmentBatch(eventCount, batchSize);
+    final var batchLength = computeBatchLength(eventCount, batchSize);
+    return logWriteBuffer.canClaimFragmentBatch(eventCount, batchLength);
   }
 
   @Override

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImplTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImplTest.java
@@ -68,6 +68,49 @@ final class LogStreamBatchWriterImplTest {
     verifyNoMoreInteractions(dispatcher);
   }
 
+  /**
+   * This test asserts that {@link LogStreamBatchWriterImpl#canWriteAdditionalEvent(int, int)}
+   * computes the correct batch length before passing it on to the dispatcher to check if it's
+   * acceptable. It also verifies that the same length is passed to the dispatcher when actually
+   * writing, ensuring both methods remain consistent with each other.
+   */
+  @Test
+  void canWriteAdditionalEventWithEventCount() {
+    // given
+    final DirectBuffer value = BufferUtil.wrapString("foo");
+    final DirectBuffer metadata = BufferUtil.wrapString("bar");
+
+    final var expectedFragmentCount = 4;
+    final var expectedFramingLength =
+        expectedFragmentCount * LogEntryDescriptor.HEADER_BLOCK_LENGTH;
+    final var expectedEventsLength =
+        expectedFragmentCount * (value.capacity() + metadata.capacity());
+    final var expectedBatchLength = expectedEventsLength + expectedFramingLength;
+
+    // when
+    when(dispatcher.canClaimFragmentBatch(anyInt(), anyInt())).thenReturn(false);
+    when(dispatcher.canClaimFragmentBatch(expectedFragmentCount, expectedBatchLength))
+        .thenReturn(true);
+    when(dispatcher.claimFragmentBatch(any(), anyInt(), anyInt()))
+        .then(this::mockClaimFragmentBatch);
+
+    final boolean canWriteAdditionalEvent =
+        writer.canWriteAdditionalEvent(expectedFragmentCount, expectedEventsLength);
+
+    for (int i = 0; i < expectedFragmentCount; i++) {
+      writer.event().value(value).metadata(metadata).done();
+    }
+    writer.tryWrite();
+
+    // then
+    verify(dispatcher, times(1)).canClaimFragmentBatch(expectedFragmentCount, expectedBatchLength);
+    verify(dispatcher, times(1))
+        .claimFragmentBatch(
+            any(ClaimedFragmentBatch.class), eq(expectedFragmentCount), eq(expectedBatchLength));
+    assertThat(canWriteAdditionalEvent).isTrue();
+    verifyNoMoreInteractions(dispatcher);
+  }
+
   private long mockClaimFragmentBatch(final InvocationOnMock i) {
     final var batch = i.getArgument(0, ClaimedFragmentBatch.class);
     final var writeBuffer = new UnsafeBuffer(new ExpandableArrayBuffer(1024));


### PR DESCRIPTION
## Description

The previous state of canWriteAdditionalEvent was missing the header length for the batchSize.

This is a specific fix for the 8.1 stable branch only. In 8.0 the affected method wasn't present. For 8.2/main I'm following up.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #11480

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
