### PR TITLE
feat: allow marking records as processed

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
@@ -39,6 +39,11 @@ public final class LoggedEventImpl implements LoggedEvent {
   }
 
   @Override
+  public boolean isProcessed() {
+    return LogEntryDescriptor.isProcessed(buffer, messageOffset);
+  }
+
+  @Override
   public long getPosition() {
     return LogEntryDescriptor.getPosition(buffer, fragmentOffset);
   }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.logstreams.impl.serializer;
 
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.markAsProcessed;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.metadataOffset;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setKey;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setMetadataLength;
@@ -88,6 +89,9 @@ final class LogAppendEntrySerializer {
     final var entryOffset = writeBufferOffset + DataFrameDescriptor.HEADER_LENGTH;
 
     // Write the entry
+    if (entry.isProcessed()) {
+      markAsProcessed(writeBuffer, entryOffset);
+    }
     setPosition(writeBuffer, entryOffset, position);
     setSourceEventPosition(writeBuffer, entryOffset, sourcePosition);
     setKey(writeBuffer, entryOffset, key);

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogAppendEntry.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogAppendEntry.java
@@ -93,8 +93,8 @@ public interface LogAppendEntry {
   }
 
   /**
-   * Creates a new {@link LogAppendEntry} which wraps the given {@link LogAppendEntry} and
-   * marks the entry as processed.
+   * Creates a new {@link LogAppendEntry} which wraps the given {@link LogAppendEntry} and marks the
+   * entry as processed.
    *
    * @param entry the entry which should be written to the log
    * @return a simple value class implementation of a {@link LogAppendEntry} with the parameters

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogAppendEntry.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogAppendEntry.java
@@ -49,6 +49,13 @@ public interface LogAppendEntry {
   }
 
   /**
+   * @return true if the entry was already processed, defaults to false
+   */
+  default boolean isProcessed() {
+    return false;
+  }
+
+  /**
    * Creates a default representation of a {@link LogAppendEntry} using default null values for the
    * key and source index.
    *
@@ -83,5 +90,16 @@ public interface LogAppendEntry {
         -1,
         Objects.requireNonNull(recordMetadata, "must specify metadata"),
         Objects.requireNonNull(recordValue, "must specify value"));
+  }
+
+  /**
+   * Creates a new {@link LogAppendEntry} which wraps the given {@link LogAppendEntry} and
+   * marks the entry as processed.
+   *
+   * @param entry the entry which should be written to the log
+   * @return a simple value class implementation of a {@link LogAppendEntry} with the parameters
+   */
+  static LogAppendEntry ofProcessed(final LogAppendEntry entry) {
+    return new ProcessedLogAppendEntryImpl(entry);
   }
 }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
