### PR TITLE
Add sequencer metrics

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -300,7 +300,7 @@ public final class LogStreamImpl extends Actor
   }
 
   private Sequencer createAndScheduleWriteBuffer(final long initialPosition) {
-    return new Sequencer(partitionId, initialPosition, maxFragmentSize);
+    return new Sequencer(initialPosition, maxFragmentSize, new SequencerMetrics(partitionId));
   }
 
   private ActorFuture<Void> createAndScheduleLogStorageAppender(final Sequencer sequencer) {

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
@@ -11,15 +11,33 @@ import io.camunda.zeebe.logstreams.impl.serializer.SequencedBatchSerializer;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.List;
+import java.util.Objects;
 import org.agrona.MutableDirectBuffer;
 
 public record SequencedBatch(
-    long timestamp, long firstPosition, long sourcePosition, List<LogAppendEntry> entries)
+    long timestamp,
+    long firstPosition,
+    long sourcePosition,
+    List<LogAppendEntry> entries,
+    int length)
     implements BufferWriter {
+
+  public SequencedBatch(
+      final long timestamp,
+      final long firstPosition,
+      final long sourcePosition,
+      final List<LogAppendEntry> entries) {
+    this(
+        timestamp,
+        firstPosition,
+        sourcePosition,
+        Objects.requireNonNull(entries, "must specify a list of entries"),
+        SequencedBatchSerializer.calculateBatchSize(entries));
+  }
 
   @Override
   public int getLength() {
-    return SequencedBatchSerializer.calculateBatchSize(this);
+    return length;
   }
 
   @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.scheduler.ActorCondition;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.io.Closeable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.locks.ReentrantLock;
@@ -34,7 +35,6 @@ import org.slf4j.LoggerFactory;
  */
 final class Sequencer implements LogStreamWriter, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(Sequencer.class);
-  private final int partitionId;
   private final int maxFragmentSize;
 
   private volatile long position;
@@ -44,12 +44,11 @@ final class Sequencer implements LogStreamWriter, Closeable {
   private final ReentrantLock lock = new ReentrantLock();
   private final SequencerMetrics metrics;
 
-  Sequencer(final int partitionId, final long initialPosition, final int maxFragmentSize) {
+  Sequencer(final long initialPosition, final int maxFragmentSize, final SequencerMetrics metrics) {
     LOG.trace("Starting new sequencer at position {}", initialPosition);
     position = initialPosition;
-    this.partitionId = partitionId;
     this.maxFragmentSize = maxFragmentSize;
-    metrics = new SequencerMetrics(partitionId);
+    this.metrics = Objects.requireNonNull(metrics, "must specify metrics");
   }
 
   /** {@inheritDoc} */

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -28,13 +28,25 @@ final class SequencerMetrics {
           .buckets(1, 2, 3, 5, 10, 25, 50, 100, 500, 1000)
           .labelNames("partition")
           .register();
+
+  private static final Histogram BATCH_LENGTH_BYTES =
+      Histogram.build()
+          .namespace("zeebe")
+          .name("sequencer_batch_length_bytes")
+          .help("Histogram over the size, in Kilobytes, of the sequenced batches")
+          .buckets(0.256, 0.512, 1, 4, 8, 32, 128, 512, 1024, 4096)
+          .labelNames("partition")
+          .register();
+
   private final Gauge.Child queueSize;
   private final Histogram.Child batchSize;
+  private final Histogram.Child batchLengthBytes;
 
   SequencerMetrics(final int partitionId) {
     final var partitionLabel = String.valueOf(partitionId);
-    this.queueSize = QUEUE_SIZE.labels(partitionLabel);
-    this.batchSize = BATCH_SIZE.labels(partitionLabel);
+    queueSize = QUEUE_SIZE.labels(partitionLabel);
+    batchSize = BATCH_SIZE.labels(partitionLabel);
+    batchLengthBytes = BATCH_LENGTH_BYTES.labels(partitionLabel);
   }
 
   void setQueueSize(final int length) {
@@ -43,5 +55,10 @@ final class SequencerMetrics {
 
   void observeBatchSize(final int size) {
     batchSize.observe(size);
+  }
+
+  void observeBatchLengthBytes(final int lengthBytes) {
+    final int batchLengthKiloBytes = Math.floorDiv(lengthBytes, 1024);
+    batchLengthBytes.observe(batchLengthKiloBytes);
   }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -37,7 +37,7 @@ public final class LogStorageAppenderHealthTest {
   @Before
   public void setUp() {
     failingLogStorage = new ControllableLogStorage();
-    sequencer = new Sequencer(1, 0, 4 * 1024 * 1024);
+    sequencer = new Sequencer(0, 4 * 1024 * 1024, new SequencerMetrics(1));
 
     appender = new LogStorageAppender("appender", PARTITION_ID, failingLogStorage, sequencer);
   }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -55,7 +55,7 @@ final class LogStorageAppenderTest {
   @BeforeEach
   void beforeEach() {
     scheduler.start();
-    sequencer = new Sequencer(1, INITIAL_POSITION, 4 * 1024 * 1024);
+    sequencer = new Sequencer(INITIAL_POSITION, 4 * 1024 * 1024, new SequencerMetrics(1));
     appender = new LogStorageAppender("appender", PARTITION_ID, logStorage, sequencer);
     reader = new LogStreamReaderImpl(logStorage.newReader());
   }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -28,7 +28,7 @@ final class SequencerTest {
   @Test
   void notifiesConsumerOnWrite() {
     // given
-    final var sequencer = new Sequencer(1, 0, 16);
+    final var sequencer = new Sequencer(0, 16, new SequencerMetrics(1));
     final var consumer = Mockito.mock(ActorCondition.class);
 
     // when
@@ -42,7 +42,7 @@ final class SequencerTest {
   @Test
   void notifiesConsumerOnBatchWrite() {
     // given
-    final var sequencer = new Sequencer(1, 0, 16);
+    final var sequencer = new Sequencer(0, 16, new SequencerMetrics(1));
     final var consumer = Mockito.mock(ActorCondition.class);
 
     // when
@@ -56,7 +56,7 @@ final class SequencerTest {
   @Test
   void canReadAfterSingleWrite() {
     // given
-    final var sequencer = new Sequencer(1, 1, 16);
+    final var sequencer = new Sequencer(1, 16, new SequencerMetrics(1));
     final var entry = TestEntry.ofDefaults();
 
     // when
@@ -70,7 +70,7 @@ final class SequencerTest {
   @Test
   void canReadAfterBatchWrite() {
     // given
-    final var sequencer = new Sequencer(1, 1, 16);
+    final var sequencer = new Sequencer(1, 16, new SequencerMetrics(1));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
 
@@ -85,7 +85,7 @@ final class SequencerTest {
   @Test
   void cannotReadEmpty() {
     // given
-    final var sequencer = new Sequencer(1, 1, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(1));
 
     // then
     final var read = sequencer.tryRead();
@@ -95,7 +95,7 @@ final class SequencerTest {
   @Test
   void eventuallyRejectsWritesWithoutReader() {
     // given
-    final var sequencer = new Sequencer(1, 1, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(1));
 
     // then
     Awaitility.await("sequencer rejects writes")
@@ -107,7 +107,7 @@ final class SequencerTest {
   @Test
   void eventuallyRejectsBatchWritesWithoutReader() {
     // given
-    final var sequencer = new Sequencer(1, 1, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(1));
 
     // then
     Awaitility.await("sequencer rejects writes")
@@ -122,7 +122,7 @@ final class SequencerTest {
   void writingSingleEntryIncreasesPositions() {
     // given
     final var initialPosition = 1;
-    final var sequencer = new Sequencer(1, initialPosition, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(1));
 
     // when
     final var result = sequencer.tryWrite(TestEntry.ofDefaults());
@@ -135,7 +135,7 @@ final class SequencerTest {
   void writingMultipleEntriesIncreasesPositions() {
     // given
     final var initialPosition = 1;
-    final var sequencer = new Sequencer(1, initialPosition, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(1));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
     // when
@@ -148,7 +148,7 @@ final class SequencerTest {
   @Test
   void notifiesReaderWhenRejectingWriteDueToFullQueue() {
     // given
-    final var sequencer = new Sequencer(1, 1, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(1));
     Awaitility.await("sequencer rejects writes")
         .pollInSameThread()
         .pollInterval(Duration.ZERO)
@@ -167,7 +167,7 @@ final class SequencerTest {
   @Test
   void notifiesReaderWhenRejectingBatchWriteDueToFullQueue() {
     // given
-    final var sequencer = new Sequencer(1, 1, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(1));
     Awaitility.await("sequencer rejects writes")
         .pollInSameThread()
         .pollInterval(Duration.ZERO)
@@ -188,7 +188,7 @@ final class SequencerTest {
     // given
     final var initialPosition = 1L;
     final var entriesToWrite = 10_000L;
-    final var sequencer = new Sequencer(1, initialPosition, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(1));
     final var batch = List.of(TestEntry.ofKey(1));
     final var reader = newReaderThread(sequencer, initialPosition, entriesToWrite);
     final var writer = newWriterThread(sequencer, initialPosition, entriesToWrite, batch, true);
@@ -210,7 +210,7 @@ final class SequencerTest {
     final var initialPosition = 1L;
     final var entriesToWrite = 10_000L;
     final var entriesToRead = writers * entriesToWrite;
-    final var sequencer = new Sequencer(1, initialPosition, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(1));
     final var reader = newReaderThread(sequencer, initialPosition, entriesToRead);
     final var batch = List.of(TestEntry.ofKey(1));
     final var writerThreads =
@@ -243,7 +243,7 @@ final class SequencerTest {
     final var initialPosition = 1L;
     final var batchesToWrite = 10_000L;
     final var batchesToRead = writers * batchesToWrite;
-    final var sequencer = new Sequencer(1, initialPosition, 16 * 1024 * 1024);
+    final var sequencer = new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(1));
     final var reader = newReaderThread(sequencer, initialPosition, batchesToRead);
     final var batch =
         List.of(TestEntry.ofKey(1), TestEntry.ofKey(1), TestEntry.ofKey(1), TestEntry.ofKey(1));

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -1,4 +1,77 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.3.6"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph (old)",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table-old",
+      "name": "Table (old)",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -24,6 +97,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -48,6 +122,7 @@
           "fieldConfig": {
             "defaults": {
               "custom": {
+                "align": "auto",
                 "displayMode": "auto",
                 "filterable": false,
                 "inspect": false
@@ -57,7 +132,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "orange"
+                    "color": "orange",
+                    "value": null
                   }
                 ]
               }
@@ -104,7 +180,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 73
+            "y": 2
           },
           "id": 68,
           "links": [],
@@ -124,7 +200,7 @@
               }
             ]
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
               "datasource": {
@@ -211,7 +287,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -230,7 +307,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 73
+            "y": 2
           },
           "id": 243,
           "options": {
@@ -248,7 +325,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
               "datasource": {
@@ -286,7 +363,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 73
+            "y": 2
           },
           "hiddenSeries": false,
           "id": 116,
@@ -309,7 +386,7 @@
             "alertThreshold": true
           },
           "percentage": true,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -401,7 +478,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 79
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 58,
@@ -427,7 +504,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -508,7 +585,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 79
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 270,
@@ -534,7 +611,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -608,7 +685,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 84
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 62,
@@ -628,7 +705,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -703,7 +780,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -723,7 +801,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 84
+            "y": 13
           },
           "id": 232,
           "links": [],
@@ -742,7 +820,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
               "datasource": {
@@ -780,7 +858,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 84
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 74,
@@ -801,7 +879,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -877,7 +955,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -893,7 +972,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 86
+            "y": 15
           },
           "id": 118,
           "links": [],
@@ -912,7 +991,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
               "datasource": {
@@ -953,7 +1032,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -969,7 +1049,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 88
+            "y": 17
           },
           "id": 117,
           "links": [],
@@ -988,7 +1068,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
               "datasource": {
@@ -1024,7 +1104,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 90
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 39,
@@ -1045,7 +1125,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1119,7 +1199,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1135,7 +1216,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 90
+            "y": 19
           },
           "id": 190,
           "links": [],
@@ -1154,7 +1235,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "targets": [
             {
               "datasource": {
@@ -1201,7 +1282,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 90
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 33,
@@ -1223,7 +1304,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1348,7 +1429,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 2
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 272,
@@ -1368,7 +1449,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1498,7 +1579,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 39
           },
           "id": 192,
           "options": {
@@ -1546,7 +1627,7 @@
             "h": 4,
             "w": 7,
             "x": 12,
-            "y": 9
+            "y": 39
           },
           "id": 196,
           "showHeader": true,
@@ -1623,7 +1704,7 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 9
+            "y": 39
           },
           "id": 200,
           "showHeader": true,
@@ -1750,7 +1831,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 13
+            "y": 43
           },
           "id": 194,
           "options": {
@@ -1795,7 +1876,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 13
+            "y": 43
           },
           "id": 199,
           "showHeader": true,
@@ -1872,7 +1953,7 @@
             "h": 12,
             "w": 5,
             "x": 12,
-            "y": 13
+            "y": 43
           },
           "id": 198,
           "showHeader": true,
@@ -1949,7 +2030,7 @@
             "h": 12,
             "w": 7,
             "x": 17,
-            "y": 13
+            "y": 43
           },
           "id": 268,
           "showHeader": true,
@@ -2076,7 +2157,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 19
+            "y": 49
           },
           "id": 189,
           "options": {
@@ -2124,7 +2205,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 19
+            "y": 49
           },
           "id": 201,
           "showHeader": true,
@@ -2224,7 +2305,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 83
           },
           "hideTimeOverride": false,
           "id": 12,
@@ -2285,7 +2366,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 75
+            "y": 83
           },
           "hideTimeOverride": false,
           "id": 13,
@@ -2357,7 +2438,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 88
           },
           "hiddenSeries": false,
           "id": 2,
@@ -2458,7 +2539,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 80
+            "y": 88
           },
           "hiddenSeries": false,
           "id": 3,
@@ -2561,7 +2642,7 @@
             "h": 6,
             "w": 9,
             "x": 0,
-            "y": 86
+            "y": 94
           },
           "hiddenSeries": false,
           "id": 4,
@@ -2655,7 +2736,7 @@
             "h": 6,
             "w": 7,
             "x": 9,
-            "y": 86
+            "y": 94
           },
           "hiddenSeries": false,
           "id": 266,
@@ -2750,7 +2831,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 86
+            "y": 94
           },
           "hiddenSeries": false,
           "id": 267,
@@ -2840,7 +2921,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 290,
@@ -2927,7 +3008,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 291,
@@ -3014,7 +3095,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 288,
@@ -3101,7 +3182,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 289,
@@ -3219,7 +3300,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 76
+            "y": 84
           },
           "hiddenSeries": false,
           "id": 102,
@@ -3313,7 +3394,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 76
+            "y": 84
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -3373,7 +3454,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 105,
@@ -3465,7 +3546,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 92
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -3524,7 +3605,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 182,
@@ -3640,7 +3721,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 77
+            "y": 85
           },
           "hiddenSeries": false,
           "id": 261,
@@ -3762,7 +3843,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 285,
@@ -3848,7 +3929,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 286,
@@ -3939,7 +4020,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 98,
@@ -4055,7 +4136,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 35,
@@ -4172,7 +4253,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 86
           },
           "hiddenSeries": false,
           "id": 64,
@@ -4273,7 +4354,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 86
           },
           "hiddenSeries": false,
           "id": 294,
@@ -4398,7 +4479,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 79
+            "y": 87
           },
           "hiddenSeries": false,
           "id": 260,
@@ -4499,7 +4580,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 37,
@@ -4609,7 +4690,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 40,
@@ -4703,7 +4784,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 122,
@@ -4794,7 +4875,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 124,
@@ -4885,7 +4966,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 100
+            "y": 108
           },
           "hiddenSeries": false,
           "id": 126,
@@ -4976,7 +5057,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 100
+            "y": 108
           },
           "hiddenSeries": false,
           "id": 127,
@@ -5101,7 +5182,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 8
+            "y": 16
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5227,7 +5308,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 8
+            "y": 16
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5381,7 +5462,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 24
           },
           "id": 343,
           "links": [],
@@ -5502,7 +5583,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 24
           },
           "id": 345,
           "links": [],
@@ -5621,7 +5702,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 34
           },
           "id": 347,
           "options": {
@@ -5712,7 +5793,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 34
           },
           "id": 349,
           "options": {
@@ -5803,7 +5884,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 42
           },
           "id": 353,
           "options": {
@@ -5895,7 +5976,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 42
           },
           "id": 351,
           "options": {
@@ -5976,7 +6057,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 10
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6023,7 +6104,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -6076,7 +6157,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 80
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 222,
@@ -6097,7 +6178,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6195,7 +6276,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88
+            "y": 18
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6242,7 +6323,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -6306,7 +6387,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88
+            "y": 18
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6353,7 +6434,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "9.3.6",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -6417,7 +6498,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 96
+            "y": 26
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6528,7 +6609,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 103
+            "y": 33
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6639,7 +6720,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 103
+            "y": 33
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -6732,7 +6813,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 110
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 310,
@@ -6849,7 +6930,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 110
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 311,
@@ -6984,7 +7065,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 117
+            "y": 47
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7095,7 +7176,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 117
+            "y": 47
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7220,7 +7301,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 88
           },
           "hiddenSeries": false,
           "id": 26,
@@ -7313,7 +7394,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 80
+            "y": 88
           },
           "hiddenSeries": false,
           "id": 27,
@@ -7418,7 +7499,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 87
+            "y": 95
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7481,7 +7562,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 87
+            "y": 95
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7544,7 +7625,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 87
+            "y": 95
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7633,7 +7714,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 89
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7692,7 +7773,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 97
           },
           "hiddenSeries": false,
           "id": 166,
@@ -7784,7 +7865,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 97
           },
           "hiddenSeries": false,
           "id": 168,
@@ -7902,7 +7983,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 278,
@@ -7999,7 +8080,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 91
+            "y": 99
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8061,7 +8142,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 91
+            "y": 99
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8122,7 +8203,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 97
+            "y": 105
           },
           "hiddenSeries": false,
           "id": 283,
@@ -8218,7 +8299,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 104
+            "y": 112
           },
           "hiddenSeries": false,
           "id": 79,
@@ -8312,7 +8393,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 104
+            "y": 112
           },
           "hiddenSeries": false,
           "id": 114,
@@ -8404,7 +8485,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 111
+            "y": 119
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8464,7 +8545,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 111
+            "y": 119
           },
           "hiddenSeries": false,
           "id": 300,
@@ -8568,7 +8649,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 118
+            "y": 126
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8629,7 +8710,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 118
+            "y": 126
           },
           "hiddenSeries": false,
           "id": 305,
