### PR TITLE
build: docker image can be built from sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,7 @@ jobs:
           no-color: true
           verbose: true
       - name: Upload Hadolint Results
+        if: always()
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ./hadolint.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,36 @@
+# syntax=docker/dockerfile:1.4
 # This Dockerfile requires BuildKit to be enabled, by setting the environment variable
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 ARG BASE_DIGEST_AMD64="sha256:d1c582c712e8ae049014a3e81296c522360949cbac7ade7e50a0d4d310706066"
 ARG BASE_DIGEST_ARM64="sha256:dac99a547dae7b46de7f0c34f57002094e054724058e8c9f51243d53286bf89e"
 
-#### Builder image ####
-FROM ubuntu:jammy as builder
-ARG DISTBALL
+# set to "build" to build zeebe from scratch instead of using a distball
+ARG DIST="distball"
 
-ENV TMP_ARCHIVE=/tmp/zeebe.tar.gz \
-    TMP_DIR=/tmp/zeebe
-
-COPY ${DISTBALL} ${TMP_ARCHIVE}
-
-RUN mkdir -p ${TMP_DIR} && \
-    tar xfvz ${TMP_ARCHIVE} --strip 1 -C ${TMP_DIR} && \
-    # already create volume dir to later have correct rights
-    mkdir ${TMP_DIR}/data && \
+### Init image containing tini and the startup script ###
+FROM ubuntu:jammy as init
+RUN --mount=type=cache,target=/var/apt/cache,rw \
     apt-get -qq update && \
     apt-get install -y --no-install-recommends tini=0.19.0-1 && \
-    cp /usr/bin/tini ${TMP_DIR}/bin/tini
+    cp /usr/bin/tini .
+COPY --link --chown=1000:0 docker/utils/startup.sh .
 
-COPY docker/utils/startup.sh ${TMP_DIR}/bin/startup.sh
-RUN chmod +x -R ${TMP_DIR}/bin/ && \
-    chmod 0775 ${TMP_DIR} ${TMP_DIR}/data
+### Build zeebe from scratch ###
+FROM maven as build
+ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
+COPY --link . ./
+RUN --mount=type=cache,target=/root/.m2,rw mvn -B -am -pl dist package -T1C -D skipChecks -D skipTests
+RUN mv dist/target/camunda-zeebe .
+
+### Extract zeebe from distball ###
+FROM ubuntu:jammy as distball
+ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
+COPY --link ${DISTBALL} zeebe.tar.gz
+RUN mkdir camunda-zeebe && tar xfvz zeebe.tar.gz --strip 1 -C camunda-zeebe
+
+### Image containing the zeebe distribution ###
+FROM ${DIST} as dist
 
 ### AMD64 base image ###
 # BASE_DIGEST_AMD64 is defined at the top of the Dockerfile
@@ -86,9 +93,12 @@ RUN groupadd -g 1000 zeebe && \
     adduser -u 1000 zeebe --system --ingroup zeebe && \
     chmod g=u /etc/passwd && \
     chown 1000:0 ${ZB_HOME} && \
-    chmod 0775 ${ZB_HOME}
+    chmod 0775 ${ZB_HOME} && \
+    mkdir ${ZB_HOME}/data && \
+    chmod 0775 ${ZB_HOME}/data
 
-COPY --from=builder --chown=1000:0 /tmp/zeebe/bin/startup.sh /usr/local/bin/startup.sh
-COPY --from=builder --chown=1000:0 /tmp/zeebe ${ZB_HOME}
+COPY --from=init --chown=1000:0 tini ${ZB_HOME}/bin/
+COPY --from=init --chown=1000:0 startup.sh /usr/local/bin/startup.sh
+COPY --from=dist --chown=1000:0 camunda-zeebe ${ZB_HOME}
 
 ENTRYPOINT ["tini", "--", "/usr/local/bin/startup.sh"]

--- a/docs/building_docker_images.md
+++ b/docs/building_docker_images.md
@@ -1,11 +1,13 @@
 # Building Docker Images
 
-This document contains information on how to build native zeebe docker images for other platforms than the default amd64 architecture (e.g. for Apple Silicon/M1 based Macs).
+This document contains information on how to build native zeebe docker images for other platforms
+than the default amd64 architecture (e.g. for Apple Silicon/M1 based Macs).
 
 > **Note**
-> These instructions are meant for local development and testing (especially on ARM-based machines), not for production use.
+> These instructions are meant for local development and testing (especially on ARM-based machines),
+> not for production use.
 
-## Get the Distball
+## Optional: Get the Distball
 
 Either build the project yourself or download an existing artifact, specifying the desired version:
 
@@ -23,7 +25,8 @@ mvn dependency:copy -B \
 
 ## Make sure BuildKit is enabled
 
-The Dockerfile for Zeebe requires [BuildKit](https://docs.docker.com/build/buildkit/#getting-started),
+The Dockerfile for Zeebe
+requires [BuildKit](https://docs.docker.com/build/buildkit/#getting-started),
 which is enabled by default if Docker Desktop is installed.
 On Linux you may need to enable it explictly by setting the environment variable
 
@@ -36,14 +39,24 @@ DOCKER_BUILDKIT=1
 Now build the image for your local platform (supported for AMD64 and ARM64):
 
 ```bash
+docker build --build-arg DIST=build -t my-zeebe:latest .
+```
+
+If you already built or downloaded a distball you can use that too:
+
+```bash
 docker build --build-arg DISTBALL=camunda-zeebe.tar.gz -t my-zeebe:latest .
 ```
 
-If you need a specific version of the [`eclipse-temurin:17-jre-focal`](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-focal/images/sha256-e7fe469c4e729ff0ed6ff464f41eaff0e4cb9b6fe7efe71754d8935c8118eb87?context=explore) base image,
-you can override the default BASE_DIGEST[_AMD64|ARM64] depending on your local architecture like that:
+If you need a specific version of
+the [`eclipse-temurin:17-jre-focal`](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-focal/images/sha256-e7fe469c4e729ff0ed6ff464f41eaff0e4cb9b6fe7efe71754d8935c8118eb87?context=explore)
+base image,
+you can override the default BASE_DIGEST[_AMD64|ARM64] depending on your local architecture like
+that:
 amd64: `--build-arg BASE_DIGEST_AMD64="sha256:00a5775f5eb7c24a19cb76ded742cbfcc50c61f062105af9730dadde217e4390"`
 arm64: `--build-arg BASE_DIGEST_ARM64="sha256:ce46be0c4b4edd9f519e99ad68a6b5765abe577fbf1662d8ad2550838eb29823"`
 
 ## Use it
 
-In your [docker-compose.yaml](../docker/compose/docker-compose.yaml), change `camunda/zeebe` to `my-zeebe` to use the newly created image.
+In your [docker-compose.yaml](../docker/compose/docker-compose.yaml), change `camunda/zeebe`
+to `my-zeebe` to use the newly created image.


### PR DESCRIPTION
This adds another indirection for our dockerfile, allowing us to choose between building the image based on an already existing distball with build argument `DISTBALL=some/path` and building the distribution from sources with build argument `DIST=build`. The default remains building from a pre-existing distball but we could consider changing this in the future.

This reduces the steps to build a Zeebe image from:
```bash
mvn -DskipTests -DkskipChecks package
docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz .
```

to
```bash
docker build --build-arg DIST=build .
```

with the final goal being:
```bash
docker build .
```

The final goal would be achieved when we switch the `DIST` argument default value from `distball` to `build`.