### PR TITLE
Run e2e test for multiregion failover weekly

### DIFF
--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -19,10 +19,19 @@ on:
         required: false
         type: string
       clusterPlan:
-        description: `Cluster plan used by testbench to create the test cluster`
+        description: 'Cluster plan used by testbench to create the test cluster'
         default: 'Production - M'
         required: false
         type: string
+      fault:
+        ## The fault added to variables as follows
+        ## \"fault\": ${{ inputs.fault || 'null' }}
+        ## So the input should contain escape quotes.
+        description: 'Fault to inject in the test cluster. Eg:- \"restart-leader-1\". Specify the quotes with escape.'
+        default: null
+        required: false
+        type: string
+
   workflow_call:
     inputs:
       maxTestDuration:
@@ -41,8 +50,13 @@ on:
         required: false
         type: string
       clusterPlan:
-        description: `Cluster plan used by testbench to create the test cluster`
+        description: 'Cluster plan used by testbench to create the test cluster'
         default: 'Production - M'
+        required: false
+        type: string
+      fault:
+        description: 'Fault to inject in the test cluster. Eg:- \"restart-leader-1\". Specify the quotes with escape.'
+        default: null
         required: false
         type: string
 
@@ -59,7 +73,7 @@ jobs:
         \"channel\": \"Internal Dev\",
         \"branch\": \"${{ inputs.branch || 'main' }}\",
         \"build\":  \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
-        \"clusterPlan\":\"${{ input.clusterPlan }}\",
+        \"clusterPlan\":\"${{ inputs.clusterPlan }}\",
         \"region\":\"new chaos\",
         \"properties\":[\"allInstancesAreCompleted\"],
         \"testProcessId\": \"e2e-test\",
@@ -67,7 +81,8 @@ jobs:
         {
         \"maxTestDuration\": \"${{ inputs.maxTestDuration || 'P5D' }}\",
         \"starter\": [ {\"rate\": 50, \"processId\": \"one-task-one-timer\" } ],
-        \"verifier\" : { \"maxInstanceDuration\" : \"15m\" }
+        \"verifier\" : { \"maxInstanceDuration\" : \"15m\" },
+        \"fault\": ${{ inputs.fault || 'null' }}
         }
         }
     secrets: inherit

--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -46,10 +46,6 @@ on:
         required: false
         type: string
 
-  schedule:
-    # Run at 7:00 on every monday
-    - cron:  '0 7 * * 1'
-
 jobs:
   e2e:
     name: Run e2e testbench process

--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -18,6 +18,34 @@ on:
         default: 'main'
         required: false
         type: string
+      clusterPlan:
+        description: `Cluster plan used by testbench to create the test cluster`
+        default: 'Production - M'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      maxTestDuration:
+        description: 'Test duration (Eg: PT2H, P3D)'
+        required: false
+        default: 'P5D'
+        type: string
+      generation:
+        description: 'Specifies the generation template which should be used by the testbench run'
+        required: false
+        default: 'Zeebe SNAPSHOT'
+        type: string
+      branch:
+        description: 'Specifies the branch, for which the E2E run should be executed'
+        default: 'main'
+        required: false
+        type: string
+      clusterPlan:
+        description: `Cluster plan used by testbench to create the test cluster`
+        default: 'Production - M'
+        required: false
+        type: string
+
   schedule:
     # Run at 7:00 on every monday
     - cron:  '0 7 * * 1'
@@ -35,7 +63,7 @@ jobs:
         \"channel\": \"Internal Dev\",
         \"branch\": \"${{ inputs.branch || 'main' }}\",
         \"build\":  \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
-        \"clusterPlan\":\"Production - M\",
+        \"clusterPlan\":\"${{ input.clusterPlan }}\",
         \"region\":\"new chaos\",
         \"properties\":[\"allInstancesAreCompleted\"],
         \"testProcessId\": \"e2e-test\",

--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -1,0 +1,23 @@
+# This workflow runs e2e tests weekly. It runs each test suite against the
+# development head (e.g. main).
+
+# As this is meant to be run via scheduling, the workflow itself only runs on the default branch
+# (e.g. main), so any changes you make will affect any other branches we test via this workflow.
+name: Weekly E2E tests
+
+on:
+  workflow_dispatch: { }
+  schedule:
+    # Run at 7:00 on every monday
+    - cron: '0 7 * * 1'
+
+jobs:
+  e2e:
+    name: Weekly E2E
+    uses: ./.github/workflows/e2e-testbench.yaml
+    with:
+      branch: main
+      generation: Zeebe SNAPSHOT
+      maxTestDuration: P5D
+      clusterPlan: Production - M
+    secrets: inherit

--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -21,3 +21,14 @@ jobs:
       maxTestDuration: P5D
       clusterPlan: Production - M
     secrets: inherit
+
+  e2e-multiregion-failover:
+    name: Multi-region failover with data loss
+    uses: ./.github/workflows/e2e-testbench.yaml
+    with:
+      branch: main
+      generation: Zeebe SNAPSHOT
+      maxTestDuration: P1D
+      clusterPlan: Multiregion test simulation
+      fault: \"2-region-dataloss-failover\"
+    secrets: inherit


### PR DESCRIPTION
## Description

This PR adds a weekly schedule to run e2e tests with multi-region failover with dataloss. The test simulates a cluster deployed over two regions with a replication factor 4. When one region is down, 2 replicas with their data is lost. A manual recovery by moving the failed brokers to the healthy region is also simulated. The expectation is that there is no data loss and the cluster can eventually become healthy after the failover.

We already have a chaos test and raft unit test for verifying the cluster is healthy after a dataloss upto one replica in a cluster with replication factor 3. So this setup is not included in the e2e test.

The test is scheduled weekly and the test duration is one day.

## Related issues

closes #9960 

