### PR TITLE
Make processing batch limit configurable in StreamProcessor

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -103,6 +103,7 @@ public final class EngineRule extends ExternalResource {
       new Int2ObjectHashMap<>();
 
   private long lastProcessedPosition = -1L;
+  private int batchLimit;
 
   private EngineRule(final int partitionCount) {
     this(partitionCount, null);
@@ -396,6 +397,11 @@ public final class EngineRule extends ExternalResource {
 
   public boolean hasReachedEnd() {
     return getStreamProcessor(PARTITION_ID).hasProcessingReachedTheEnd().join();
+  }
+
+  public EngineRule processingBatchLimit(final int processingBatchLimit) {
+    environmentRule.processingBatchLimit(processingBatchLimit);
+    return this;
   }
 
   private static final class VersatileBlob implements DbKey, DbValue {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.stream.impl.StreamProcessorContext;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
@@ -60,6 +61,7 @@ public final class StreamProcessorRule implements TestRule {
   private StreamProcessingComposite streamProcessingComposite;
   private ListLogStorage sharedStorage = null;
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
+  private int processingBatchLimit = StreamProcessorContext.DEFAULT_PROCESSING_BATCH_LIMIT;
 
   public StreamProcessorRule() {
     this(new TemporaryFolder());
@@ -218,6 +220,10 @@ public final class StreamProcessorRule implements TestRule {
     streamProcessingComposite.snapshot(partitionId);
   }
 
+  public void processingBatchLimit(final int processingBatchLimit) {
+    this.processingBatchLimit = processingBatchLimit;
+  }
+
   private class SetupRule extends ExternalResource {
 
     private final int startPartitionId;
@@ -232,6 +238,7 @@ public final class StreamProcessorRule implements TestRule {
     protected void before() {
       streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
       streams.withStreamProcessorMode(streamProcessorMode);
+      streams.processingBatchLimit(processingBatchLimit);
 
       int partitionId = startPartitionId;
       for (int i = 0; i < partitionCount; i++) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.stream.impl.StreamProcessorContext;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.stream.impl.TypedEventRegistry;
@@ -84,8 +85,8 @@ public final class TestStreams {
   private final Map<String, LogContext> logContextMap = new HashMap<>();
   private final Map<String, ProcessorContext> streamContextMap = new HashMap<>();
   private boolean snapshotWasTaken = false;
-
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
+  private int processingBatchLimit = StreamProcessorContext.DEFAULT_PROCESSING_BATCH_LIMIT;
 
   public TestStreams(
       final TemporaryFolder dataDirectory,
@@ -259,6 +260,7 @@ public final class TestStreams {
             .listener(new StreamProcessorListenerRelay(streamProcessorListeners))
             .recordProcessors(List.of(new Engine(wrappedFactory)))
             .streamProcessorMode(streamProcessorMode)
+            .processingBatchLimit(processingBatchLimit)
             .partitionCommandSender(mock(InterPartitionCommandSender.class));
 
     final StreamProcessor streamProcessor = builder.build();
@@ -307,6 +309,10 @@ public final class TestStreams {
         .map(c -> c.streamProcessor)
         .orElseThrow(
             () -> new NoSuchElementException("No stream processor found with name: " + streamName));
+  }
+
+  public void processingBatchLimit(final int processingBatchLimit) {
+    this.processingBatchLimit = processingBatchLimit;
   }
 
   public static class FluentLogWriter {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -125,4 +125,9 @@ public final class StreamProcessorBuilder {
           "No partition command sender provided");
     }
   }
+
+  public StreamProcessorBuilder processingBatchLimit(final int processingBatchLimit) {
+    streamProcessorContext.processingBatchLimit(processingBatchLimit);
+    return this;
+  }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -26,6 +26,7 @@ import java.util.function.BooleanSupplier;
 
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
 
+  public static final int DEFAULT_PROCESSING_BATCH_LIMIT = 1;
   private static final StreamProcessorListener NOOP_LISTENER =
       new StreamProcessorListener() {
         @Override
@@ -34,7 +35,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
         @Override
         public void onSkipped(final LoggedEvent skippedRecord) {}
       };
-
   private ActorControl actor;
   private LogStream logStream;
   private LogStreamReader logStreamReader;
@@ -55,6 +55,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   // this is accessed outside, which is why we need to make sure that it is thread-safe
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
   private KeyGeneratorControls keyGeneratorControls;
+  private int processingBatchLimit = DEFAULT_PROCESSING_BATCH_LIMIT;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -195,5 +196,14 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public void streamProcessorPhase(final Phase phase) {
     this.phase = phase;
+  }
+
+  public StreamProcessorContext processingBatchLimit(final int processingBatchLimit) {
+    this.processingBatchLimit = processingBatchLimit;
+    return this;
+  }
+
+  public int getProcessingBatchLimit() {
+    return processingBatchLimit;
   }
 }


### PR DESCRIPTION
## Description

- [feat: make processingBatchLimit configurable](https://github.com/camunda/zeebe/pull/11527/commits/d6fbf5664d78f52cc521b74e2b7959960828502f)
- [test: make processingBatchLimit configurable in Rule](https://github.com/camunda/zeebe/pull/11527/commits/0b1ce5664b0f966602a39d41d44f8e69bd5df225)

<!-- Please explain the changes you made here. -->

## Related issues

relates to https://github.com/camunda/zeebe/issues/11416
<!-- Which issues are closed by this PR or are related -->

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
