### PR TITLE
Fix daily QA vault secrets

### DIFF
--- a/.github/actions/build-push-docker-gcr/action.yml
+++ b/.github/actions/build-push-docker-gcr/action.yml
@@ -47,9 +47,9 @@ runs:
     # Also setup java
     - uses: ./.github/actions/setup-zeebe
       with:
-        secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-        secret_vault_address: ${{ secrets.VAULT_ADDR }}
-        secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secret_vault_secretId: ${{ inputs.secret_vault_secretId }}
+        secret_vault_address: ${{ inputs.secret_vault_address }}
+        secret_vault_roleId: ${{ inputs.secret_vault_roleId }}
     # Set further environment variables, which are needed for the QA Testbench run
     - id: generate-tag
       name: Generate image tag


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The `daily-qa` workflow calls the `qa-testbench` workflow, which calls the `testbench` workflow. All these workflow calls inherit the secrets, specified by `secrets: inherit`.
The `Testbench` workflow goes on to call the `build-push-docker-gcr action`. This action takes the secrets as input. It does not inherit the secrets, and thus has no access to them. Trying to reference them with `${{ secrets.FOO }}` is not possible. Instead we should use the inputs we already have available here.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
