### PR TITLE
feat(zb-db): disable rocksdb WAL by default

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -76,7 +76,7 @@ public final class RocksdbCfgTest {
     assertThat(rocksDbConfiguration.getMaxWriteBufferNumber()).isEqualTo(6);
     assertThat(rocksDbConfiguration.getMinWriteBufferNumberToMerge()).isEqualTo(3);
     assertThat(rocksDbConfiguration.getIoRateBytesPerSecond()).isZero();
-    assertThat(rocksDbConfiguration.isWalDisabled()).isFalse();
+    assertThat(rocksDbConfiguration.isWalDisabled()).isTrue();
   }
 
   @Test

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -818,10 +818,10 @@
 
         # Configures if the RocksDB write-ahead-log is used or not. By default, every write in RocksDB goes to the active write buffer and the WAL; this
         # helps recover a RocksDB instance should it crash before the write buffer is flushed. Zeebe however only recovers from specific point-in-time snapshot,
-        # and never from a previously active RocksDB instance, which makes it a good candidate to disable the WAL. It's currently disabled by default as
-        # performance is a bit less predictable when disabling the WAL.
+        # and never from a previously active RocksDB instance, which makes it a good candidate to disable the WAL.
+        # WAL is disabled by default as it can improve performance of Zeebe.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL
-        # disableWal: false
+        # disableWal: true
 
       # consistencyChecks:
         # Configures if the basic operations on RocksDB, such as inserting or deleting key-value pairs, should check preconditions,

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -748,10 +748,10 @@
 
         # Configures if the RocksDB write-ahead-log is used or not. By default, every write in RocksDB goes to the active write buffer and the WAL; this
         # helps recover a RocksDB instance should it crash before the write buffer is flushed. Zeebe however only recovers from specific point-in-time snapshot,
-        # and never from a previously active RocksDB instance, which makes it a good candidate to disable the WAL. It's currently disabled by default as
-        # performance is a bit less predictable when disabling the WAL.
+        # and never from a previously active RocksDB instance, which makes it a good candidate to disable the WAL.
+        # WAL is disabled by default as it can improve performance of Zeebe.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL
-        # disableWal: false
+        # disableWal: true
 
       # consistencyChecks:
         # Configures if the basic operations on RocksDB, such as inserting or deleting key-value pairs, should check preconditions,

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -16,7 +16,22 @@ public final class RocksDbConfiguration {
   public static final int DEFAULT_MAX_WRITE_BUFFER_NUMBER = 6;
   public static final int DEFAULT_MIN_WRITE_BUFFER_NUMBER_TO_MERGE = 3;
   public static final boolean DEFAULT_STATISTICS_ENABLED = false;
-  public static final boolean DEFAULT_WAL_DISABLED = false;
+
+  /**
+   * WARN: It is safe to disable wal as long as there is only one column family. With more than one
+   * column family, consistency across multiple column family is ensured by WAL while taking a
+   * checkpoint.
+   *
+   * <p>http://rocksdb.org/blog/2015/11/10/use-checkpoints-for-efficient-snapshots.html >>> The
+   * Checkpoint feature enables RocksDB to create a consistent snapshot of a given RocksDB database
+   * in the specified directory. If the snapshot is on the same filesystem as the original database,
+   * the SST files will be hard-linked, otherwise SST files will be copied. The manifest and CURRENT
+   * files will be copied. In addition, if there are multiple column families, log files will be
+   * copied for the period covering the start and end of the checkpoint, in order to provide a
+   * consistent snapshot across column families. <<<
+   */
+  public static final boolean DEFAULT_WAL_DISABLED = true;
+
   public static final int DEFAULT_IO_RATE_BYTES_PER_SECOND = 0;
 
   private Properties columnFamilyOptions = new Properties();


### PR DESCRIPTION
## Description

WAL is useful to crash recovery. Since after crash we always use the last checkpoint and Zeebe's logstream to rebuild the state. there is no need to keep the WAL. As discussed in https://github.com/camunda/zeebe/issues/6161#issuecomment-771722771 it seems to be safe while taking checkpoints as well. It is not to safe to disable WAL if we add more than one column families. 

Throughput with WAL disabled
![image](https://user-images.githubusercontent.com/1997478/216024261-c02e9afd-6201-43f8-8c78-56f763971810.png)

compared to medic-cw-05
![image](https://user-images.githubusercontent.com/1997478/216024326-3b96fac5-f01d-4e0f-b416-b1bda4f87ae9.png)

- [E2E test ](https://bru-3.operate.ultrawombat.com/7b2cd3f5-cfcc-4a65-ab22-0ccaa071e68e/processes/2251799961231250) successfully ran with this change. 
- Benchmark is running.

## Related issues

closes #11455 

