### PR TITLE
[Backport stable/8.1] Flush log before committing a snapshot if raft flush is disabled

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -302,7 +302,7 @@ public interface RaftServer {
   CompletableFuture<Void> compact();
 
   /**
-   * Ensures that all records written to the log is flushed to disk
+   * Ensures that all records written to the log are flushed to disk
    *
    * @return a future which will be completed after the log is flushed to disk
    */

--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -302,6 +302,13 @@ public interface RaftServer {
   CompletableFuture<Void> compact();
 
   /**
+   * Ensures that all records written to the log is flushed to disk
+   *
+   * @return a future which will be completed after the log is flushed to disk
+   */
+  CompletableFuture<Void> flushLog();
+
+  /**
    * Shuts down the server without leaving the Raft cluster.
    *
    * @return A completable future to be completed once the server has been shutdown.

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -110,6 +110,11 @@ public class DefaultRaftServer implements RaftServer {
     return context.compact();
   }
 
+  @Override
+  public CompletableFuture<Void> flushLog() {
+    return context.flushLog();
+  }
+
   /**
    * Shuts down the server without leaving the Raft cluster.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -516,6 +516,24 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return future;
   }
 
+  /**
+   * Ensures everything written to the log until this point, is flushed to disk.
+   *
+   * @return a future to be completed once the log is flushed to disk
+   */
+  public CompletableFuture<Void> flushLog() {
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+    threadContext.execute(
+        () -> {
+          // Only flush if explicit flush is disabled
+          if (!raftLog.shouldFlushExplicitly()) {
+            raftLog.flush();
+          }
+          future.complete(null);
+        });
+    return future;
+  }
+
   /** Attempts to become the leader. */
   public CompletableFuture<Void> anoint() {
     if (role.role() == Role.LEADER) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -517,20 +517,27 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
-   * Ensures everything written to the log until this point, is flushed to disk.
+   * Ensures everything written to the log until this point, is flushed to disk. If default raft
+   * flush is enabled, then this will not flush because the logs are flushed when necessary to
+   * achieve expected consistency guarantees.
    *
    * @return a future to be completed once the log is flushed to disk
    */
   public CompletableFuture<Void> flushLog() {
     final CompletableFuture<Void> future = new CompletableFuture<>();
-    threadContext.execute(
-        () -> {
-          // Only flush if explicit flush is disabled
-          if (!raftLog.shouldFlushExplicitly()) {
+    if (raftLog.shouldFlushExplicitly()) {
+      // If default explicit flush is enabled, then the log is flushed by default before committing.
+      // Hence, there is no need to flush them again here. This is an optimization to ensure we are
+      // not unnecessarily blocking raft thread to do an i/o.
+      future.complete(null);
+    } else {
+      threadContext.execute(
+          () -> {
             raftLog.flush();
-          }
-          future.complete(null);
-        });
+            future.complete(null);
+          });
+    }
+
     return future;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -194,6 +194,10 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
     return server.compact();
   }
 
+  public CompletableFuture<Void> flushLog() {
+    return server.flushLog();
+  }
+
   public void setCompactableIndex(final long index) {
     // Don't compact everything, leave enough entries so that slow followers are not forced into
     // snapshot replication immediately.

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -169,9 +169,7 @@ public final class RaftLog implements Closeable {
   }
 
   public void flush() {
-    if (flushExplicitly) {
-      journal.flush();
-    }
+    journal.flush();
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -18,7 +18,6 @@ package io.atomix.raft.storage.log;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import io.atomix.cluster.MemberId;
@@ -225,19 +224,6 @@ class RaftLogTest {
 
     // then
     verify(journal).flush();
-  }
-
-  @Test
-  void shouldNotFlushWhenFlushExplicitlyFalse() {
-    // given
-    final Journal journal = mock(Journal.class);
-    final var log = new RaftLog(journal, false);
-
-    // when
-    log.flush();
-
-    // then
-    verify(journal, timeout(1).times(0)).flush();
   }
 
   private ApplicationEntry createApplicationEntryAfter(final ApplicationEntry applicationEntry) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 
 public final class SnapshotDirectorPartitionTransitionStep implements PartitionTransitionStep {
 
@@ -49,7 +49,7 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
     if ((context.getSnapshotDirector() == null && targetRole != Role.INACTIVE)
         || shouldInstallOnTransition(targetRole, context.getCurrentRole())) {
       final var server = context.getRaftPartition().getServer();
-      final Supplier<CompletableFuture<Void>> flushLog = server::flushLog;
+      final Callable<CompletableFuture<Void>> flushLog = server::flushLog;
 
       final Duration snapshotPeriod = context.getBrokerCfg().getData().getSnapshotPeriod();
       final AsyncSnapshotDirector director;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.test.util.AutoCloseableRule;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.Before;
@@ -102,14 +103,24 @@ public final class AsyncSnapshottingTest {
   private void createAsyncSnapshotDirectorOfProcessingMode() {
     asyncSnapshotDirector =
         AsyncSnapshotDirector.ofProcessingMode(
-            0, 1, mockStreamProcessor, snapshotController, Duration.ofMinutes(1));
+            0,
+            1,
+            mockStreamProcessor,
+            snapshotController,
+            Duration.ofMinutes(1),
+            () -> CompletableFuture.completedFuture(null));
     actorSchedulerRule.submitActor(asyncSnapshotDirector).join();
   }
 
   private void createAsyncSnapshotDirectorOfReplayMode() {
     asyncSnapshotDirector =
         AsyncSnapshotDirector.ofReplayMode(
-            0, 1, mockStreamProcessor, snapshotController, Duration.ofMinutes(1));
+            0,
+            1,
+            mockStreamProcessor,
+            snapshotController,
+            Duration.ofMinutes(1),
+            () -> CompletableFuture.completedFuture(null));
     actorSchedulerRule.submitActor(asyncSnapshotDirector).join();
   }
 


### PR DESCRIPTION
# Description
Backport of #11487 to `stable/8.1`.

relates to #11423