@@ -8733,7 +8814,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 125
+            "y": 133
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8795,7 +8876,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 125
+            "y": 133
           },
           "hiddenSeries": false,
           "id": 72,
@@ -8892,7 +8973,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 133
+            "y": 141
           },
           "hiddenSeries": false,
           "id": 95,
@@ -9001,7 +9082,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 133
+            "y": 141
           },
           "hiddenSeries": false,
           "id": 180,
@@ -9092,7 +9173,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 141
+            "y": 149
           },
           "id": 205,
           "maxPerRow": 6,
@@ -9166,7 +9247,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 146
+            "y": 154
           },
           "id": 209,
           "maxPerRow": 6,
@@ -9246,7 +9327,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 151
+            "y": 159
           },
           "id": 215,
           "options": {
@@ -9304,7 +9385,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 151
+            "y": 159
           },
           "id": 217,
           "options": {
@@ -9350,6 +9431,344 @@
     },
     {
       "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 355,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Number of batches in the sequencer's queue",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 13
+          },
+          "id": 356,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true,
+              "width": 250
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "9.3.6",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_sequencer_queue_size{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[1m])) by (pod, partition)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}}-{{partition}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sequencer Queue Size",
+          "type": "timeseries"
+        },
+        {
+          "cards": {},
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Shows the distribution of the # of entries per batch",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 357,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#ef843c",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false
+            }
+          },
+          "pluginVersion": "9.3.6",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_sequencer_batch_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sequencer Batch Entry Count",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "format": "dtdurations",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
+        },
+        {
+          "cards": {},
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Shows the distribution of the size of each enqueued batch, in kilobytes.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 358,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#ef843c",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "kbytes"
+            }
+          },
+          "pluginVersion": "9.3.6",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_sequencer_batch_length_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sequencer Batch Size (KB)",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "format": "dtdurations",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
+        }
+      ],
+      "title": "Logstream",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
       "datasource": {
         "uid": "${DS_PROMETHEUS}"
       },