@@ -13,6 +13,12 @@ import org.agrona.DirectBuffer;
 
 /** Represents an event on the log stream. */
 public interface LoggedEvent extends BufferWriter {
+
+  /**
+   * @return returns true if record is already processed
+   */
+  boolean isProcessed();
+
   /**
    * @return the event's position in the log.
    */

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/ProcessedLogAppendEntryImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/ProcessedLogAppendEntryImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.log;
+
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+
+record ProcessedLogAppendEntryImpl(LogAppendEntry entry)
+    implements LogAppendEntry {
+
+  @Override
+  public long key() {
+    return entry.key();
+  }
+
+  @Override
+  public int sourceIndex() {
+    return entry.sourceIndex();
+  }
+
+  @Override
+  public RecordMetadata recordMetadata() {
+    return entry.recordMetadata();
+  }
+
+  @Override
+  public UnifiedRecordValue recordValue() {
+    return entry.recordValue();
+  }
+
+  @Override
+  public boolean isProcessed() {
+    // this class only purpose is to mark the entry as processed
+    return true;
+  }
+}

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/ProcessedLogAppendEntryImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/ProcessedLogAppendEntryImpl.java
@@ -10,8 +10,7 @@ package io.camunda.zeebe.logstreams.log;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 
-record ProcessedLogAppendEntryImpl(LogAppendEntry entry)
-    implements LogAppendEntry {
+record ProcessedLogAppendEntryImpl(LogAppendEntry entry) implements LogAppendEntry {
 
   @Override
   public long key() {

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LogEntryDescriptorTest {
+
+  @Test
+  public void shouldBeNonProcessedAsDefault() {
+    // given
+    final var buffer = new UnsafeBuffer(new byte[128]);
+
+    // when
+    final boolean processed = LogEntryDescriptor.isProcessed(buffer, 0);
+
+    // then
+    Assertions.assertThat(processed).isFalse();
+  }
+
+  @Test
+  public void shouldMarkAsProcessed() {
+    // given
+    final var buffer = new UnsafeBuffer(new byte[128]);
+
+    // when
+    LogEntryDescriptor.markAsProcessed(buffer, 0);
+
+    // then
+    Assertions.assertThat(LogEntryDescriptor.isProcessed(buffer, 0)).isTrue();
+  }
+}

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.util.TestEntry;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -37,6 +38,28 @@ final class LogAppendEntrySerializerTest {
     assertThat(event.getPosition()).isEqualTo(2);
     assertThat(event.getSourceEventPosition()).isEqualTo(3);
     assertThat(event.getTimestamp()).isEqualTo(4);
+    assertThat(event.isProcessed()).isFalse();
+  }
+
+  @Test
+  void shouldMarkEntryAsProcessed() {
+    // given
+    final var serializer = new LogAppendEntrySerializer();
+    final var event = new LoggedEventImpl();
+    final var entry = TestEntry.ofKey(1);
+    final var processedEntry = LogAppendEntry.ofProcessed(entry);
+
+    // when
+    serializer.serialize(writeBuffer, 0, processedEntry, 2, 3, 4);
+
+    // then
+    event.wrap(writeBuffer, 0);
+    assertThatEntry(entry).matchesLoggedEvent(event);
+    assertThat(event.getKey()).isEqualTo(1);
+    assertThat(event.getPosition()).isEqualTo(2);
+    assertThat(event.getSourceEventPosition()).isEqualTo(3);
+    assertThat(event.getTimestamp()).isEqualTo(4);
+    assertThat(event.isProcessed()).isTrue();
   }
 
   @Test

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogAppendEntryTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogAppendEntryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.log;
+
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LogAppendEntryTest {
+
+  @Test
+  public void shouldWrapValues() {
+    // given
+    final var recordMetadata = new RecordMetadata();
+    final var unifiedRecordValue = new UnifiedRecordValue();
+
+    // when
+    final var logAppendEntry = LogAppendEntry.of(recordMetadata, unifiedRecordValue);
+
+    // then
+    Assertions.assertThat(logAppendEntry.recordValue()).isEqualTo(unifiedRecordValue);
+    Assertions.assertThat(logAppendEntry.recordMetadata()).isEqualTo(recordMetadata);
+  }
+
+  @Test
+  public void shouldNotBeProcessedPerDefault() {
+    // given
+    final var recordMetadata = new RecordMetadata();
+    final var unifiedRecordValue = new UnifiedRecordValue();
+
+    // when
+    final var logAppendEntry = LogAppendEntry.of(recordMetadata, unifiedRecordValue);
+
+    // then
+    Assertions.assertThat(logAppendEntry.isProcessed()).isFalse();
+    Assertions.assertThat(logAppendEntry.recordValue()).isEqualTo(unifiedRecordValue);
+    Assertions.assertThat(logAppendEntry.recordMetadata()).isEqualTo(recordMetadata);
+  }
+
+  @Test
+  public void shouldMarkEntryAsProcessed() {
+    // given
+    final var recordMetadata = new RecordMetadata();
+    final var unifiedRecordValue = new UnifiedRecordValue();
+    final var logAppendEntry = LogAppendEntry.of(recordMetadata, unifiedRecordValue);
+
+    // when
+    final var processedEntry = LogAppendEntry.ofProcessed(logAppendEntry);
+
+    // then
+    Assertions.assertThat(processedEntry.isProcessed()).isTrue();
+    Assertions.assertThat(logAppendEntry.recordValue()).isEqualTo(unifiedRecordValue);
+    Assertions.assertThat(logAppendEntry.recordMetadata()).isEqualTo(recordMetadata);
+  }
+}


### PR DESCRIPTION
Uses a [previously unused](https://github.com/camunda/zeebe/issues/11504#issuecomment-1410027654) byte in the `LogEntryDescriptor` as a field for arbitrary boolean flags, first used to mark records as already processed.

This allows the stream processor to mark new records as processed and read the `isProcessed` flag back during processing which is useful for batch processing.

By default, entries are assumed to be not processed yet.

closes #11504