### PR TITLE
[Backport stable/8.1] feat(logstream): log entries can be marked as `skipProcessing`

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
@@ -73,6 +73,11 @@ public final class LoggedEventImpl implements ReadableFragment, LoggedEvent {
   }
 
   @Override
+  public boolean shouldSkipProcessing() {
+    return LogEntryDescriptor.shouldSkipProcessing(buffer, messageOffset);
+  }
+
+  @Override
   public long getPosition() {
     return LogEntryDescriptor.getPosition(buffer, fragmentOffset);
   }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchWriter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchWriter.java
@@ -50,6 +50,13 @@ public interface LogStreamBatchWriter extends LogStreamWriter {
 
   /** Builder to add a log entry to the batch. */
   interface LogEntryBuilder {
+
+    /**
+     * Log entry should be skipped during processing, for example because it was part of batch
+     * processing.
+     */
+    LogEntryBuilder skipProcessing();
+
     /** Use the default values as key. */
     LogEntryBuilder keyNull();
 

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamRecordWriter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamRecordWriter.java
@@ -14,6 +14,8 @@ public interface LogStreamRecordWriter extends LogStreamWriter {
 
   LogStreamRecordWriter keyNull();
 
+  LogStreamRecordWriter skipProcessing();
+
   LogStreamRecordWriter key(long key);
 
   LogStreamRecordWriter sourceRecordPosition(long position);

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
@@ -13,6 +13,12 @@ import org.agrona.DirectBuffer;
 
 /** Represents an event on the log stream. */
 public interface LoggedEvent extends BufferWriter {
+
+  /**
+   * @return true if record should be skipped during processing.
+   */
+  boolean shouldSkipProcessing();
+
   /**
    * @return the event's position in the log.
    */

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class LogEntryDescriptorTest {
+
+  @Test
+  void shouldNotSkipProcessingByDefault() {
+    // given
+    final var buffer = new UnsafeBuffer(new byte[128]);
+
+    // when
+    final boolean skip = LogEntryDescriptor.shouldSkipProcessing(buffer, 0);
+
+    // then
+    Assertions.assertThat(skip).isFalse();
+  }
+
+  @Test
+  void canSetSkipProcessingFlag() {
+    // given
+    final var buffer = new UnsafeBuffer(new byte[128]);
+
+    // when
+    LogEntryDescriptor.skipProcessing(buffer, 0);
+
+    // then
+    Assertions.assertThat(LogEntryDescriptor.shouldSkipProcessing(buffer, 0)).isTrue();
+  }
+}

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamBatchWriterTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamBatchWriterTest.java
@@ -165,6 +165,35 @@ public final class LogStreamBatchWriterTest {
   }
 
   @Test
+  public void canSetSkipProcessingFlag() {
+    final long position =
+        write(
+            w ->
+                w.event()
+                    .skipProcessing()
+                    .value(EVENT_VALUE_1)
+                    .metadata(EVENT_METADATA_1)
+                    .done()
+                    .event()
+                    .value(EVENT_VALUE_2)
+                    .metadata(EVENT_METADATA_2)
+                    .done());
+    // then
+    final List<LoggedEvent> events = getWrittenEvents(position);
+    assertThat(events.get(0).shouldSkipProcessing()).isTrue();
+    assertThat(events.get(1).shouldSkipProcessing()).isFalse();
+  }
+
+  @Test
+  public void shouldNotSkipProcessingByDefault() {
+    final long position =
+        write(w -> w.event().value(EVENT_VALUE_1).metadata(EVENT_METADATA_1).done());
+    // then
+    final List<LoggedEvent> events = getWrittenEvents(position);
+    assertThat(events.get(0).shouldSkipProcessing()).isFalse();
+  }
+
+  @Test
   public void shouldWriteEventWithValueBufferPartially() {
     // when
     final long position =

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -72,7 +72,19 @@ public final class LogStreamWriterTest {
   }
 
   @Test
-  public void shouldReturnPositionOfWrittenEvent() {
+  public void canSetSkipProcessingFlagToTrue() {
+    // when
+    final long position = writer.skipProcessing().value(EVENT_VALUE).tryWrite();
+
+    // then
+    assertThat(position).isGreaterThan(0);
+
+    final LoggedEvent event = getWrittenEvent(position);
+    assertThat(event.shouldSkipProcessing()).isTrue();
+  }
+
+  @Test
+  public void shouldNotSkipProcessingByDefault() {
     // when
     final long position = writer.value(EVENT_VALUE).tryWrite();
 
@@ -80,7 +92,7 @@ public final class LogStreamWriterTest {
     assertThat(position).isGreaterThan(0);
 
     final LoggedEvent event = getWrittenEvent(position);
-    assertThat(event.getPosition()).isEqualTo(position);
+    assertThat(event.shouldSkipProcessing()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
This uses an unused, previously reserved, byte in the `LogEntryDescriptor` for arbitrary boolean flags. The first use case is to mark entries that should be skipped during processing. This is useful for batch processing where some commands that are written are already processed and should be skipped the next time they are read.

It's an extended version of #11509 adapted for 8.1 where the dispatcher still exists. The naming and functionality is slightly different, this will need to be adjusted on main.