@@ -9357,7 +9776,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 140,
       "panels": [
@@ -9383,7 +9802,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 83
+            "y": 91
           },
           "hiddenSeries": false,
           "id": 154,
@@ -9476,7 +9895,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 83
+            "y": 91
           },
           "hiddenSeries": false,
           "id": 144,
@@ -9567,7 +9986,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 97
           },
           "hiddenSeries": false,
           "id": 142,
@@ -9658,7 +10077,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 95
+            "y": 103
           },
           "hiddenSeries": false,
           "id": 151,
@@ -9750,7 +10169,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 95
+            "y": 103
           },
           "hiddenSeries": false,
           "id": 152,
@@ -9842,7 +10261,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 101
+            "y": 109
           },
           "hiddenSeries": false,
           "id": 150,
@@ -9934,7 +10353,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 107
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 147,
@@ -10026,7 +10445,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 107
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 149,
@@ -10119,7 +10538,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 114
+            "y": 122
           },
           "hiddenSeries": false,
           "id": 148,
@@ -10210,7 +10629,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 120
+            "y": 128
           },
           "hiddenSeries": false,
           "id": 155,
@@ -10301,7 +10720,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 120
+            "y": 128
           },
           "hiddenSeries": false,
           "id": 156,
@@ -10393,7 +10812,7 @@
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 128
+            "y": 136
           },
           "id": 158,
           "pluginVersion": "6.7.1",
