### PR TITLE
Handle batch size exceeding

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -275,12 +275,23 @@ public final class ProcessingStateMachine {
     } catch (final UnrecoverableException unrecoverableException) {
       throw unrecoverableException;
     } catch (final ExceededBatchRecordSizeException exceededBatchRecordSizeException) {
-      onError(exceededBatchRecordSizeException, () -> processCommand(loggedEvent));
+      if (processedCommandsCount > 0) {
+        onError(() -> processCommand(loggedEvent));
+      } else {
+        onError(
+            () -> {
+              errorHandlingInTransaction(exceededBatchRecordSizeException);
+              writeRecords();
+            });
+      }
     } catch (final Exception e) {
-      onError(e, this::writeRecords);
+      onError(
+          () -> {
+            errorHandlingInTransaction(e);
+            writeRecords();
+          });
     }
   }
-
   /**
    * Starts the batch processing with the given initial command and iterates over ProcessingResult
    * and applies all follow-up commands until the command limit is reached or no more follow-up
@@ -375,7 +386,7 @@ public final class ProcessingStateMachine {
     return new BatchProcessingStepResult(commandsToProcess, toWriteEntries);
   }
 
-  private void onError(final Throwable processingException, final Runnable nextStep) {
+  private void onError(final NextProcessingStep nextStep) {
     onErrorRetries++;
     if (onErrorRetries > 1) {
       onErrorHandlingLoop = true;
@@ -395,15 +406,9 @@ public final class ProcessingStateMachine {
             LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentRecord, metadata, throwable);
           }
           try {
-            if (processingException instanceof ExceededBatchRecordSizeException
-                && processedCommandsCount > 0) {
-              nextStep.run();
-            } else {
-              errorHandlingInTransaction(processingException);
-              nextStep.run();
-            }
+            nextStep.run();
           } catch (final Exception ex) {
-            onError(ex, nextStep);
+            onError(nextStep);
           }
         });
   }
@@ -440,7 +445,11 @@ public final class ProcessingStateMachine {
         (bool, t) -> {
           if (t != null) {
             LOG.error(ERROR_MESSAGE_WRITE_RECORD_ABORTED, currentRecord, metadata, t);
-            onError(t, this::writeRecords);
+            onError(
+                () -> {
+                  errorHandlingInTransaction(t);
+                  writeRecords();
+                });
           } else {
             // We write various type of records. The positions are always increasing and
             // incremented by 1 for one record (even in a batch), so we can count the amount
@@ -469,7 +478,11 @@ public final class ProcessingStateMachine {
         (bool, throwable) -> {
           if (throwable != null) {
             LOG.error(ERROR_MESSAGE_UPDATE_STATE_FAILED, currentRecord, metadata, throwable);
-            onError(throwable, this::updateState);
+            onError(
+                () -> {
+                  errorHandlingInTransaction(throwable);
+                  updateState();
+                });
           } else {
             executeSideEffects();
           }
@@ -581,4 +594,9 @@ public final class ProcessingStateMachine {
 
   private record BatchProcessingStepResult(
       List<TypedRecord<?>> toProcess, List<LogAppendEntry> toWrite) {}
+
+  @FunctionalInterface
+  private interface NextProcessingStep {
+    void run() throws Exception;
+  }
 }


### PR DESCRIPTION
## Description

[fix: handle batch size exceeding](https://github.com/camunda/zeebe/commit/3ea56b4dd9444c8743776f8140ed2edb2bcf7b05)
Handle batch size exceeding which might happen inside a command processing. Rolls the current transaction
back (and the processing result). Retries the processing until the last successful processed command, as
we know this fits into the batch. The failing follow up commands will be then tried in a separate batch.

[fix(streams): don't loop when exceeding batch on first command](https://github.com/camunda/zeebe/commit/fbbdf7539578a26fdd0a60e706c0dfe5befdf932)
When processing the first command fails due to exceeding the batch size,
error handling should rollback, call the processor error handler, and
then write the resulting records. This fixes a bug where all batch size
exceeded exception would lead to retrying normal processing instead of
calling the processors error handler.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to https://github.com/camunda/zeebe/issues/11416

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
