### PR TITLE
Corrolate message directly with batch processing

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -73,6 +73,8 @@ public final class EngineProcessors {
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(zeebeState.getPartitionId());
 
+    subscriptionCommandSender.setWriters(writers);
+
     final var decisionBehavior =
         new DecisionBehavior(
             DecisionEngineFactory.createDecisionEngine(), zeebeState, processEngineMetrics);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -57,6 +57,7 @@ public final class CatchEventBehavior {
   private final TimerRecord timerRecord = new TimerRecord();
   private final DueDateTimerChecker timerChecker;
   private final KeyGenerator keyGenerator;
+  private final int currentPartitionId;
 
   public CatchEventBehavior(
       final ZeebeState zeebeState,
@@ -79,6 +80,8 @@ public final class CatchEventBehavior {
 
     this.keyGenerator = keyGenerator;
     this.timerChecker = timerChecker;
+
+    currentPartitionId = zeebeState.getPartitionId();
   }
 
   /**
@@ -240,16 +243,14 @@ public final class CatchEventBehavior {
     stateWriter.appendFollowUpEvent(
         subscriptionKey, ProcessMessageSubscriptionIntent.CREATING, subscription);
 
-    sideEffectWriter.appendSideEffect(
-        () ->
-            sendOpenMessageSubscription(
-                subscriptionPartitionId,
-                processInstanceKey,
-                elementInstanceKey,
-                bpmnProcessId,
-                messageName,
-                correlationKey,
-                event.isInterrupting()));
+    sendOpenMessageSubscription(
+        subscriptionPartitionId,
+        processInstanceKey,
+        elementInstanceKey,
+        bpmnProcessId,
+        messageName,
+        correlationKey,
+        event.isInterrupting());
   }
 
   private void subscribeToTimerEvents(
@@ -342,10 +343,8 @@ public final class CatchEventBehavior {
 
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, subscription.getRecord());
-    sideEffectWriter.appendSideEffect(
-        () ->
-            sendCloseMessageSubscriptionCommand(
-                subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName));
+    sendCloseMessageSubscriptionCommand(
+        subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName);
   }
 
   private boolean sendCloseMessageSubscriptionCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -22,13 +22,16 @@ public final class MessageCorrelator {
   private final MessageState messageState;
   private final SubscriptionCommandSender commandSender;
   private final StateWriter stateWriter;
-  private SideEffectWriter sideEffectWriter;
+  private final SideEffectWriter sideEffectWriter;
+  private final int currentPartitionId;
 
   public MessageCorrelator(
+      final int currentPartitionId,
       final MessageState messageState,
       final SubscriptionCommandSender commandSender,
       final StateWriter stateWriter,
       final SideEffectWriter sideEffectWriter) {
+    this.currentPartitionId = currentPartitionId;
     this.messageState = messageState;
     this.commandSender = commandSender;
     this.stateWriter = stateWriter;
@@ -72,7 +75,7 @@ public final class MessageCorrelator {
       stateWriter.appendFollowUpEvent(
           subscriptionKey, MessageSubscriptionIntent.CORRELATING, subscriptionRecord);
 
-      sideEffectWriter.appendSideEffect(() -> sendCorrelateCommand(subscriptionRecord));
+      sendCorrelateCommand(subscriptionRecord);
     }
 
     return correlateMessage;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -45,6 +45,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE,
             MessageIntent.PUBLISH,
             new MessagePublishProcessor(
+                zeebeState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 startEventSubscriptionState,
@@ -61,12 +62,21 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CREATE,
             new MessageSubscriptionCreateProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers, keyGenerator))
+                zeebeState.getPartitionId(),
+                messageState,
+                subscriptionState,
+                subscriptionCommandSender,
+                writers,
+                keyGenerator))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
             new MessageSubscriptionCorrelateProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers))
+                zeebeState.getPartitionId(),
+                messageState,
+                subscriptionState,
+                subscriptionCommandSender,
+                writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.DELETE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -32,17 +32,21 @@ public final class MessageSubscriptionCorrelateProcessor
   private final MessageCorrelator messageCorrelator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
+  private final int partitionId;
 
   public MessageSubscriptionCorrelateProcessor(
+      final int partitionId,
       final MessageState messageState,
       final MessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender commandSender,
       final Writers writers) {
+    this.partitionId = partitionId;
     this.subscriptionState = subscriptionState;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     messageCorrelator =
-        new MessageCorrelator(messageState, commandSender, stateWriter, writers.sideEffect());
+        new MessageCorrelator(
+            partitionId, messageState, commandSender, stateWriter, writers.sideEffect());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -64,7 +64,7 @@ public final class MessageSubscriptionDeleteProcessor
       rejectCommand(record);
     }
 
-    sideEffectWriter.appendSideEffect(this::sendAcknowledgeCommand);
+    sendAcknowledgeCommand();
   }
 
   private void rejectCommand(final TypedRecord<MessageSubscriptionRecord> record) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -93,8 +93,7 @@ public final class MessageSubscriptionRejectProcessor
                 subscription.getKey(),
                 MessageSubscriptionIntent.CORRELATING,
                 correlatingSubscription);
-
-            sideEffectWriter.appendSideEffect(() -> sendCorrelateCommand(correlatingSubscription));
+            sendCorrelateCommand(correlatingSubscription);
           }
           return !canBeCorrelated;
         });

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.engine.processing.message.command;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
@@ -57,42 +59,18 @@ public class SubscriptionCommandSender {
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate) {
-
-    if (subscriptionPartitionId == senderPartition) {
-      writers
-          .command()
-          .appendNewCommand(
-              MessageSubscriptionIntent.CREATE,
-              new MessageSubscriptionRecord()
-                  .setProcessInstanceKey(processInstanceKey)
-                  .setElementInstanceKey(elementInstanceKey)
-                  .setBpmnProcessId(bpmnProcessId)
-                  .setMessageKey(-1)
-                  .setMessageName(messageName)
-                  .setCorrelationKey(correlationKey)
-                  .setInterrupting(closeOnCorrelate));
-    } else {
-
-      writers
-          .sideEffect()
-          .appendSideEffect(
-              () -> {
-                interPartitionCommandSender.sendCommand(
-                    subscriptionPartitionId,
-                    ValueType.MESSAGE_SUBSCRIPTION,
-                    MessageSubscriptionIntent.CREATE,
-                    new MessageSubscriptionRecord()
-                        .setProcessInstanceKey(processInstanceKey)
-                        .setElementInstanceKey(elementInstanceKey)
-                        .setBpmnProcessId(bpmnProcessId)
-                        .setMessageKey(-1)
-                        .setMessageName(messageName)
-                        .setCorrelationKey(correlationKey)
-                        .setInterrupting(closeOnCorrelate));
-                return true;
-              });
-    }
-    return true;
+    return handleFollowUpCommandBasedOnPartition(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.CREATE,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageKey(-1)
+            .setMessageName(messageName)
+            .setCorrelationKey(correlationKey)
+            .setInterrupting(closeOnCorrelate));
   }
 
   public boolean openProcessMessageSubscription(
@@ -100,39 +78,17 @@ public class SubscriptionCommandSender {
       final long elementInstanceKey,
       final DirectBuffer messageName,
       final boolean closeOnCorrelate) {
-    final int receiverPartitionId = Protocol.decodePartitionId(processInstanceKey);
-    if (receiverPartitionId == senderPartition) {
-      writers
-          .command()
-          .appendNewCommand(
-              ProcessMessageSubscriptionIntent.CREATE,
-              new ProcessMessageSubscriptionRecord()
-                  .setSubscriptionPartitionId(senderPartition)
-                  .setProcessInstanceKey(processInstanceKey)
-                  .setElementInstanceKey(elementInstanceKey)
-                  .setMessageKey(-1)
-                  .setMessageName(messageName)
-                  .setInterrupting(closeOnCorrelate));
-    } else {
-      writers
-          .sideEffect()
-          .appendSideEffect(
-              () -> {
-                interPartitionCommandSender.sendCommand(
-                    receiverPartitionId,
-                    ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
-                    ProcessMessageSubscriptionIntent.CREATE,
-                    new ProcessMessageSubscriptionRecord()
-                        .setSubscriptionPartitionId(senderPartition)
-                        .setProcessInstanceKey(processInstanceKey)
-                        .setElementInstanceKey(elementInstanceKey)
-                        .setMessageKey(-1)
-                        .setMessageName(messageName)
-                        .setInterrupting(closeOnCorrelate));
-                return true;
-              });
-    }
-    return true;
+    return handleFollowUpCommandBasedOnPartition(
+        Protocol.decodePartitionId(processInstanceKey),
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+        ProcessMessageSubscriptionIntent.CREATE,
+        new ProcessMessageSubscriptionRecord()
+            .setSubscriptionPartitionId(senderPartition)
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setMessageKey(-1)
+            .setMessageName(messageName)
+            .setInterrupting(closeOnCorrelate));
   }
 
   public boolean correlateProcessMessageSubscription(
@@ -143,43 +99,19 @@ public class SubscriptionCommandSender {
       final long messageKey,
       final DirectBuffer variables,
       final DirectBuffer correlationKey) {
-    final int receiverPartitionId = Protocol.decodePartitionId(processInstanceKey);
-    if (receiverPartitionId == senderPartition) {
-      writers
-          .command()
-          .appendNewCommand(
-              ProcessMessageSubscriptionIntent.CORRELATE,
-              new ProcessMessageSubscriptionRecord()
-                  .setSubscriptionPartitionId(senderPartition)
-                  .setProcessInstanceKey(processInstanceKey)
-                  .setElementInstanceKey(elementInstanceKey)
-                  .setBpmnProcessId(bpmnProcessId)
-                  .setMessageKey(messageKey)
-                  .setMessageName(messageName)
-                  .setVariables(variables)
-                  .setCorrelationKey(correlationKey));
-    } else {
-      writers
-          .sideEffect()
-          .appendSideEffect(
-              () -> {
-                interPartitionCommandSender.sendCommand(
-                    receiverPartitionId,
-                    ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
-                    ProcessMessageSubscriptionIntent.CORRELATE,
-                    new ProcessMessageSubscriptionRecord()
-                        .setSubscriptionPartitionId(senderPartition)
-                        .setProcessInstanceKey(processInstanceKey)
-                        .setElementInstanceKey(elementInstanceKey)
-                        .setBpmnProcessId(bpmnProcessId)
-                        .setMessageKey(messageKey)
-                        .setMessageName(messageName)
-                        .setVariables(variables)
-                        .setCorrelationKey(correlationKey));
-                return true;
-              });
-    }
-    return true;
+    return handleFollowUpCommandBasedOnPartition(
+        Protocol.decodePartitionId(processInstanceKey),
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+        ProcessMessageSubscriptionIntent.CORRELATE,
+        new ProcessMessageSubscriptionRecord()
+            .setSubscriptionPartitionId(senderPartition)
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageKey(messageKey)
+            .setMessageName(messageName)
+            .setVariables(variables)
+            .setCorrelationKey(correlationKey));
   }
 
   public boolean correlateMessageSubscription(
@@ -188,36 +120,16 @@ public class SubscriptionCommandSender {
       final long elementInstanceKey,
       final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName) {
-    if (subscriptionPartitionId == senderPartition) {
-      writers
-          .command()
-          .appendNewCommand(
-              MessageSubscriptionIntent.CORRELATE,
-              new MessageSubscriptionRecord()
-                  .setProcessInstanceKey(processInstanceKey)
-                  .setElementInstanceKey(elementInstanceKey)
-                  .setBpmnProcessId(bpmnProcessId)
-                  .setMessageKey(-1)
-                  .setMessageName(messageName));
-    } else {
-      writers
-          .sideEffect()
-          .appendSideEffect(
-              () -> {
-                interPartitionCommandSender.sendCommand(
-                    subscriptionPartitionId,
-                    ValueType.MESSAGE_SUBSCRIPTION,
-                    MessageSubscriptionIntent.CORRELATE,
-                    new MessageSubscriptionRecord()
-                        .setProcessInstanceKey(processInstanceKey)
-                        .setElementInstanceKey(elementInstanceKey)
-                        .setBpmnProcessId(bpmnProcessId)
-                        .setMessageKey(-1)
-                        .setMessageName(messageName));
-                return true;
-              });
-    }
-    return true;
+    return handleFollowUpCommandBasedOnPartition(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.CORRELATE,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageKey(-1)
+            .setMessageName(messageName));
   }
 
   public boolean closeMessageSubscription(
@@ -225,73 +137,31 @@ public class SubscriptionCommandSender {
       final long processInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer messageName) {
-    if (subscriptionPartitionId == senderPartition) {
-      writers
-          .command()
-          .appendNewCommand(
-              ProcessMessageSubscriptionIntent.DELETE,
-              new MessageSubscriptionRecord()
-                  .setProcessInstanceKey(processInstanceKey)
-                  .setElementInstanceKey(elementInstanceKey)
-                  .setMessageKey(-1L)
-                  .setMessageName(messageName));
-    } else {
-      writers
-          .sideEffect()
-          .appendSideEffect(
-              () -> {
-                interPartitionCommandSender.sendCommand(
-                    subscriptionPartitionId,
-                    ValueType.MESSAGE_SUBSCRIPTION,
-                    MessageSubscriptionIntent.DELETE,
-                    new MessageSubscriptionRecord()
-                        .setProcessInstanceKey(processInstanceKey)
-                        .setElementInstanceKey(elementInstanceKey)
-                        .setMessageKey(-1L)
-                        .setMessageName(messageName));
-                return true;
-              });
-    }
-    return true;
+    return handleFollowUpCommandBasedOnPartition(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.DELETE,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setMessageKey(-1L)
+            .setMessageName(messageName));
   }
 
   public boolean closeProcessMessageSubscription(
       final long processInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer messageName) {
-
-    final int receiverPartitionId = Protocol.decodePartitionId(processInstanceKey);
-    if (receiverPartitionId == senderPartition) {
-      writers
-          .command()
-          .appendNewCommand(
-              ProcessMessageSubscriptionIntent.DELETE,
-              new ProcessMessageSubscriptionRecord()
-                  .setSubscriptionPartitionId(senderPartition)
-                  .setProcessInstanceKey(processInstanceKey)
-                  .setElementInstanceKey(elementInstanceKey)
-                  .setMessageKey(-1)
-                  .setMessageName(messageName));
-    } else {
-      writers
-          .sideEffect()
-          .appendSideEffect(
-              () -> {
-                interPartitionCommandSender.sendCommand(
-                    receiverPartitionId,
-                    ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
-                    ProcessMessageSubscriptionIntent.DELETE,
-                    new ProcessMessageSubscriptionRecord()
-                        .setSubscriptionPartitionId(senderPartition)
-                        .setProcessInstanceKey(processInstanceKey)
-                        .setElementInstanceKey(elementInstanceKey)
-                        .setMessageKey(-1)
-                        .setMessageName(messageName));
-                return true;
-              });
-    }
-
-    return true;
+    return handleFollowUpCommandBasedOnPartition(
+        Protocol.decodePartitionId(processInstanceKey),
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+        ProcessMessageSubscriptionIntent.DELETE,
+        new ProcessMessageSubscriptionRecord()
+            .setSubscriptionPartitionId(senderPartition)
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setMessageKey(-1)
+            .setMessageName(messageName));
   }
 
   public boolean rejectCorrelateMessageSubscription(
@@ -300,38 +170,47 @@ public class SubscriptionCommandSender {
       final long messageKey,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey) {
+    return handleFollowUpCommandBasedOnPartition(
+        Protocol.decodePartitionId(processInstanceKey),
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.REJECT,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(-1L)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageName(messageName)
+            .setCorrelationKey(correlationKey)
+            .setMessageKey(messageKey)
+            .setInterrupting(false));
+  }
 
-    final int receiverPartitionId = Protocol.decodePartitionId(processInstanceKey);
+  /**
+   * Handles the follow-up / result command based on the partition ID.
+   *
+   * <p>If the {@see receiverPartitionId} is similar to the sendPartitionId, then we will write a
+   * follow-up command to the log, via the internal writers. If the partition id is different then
+   * the command is sent over the wire to the receiverPartitionId.
+   *
+   * @param receiverPartitionId to which partition the command should be sent/written to
+   * @param valueType the value type of the follow-up command
+   * @param intent the intent of the follow-up command
+   * @param record the record value of the follow-up command
+   * @return always true
+   */
+  private boolean handleFollowUpCommandBasedOnPartition(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final UnifiedRecordValue record) {
     if (receiverPartitionId == senderPartition) {
-      writers
-          .command()
-          .appendNewCommand(
-              MessageSubscriptionIntent.REJECT,
-              new MessageSubscriptionRecord()
-                  .setProcessInstanceKey(processInstanceKey)
-                  .setElementInstanceKey(-1L)
-                  .setBpmnProcessId(bpmnProcessId)
-                  .setMessageName(messageName)
-                  .setCorrelationKey(correlationKey)
-                  .setMessageKey(messageKey)
-                  .setInterrupting(false));
+      writers.command().appendNewCommand(intent, record);
     } else {
       writers
           .sideEffect()
           .appendSideEffect(
               () -> {
                 interPartitionCommandSender.sendCommand(
-                    receiverPartitionId,
-                    ValueType.MESSAGE_SUBSCRIPTION,
-                    MessageSubscriptionIntent.REJECT,
-                    new MessageSubscriptionRecord()
-                        .setProcessInstanceKey(processInstanceKey)
-                        .setElementInstanceKey(-1L)
-                        .setBpmnProcessId(bpmnProcessId)
-                        .setMessageName(messageName)
-                        .setCorrelationKey(correlationKey)
-                        .setMessageKey(messageKey)
-                        .setInterrupting(false));
+                    receiverPartitionId, valueType, intent, record);
                 return true;
               });
     }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
@@ -94,7 +94,7 @@ public final class MessageCorrelationMultiplePartitionsTest {
   }
 
   @Test
-  public void shouldCorrelateMessageOnDifferentPartitions() {
+  public void shouldCorrelateMessageOnDifferentPartitions() throws InterruptedException {
     // given
     engine.forEachPartition(
         partitionId ->

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.message.command;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SubscriptionCommandSenderTest {
+
+  private static final long DIFFERENT_RECEIVER_PARTITION_KEY = Protocol.encodePartitionId(2, 1);
+  private static final long SAME_RECEIVER_PARTITION_KEY = Protocol.encodePartitionId(1, 1);
+  private static final int SENDER_PARTITION = 1;
+
+  private static final long DEFAULT_ELEMENT_INSTANCE_KEY = 111;
+  private static final DirectBuffer DEFAULT_MESSAGE_NAME = BufferUtil.wrapString("msg");
+
+  private InterPartitionCommandSender mockInterPartitionCommandSender;
+  private SubscriptionCommandSender subscriptionCommandSender;
+  private ProcessingResultBuilder mockProcessingResultBuilder;
+
+  @BeforeEach
+  public void setup() {
+    mockInterPartitionCommandSender = mock(InterPartitionCommandSender.class);
+    subscriptionCommandSender =
+        new SubscriptionCommandSender(SENDER_PARTITION, mockInterPartitionCommandSender);
+    mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
+    final var writers =
+        new Writers(() -> mockProcessingResultBuilder, (key, intent, recordValue) -> {});
+    subscriptionCommandSender.setWriters(writers);
+  }
+
+  @Test
+  public void shouldSentFollowUpCommandForCloseProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.closeProcessMessageSubscription(
+        DIFFERENT_RECEIVER_PARTITION_KEY, DEFAULT_ELEMENT_INSTANCE_KEY, DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockProcessingResultBuilder).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWriteFollowUpCommandForCloseProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.closeProcessMessageSubscription(
+        SAME_RECEIVER_PARTITION_KEY, DEFAULT_ELEMENT_INSTANCE_KEY, DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -19,18 +19,25 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SubscriptionCommandSenderTest {
 
-  private static final long DIFFERENT_RECEIVER_PARTITION_KEY = Protocol.encodePartitionId(2, 1);
-  private static final long SAME_RECEIVER_PARTITION_KEY = Protocol.encodePartitionId(1, 1);
-  private static final int SENDER_PARTITION = 1;
-
+  public static final DirectBuffer DEFAULT_PROCESS_ID = BufferUtil.wrapString("process");
+  public static final int DEFAULT_MESSAGE_KEY = 123;
+  public static final UnsafeBuffer DEFAULT_VARIABLES = new UnsafeBuffer();
+  public static final DirectBuffer DEFAULT_CORRELATION_KEY =
+      BufferUtil.wrapString("correlationKey");
+  private static final int SAME_PARTITION = 1;
+  private static final int DIFFERENT_PARTITION = 2;
+  private static final long DIFFERENT_RECEIVER_PARTITION_KEY =
+      Protocol.encodePartitionId(DIFFERENT_PARTITION, 1);
+  private static final long SAME_RECEIVER_PARTITION_KEY =
+      Protocol.encodePartitionId(SAME_PARTITION, 1);
   private static final long DEFAULT_ELEMENT_INSTANCE_KEY = 111;
   private static final DirectBuffer DEFAULT_MESSAGE_NAME = BufferUtil.wrapString("msg");
-
   private InterPartitionCommandSender mockInterPartitionCommandSender;
   private SubscriptionCommandSender subscriptionCommandSender;
   private ProcessingResultBuilder mockProcessingResultBuilder;
@@ -39,7 +46,7 @@ public class SubscriptionCommandSenderTest {
   public void setup() {
     mockInterPartitionCommandSender = mock(InterPartitionCommandSender.class);
     subscriptionCommandSender =
-        new SubscriptionCommandSender(SENDER_PARTITION, mockInterPartitionCommandSender);
+        new SubscriptionCommandSender(SAME_PARTITION, mockInterPartitionCommandSender);
     mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
     final var writers =
         new Writers(() -> mockProcessingResultBuilder, (key, intent, recordValue) -> {});
@@ -67,6 +74,214 @@ public class SubscriptionCommandSenderTest {
     // when
     subscriptionCommandSender.closeProcessMessageSubscription(
         SAME_RECEIVER_PARTITION_KEY, DEFAULT_ELEMENT_INSTANCE_KEY, DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldSentFollowUpCommandForCorrelateProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.correlateProcessMessageSubscription(
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_MESSAGE_KEY,
+        DEFAULT_VARIABLES,
+        DEFAULT_CORRELATION_KEY);
+
+    // then
+    verify(mockProcessingResultBuilder).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWriteFollowUpCommandForCorrelateProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.correlateProcessMessageSubscription(
+        SAME_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_MESSAGE_KEY,
+        DEFAULT_VARIABLES,
+        DEFAULT_CORRELATION_KEY);
+
+    // then
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldSentFollowUpCommandForCloseMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.closeMessageSubscription(
+        DIFFERENT_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockProcessingResultBuilder).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWriteFollowUpCommandForCloseMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.closeMessageSubscription(
+        SAME_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldSentFollowUpCommandForOpenMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.openMessageSubscription(
+        DIFFERENT_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_CORRELATION_KEY,
+        true);
+
+    // then
+    verify(mockProcessingResultBuilder).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWriteFollowUpCommandForOpenMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.openMessageSubscription(
+        SAME_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_CORRELATION_KEY,
+        true);
+
+    // then
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldSentFollowUpCommandForOpenProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.openProcessMessageSubscription(
+        DIFFERENT_PARTITION, DIFFERENT_RECEIVER_PARTITION_KEY, DEFAULT_MESSAGE_NAME, true);
+
+    // then
+    verify(mockProcessingResultBuilder).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWriteFollowUpCommandForOpenProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.openProcessMessageSubscription(
+        SAME_RECEIVER_PARTITION_KEY, DIFFERENT_RECEIVER_PARTITION_KEY, DEFAULT_MESSAGE_NAME, true);
+
+    // then
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldSentFollowUpCommandForRejectCorrelateMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.rejectCorrelateMessageSubscription(
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_KEY,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_CORRELATION_KEY);
+
+    // then
+    verify(mockProcessingResultBuilder).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWriteFollowUpCommandForRejectCorrelateMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.rejectCorrelateMessageSubscription(
+        SAME_RECEIVER_PARTITION_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_KEY,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_CORRELATION_KEY);
+
+    // then
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldSentFollowUpCommandForCorrelateMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.correlateMessageSubscription(
+        DIFFERENT_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockProcessingResultBuilder).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWriteFollowUpCommandForCorrelateMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.correlateMessageSubscription(
+        SAME_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());


### PR DESCRIPTION
## Description

Based on https://github.com/camunda/zeebe/pull/11408 I cherry-picked the changes for correlating directly (via writing follow-up commands). I rebased the changes with the real batch processing https://github.com/camunda/zeebe/pull/11531

**Details to the PR:**

When message correlation is happening on the same partition, we can directly write a follow-up command instead of sending an inter partition request.

This PR adds some conditional checks in order to distinguish between correlating to a different partition or to the same partition.

In combination with batch processing, this means that we can also directly process the follow-up command in the same batch and continue with the process instance execution. This allows to remove of several commit latency wait times.

Before: this command has been sent out, over loopback it has been written to the log. It needed to be committed and read again by the processor in order to continue. Benchmarks show that it can help significantly on
certain user bases, which control the message distribution and correlations.

For example, Falko has some benchmark run for certain user scenarios, where we reduce the complete process instance execution time by another 1 sec. https://camunda.slack.com/archives/C049E6APFNZ/p1675754034646389 

We can use this PR to verify whether it works with our benchmarks and in certain scenarios 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes  https://github.com/camunda/zeebe/issues/11494

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