@@ -10503,7 +10922,7 @@
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 128
+            "y": 136
           },
           "hiddenSeries": false,
           "id": 157,
@@ -10594,7 +11013,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 128
+            "y": 136
           },
           "hiddenSeries": false,
           "id": 146,
@@ -10685,7 +11104,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 134
+            "y": 142
           },
           "hiddenSeries": false,
           "id": 159,
@@ -10776,7 +11195,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 134
+            "y": 142
           },
           "hiddenSeries": false,
           "id": 160,
@@ -10867,7 +11286,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 134
+            "y": 142
           },
           "hiddenSeries": false,
           "id": 153,
@@ -10958,7 +11377,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 50,
       "panels": [
@@ -10985,7 +11404,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 92
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -11046,7 +11465,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 255,
@@ -11140,7 +11559,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 94
+            "y": 102
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -11200,7 +11619,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 94
+            "y": 102
           },
           "hiddenSeries": false,
           "id": 185,
@@ -11296,7 +11715,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 104
+            "y": 112
           },
           "height": "400",
           "hiddenSeries": false,
@@ -11411,7 +11830,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 176,
       "panels": [
@@ -11449,7 +11868,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 86
+            "y": 94
           },
           "id": 170,
           "maxPerRow": 6,
@@ -11529,7 +11948,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 100
           },
           "id": 174,
           "options": {
@@ -11595,7 +12014,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 100
           },
           "id": 265,
           "options": {
@@ -11650,7 +12069,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "id": 315,
       "panels": [
@@ -11677,7 +12096,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 87
+            "y": 95
           },
           "id": 329,
           "options": {
@@ -11743,7 +12162,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 87
+            "y": 95
           },
           "id": 319,
           "options": {
@@ -11801,7 +12220,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 95
+            "y": 103
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -11875,7 +12294,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 95
+            "y": 103
           },
           "id": 325,
           "options": {
@@ -11959,7 +12378,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 103
+            "y": 111
           },
           "id": 313,
           "options": {
@@ -12019,7 +12438,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 103
+            "y": 111
           },
           "id": 321,
           "options": {
@@ -12101,7 +12520,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 111
+            "y": 119
           },
           "id": 335,
           "options": {
@@ -12159,7 +12578,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 111
+            "y": 119
           },
           "id": 317,
           "options": {
@@ -12221,7 +12640,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 119
+            "y": 127
           },
           "id": 327,
           "options": {
@@ -12294,11 +12713,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
@@ -12325,11 +12740,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
@@ -12355,11 +12766,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
@@ -12385,11 +12792,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
@@ -12416,7 +12819,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {
@@ -12446,6 +12849,6 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 5,
+  "version": 6,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description

Adds a new metric to show the size of the batches in KiB, and adds the graph visualization to the Grafana dashboard. Also slight refactoring of injecting the metrics directly into the sequencer instead of the partition ID, since that was used only to create the metrics. This better highlights the dependency for the constructor args. Very minor though, so happy to revert.

There were a bunch of unexpected Grafana changes, but I don't think they're negative. I just exported a fresh dashboard, and it added a few new fields. I suspect it's because the version changed since the last time the dashboard was updated? I would leave them in, but happy to remove them.

I'm also marking #11369 as closed since we will likely merge the storage appender + sequencer, and adding metrics in the storage would be redundant to those here.

You can preview the changes [here](https://grafana.dev.zeebe.io/goto/toNP640Vz?orgId=1)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11370 
closes #11369

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
