### PR TITLE
Enable Batch processing

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityInterruptionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityInterruptionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CallActivityInterruptionTest {
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          // Disable batch processing. Interrupting behaviour is only reproducible if
+          // termination of call activity does not finish within one batch.
+          .processingBatchLimit(1);
+
+  private static final String PROCESS_ID_PARENT = "wf-parent";
+  private static final String PROCESS_ID_CHILD = "wf-child";
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  private String jobType;
+
+  @Before
+  public void init() {
+    jobType = helper.getJobType();
+
+    final var parentProcess = parentProcess(CallActivityBuilder::done);
+
+    final var childProcess =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD)
+            .startEvent()
+            .serviceTask("child-task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-parent.bpmn", parentProcess)
+        .withXmlResource("wf-child.bpmn", childProcess)
+        .deploy();
+  }
+
+  @Test
+  public void shouldTriggerBoundaryEventIfChildIsCompleting() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            "parent-wf.bpmn",
+            parentProcess(
+                callActivity ->
+                    callActivity
+                        .boundaryEvent()
+                        .cancelActivity(true)
+                        .timerWithDuration("PT1M")
+                        .endEvent()))
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID_PARENT).create();
+
+    final var timerCreated =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var childTaskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+
+    // when trigger the boundary event and complete the child instance concurrently
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, childTaskActivated.getValue())
+            .key(childTaskActivated.getKey()),
+        RecordToWrite.command()
+            .timer(TimerIntent.TRIGGER, timerCreated.getValue())
+            .key(timerCreated.getKey()));
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .betweenProcessInstance(processInstanceKey)
+                .processInstanceRecords())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.TERMINATE_ELEMENT),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  private static BpmnModelInstance parentProcess(final Consumer<CallActivityBuilder> consumer) {
+    final var builder =
+        Bpmn.createExecutableProcess(PROCESS_ID_PARENT)
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId(PROCESS_ID_CHILD));
+
+    consumer.accept(builder);
+
+    return builder.endEvent().done();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayConcurrencyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayConcurrencyTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class EventBasedGatewayConcurrencyTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          // Disable batch processing. Interrupting behaviour is only reproducible if
+          // process instance is not completed in one batch.
+          .processingBatchLimit(1);
+
+  private static final BpmnModelInstance PROCESS_WITH_EQUAL_TIMERS =
+      Bpmn.createExecutableProcess("PROCESS_WITH_EQUAL_TIMERS")
+          .startEvent("start")
+          .eventBasedGateway()
+          .id("gateway")
+          .intermediateCatchEvent("timer-1", c -> c.timerWithDuration("PT2S"))
+          .sequenceFlowId("to-end1")
+          .endEvent("end1")
+          .moveToLastGateway()
+          .intermediateCatchEvent("timer-2", c -> c.timerWithDuration("PT2S"))
+          .sequenceFlowId("to-end2")
+          .endEvent("end2")
+          .done();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @BeforeClass
+  public static void init() {
+    ENGINE.deployment().withXmlResource(PROCESS_WITH_EQUAL_TIMERS).deploy();
+  }
+
+  @Test
+  public void shouldOnlyExecuteOneBranchWithEqualTimers() {
+    // given
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("PROCESS_WITH_EQUAL_TIMERS").create();
+
+    // when
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).limit(2).count()).isEqualTo(2);
+    ENGINE.increaseTime(Duration.ofSeconds(2));
+
+    // then
+    final List<String> timers =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(2)
+            .map(r -> r.getValue().getTargetElementId())
+            .collect(Collectors.toList());
+
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+                .withHandlerNodeId(timers.get(0))
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+
+    Assertions.assertThat(
+            RecordingExporter.timerRecords(TimerIntent.TRIGGER)
+                .withHandlerNodeId(timers.get(1))
+                .withProcessInstanceKey(processInstanceKey)
+                .onlyCommandRejections()
+                .getFirst())
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventbasedGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventbasedGatewayTest.java
@@ -275,7 +275,7 @@ public final class EventbasedGatewayTest {
                 .withProcessInstanceKey(processInstanceKey)
                 .onlyCommandRejections()
                 .getFirst())
