### PR TITLE
[Backport stable/8.1] fix: append an empty expired message command

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
@@ -22,12 +22,17 @@ public interface MessageState {
 
   StoredMessage getMessage(long messageKey);
 
-  void visitMessagesWithDeadlineBefore(long timestamp, MessageVisitor visitor);
+  void visitMessagesWithDeadlineBefore(long timestamp, ExpiredMessageVisitor visitor);
 
   boolean exist(DirectBuffer name, DirectBuffer correlationKey, DirectBuffer messageId);
 
   @FunctionalInterface
   interface MessageVisitor {
     boolean visit(StoredMessage message);
+  }
+
+  @FunctionalInterface
+  interface ExpiredMessageVisitor {
+    boolean visit(long messageKey);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -336,14 +336,14 @@ public final class DbMessageState implements MutableMessageState {
   }
 
   @Override
-  public void visitMessagesWithDeadlineBefore(final long timestamp, final MessageVisitor visitor) {
+  public void visitMessagesWithDeadlineBefore(
+      final long timestamp, final ExpiredMessageVisitor visitor) {
     deadlineColumnFamily.whileTrue(
         ((compositeKey, zbNil) -> {
           final long deadline = compositeKey.first().getValue();
           if (deadline <= timestamp) {
             final long messageKey = compositeKey.second().inner().getValue();
-            final StoredMessage message = getMessage(messageKey);
-            return visitor.visit(message);
+            return visitor.visit(messageKey);
           }
           return false;
         }));

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
@@ -189,11 +189,7 @@ public final class PublishMessageTest {
             .withRecordKey(publishedRecord.getKey())
             .getFirst();
 
-    Assertions.assertThat(deletedEvent.getValue())
-        .hasName("")
-        .hasCorrelationKey("")
-        .hasTimeToLive(-1L)
-        .hasMessageId("");
+    Assertions.assertThat(deletedEvent).hasKey(publishedRecord.getKey());
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
@@ -190,9 +190,9 @@ public final class PublishMessageTest {
             .getFirst();
 
     Assertions.assertThat(deletedEvent.getValue())
-        .hasName("order canceled")
-        .hasCorrelationKey("order-123")
-        .hasTimeToLive(100L)
+        .hasName("")
+        .hasCorrelationKey("")
+        .hasTimeToLive(-1L)
         .hasMessageId("");
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -191,7 +191,7 @@ public final class MessageStateTest {
     messageState.put(2L, message2);
 
     // then
-    final List<StoredMessage> readMessage = new ArrayList<>();
+    final List<Long> readMessage = new ArrayList<>();
     messageState.visitMessagesWithDeadlineBefore(1_000, readMessage::add);
 
     assertThat(readMessage).isEmpty();
@@ -207,11 +207,11 @@ public final class MessageStateTest {
     messageState.put(2L, message2);
 
     // then
-    final List<StoredMessage> readMessage = new ArrayList<>();
+    final List<Long> readMessage = new ArrayList<>();
     messageState.visitMessagesWithDeadlineBefore(1_999, readMessage::add);
 
     assertThat(readMessage.size()).isEqualTo(1);
-    assertThat(readMessage.get(0).getMessageKey()).isEqualTo(1L);
+    assertThat(readMessage.get(0)).isEqualTo(1L);
   }
 
   @Test
@@ -230,7 +230,7 @@ public final class MessageStateTest {
 
     // then
     final List<Long> readMessage = new ArrayList<>();
-    messageState.visitMessagesWithDeadlineBefore(deadline, m -> readMessage.add(m.getMessageKey()));
+    messageState.visitMessagesWithDeadlineBefore(deadline, m -> readMessage.add(m));
 
     assertThat(readMessage.size()).isEqualTo(2);
     assertThat(readMessage).containsExactly(1L, 2L);
@@ -249,7 +249,7 @@ public final class MessageStateTest {
     messageState.remove(1L);
 
     // then
-    final List<StoredMessage> readMessages = new ArrayList<>();
+    final List<Long> readMessages = new ArrayList<>();
     messageState.visitMessagesWithDeadlineBefore(2000, readMessages::add);
 
     assertThat(readMessages.size()).isEqualTo(0);
@@ -283,7 +283,7 @@ public final class MessageStateTest {
     messageState.remove(1L);
 
     // then
-    final List<StoredMessage> readMessages = new ArrayList<>();
+    final List<Long> readMessages = new ArrayList<>();
     messageState.visitMessagesWithDeadlineBefore(2000, readMessages::add);
 
     assertThat(readMessages.size()).isEqualTo(0);
@@ -308,7 +308,7 @@ public final class MessageStateTest {
     messageState.remove(1L);
 
     // then
-    final List<StoredMessage> readMessages = new ArrayList<>();
+    final List<Long> readMessages = new ArrayList<>();
     messageState.visitMessagesWithDeadlineBefore(2000, readMessages::add);
 
     assertThat(readMessages.size()).isEqualTo(0);
@@ -344,7 +344,7 @@ public final class MessageStateTest {
 
     // then
     final long deadline = ActorClock.currentTimeMillis() + 2_000L;
-    final List<StoredMessage> readMessages = new ArrayList<>();
+    final List<Long> readMessages = new ArrayList<>();
     messageState.visitMessagesWithDeadlineBefore(deadline, readMessages::add);
 
     assertThat(readMessages.size()).isEqualTo(1);


### PR DESCRIPTION
## Description
To discard an expired message the processor and applier only need the message key. All other information is not necessary to process a expire message command. That's why only the `messageKey` is submitted to the command to expire a message.

This prevents the message checker to stop too early when collecting expired messages and not being able to collect as many as necessary expired messages in one batch to prevent building up state.

## Related issues
closes #10643 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
