### PR TITLE
[Backport stable/8.1] test(backup/s3): don't fail test if localstack takes longer to delete

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -139,6 +139,12 @@
       <artifactId>aws-java-sdk-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -163,14 +164,22 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
     getStore().delete(backup.id()).join();
 
     // then
-    final var listed =
-        getClient()
-            .listObjectsV2(
-                req ->
-                    req.bucket(getConfig().bucketName())
-                        .prefix(S3BackupStore.objectPrefix(backup.id())))
-            .join();
-    Assertions.assertThat(listed.contents()).isEmpty();
+
+    // Retry a couple of times because LocalStack takes a moment to actually delete every object.
+    Awaitility.await("Finds no objects after deleting")
+        .pollInterval(Duration.ofSeconds(1))
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var listed =
+                  getClient()
+                      .listObjectsV2(
+                          req ->
+                              req.bucket(getConfig().bucketName())
+                                  .prefix(S3BackupStore.objectPrefix(backup.id())))
+                      .join();
+              Assertions.assertThat(listed.contents()).isEmpty();
+            });
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Manual backport of #11514