-        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRecordType(RecordType.COMMAND_REJECTION);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessConcurrencyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessConcurrencyTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.subprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.EmbeddedSubProcessBuilder;
+import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class EmbeddedSubProcessConcurrencyTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          // Disable batch processing. Interrupting behaviour is only reproducible if
+          // process instance is not completed in one batch.
+          .processingBatchLimit(1);
+
+  private static final String PROCESS_ID = "process-with-sub-process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldNotTriggerBoundaryEventWhenFlowscopeIsInterrupted() {
+    // given
+    final Consumer<EmbeddedSubProcessBuilder> subProcessBuilder =
+        subprocess ->
+            subprocess
+                .startEvent()
+                .serviceTask("task", b -> b.zeebeJobType("task"))
+                .endEvent()
+                .moveToActivity("subProcess")
+                .boundaryEvent(
+                    "msgBoundary",
+                    boundary ->
+                        boundary
+                            .cancelActivity(true)
+                            .message(
+                                msg ->
+                                    msg.name("boundary")
+                                        .zeebeCorrelationKeyExpression("correlationKey")))
+                .endEvent()
+                .done();
+
+    final Consumer<EventSubProcessBuilder> eventSubProcessBuilder =
+        eventSubProcess ->
+            eventSubProcess
+                .startEvent("eventSubProcessStartEvent")
+                .message(
+                    m -> m.name("eventSubProcess").zeebeCorrelationKeyExpression("correlationKey"))
+                .endEvent();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess("eventSubProcess", eventSubProcessBuilder)
+                .startEvent()
+                .subProcess(
+                    "subProcess",
+                    subProcess -> subProcessBuilder.accept(subProcess.embeddedSubProcess()))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("correlationKey", "correlationKey")
+            .create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("task")
+        .await();
+
+    // when
+    // We need to make sure no records are written in between the publish commands. This could
+    // cause the test to become flaky.
+    ENGINE.writeRecords(
+        // First we publish a message to try and trigger the boundary event
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord()
+                    .setName("boundary")
+                    .setTimeToLive(0L)
+                    .setCorrelationKey("correlationKey")
+                    .setVariables(BufferUtil.wrapString(""))),
+        // Next we publish a message to trigger the event sub process. This will interrupt the
+        // flow scope of the sub process, whilst the subprocess is being terminated because of the
+        // boundary event
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord()
+                    .setName("eventSubProcess")
+                    .setTimeToLive(0L)
+                    .setCorrelationKey("correlationKey")
+                    .setVariables(BufferUtil.wrapString(""))));
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .filter(r -> r.getValueType() == ValueType.PROCESS_EVENT)
+                .withIntent(ProcessEventIntent.TRIGGERING))
+        .extracting(r -> ((ProcessEventRecordValue) r.getValue()).getTargetElementId())
+        .containsExactly("msgBoundary", "eventSubProcessStartEvent");
+
+    // No event should be TRIGGERED. We don't want to trigger the boundary event.
+    // The event sub process does not write a TRIGGERED event.
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .withIntent(ProcessEventIntent.TRIGGERED))
+        .isEmpty();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .onlyEvents()
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .contains(
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
@@ -11,28 +11,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.EmbeddedSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
-import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
-import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.intent.MessageIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.util.function.Consumer;
 import org.junit.ClassRule;
@@ -571,124 +563,5 @@ public final class EmbeddedSubProcessTest {
                 .withScopeKey(processInstanceKey))
         .extracting(var -> tuple(var.getIntent(), var.getValue().getValue()))
         .containsExactly(tuple(VariableIntent.CREATED, "1"), tuple(VariableIntent.UPDATED, "2"));
-  }
-
-  @Test
-  public void shouldNotTriggerBoundaryEventWhenFlowscopeIsInterrupted() {
-    // given
-    final Consumer<EmbeddedSubProcessBuilder> subProcessBuilder =
-        subprocess ->
-            subprocess
-                .startEvent()
-                .serviceTask("task", b -> b.zeebeJobType("task"))
-                .endEvent()
-                .moveToActivity("subProcess")
-                .boundaryEvent(
-                    "msgBoundary",
-                    boundary ->
-                        boundary
-                            .cancelActivity(true)
-                            .message(
-                                msg ->
-                                    msg.name("boundary")
-                                        .zeebeCorrelationKeyExpression("correlationKey")))
-                .endEvent()
-                .done();
-
-    final Consumer<EventSubProcessBuilder> eventSubProcessBuilder =
-        eventSubProcess ->
-            eventSubProcess
-                .startEvent("eventSubProcessStartEvent")
-                .message(
-                    m -> m.name("eventSubProcess").zeebeCorrelationKeyExpression("correlationKey"))
-                .endEvent();
-
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .eventSubProcess("eventSubProcess", eventSubProcessBuilder)
-                .startEvent()
-                .subProcess(
-                    "subProcess",
-                    subProcess -> subProcessBuilder.accept(subProcess.embeddedSubProcess()))
-                .endEvent()
-                .done())
-        .deploy();
-
-    final var processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withVariable("correlationKey", "correlationKey")
-            .create();
-
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("task")
-        .await();
-
-    // when
-    // We need to make sure no records are written in between the publish commands. This could
-    // cause the test to become flaky.
-    ENGINE.writeRecords(
-        // First we publish a message to try and trigger the boundary event
-        RecordToWrite.command()
-            .message(
-                MessageIntent.PUBLISH,
-                new MessageRecord()
-                    .setName("boundary")
-                    .setTimeToLive(0L)
-                    .setCorrelationKey("correlationKey")
-                    .setVariables(BufferUtil.wrapString(""))),
-        // Next we publish a message to trigger the event sub process. This will interrupt the
-        // flow scope of the sub process, whilst the subprocess is being terminated because of the
-        // boundary event
-        RecordToWrite.command()
-            .message(
-                MessageIntent.PUBLISH,
-                new MessageRecord()
-                    .setName("eventSubProcess")
-                    .setTimeToLive(0L)
-                    .setCorrelationKey("correlationKey")
-                    .setVariables(BufferUtil.wrapString(""))));
-
-    // then
-    assertThat(
-            RecordingExporter.records()
-                .limitToProcessInstance(processInstanceKey)
-                .filter(r -> r.getValueType() == ValueType.PROCESS_EVENT)
-                .withIntent(ProcessEventIntent.TRIGGERING))
-        .extracting(r -> ((ProcessEventRecordValue) r.getValue()).getTargetElementId())
-        .containsExactly("msgBoundary", "eventSubProcessStartEvent");
-
-    // No event should be TRIGGERED. We don't want to trigger the boundary event.
-    // The event sub process does not write a TRIGGERED event.
-    assertThat(
-            RecordingExporter.records()
-                .limitToProcessInstance(processInstanceKey)
-                .withIntent(ProcessEventIntent.TRIGGERED))
-        .isEmpty();
-
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey)
-                .onlyEvents()
-                .limitToProcessInstanceCompleted())
-        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
-        .containsSubsequence(
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
-            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
-            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED))
-        .contains(
-            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED))
-        .doesNotContain(
-            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessConcurrencyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessConcurrencyTest.java
@@ -31,7 +31,12 @@ public class InterruptingEventSubprocessConcurrencyTest {
   private static final String PROCESS_ID = "proc";
   private static final String MSG_NAME = "messageName";
 
-  @Rule public final EngineRule engineRule = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engineRule =
+      EngineRule.singlePartition()
+          // Disable batch processing. Interrupting behaviour is only reproducible if
+          // process instance is not completed in one batch.
+          .processingBatchLimit(1);
 
   @Test
   // https://github.com/camunda/zeebe/issues/6552

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessConcurrencyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessConcurrencyTest.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
-import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -89,127 +88,6 @@ public class InterruptingEventSubprocessConcurrencyTest {
             .processMessageSubscription(
                 ProcessMessageSubscriptionIntent.CORRELATE,
                 eventSubprocessSubscriptionCreated.getValue()));
-
-    // then
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
-        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
-        .containsSubsequence(
-            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
-  }
-
-  @Test
-  // https://github.com/camunda/zeebe/issues/6565
-  public void shouldEndProcessWithParallelFlow() {
-    // given
-    final ProcessBuilder process = Bpmn.createExecutableProcess(PROCESS_ID);
-
-    process
-        .eventSubProcess("event_sub_proc")
-        .startEvent("event_sub_start")
-        .interrupting(true)
-        .message(b -> b.name(MSG_NAME).zeebeCorrelationKeyExpression("key"))
-        .endEvent("event_sub_end");
-
-    final BpmnModelInstance model =
-        process
-            .startEvent("start_proc")
-            .sequenceFlowId("toParallel")
-            .parallelGateway("parallel")
-            .intermediateCatchEvent("catch")
-            .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
-            .endEvent("end_proc")
-            .moveToLastGateway()
-            .intermediateCatchEvent("catch1")
-            .message(m -> m.name("msg1").zeebeCorrelationKeyExpression("key1"))
-            .endEvent("end_proc1")
-            .done();
-
-    engineRule.deployment().withXmlResource(model).deploy();
-
-    final long processInstanceKey =
-        engineRule
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withVariables(Map.of("key", 123, "key1", 123))
-            .create();
-
-    // when
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withMessageName(MSG_NAME)
-        .await();
-    RecordingExporter.processInstanceRecords()
-        .withElementType(BpmnElementType.START_EVENT)
-        .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
-        .withElementId("start_proc")
-        .withProcessInstanceKey(processInstanceKey)
-        .await();
-
-    engineRule
-        .message()
-        .withName(MSG_NAME)
-        .withCorrelationKey("123")
-        .withVariables(Map.of("key", "123"))
-        .publish();
-
-    // then
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
-        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
-        .containsSubsequence(
-            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
-  }
-
-  @Test
-  public void shouldTerminateXorWithIncident() {
-    // given
-    final ProcessBuilder process = Bpmn.createExecutableProcess(PROCESS_ID);
-
-    process
-        .eventSubProcess("event_sub_proc")
-        .startEvent("event_sub_start")
-        .interrupting(true)
-        .message(b -> b.name(MSG_NAME).zeebeCorrelationKeyExpression("key"))
-        .endEvent("event_sub_end");
-
-    final BpmnModelInstance model =
-        process
-            .startEvent("start_proc")
-            .sequenceFlowId("toXor")
-            .exclusiveGateway("xor")
-            .condition("=yolo")
-            .endEvent()
-            .done();
-
-    engineRule.deployment().withXmlResource(model).deploy();
-
-    final long processInstanceKey =
-        engineRule
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withVariables(Map.of("key", 123, "key1", 123))
-            .create();
-
-    // when
-    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .await();
-
-    engineRule
-        .message()
-        .withName(MSG_NAME)
-        .withCorrelationKey("123")
-        .withVariables(Map.of("key", "123"))
-        .publish();
 
     // then
     assertThat(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -281,7 +281,6 @@ public class InterruptingEventSubprocessTest {
 
     assertThat(eventSubproc.getValue().getFlowScopeKey()).isEqualTo(subProcess.getKey());
     assertThat(subProcess.getValue().getFlowScopeKey()).isEqualTo(processInstanceKey);
-    assertThat(subProcess.getSourceRecordPosition()).isEqualTo(eventSubproc.getPosition());
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
                 .withProcessInstanceKey(processInstanceKey)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobFailIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobFailIncidentTest.java
@@ -355,10 +355,6 @@ public final class JobFailIncidentTest {
             .getFirst();
 
     assertThat(resolvedIncidentEvent.getKey()).isEqualTo(incidentCreatedEvent.getKey());
-    assertThat(resolvedIncidentEvent.getSourceRecordPosition())
-        .isEqualTo(terminateTaskCommand.getPosition());
-    assertThat(jobCancelled.getSourceRecordPosition())
-        .isEqualTo(terminateTaskCommand.getPosition());
 
     assertThat(resolvedIncidentEvent.getValue())
         .hasErrorType(ErrorType.JOB_NO_RETRIES)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
@@ -88,7 +88,6 @@ public final class MappingIncidentTest {
             .getFirst();
 
     assertThat(incidentEvent.getKey()).isGreaterThan(0);
-    assertThat(incidentEvent.getSourceRecordPosition()).isEqualTo(failureCommand.getPosition());
     assertThat(incidentEvent.getValue().getVariableScopeKey()).isEqualTo(failureCommand.getKey());
 
     final IncidentRecordValue incidentEventValue = incidentEvent.getValue();
@@ -461,8 +460,6 @@ public final class MappingIncidentTest {
             .getFirst();
 
     assertThat(incidentResolvedEvent.getKey()).isEqualTo(incidentCreatedEvent.getKey());
-    assertThat(terminateActivity.getPosition())
-        .isEqualTo(incidentResolvedEvent.getSourceRecordPosition());
 
     Assertions.assertThat(incidentResolvedEvent.getValue())
         .hasErrorType(ErrorType.IO_MAPPING_ERROR)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceConcurrentModificationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceConcurrentModificationTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MultiInstanceConcurrentModificationTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          // Disable batch processing. Concurrent modification is only reproducible if
+          // we do not process multi instance in batch.
+          .processingBatchLimit(1);
+
+  private static final String MULTI_TASK_PROCESS = "multi-task-process";
+  private static final String ELEMENT_ID = "task";
+  private static final String INPUT_COLLECTION = "items";
+  private static final String INPUT_ELEMENT = "item";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  private String jobType;
+
+  @Before
+  public void init() {
+    jobType = helper.getJobType();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(MULTI_TASK_PROCESS)
+                .startEvent()
+                .serviceTask(
+                    ELEMENT_ID,
+                    t ->
+                        t.zeebeJobType(jobType)
+                            .multiInstance(
+                                b ->
+                                    b.zeebeInputCollectionExpression(INPUT_COLLECTION)
+                                        .zeebeInputElement(INPUT_ELEMENT)
+                                        .zeebeOutputElementExpression("{x: undefined_var}")
+                                        .zeebeOutputCollection("results")))
+                .endEvent()
+                .done())
+        .deploy();
+  }
+
+  /**
+   * This test is a bit more complex then shouldResolveIncidentDueToInputCollection, because it
+   * tests a parallel multi-instance body that is about to activate, but while it's activating (and
+   * before it's children activate) the input collection is modified. This should result in
+   * incidents on each of the children's activations, which can be resolved individually.
+   */
+  @Test
+  public void shouldCreateIncidentWhenInputCollectionModifiedConcurrently() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("multi-task")
+            .startEvent()
+            .serviceTask(ELEMENT_ID, t -> t.zeebeJobType(jobType))
+            .sequenceFlowId("from-task-to-multi-instance")
+            .serviceTask("multi-instance", t -> t.zeebeJobType(jobType))
+            .multiInstance(
+                b ->
+                    b.parallel()
+                        .zeebeInputCollectionExpression(INPUT_COLLECTION)
+                        .zeebeInputElement(INPUT_ELEMENT))
+            .endEvent()
+            .done();
+    final var deployment = ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("multi-task")
+            .withVariable(INPUT_COLLECTION, List.of(1, 2, 3))
+            .create();
+    final var serviceTask =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+    final var job = findNthJob(processInstanceKey, 1);
+    ENGINE.stop();
+    RecordingExporter.reset();
+
+    // when
+    final ProcessInstanceRecord sequenceFlow =
+        Records.processInstance(processInstanceKey, "multi-task")
+            .setBpmnElementType(BpmnElementType.SEQUENCE_FLOW)
+            .setElementId("from-task-to-multi-instance")
+            .setFlowScopeKey(processInstanceKey)
+            .setProcessDefinitionKey(
+                deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey());
+    final ProcessInstanceRecord multiInstanceBody =
+        Records.processInstance(processInstanceKey, "multi-task")
+            .setBpmnElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+            .setElementId("multi-instance")
+            .setFlowScopeKey(processInstanceKey)
+            .setProcessDefinitionKey(
+                deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey());
+
+    ENGINE.writeRecords(
+        RecordToWrite.command().key(job.getKey()).job(JobIntent.COMPLETE, job.getValue()),
+        RecordToWrite.event()
+            .causedBy(0)
+            .key(job.getKey())
+            .job(JobIntent.COMPLETED, job.getValue()),
+        RecordToWrite.command()
+            .causedBy(0)
+            .key(serviceTask.getKey())
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, serviceTask.getValue()),
+        RecordToWrite.event()
+            .causedBy(2)
+            .key(serviceTask.getKey())
+            .processInstance(ProcessInstanceIntent.ELEMENT_COMPLETING, serviceTask.getValue()),
+        RecordToWrite.event()
+            .causedBy(2)
+            .key(serviceTask.getKey())
+            .processInstance(ProcessInstanceIntent.ELEMENT_COMPLETED, serviceTask.getValue()),
+        RecordToWrite.event()
+            .causedBy(2)
+            .key(-1L)
+            .processInstance(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, sequenceFlow),
+        RecordToWrite.command()
+            .causedBy(2)
+            .processInstance(ProcessInstanceIntent.ACTIVATE_ELEMENT, multiInstanceBody),
+        RecordToWrite.command()
+            .variable(
+                VariableDocumentIntent.UPDATE,
+                Records.variableDocument(processInstanceKey, "{\"items\":0}")));
+    ENGINE.start();
+
+    // then
+    final var incidents =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(3)
+            .asList();
+    assertThat(incidents)
+        .describedAs(
+            "Should create incident for each child when input element cannot be retrieved from input collection")
+        .extracting(Record::getValue)
+        .extracting(
+            IncidentRecordValue::getElementId,
+            IncidentRecordValue::getErrorType,
+            IncidentRecordValue::getErrorMessage)
+        .containsOnly(
+            tuple(
+                "multi-instance",
+                ErrorType.EXTRACT_VALUE_ERROR,
+                "Expected result of the expression 'items' to be 'ARRAY', but was 'NUMBER'."));
+
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Collections.singletonMap(INPUT_COLLECTION, List.of(1, 2, 3)))
+        .update();
+
+    incidents.forEach(
+        i -> ENGINE.incident().ofInstance(processInstanceKey).withKey(i.getKey()).resolve());
+
+    completeNthJob(processInstanceKey, 2);
+    completeNthJob(processInstanceKey, 3);
+    completeNthJob(processInstanceKey, 4);
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  private static void completeNthJob(final long processInstanceKey, final int n) {
+    final var nthJob = findNthJob(processInstanceKey, n);
+    ENGINE.job().withKey(nthJob.getKey()).complete();
+  }
+
+  private static Record<JobRecordValue> findNthJob(final long processInstanceKey, final int n) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .skip(n - 1)
+        .getFirst();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -12,18 +12,14 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.engine.util.RecordToWrite;
-import io.camunda.zeebe.engine.util.Records;
 import io.camunda.zeebe.engine.util.client.IncidentClient.ResolveIncidentClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -392,130 +388,6 @@ public final class MultiInstanceIncidentTest {
         .withProcessInstanceKey(processInstanceKey)
         .withElementType(BpmnElementType.PROCESS)
         .limitToProcessInstanceCompleted()
-        .await();
-  }
-
-  /**
-   * This test is a bit more complex then shouldResolveIncidentDueToInputCollection, because it
-   * tests a parallel multi-instance body that is about to activate, but while it's activating (and
-   * before it's children activate) the input collection is modified. This should result in
-   * incidents on each of the children's activations, which can be resolved individually.
-   */
-  @Test
-  public void shouldCreateIncidentWhenInputCollectionModifiedConcurrently() {
-    // given
-    final var process =
-        Bpmn.createExecutableProcess("multi-task")
-            .startEvent()
-            .serviceTask(ELEMENT_ID, t -> t.zeebeJobType(jobType))
-            .sequenceFlowId("from-task-to-multi-instance")
-            .serviceTask("multi-instance", t -> t.zeebeJobType(jobType))
-            .multiInstance(
-                b ->
-                    b.parallel()
-                        .zeebeInputCollectionExpression(INPUT_COLLECTION)
-                        .zeebeInputElement(INPUT_ELEMENT))
-            .endEvent()
-            .done();
-    final var deployment = ENGINE.deployment().withXmlResource(process).deploy();
-    final long processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId("multi-task")
-            .withVariable(INPUT_COLLECTION, List.of(1, 2, 3))
-            .create();
-    final var serviceTask =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .getFirst();
-    final var job = findNthJob(processInstanceKey, 1);
-    ENGINE.stop();
-    RecordingExporter.reset();
-
-    // when
-    final ProcessInstanceRecord sequenceFlow =
-        Records.processInstance(processInstanceKey, "multi-task")
-            .setBpmnElementType(BpmnElementType.SEQUENCE_FLOW)
-            .setElementId("from-task-to-multi-instance")
-            .setFlowScopeKey(processInstanceKey)
-            .setProcessDefinitionKey(
-                deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey());
-    final ProcessInstanceRecord multiInstanceBody =
-        Records.processInstance(processInstanceKey, "multi-task")
-            .setBpmnElementType(BpmnElementType.MULTI_INSTANCE_BODY)
-            .setElementId("multi-instance")
-            .setFlowScopeKey(processInstanceKey)
-            .setProcessDefinitionKey(
-                deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey());
-
-    ENGINE.writeRecords(
-        RecordToWrite.command().key(job.getKey()).job(JobIntent.COMPLETE, job.getValue()),
-        RecordToWrite.event()
-            .causedBy(0)
-            .key(job.getKey())
-            .job(JobIntent.COMPLETED, job.getValue()),
-        RecordToWrite.command()
-            .causedBy(0)
-            .key(serviceTask.getKey())
-            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, serviceTask.getValue()),
-        RecordToWrite.event()
-            .causedBy(2)
-            .key(serviceTask.getKey())
-            .processInstance(ProcessInstanceIntent.ELEMENT_COMPLETING, serviceTask.getValue()),
-        RecordToWrite.event()
-            .causedBy(2)
-            .key(serviceTask.getKey())
-            .processInstance(ProcessInstanceIntent.ELEMENT_COMPLETED, serviceTask.getValue()),
-        RecordToWrite.event()
-            .causedBy(2)
-            .key(-1L)
-            .processInstance(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, sequenceFlow),
-        RecordToWrite.command()
-            .causedBy(2)
-            .processInstance(ProcessInstanceIntent.ACTIVATE_ELEMENT, multiInstanceBody),
-        RecordToWrite.command()
-            .variable(
-                VariableDocumentIntent.UPDATE,
-                Records.variableDocument(processInstanceKey, "{\"items\":0}")));
-    ENGINE.start();
-
-    // then
-    final var incidents =
-        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .limit(3)
-            .asList();
-    assertThat(incidents)
-        .describedAs(
-            "Should create incident for each child when input element cannot be retrieved from input collection")
-        .extracting(Record::getValue)
-        .extracting(
-            IncidentRecordValue::getElementId,
-            IncidentRecordValue::getErrorType,
-            IncidentRecordValue::getErrorMessage)
-        .containsOnly(
-            tuple(
-                "multi-instance",
-                ErrorType.EXTRACT_VALUE_ERROR,
-                "Expected result of the expression 'items' to be 'ARRAY', but was 'NUMBER'."));
-
-    ENGINE
-        .variables()
-        .ofScope(processInstanceKey)
-        .withDocument(Collections.singletonMap(INPUT_COLLECTION, List.of(1, 2, 3)))
-        .update();
-
-    incidents.forEach(
-        i -> ENGINE.incident().ofInstance(processInstanceKey).withKey(i.getKey()).resolve());
-
-    completeNthJob(processInstanceKey, 2);
-    completeNthJob(processInstanceKey, 3);
-    completeNthJob(processInstanceKey, 4);
-
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementType(BpmnElementType.PROCESS)
         .await();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
@@ -136,7 +136,6 @@ public class OutputMappingIncidentTest {
             .getFirst();
 
     assertThat(incidentEvent.getKey()).isGreaterThan(0);
-    assertThat(incidentEvent.getSourceRecordPosition()).isEqualTo(failureCommand.getPosition());
 
     Assertions.assertThat(incidentEvent.getValue())
         .hasErrorType(ErrorType.IO_MAPPING_ERROR)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
@@ -328,8 +328,6 @@ public final class CancelProcessInstanceTest {
             .getFirst();
 
     assertThat(jobCanceledEvent.getKey()).isEqualTo(jobCreatedEvent.getKey());
-    assertThat(jobCanceledEvent.getSourceRecordPosition())
-        .isEqualTo(terminateActivity.getPosition());
 
     final JobRecordValue jobCanceledEventValue = jobCanceledEvent.getValue();
     assertThat(jobCanceledEventValue.getProcessInstanceKey()).isEqualTo(processInstanceKey);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
@@ -558,13 +558,13 @@ public class ModifyProcessInstanceTerminationTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit("C", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+                .limit("A", ProcessInstanceIntent.ELEMENT_TERMINATED))
         .extracting(
             r -> r.getValue().getBpmnElementType(),
             r -> r.getValue().getElementId(),
             Record::getIntent)
         .describedAs("Ensure the precondition of a pending activation")
-        .containsSequence(
+        .containsSubsequence(
             tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(
                 BpmnElementType.SEQUENCE_FLOW, "b-to-c", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
@@ -31,7 +31,7 @@ public final class ProcessInstanceCommandRejectionTest {
 
   private static final String PROCESS_ID = "process";
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final EngineRule engine = EngineRule.singlePartition().processingBatchLimit(1);
 
   @Test
   public void shouldRejectActivateIfFlowScopeIsActivating() {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -26,7 +26,7 @@ import java.util.function.BooleanSupplier;
 
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
 
-  public static final int DEFAULT_PROCESSING_BATCH_LIMIT = 1;
+  public static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
   private static final StreamProcessorListener NOOP_LISTENER =
       new StreamProcessorListener() {
         @Override


### PR DESCRIPTION
## Description

Enables the batch processing via setting the processing batch limit to `100`. The PR mostly contains test adjustments and fixes. 

Depends on previous PR's which contains several bug fixes.

- [x] https://github.com/camunda/zeebe/pull/11527
- [x]  https://github.com/camunda/zeebe/pull/11528
- [x]  https://github.com/camunda/zeebe/pull/11530

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->
relates to https://github.com/camunda/zeebe/issues/11416

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
