### PR TITLE
chore(GHA): use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml

### DIFF
--- a/.github/actions/build-push-docker-gcr/action.yml
+++ b/.github/actions/build-push-docker-gcr/action.yml
@@ -46,6 +46,10 @@ runs:
         ref: "${{ github.event.inputs.branch }}"
     # Also setup java
     - uses: ./.github/actions/setup-zeebe
+      with:
+        secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secret_vault_address: ${{ secrets.VAULT_ADDR }}
+        secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
     # Set further environment variables, which are needed for the QA Testbench run
     - id: generate-tag
       name: Generate image tag

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -30,12 +30,32 @@ inputs:
     description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
     default: "default"
     required: false
+  secret_vault_address:
+    description: 'secret vault url'
+    required: true
+  secret_vault_roleId:
+    description: 'secret vault roleId'
+    required: true
+  secret_vault_secretId:
+    description: 'secret valut secret id'
+    required: true
 
 outputs: {}
 
 runs:
   using: composite
   steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2.4.3
+      with:
+        url: ${{ inputs.secret_vault_address }}
+        method: approle
+        roleId: ${{ inputs.secret_vault_roleId }}
+        secretId: ${{ inputs.secret_vault_secretId }}
+        secrets: |
+          secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
+          secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
     - if: ${{ inputs.java == 'true' }}
       uses: actions/setup-java@v3
       with:
@@ -48,6 +68,18 @@ runs:
       uses: stCarolas/setup-maven@v4.5
       with:
         maven-version: '3.8.6'
+    # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+    - name: 'Create settings.xml'
+      uses: s4u/maven-settings-action@v2.8.0
+      with:
+        githubServer: false
+        servers: |
+          [{
+            "id": "camunda-nexus",
+            "username": "${{ steps.secrets.outputs.ARTIFACTS_USR }}",
+            "password": "${{ steps.secrets.outputs.ARTIFACTS_PSW }}"
+          }]
+        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
     - if: ${{ inputs.maven-cache == 'true' }}
       name: Cache local Maven repository
       uses: actions/cache@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,6 +67,9 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           maven-cache: 'true'
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - name: Get image tag
         id: image-tag
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           maven-cache: 'true'
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -99,6 +102,9 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           maven-cache: 'true'
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -147,6 +153,9 @@ jobs:
         with:
           go: false
           maven-cache: 'true'
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -202,6 +211,9 @@ jobs:
           go: false
           # setting up maven often times out on macOS
           maven: ${{ runner.os != 'macOS' }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -242,6 +254,9 @@ jobs:
         with:
           go: false
           maven-cache: 'true'
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -272,6 +287,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       # Once we're on Go 1.18, use the official gorelease to do this
@@ -306,6 +325,9 @@ jobs:
           go: false
           maven-cache: 'true'
           maven-cache-key-modifier: java-client
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -349,6 +371,9 @@ jobs:
         with:
           go: false
           maven-cache: 'true'
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -383,6 +408,9 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           java: false
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -398,6 +426,9 @@ jobs:
           go: false
           maven-cache: 'true'
           maven-cache-key-modifier: java-checks
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify
   docker-checks:
     name: Docker checks
@@ -426,6 +457,10 @@ jobs:
         with:
           sarif_file: ./hadolint.sarif
       - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-docker
@@ -512,9 +547,18 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          server-id: camunda-nexus
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+              "id": "camunda-nexus",
+              "username": "${{ steps.secrets.outputs.ARTIFACTS_USR }}",
+              "password": "${{ steps.secrets.outputs.ARTIFACTS_PSW }}"
+            }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
       # not resolve-able by the Javadoc generator
@@ -549,6 +593,10 @@ jobs:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
       - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,10 @@ jobs:
           && sudo apt install gh -y
       - name: Setup Zeebe Build Tooling
         uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - name: Additional Go tooling setup
         run: |
           go install github.com/go-bindata/go-bindata/...@v3
@@ -128,6 +132,13 @@ jobs:
                 "id": "central",
                 "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
                 "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+            }]
+          mirrors: |
+            [{
+                "id": "camunda-nexus",
+                "name": "Camunda Nexus",
+                "mirrorOf": "camunda-nexus",
+                "url": "https://repository.nexus.camunda.cloud/content/groups/internal/"
             }]
       - name: Maven Release
         id: maven-release


### PR DESCRIPTION
## Description

- chore(GHA): use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml 
- we agreed to use the existing action instead of recreating new one. 


## Related issues

Related to https://github.com/camunda/team-infrastructure/issues/308


