### PR TITLE
Process a ResourceDeletion.DELETE command for DMN resources

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -44,7 +44,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.PROCESS_INSTANCE_MODIFICATION);
+      EnumSet.range(ValueType.JOB, ValueType.RESOURCE_DELETION);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -11,10 +11,18 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class ResourceDeletionProcessor implements TypedRecordProcessor<ResourceDeletionRecord> {
 
@@ -32,5 +40,49 @@ public class ResourceDeletionProcessor implements TypedRecordProcessor<ResourceD
   }
 
   @Override
-  public void processRecord(final TypedRecord<ResourceDeletionRecord> command) {}
+  public void processRecord(final TypedRecord<ResourceDeletionRecord> command) {
+    final var value = command.getValue();
+
+    final var drgOptional = decisionState.findDecisionRequirementsByKey(value.getResourceKey());
+    if (drgOptional.isPresent()) {
+      deleteDecisionRequirements(drgOptional.get());
+    }
+
+    final long eventKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
+    responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETED, value, command);
+  }
+
+  private void deleteDecisionRequirements(final PersistedDecisionRequirements drg) {
+    decisionState
+        .findDecisionsByDecisionRequirementsKey(drg.getDecisionRequirementsKey())
+        .forEach(this::deleteDecision);
+
+    final var drgRecord =
+        new DecisionRequirementsRecord()
+            .setDecisionRequirementsId(BufferUtil.bufferAsString(drg.getDecisionRequirementsId()))
+            .setDecisionRequirementsName(
+                BufferUtil.bufferAsString(drg.getDecisionRequirementsName()))
+            .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
+            .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
+            .setResourceName(BufferUtil.bufferAsString(drg.getResourceName()))
+            .setChecksum(drg.getChecksum())
+            .setResource(drg.getResource());
+
+    stateWriter.appendFollowUpEvent(
+        keyGenerator.nextKey(), DecisionRequirementsIntent.DELETED, drgRecord);
+  }
+
+  private void deleteDecision(final PersistedDecision persistedDecision) {
+    final var decisionRecord =
+        new DecisionRecord()
+            .setDecisionId(BufferUtil.bufferAsString(persistedDecision.getDecisionId()))
+            .setDecisionName(BufferUtil.bufferAsString(persistedDecision.getDecisionName()))
+            .setVersion(persistedDecision.getVersion())
+            .setDecisionKey(persistedDecision.getDecisionKey())
+            .setDecisionRequirementsId(
+                BufferUtil.bufferAsString(persistedDecision.getDecisionRequirementsId()))
+            .setDecisionRequirementsKey(persistedDecision.getDecisionRequirementsKey());
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), DecisionIntent.DELETED, decisionRecord);
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class ResourceDeletionProcessor implements TypedRecordProcessor<ResourceDeletionRecord> {
+
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final KeyGenerator keyGenerator;
+  private final DecisionState decisionState;
+
+  public ResourceDeletionProcessor(
+      final Writers writers, final KeyGenerator keyGenerator, final DecisionState decisionState) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    this.keyGenerator = keyGenerator;
+    this.decisionState = decisionState;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ResourceDeletionRecord> command) {}
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ResourceDeletionTest {
+
+  private static final String DRG_SINGLE_DECISION = "/dmn/decision-table.dmn";
+  private static final String DRG_MULTIPLE_DECISIONS = "/dmn/drg-force-user.dmn";
+
+  @Rule public final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldWriteDeletedEventsForSingleDecision() {
+    // given
+    final long drgKey = deployDrg(DRG_SINGLE_DECISION);
+
+    // when
+    ENGINE.resourceDeletion().withResourceKey(drgKey).delete();
+
+    // then
+    verifyDecisionIsDeleted(drgKey, "jedi_or_sith", 1);
+    verifyDecisionRequirementsIsDeleted(drgKey);
+    verifyResourceIsDeleted(drgKey);
+  }
+
+  @Test
+  public void shouldWriteDeletedEventsForMultipleDecisions() {
+    // given
+    final long drgKey = deployDrg(DRG_MULTIPLE_DECISIONS);
+
+    // when
+    ENGINE.resourceDeletion().withResourceKey(drgKey).delete();
+
+    // then
+    verifyDecisionIsDeleted(drgKey, "jedi_or_sith", 1);
+    verifyDecisionIsDeleted(drgKey, "force_user", 1);
+    verifyDecisionRequirementsIsDeleted(drgKey);
+    verifyResourceIsDeleted(drgKey);
+  }
+
+  private long deployDrg(final String drgResource) {
+    return ENGINE
+        .deployment()
+        .withXmlResource(readResource(drgResource), drgResource)
+        .deploy()
+        .getValue()
+        .getDecisionRequirementsMetadata()
+        .get(0)
+        .getDecisionRequirementsKey();
+  }
+
+  private byte[] readResource(final String resourceName) {
+    final var resourceAsStream = getClass().getResourceAsStream(resourceName);
+    assertThat(resourceAsStream).isNotNull();
+
+    try {
+      return resourceAsStream.readAllBytes();
+    } catch (final IOException e) {
+      fail("Failed to read resource '{}'", resourceName, e);
+      return new byte[0];
+    }
+  }
+
+  private void verifyResourceIsDeleted(final long key) {
+    assertThat(
+            RecordingExporter.resourceDeletionRecords()
+                .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED)))
+        .describedAs("Expect resource to be deleted")
+        .extracting(Record::getIntent, r -> r.getValue().getResourceKey())
+        .containsOnly(
+            tuple(ResourceDeletionIntent.DELETE, key), tuple(ResourceDeletionIntent.DELETED, key));
+  }
+
+  private void verifyDecisionRequirementsIsDeleted(final long key) {
+    final var drgCreatedRecord =
+        RecordingExporter.decisionRequirementsRecords()
+            .withDecisionRequirementsKey(key)
+            .withIntent(DecisionRequirementsIntent.CREATED)
+            .getFirst()
+            .getValue();
+
+    final var drgDeletedRecord =
+        RecordingExporter.decisionRequirementsRecords()
+            .withDecisionRequirementsKey(key)
+            .withIntent(DecisionRequirementsIntent.DELETED)
+            .getFirst()
+            .getValue();
+
+    assertThat(drgDeletedRecord)
+        .describedAs("Expect deleted DRG to match the created DRG")
+        .extracting(
+            DecisionRequirementsMetadataValue::getDecisionRequirementsId,
+            DecisionRequirementsMetadataValue::getDecisionRequirementsName,
+            DecisionRequirementsMetadataValue::getDecisionRequirementsVersion,
+            DecisionRequirementsMetadataValue::getDecisionRequirementsKey,
+            DecisionRequirementsMetadataValue::getResourceName,
+            DecisionRequirementsMetadataValue::getChecksum)
+        .containsOnly(
+            drgCreatedRecord.getDecisionRequirementsId(),
+            drgCreatedRecord.getDecisionRequirementsName(),
+            drgCreatedRecord.getDecisionRequirementsVersion(),
+            drgCreatedRecord.getDecisionRequirementsKey(),
+            drgCreatedRecord.getResourceName(),
+            drgCreatedRecord.getChecksum());
+  }
+
+  private void verifyDecisionIsDeleted(
+      final long drgKey, final String decisionId, final int version) {
+    final var decisionCreatedRecord =
+        RecordingExporter.decisionRecords()
+            .withDecisionRequirementsKey(drgKey)
+            .withDecisionId(decisionId)
+            .withVersion(version)
+            .withIntent(DecisionIntent.CREATED)
+            .getFirst()
+            .getValue();
+
+    final var decisionDeletedRecord =
+        RecordingExporter.decisionRecords()
+            .withDecisionRequirementsKey(drgKey)
+            .withDecisionId(decisionId)
+            .withVersion(version)
+            .withIntent(DecisionIntent.DELETED)
+            .getFirst()
+            .getValue();
+
+    assertThat(decisionDeletedRecord)
+        .describedAs("Expect deleted decision to match the created decision")
+        .extracting(
+            DecisionRecordValue::getDecisionId,
+            DecisionRecordValue::getDecisionName,
+            DecisionRecordValue::getVersion,
+            DecisionRecordValue::getDecisionKey,
+            DecisionRecordValue::getDecisionRequirementsId,
+            DecisionRecordValue::getDecisionRequirementsKey,
+            DecisionRecordValue::isDuplicate)
+        .containsOnly(
+            decisionCreatedRecord.getDecisionId(),
+            decisionCreatedRecord.getDecisionName(),
+            decisionCreatedRecord.getVersion(),
+            decisionCreatedRecord.getDecisionKey(),
+            decisionCreatedRecord.getDecisionRequirementsId(),
+            decisionCreatedRecord.getDecisionRequirementsKey(),
+            decisionCreatedRecord.isDuplicate());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -29,7 +29,7 @@ public class ResourceDeletionTest {
   private static final String DRG_SINGLE_DECISION = "/dmn/decision-table.dmn";
   private static final String DRG_MULTIPLE_DECISIONS = "/dmn/drg-force-user.dmn";
 
-  @Rule public final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
   @Test
@@ -38,7 +38,7 @@ public class ResourceDeletionTest {
     final long drgKey = deployDrg(DRG_SINGLE_DECISION);
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(drgKey).delete();
+    engine.resourceDeletion().withResourceKey(drgKey).delete();
 
     // then
     verifyDecisionIsDeleted(drgKey, "jedi_or_sith", 1);
@@ -52,7 +52,7 @@ public class ResourceDeletionTest {
     final long drgKey = deployDrg(DRG_MULTIPLE_DECISIONS);
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(drgKey).delete();
+    engine.resourceDeletion().withResourceKey(drgKey).delete();
 
     // then
     verifyDecisionIsDeleted(drgKey, "jedi_or_sith", 1);
@@ -62,7 +62,7 @@ public class ResourceDeletionTest {
   }
 
   private long deployDrg(final String drgResource) {
-    return ENGINE
+    return engine
         .deployment()
         .withXmlResource(readResource(drgResource), drgResource)
         .deploy()

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.util.client.JobActivationClient;
 import io.camunda.zeebe.engine.util.client.JobClient;
 import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
 import io.camunda.zeebe.engine.util.client.PublishMessageClient;
+import io.camunda.zeebe.engine.util.client.ResourceDeletionClient;
 import io.camunda.zeebe.engine.util.client.VariableClient;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
@@ -316,6 +317,10 @@ public final class EngineRule extends ExternalResource {
 
   public IncidentClient incident() {
     return new IncidentClient(environmentRule);
+  }
+
+  public ResourceDeletionClient resourceDeletion() {
+    return new ResourceDeletionClient(environmentRule);
   }
 
   public Record<JobRecordValue> createJob(final String type, final String processId) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.engine.util.StreamProcessorRule;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.Function;
+
+public class ResourceDeletionClient {
+
+  private static final Function<Long, Record<ResourceDeletionRecordValue>> SUCCESS_EXPECTATION =
+      (position) ->
+          RecordingExporter.resourceDeletionRecords(ResourceDeletionIntent.DELETED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private final StreamProcessorRule environmentRule;
+  private final ResourceDeletionRecord resourceDeletionRecord = new ResourceDeletionRecord();
+  private final Function<Long, Record<ResourceDeletionRecordValue>> expectation =
+      SUCCESS_EXPECTATION;
+
+  public ResourceDeletionClient(final StreamProcessorRule environmentRule) {
+    this.environmentRule = environmentRule;
+  }
+
+  public ResourceDeletionClient withResourceKey(final long resourceKey) {
+    resourceDeletionRecord.setResourceKey(resourceKey);
+    return this;
+  }
+
+  public Record<ResourceDeletionRecordValue> delete() {
+    final long position =
+        environmentRule.writeCommand(ResourceDeletionIntent.DELETE, resourceDeletionRecord);
+    return expectation.apply(position);
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -30,7 +30,7 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
       new IntegerProperty("decisionRequirementsVersion");
   private final LongProperty decisionRequirementsKeyProp =
       new LongProperty("decisionRequirementsKey");
-  private final StringProperty namespaceProp = new StringProperty("namespace");
+  private final StringProperty namespaceProp = new StringProperty("namespace", "");
 
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
@@ -87,48 +87,48 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
     return false;
   }
 
+  public DecisionRequirementsRecord setChecksum(final DirectBuffer checksum) {
+    checksumProp.setValue(checksum);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setResourceName(final String resourceName) {
+    resourceNameProp.setValue(resourceName);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setNamespace(final String namespace) {
+    namespaceProp.setValue(namespace);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsKey(final long decisionRequirementsKey) {
+    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsVersion(
+      final int decisionRequirementsVersion) {
+    decisionRequirementsVersionProp.setValue(decisionRequirementsVersion);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsName(final String decisionRequirementsName) {
+    decisionRequirementsNameProp.setValue(decisionRequirementsName);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsId(final String decisionRequirementsId) {
+    decisionRequirementsIdProp.setValue(decisionRequirementsId);
+    return this;
+  }
+
   @Override
   public byte[] getResource() {
     return bufferAsArray(resourceProp.getValue());
   }
 
-  public DecisionRequirementsRecord setDecisionRequirementsId(String decisionRequirementsId) {
-    decisionRequirementsIdProp.setValue(decisionRequirementsId);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setDecisionRequirementsName(String decisionRequirementsName) {
-    decisionRequirementsNameProp.setValue(decisionRequirementsName);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setDecisionRequirementsVersion(
-      int decisionRequirementsVersion) {
-    decisionRequirementsVersionProp.setValue(decisionRequirementsVersion);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setDecisionRequirementsKey(long decisionRequirementsKey) {
-    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setNamespace(String namespace) {
-    namespaceProp.setValue(namespace);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setResourceName(String resourceName) {
-    resourceNameProp.setValue(resourceName);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setChecksum(DirectBuffer checksum) {
-    checksumProp.setValue(checksum);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setResource(DirectBuffer resource) {
+  public DecisionRequirementsRecord setResource(final DirectBuffer resource) {
     resourceProp.setValue(resource);
     return this;
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -113,7 +113,8 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
     return this;
   }
 
-  public DecisionRequirementsRecord setDecisionRequirementsName(final String decisionRequirementsName) {
+  public DecisionRequirementsRecord setDecisionRequirementsName(
+      final String decisionRequirementsName) {
     decisionRequirementsNameProp.setValue(decisionRequirementsName);
     return this;
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
@@ -70,6 +71,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.DECISION, DecisionRecord.class);
     registry.put(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecord.class);
     registry.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord.class);
+    registry.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord.class);
 
     registry.put(ValueType.CHECKPOINT, CheckpointRecord.class);
     registry.put(ValueType.ESCALATION, EscalationRecord.class);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRecordStream.java
@@ -34,4 +34,12 @@ public class DecisionRecordStream
   public DecisionRecordStream withDecisionKey(final long decisionKey) {
     return valueFilter(v -> v.getDecisionKey() == decisionKey);
   }
+
+  public DecisionRecordStream withDecisionRequirementsKey(final long decisionRequirementsKey) {
+    return valueFilter(v -> v.getDecisionRequirementsKey() == decisionRequirementsKey);
+  }
+
+  public DecisionRecordStream withVersion(final int version) {
+    return valueFilter(v -> v.getVersion() == version);
+  }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -43,6 +44,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
@@ -318,6 +320,16 @@ public final class RecordingExporter implements Exporter {
 
   public static SignalRecordStream signalRecords(final SignalIntent intent) {
     return signalRecords().withIntent(intent);
+  }
+
+  public static ResourceDeletionRecordStream resourceDeletionRecords() {
+    return new ResourceDeletionRecordStream(
+        records(ValueType.RESOURCE_DELETION, ResourceDeletionRecordValue.class));
+  }
+
+  public static ResourceDeletionRecordStream resourceDeletionRecords(
+      final ResourceDeletionIntent intent) {
+    return resourceDeletionRecords().withIntent(intent);
   }
 
   public static class AwaitingRecordIterator implements Iterator<Record<?>> {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ResourceDeletionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ResourceDeletionRecordStream.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import java.util.stream.Stream;
+
+public class ResourceDeletionRecordStream
+    extends ExporterRecordStream<ResourceDeletionRecordValue, ResourceDeletionRecordStream> {
+
+  public ResourceDeletionRecordStream(
+      final Stream<Record<ResourceDeletionRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ResourceDeletionRecordStream supply(
+      final Stream<Record<ResourceDeletionRecordValue>> wrappedStream) {
+    return new ResourceDeletionRecordStream(wrappedStream);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds a processor that will process the `ResourceDeletion.DELETE` command. This processor is responsible for writing the `DELETE` events for the resource passed in the command.

This PR only contains support for a `DMN` resource. When we process a `ResourceDeletion.DELETE` command we must check if the passed resource is a `DRG`. If it is we must write the `DELETED` events for the decision requirements and the decisions itself.

The appliers of these events will be responsible for making sure we delete resource from the state.


I recommend reviewing it by commit

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9770 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
