### PR TITLE
refactor(logstream): enhance log entry `skipProcessing` flag

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
@@ -24,7 +24,7 @@ import org.agrona.MutableDirectBuffer;
  *   0                   1                   2                   3
  *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
  *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *  |            VERSION             |     BOOL_FLAGS    |     R    |
+ *  |            VERSION             |    FLAGS      |       R      |
  *  +---------------------------------------------------------------+
  *  |                            POSITION                           |
  *  |                                                               |
@@ -52,9 +52,8 @@ public final class LogEntryDescriptor {
 
   public static final int VERSION_OFFSET;
 
-  // Contains the processed marker flag, can be extended with further boolean flags
-  public static final int BOOL_FLAGS_OFFSET;
-
+  // Contains arbitrary flags, currently only the `skipProcessing` flag.
+  public static final int FLAGS_OFFSET;
   public static final int POSITION_OFFSET;
 
   public static final int SOURCE_EVENT_POSITION_OFFSET;
@@ -75,7 +74,7 @@ public final class LogEntryDescriptor {
     VERSION_OFFSET = offset;
     offset += SIZE_OF_SHORT;
 
-    BOOL_FLAGS_OFFSET = offset;
+    FLAGS_OFFSET = offset;
     offset += Byte.BYTES;
 
     // reserved
@@ -150,16 +149,16 @@ public final class LogEntryDescriptor {
     buffer.putLong(keyOffset(offset), key, Protocol.ENDIANNESS);
   }
 
-  public static int boolFlagsOffset(final int offset) {
-    return BOOL_FLAGS_OFFSET + offset;
+  public static int flagsOffset(final int offset) {
+    return FLAGS_OFFSET + offset;
   }
 
-  public static boolean isProcessed(final DirectBuffer buffer, final int offset) {
-    return (buffer.getByte(boolFlagsOffset(offset)) & 0x01) > 0;
+  public static boolean shouldSkipProcessing(final DirectBuffer buffer, final int offset) {
+    return buffer.getByte(flagsOffset(offset)) != 0;
   }
 
-  public static void markAsProcessed(final MutableDirectBuffer buffer, final int offset) {
-    buffer.putByte(boolFlagsOffset(offset), (byte) 1);
+  public static void skipProcessing(final MutableDirectBuffer buffer, final int offset) {
+    buffer.putByte(flagsOffset(offset), (byte) 1);
   }
 
   public static int timestampOffset(final int offset) {

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
@@ -39,8 +39,8 @@ public final class LoggedEventImpl implements LoggedEvent {
   }
 
   @Override
-  public boolean isProcessed() {
-    return LogEntryDescriptor.isProcessed(buffer, messageOffset);
+  public boolean shouldSkipProcessing() {
+    return LogEntryDescriptor.shouldSkipProcessing(buffer, messageOffset);
   }
 
   @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.logstreams.impl.serializer;
 
-import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.markAsProcessed;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.metadataOffset;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setKey;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setMetadataLength;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setPosition;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.skipProcessing;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setSourceEventPosition;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setTimestamp;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.valueOffset;
@@ -90,7 +90,7 @@ final class LogAppendEntrySerializer {
 
     // Write the entry
     if (entry.isProcessed()) {
-      markAsProcessed(writeBuffer, entryOffset);
+      skipProcessing(writeBuffer, entryOffset);
     }
     setPosition(writeBuffer, entryOffset, position);
     setSourceEventPosition(writeBuffer, entryOffset, sourcePosition);

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
@@ -11,9 +11,9 @@ import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.metadataOf
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setKey;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setMetadataLength;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setPosition;
-import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.skipProcessing;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setSourceEventPosition;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setTimestamp;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.skipProcessing;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.valueOffset;
 
 import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
@@ -17,7 +17,7 @@ public interface LoggedEvent extends BufferWriter {
   /**
    * @return returns true if record is already processed
    */
-  boolean isProcessed();
+  boolean shouldSkipProcessing();
 
   /**
    * @return the event's position in the log.

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
@@ -15,7 +15,7 @@ import org.agrona.DirectBuffer;
 public interface LoggedEvent extends BufferWriter {
 
   /**
-   * @return returns true if record is already processed
+   * @return returns true if record has already been processed, and should be skipped
    */
   boolean shouldSkipProcessing();
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
@@ -19,7 +19,7 @@ public class LogEntryDescriptorTest {
     final var buffer = new UnsafeBuffer(new byte[128]);
 
     // when
-    final boolean processed = LogEntryDescriptor.isProcessed(buffer, 0);
+    final boolean processed = LogEntryDescriptor.shouldSkipProcessing(buffer, 0);
 
     // then
     Assertions.assertThat(processed).isFalse();
@@ -31,9 +31,9 @@ public class LogEntryDescriptorTest {
     final var buffer = new UnsafeBuffer(new byte[128]);
 
     // when
-    LogEntryDescriptor.markAsProcessed(buffer, 0);
+    LogEntryDescriptor.skipProcessing(buffer, 0);
 
     // then
-    Assertions.assertThat(LogEntryDescriptor.isProcessed(buffer, 0)).isTrue();
+    Assertions.assertThat(LogEntryDescriptor.shouldSkipProcessing(buffer, 0)).isTrue();
   }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
@@ -38,7 +38,7 @@ final class LogAppendEntrySerializerTest {
     assertThat(event.getPosition()).isEqualTo(2);
     assertThat(event.getSourceEventPosition()).isEqualTo(3);
     assertThat(event.getTimestamp()).isEqualTo(4);
-    assertThat(event.isProcessed()).isFalse();
+    assertThat(event.shouldSkipProcessing()).isFalse();
   }
 
   @Test
@@ -59,7 +59,7 @@ final class LogAppendEntrySerializerTest {
     assertThat(event.getPosition()).isEqualTo(2);
     assertThat(event.getSourceEventPosition()).isEqualTo(3);
     assertThat(event.getTimestamp()).isEqualTo(4);
-    assertThat(event.isProcessed()).isTrue();
+    assertThat(event.shouldSkipProcessing()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
This changes the name from "needsProcessing" to "skipProcessing" which is hopefully more clear.

It also refactors the flags field of `LogEntryDescriptor` to already put everything in place for when we need to add another flag.