### PR TITLE
Engine should never discard result

### DIFF
--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -41,6 +41,11 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
     return false;
   }
 
+  @Override
+  public boolean isEmpty() {
+    return records().isEmpty();
+  }
+
   record Event(
       Intent intent,
       RecordType type,

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
-import io.camunda.zeebe.stream.api.EmptyProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.RecordProcessor;
@@ -120,7 +119,7 @@ public class Engine implements RecordProcessor {
       }
 
       if (currentProcessor == null) {
-        return EmptyProcessingResult.INSTANCE;
+        return processingResultBuilder.build();
       }
 
       final boolean isNotOnBlacklist = !zeebeState.getBlackListState().isOnBlacklist(typedCommand);

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EmptyProcessingResult.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EmptyProcessingResult.java
@@ -34,4 +34,9 @@ public final class EmptyProcessingResult implements ProcessingResult {
   public boolean executePostCommitTasks() {
     return true;
   }
+
+  @Override
+  public boolean isEmpty() {
+    return true;
+  }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
@@ -36,4 +36,17 @@ public interface ProcessingResult {
    * @return <code>false</code> to indicate that the side effect could not be applied successfully
    */
   boolean executePostCommitTasks();
+
+  /**
+   * Indicates whether the processing result is empty.
+   *
+   * @return true if all the following applies:
+   *     <ul>
+   *       <li>there is no response
+   *       <li>the record batch is empty
+   *       <li>there is no tasks to execute
+   *     </ul>
+   *     false otherwise.
+   */
+  boolean isEmpty();
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/ImmutableRecordBatch.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/ImmutableRecordBatch.java
@@ -17,5 +17,12 @@ import java.util.List;
  */
 public interface ImmutableRecordBatch extends Iterable<RecordBatchEntry> {
 
+  /**
+   * @return true if no records to append
+   */
+  default boolean isEmpty() {
+    return entries().isEmpty();
+  }
+
   List<LogAppendEntry> entries();
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
@@ -60,4 +60,11 @@ final class BufferedResult implements ProcessingResult, TaskResult {
 
     return aggregatedResult;
   }
+
+  @Override
+  public boolean isEmpty() {
+    return getProcessingResponse().isEmpty()
+        && getRecordBatch().isEmpty()
+        && postCommitTasks.isEmpty();
+  }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -256,7 +256,7 @@ public final class ProcessingStateMachine {
 
       zeebeDbTransaction = transactionContext.getCurrentTransaction();
       zeebeDbTransaction.run(() -> batchProcessing(typedCommand));
-      if (EmptyProcessingResult.INSTANCE == currentProcessingResult) {
+      if (currentProcessingResult.getRecordBatch().isEmpty()) {
         skipRecord();
         return;
       }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -256,7 +256,7 @@ public final class ProcessingStateMachine {
 
       zeebeDbTransaction = transactionContext.getCurrentTransaction();
       zeebeDbTransaction.run(() -> batchProcessing(typedCommand));
-      if (currentProcessingResult.getRecordBatch().isEmpty()) {
+      if (currentProcessingResult.isEmpty()) {
         skipRecord();
         return;
       }


### PR DESCRIPTION
## Description

When the engine doesn't know a current processor for a command,
it must not return the empty processing result but must always use the
result builder. Otherwise, with batch processing, this can discard all
results of the current batch.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to https://github.com/camunda/zeebe/issues/11416
<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
