### PR TITLE
Limited Batch processing

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.stream.impl;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.logstreams.impl.Loggers;
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
@@ -32,11 +33,14 @@ import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
 import io.camunda.zeebe.stream.impl.metrics.StreamProcessorMetrics;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
+import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.prometheus.client.Histogram;
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
@@ -81,7 +85,6 @@ import org.slf4j.Logger;
  * </pre>
  */
 public final class ProcessingStateMachine {
-
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
   private static final String ERROR_MESSAGE_WRITE_RECORD_ABORTED =
       "Expected to write one or more follow-up records for record '{} {}' without errors, but exception was thrown.";
@@ -99,6 +102,8 @@ public final class ProcessingStateMachine {
       "Expected to invoke skipped listener for record '{} {}' successfully, but exception was thrown.";
 
   private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
+
+  private static final int COMMAND_LIMIT = 1;
 
   private static final MetadataFilter PROCESSING_FILTER =
       recordMetadata -> recordMetadata.getRecordType() == RecordType.COMMAND;
@@ -139,6 +144,8 @@ public final class ProcessingStateMachine {
   private final StreamProcessorContext context;
   private final List<RecordProcessor> recordProcessors;
   private ProcessingResult currentProcessingResult;
+  private List<LogAppendEntry> pendingWrites;
+
   private RecordProcessor currentProcessor;
   private final LogStreamWriter logStreamWriter;
   private boolean inProcessing;
@@ -224,7 +231,7 @@ public final class ProcessingStateMachine {
     return reachedEnd;
   }
 
-  private void processCommand(final LoggedEvent command) {
+  private void processCommand(final LoggedEvent loggedEvent) {
     // we have to mark ourself has inProcessing to not interfere with readNext calls, which
     // are triggered from commit listener
     inProcessing = true;
@@ -232,54 +239,83 @@ public final class ProcessingStateMachine {
     currentProcessingResult = EmptyProcessingResult.INSTANCE;
 
     metadata.reset();
-    command.readMetadata(metadata);
+    loggedEvent.readMetadata(metadata);
 
     // Here we need to get the current time, since we want to calculate
     // how long it took between writing to the dispatcher and processing.
     // In all other cases we should prefer to use the Prometheus Timer API.
     final var processingStartTime = ActorClock.currentTimeMillis();
     processingTimer = metrics.startProcessingDurationTimer(metadata.getRecordType());
-
     try {
-      final var value = recordValues.readRecordValue(command, metadata.getValueType());
-      typedCommand.wrap(command, metadata, value);
+      final var value = recordValues.readRecordValue(loggedEvent, metadata.getValueType());
+      typedCommand.wrap(loggedEvent, metadata, value);
 
       final long position = typedCommand.getPosition();
       final ProcessingResultBuilder processingResultBuilder =
           new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
 
-      metrics.processingLatency(command.getTimestamp(), processingStartTime);
-
-      currentProcessor =
-          recordProcessors.stream()
-              .filter(p -> p.accepts(typedCommand.getValueType()))
-              .findFirst()
-              .orElse(null);
+      metrics.processingLatency(loggedEvent.getTimestamp(), processingStartTime);
 
       zeebeDbTransaction = transactionContext.getCurrentTransaction();
+
       zeebeDbTransaction.run(
           () -> {
-            if (currentProcessor != null) {
-              currentProcessingResult =
-                  currentProcessor.process(typedCommand, processingResultBuilder);
+            var resultIndex = 0;
+            var processedCommands = 0;
+            pendingWrites = new ArrayList<>();
+            final var pendingCommands = new ArrayDeque<TypedRecord<?>>();
+            pendingCommands.addLast(typedCommand);
+
+            while (!pendingCommands.isEmpty() && processedCommands++ < COMMAND_LIMIT) {
+              final var command = pendingCommands.removeFirst();
+
+              currentProcessor =
+                  recordProcessors.stream()
+                      .filter(p -> p.accepts(command.getValueType()))
+                      .findFirst()
+                      .orElse(null);
+              if (currentProcessor != null) {
+                currentProcessingResult =
+                    currentProcessor.process(command, processingResultBuilder);
+
+                final int finalProcessedCommands = processedCommands;
+                currentProcessingResult.getRecordBatch().entries().stream()
+                    .skip(resultIndex)
+                    .forEachOrdered(
+                        entry -> {
+                          var logAppendEntry = entry;
+                          if (entry.recordMetadata().getRecordType() == RecordType.COMMAND) {
+                            if (finalProcessedCommands + pendingCommands.size() < COMMAND_LIMIT) {
+                              pendingCommands.addLast(
+                                  new UnwrittenRecord(
+                                      entry.key(),
+                                      context.getPartitionId(),
+                                      entry.recordValue(),
+                                      entry.recordMetadata()));
+                              logAppendEntry = LogAppendEntry.ofProcessed(entry);
+                            }
+                          }
+                          pendingWrites.add(logAppendEntry);
+                        });
+
+                resultIndex = currentProcessingResult.getRecordBatch().entries().size();
+              }
+              metrics.commandsProcessed();
             }
-
-            lastProcessedPositionState.markAsProcessed(position);
           });
-
-      metrics.commandsProcessed();
 
       if (EmptyProcessingResult.INSTANCE == currentProcessingResult) {
         skipRecord();
         return;
       }
 
+      lastProcessedPositionState.markAsProcessed(position);
       writeRecords();
     } catch (final RecoverableException recoverableException) {
       // recoverable
       LOG.error(
           ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING,
-          command,
+          loggedEvent,
           metadata,
           recoverableException);
       actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processCommand(currentRecord));
@@ -325,10 +361,10 @@ public final class ProcessingStateMachine {
         () -> {
           final ProcessingResultBuilder processingResultBuilder =
               new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
-
           currentProcessingResult =
               currentProcessor.onProcessingError(
                   processingException, typedCommand, processingResultBuilder);
+          pendingWrites = currentProcessingResult.getRecordBatch().entries();
         });
   }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -410,9 +410,7 @@ public final class ProcessingStateMachine {
     final ActorFuture<Boolean> retryFuture =
         writeRetryStrategy.runWithRetry(
             () -> {
-              final long position =
-                  logStreamWriter.tryWrite(
-                      currentProcessingResult.getRecordBatch().entries(), sourceRecordPosition);
+              final long position = logStreamWriter.tryWrite(pendingWrites, sourceRecordPosition);
               if (position > 0) {
                 writtenPosition = position;
               }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -205,7 +205,7 @@ public final class ProcessingStateMachine {
     if (shouldProcessNext.getAsBoolean() && hasNext && !inProcessing) {
       currentRecord = logStreamReader.next();
 
-      if (eventFilter.applies(currentRecord)) {
+      if (eventFilter.applies(currentRecord) && !currentRecord.shouldSkipProcessing()) {
         processCommand(currentRecord);
       } else {
         skipRecord();

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -241,75 +241,26 @@ public final class ProcessingStateMachine {
     metadata.reset();
     loggedEvent.readMetadata(metadata);
 
-    // Here we need to get the current time, since we want to calculate
-    // how long it took between writing to the dispatcher and processing.
-    // In all other cases we should prefer to use the Prometheus Timer API.
-    final var processingStartTime = ActorClock.currentTimeMillis();
-    processingTimer = metrics.startProcessingDurationTimer(metadata.getRecordType());
     try {
+      // Here we need to get the current time, since we want to calculate
+      // how long it took between writing to the dispatcher and processing.
+      // In all other cases we should prefer to use the Prometheus Timer API.
+      final var processingStartTime = ActorClock.currentTimeMillis();
+      metrics.processingLatency(loggedEvent.getTimestamp(), processingStartTime);
+      processingTimer = metrics.startProcessingDurationTimer(metadata.getRecordType());
+
       final var value = recordValues.readRecordValue(loggedEvent, metadata.getValueType());
       typedCommand.wrap(loggedEvent, metadata, value);
 
-      final long position = typedCommand.getPosition();
-      final ProcessingResultBuilder processingResultBuilder =
-          new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
-
-      metrics.processingLatency(loggedEvent.getTimestamp(), processingStartTime);
-
       zeebeDbTransaction = transactionContext.getCurrentTransaction();
-
-      zeebeDbTransaction.run(
-          () -> {
-            var resultIndex = 0;
-            var processedCommands = 0;
-            pendingWrites = new ArrayList<>();
-            final var pendingCommands = new ArrayDeque<TypedRecord<?>>();
-            pendingCommands.addLast(typedCommand);
-
-            while (!pendingCommands.isEmpty() && processedCommands++ < COMMAND_LIMIT) {
-              final var command = pendingCommands.removeFirst();
-
-              currentProcessor =
-                  recordProcessors.stream()
-                      .filter(p -> p.accepts(command.getValueType()))
-                      .findFirst()
-                      .orElse(null);
-              if (currentProcessor != null) {
-                currentProcessingResult =
-                    currentProcessor.process(command, processingResultBuilder);
-
-                final int finalProcessedCommands = processedCommands;
-                currentProcessingResult.getRecordBatch().entries().stream()
-                    .skip(resultIndex)
-                    .forEachOrdered(
-                        entry -> {
-                          var logAppendEntry = entry;
-                          if (entry.recordMetadata().getRecordType() == RecordType.COMMAND) {
-                            if (finalProcessedCommands + pendingCommands.size() < COMMAND_LIMIT) {
-                              pendingCommands.addLast(
-                                  new UnwrittenRecord(
-                                      entry.key(),
-                                      context.getPartitionId(),
-                                      entry.recordValue(),
-                                      entry.recordMetadata()));
-                              logAppendEntry = LogAppendEntry.ofProcessed(entry);
-                            }
-                          }
-                          pendingWrites.add(logAppendEntry);
-                        });
-
-                resultIndex = currentProcessingResult.getRecordBatch().entries().size();
-              }
-              metrics.commandsProcessed();
-            }
-          });
+      zeebeDbTransaction.run(() -> batchProcessing(typedCommand));
 
       if (EmptyProcessingResult.INSTANCE == currentProcessingResult) {
         skipRecord();
         return;
       }
 
-      lastProcessedPositionState.markAsProcessed(position);
+      lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
       writeRecords();
     } catch (final RecoverableException recoverableException) {
       // recoverable
@@ -324,6 +275,91 @@ public final class ProcessingStateMachine {
     } catch (final Exception e) {
       onError(e, this::writeRecords);
     }
+  }
+
+  /**
+   * Starts the batch processing with the given initial command and iterates over ProcessingResult
+   * and applies all follow-up commands until the command limit is reached or no more follow-up
+   * commands are created.
+   */
+  private void batchProcessing(final TypedRecord<?> initialCommand) {
+    final ProcessingResultBuilder processingResultBuilder =
+        new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
+    var lastProcessingResultSize = 0;
+    var processedCommandsCount = 0;
+    pendingWrites = new ArrayList<>();
+    final var pendingCommands = new ArrayDeque<TypedRecord<?>>();
+    pendingCommands.addLast(initialCommand);
+
+    while (!pendingCommands.isEmpty() && processedCommandsCount < COMMAND_LIMIT) {
+
+      final var command = pendingCommands.removeFirst();
+
+      currentProcessor =
+          recordProcessors.stream()
+              .filter(p -> p.accepts(command.getValueType()))
+              .findFirst()
+              .orElse(null);
+      if (currentProcessor != null) {
+        currentProcessingResult = currentProcessor.process(command, processingResultBuilder);
+
+        final BatchProcessingStepResult batchProcessingStepResult =
+            collectBatchProcessingStepResult(
+                currentProcessingResult,
+                lastProcessingResultSize,
+                // +1 since we already need include the current command in the calculation
+                pendingCommands.size() + processedCommandsCount + 1);
+
+        pendingCommands.addAll(batchProcessingStepResult.toProcess());
+        pendingWrites.addAll(batchProcessingStepResult.toWrite());
+      }
+
+      lastProcessingResultSize = currentProcessingResult.getRecordBatch().entries().size();
+      processedCommandsCount++;
+      metrics.commandsProcessed();
+    }
+  }
+
+  /**
+   * Collects from the given processing result the commands which should be processed further, and
+   * the records which should be written to the log.
+   *
+   * @param processingResult the processing result of the last processed command
+   * @param lastProcessingResultSize the size of the processing result before processing the last
+   *     command
+   * @param currentBatchSize the current batch size (only commands counted), includes already
+   *     processed and pending commands
+   * @return the result of the current batch processing step, which contains the next to processed
+   *     commands and the records which should be written to the log
+   */
+  private BatchProcessingStepResult collectBatchProcessingStepResult(
+      final ProcessingResult processingResult,
+      final int lastProcessingResultSize,
+      final int currentBatchSize) {
+
+    final var commandsToProcess = new ArrayList<TypedRecord<?>>();
+    final var toWriteEntries = new ArrayList<LogAppendEntry>();
+
+    processingResult.getRecordBatch().entries().stream()
+        .skip(lastProcessingResultSize) // because the result builder is reused
+        .forEachOrdered(
+            entry -> {
+              var toWriteEntry = entry;
+              final int potentialBatchSize = currentBatchSize + commandsToProcess.size();
+              if (entry.recordMetadata().getRecordType() == RecordType.COMMAND
+                  && potentialBatchSize < COMMAND_LIMIT) {
+                commandsToProcess.add(
+                    new UnwrittenRecord(
+                        entry.key(),
+                        context.getPartitionId(),
+                        entry.recordValue(),
+                        entry.recordMetadata()));
+                toWriteEntry = LogAppendEntry.ofProcessed(entry);
+              }
+              toWriteEntries.add(toWriteEntry);
+            });
+
+    return new BatchProcessingStepResult(commandsToProcess, toWriteEntries);
   }
 
   private void onError(final Throwable processingException, final Runnable nextStep) {
@@ -527,4 +563,7 @@ public final class ProcessingStateMachine {
 
     actor.submit(this::readNextRecord);
   }
+
+  private record BatchProcessingStepResult(
+      List<TypedRecord<?>> toProcess, List<LogAppendEntry> toWrite) {}
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl.records;
+
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class UnwrittenRecord implements TypedRecord {
+  private final long key;
+  private final int partitionId;
+  private final UnifiedRecordValue value;
+  private final RecordMetadata metadata;
+
+  public UnwrittenRecord(
+      final long key,
+      int partitionId,
+      final UnifiedRecordValue value,
+      final RecordMetadata metadata) {
+    this.key = key;
+    this.partitionId = partitionId;
+    this.value = value;
+    this.metadata = metadata;
+  }
+
+  @Override
+  public long getPosition() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getSourceRecordPosition() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getTimestamp() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Intent getIntent() {
+    return metadata.getIntent();
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public RecordType getRecordType() {
+    return metadata.getRecordType();
+  }
+
+  @Override
+  public RejectionType getRejectionType() {
+    return metadata.getRejectionType();
+  }
+
+  @Override
+  public String getRejectionReason() {
+    return metadata.getRejectionReason();
+  }
+
+  @Override
+  public String getBrokerVersion() {
+    return metadata.getBrokerVersion().toString();
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return metadata.getValueType();
+  }
+
+  @Override
+  public long getKey() {
+    return key;
+  }
+
+  @Override
+  public UnifiedRecordValue getValue() {
+    return value;
+  }
+
+  @Override
+  public int getRequestStreamId() {
+    return metadata.getRequestStreamId();
+  }
+
+  @Override
+  public long getRequestId() {
+    return metadata.getRequestId();
+  }
+
+  @Override
+  public int getLength() {
+    return metadata.getLength() + value.getLength();
+  }
+}


### PR DESCRIPTION
## Description



> **Idea:**
> Instead, to produce small batches of commands and events, every time we process a command, we want to process a process instance until we reach a wait state. Wait state can be defined as no further commands being produced to further drive the execution. This means we process all follow-up commands directly, collect all results, and write them as batches to the log.
> 

The implementation is based on previous POC's https://github.com/camunda/zeebe/pull/11368 and https://github.com/camunda/zeebe/pull/11469. The changes have been implemented together (with @oleschoenburg ) in a pair-programming session.

This PR implements batch processing by limiting the batch size. Per default the limit is set to one such that we do not break the current behavior and it works like before.

As a next increment, we can start to increase the batch size and fix failing tests.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/11505

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
