### PR TITLE
test(journal): always close journal in tests

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -83,10 +83,8 @@ final class SegmentsManager implements AutoCloseable {
 
     try {
       nextSegment.join();
-    } catch (final Throwable throwable) {
-      LOG.warn(
-          "Next segment preparation failed during close, ignoring and proceeding to close",
-          throwable);
+    } catch (final Exception e) {
+      LOG.warn("Next segment preparation failed during close, ignoring and proceeding to close", e);
     }
 
     nextSegment = null;

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Create new segments. Load existing segments from the disk. Keep track of all segments. */
-final class SegmentsManager {
+final class SegmentsManager implements AutoCloseable {
 
   private static final long FIRST_SEGMENT_ID = 1;
   private static final long INITIAL_INDEX = 1;
@@ -71,7 +71,8 @@ final class SegmentsManager {
     this.segmentLoader = segmentLoader;
   }
 
-  void close() {
+  @Override
+  public void close() {
     segments
         .values()
         .forEach(

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -79,6 +79,16 @@ final class SegmentsManager {
               LOG.debug("Closing segment: {}", segment);
               segment.close();
             });
+
+    try {
+      nextSegment.join();
+    } catch (final Throwable throwable) {
+      LOG.warn(
+          "Next segment preparation failed during close, ignoring and proceeding to close",
+          throwable);
+    }
+
+    nextSegment = null;
     currentSegment = null;
   }
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -15,25 +15,39 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 final class JournalReaderTest {
 
   private static final int ENTRIES = 4;
-  @TempDir File directory;
 
   private final UnsafeBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
   private final BufferWriter recordDataWriter = new DirectBufferWriter().wrap(data);
+  private JournalReader reader;
+  private SegmentedJournal journal;
+
+  @BeforeEach
+  public void setup(final @TempDir Path tempDir) {
+    final File directory = tempDir.resolve("data").toFile();
+
+    journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    reader = journal.openReader();
+  }
+
+  @AfterEach
+  public void teardown() {
+    journal.close();
+  }
 
   @Test
   void shouldSeek() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -49,17 +63,11 @@ final class JournalReaderTest {
       assertThat(record.data()).isEqualTo(data);
     }
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirst() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -74,17 +82,11 @@ final class JournalReaderTest {
     final JournalRecord record = reader.next();
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.asqn()).isEqualTo(1);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToLast() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -98,17 +100,11 @@ final class JournalReaderTest {
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.asqn()).isEqualTo(4);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadIfSeekIsHigherThanLast() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -119,17 +115,11 @@ final class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex() + 1);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldReadAppendedDataAfterSeek() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter).index();
     }
@@ -142,17 +132,10 @@ final class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex());
     assertThat(reader.hasNext()).isTrue();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToAsqn() {
-    // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     // given that all records with index i will have an asqn of startAsqn + i
     final long startAsqn = 10;
     for (int i = 0; i < ENTRIES; i++) {
@@ -170,17 +153,11 @@ final class JournalReaderTest {
     final JournalRecord next = reader.next();
     assertThat(next.index()).isEqualTo(nextIndex);
     assertThat(next.asqn()).isEqualTo(startAsqn + 2);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToHighestAsqnLowerThanProvidedAsqn() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(5, recordDataWriter);
 
@@ -191,17 +168,11 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToHighestAsqnWithinBoundIndex() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var firstIndex = journal.append(1, recordDataWriter).index();
     final var secondIndex = journal.append(4, recordDataWriter).index();
     final var thirdIndex = journal.append(recordDataWriter).index();
@@ -223,34 +194,22 @@ final class JournalReaderTest {
 
     assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(fourthIndex);
     assertThat(reader.next().asqn()).isEqualTo(5);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToLastAsqn() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var expectedRecord = journal.append(5, recordDataWriter);
     journal.append(recordDataWriter);
 
     // when - then
     assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(expectedRecord.index());
     assertThat(reader.next()).isEqualTo(expectedRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToHighestLowerAsqnSkippingRecordsWithNoAsqn() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
@@ -262,17 +221,11 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWhenAllAsqnIsHigher() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var expectedRecord = journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
 
@@ -284,17 +237,11 @@ final class JournalReaderTest {
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
     assertThat(reader.next().asqn()).isEqualTo(5);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirstIfLowerThanFirst() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -309,17 +256,11 @@ final class JournalReaderTest {
     assertThat(record.asqn()).isEqualTo(1);
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.data()).isEqualTo(data);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekAfterTruncate() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     long lastIndex = -1;
     for (int i = 1; i <= ENTRIES; i++) {
       lastIndex = journal.append(i, recordDataWriter).index();
@@ -334,17 +275,11 @@ final class JournalReaderTest {
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(nextIndex);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekAfterCompact() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     journal.append(1, recordDataWriter).index();
     journal.append(2, recordDataWriter).index();
     journal.append(3, recordDataWriter).index();
@@ -359,17 +294,11 @@ final class JournalReaderTest {
     assertThat(next.index()).isEqualTo(nextIndex);
     assertThat(next.asqn()).isEqualTo(3);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToIndex() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     long asqn = 1;
     JournalRecord lastRecordWritten = null;
     for (int i = 1; i <= ENTRIES; i++) {
@@ -385,51 +314,31 @@ final class JournalReaderTest {
     // then
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(nextIndex);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWithEmptyJournal() {
-    // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     // when
     final long nextIndex = reader.seekToFirst();
 
     // then
     assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToLastWithEmptyJournal() {
-    // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     // when
     final long nextIndex = reader.seekToLast();
 
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex());
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWhenNoRecordsWithValidAsqnExists() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter);
     }
@@ -441,7 +350,5 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().asqn()).isEqualTo(ASQN_IGNORE);
-
-    journal.close();
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +43,7 @@ final class JournalReaderTest {
 
   @AfterEach
   public void teardown() {
-    journal.close();
+    CloseHelper.quietClose(journal);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -15,33 +15,25 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 final class JournalReaderTest {
 
   private static final int ENTRIES = 4;
+  @TempDir File directory;
 
   private final UnsafeBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
   private final BufferWriter recordDataWriter = new DirectBufferWriter().wrap(data);
-  private JournalReader reader;
-  private SegmentedJournal journal;
-
-  @BeforeEach
-  public void setup(final @TempDir Path tempDir) {
-    final File directory = tempDir.resolve("data").toFile();
-
-    journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    reader = journal.openReader();
-  }
 
   @Test
   void shouldSeek() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -57,11 +49,17 @@ final class JournalReaderTest {
       assertThat(record.data()).isEqualTo(data);
     }
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirst() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -76,11 +74,17 @@ final class JournalReaderTest {
     final JournalRecord record = reader.next();
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.asqn()).isEqualTo(1);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToLast() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -94,11 +98,17 @@ final class JournalReaderTest {
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.asqn()).isEqualTo(4);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldNotReadIfSeekIsHigherThanLast() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -109,11 +119,17 @@ final class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex() + 1);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldReadAppendedDataAfterSeek() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter).index();
     }
@@ -126,10 +142,17 @@ final class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex());
     assertThat(reader.hasNext()).isTrue();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToAsqn() {
+    // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     // given that all records with index i will have an asqn of startAsqn + i
     final long startAsqn = 10;
     for (int i = 0; i < ENTRIES; i++) {
@@ -147,11 +170,17 @@ final class JournalReaderTest {
     final JournalRecord next = reader.next();
     assertThat(next.index()).isEqualTo(nextIndex);
     assertThat(next.asqn()).isEqualTo(startAsqn + 2);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToHighestAsqnLowerThanProvidedAsqn() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(5, recordDataWriter);
 
@@ -162,11 +191,17 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToHighestAsqnWithinBoundIndex() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var firstIndex = journal.append(1, recordDataWriter).index();
     final var secondIndex = journal.append(4, recordDataWriter).index();
     final var thirdIndex = journal.append(recordDataWriter).index();
@@ -188,22 +223,34 @@ final class JournalReaderTest {
 
     assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(fourthIndex);
     assertThat(reader.next().asqn()).isEqualTo(5);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToLastAsqn() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var expectedRecord = journal.append(5, recordDataWriter);
     journal.append(recordDataWriter);
 
     // when - then
     assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(expectedRecord.index());
     assertThat(reader.next()).isEqualTo(expectedRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToHighestLowerAsqnSkippingRecordsWithNoAsqn() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
@@ -215,11 +262,17 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWhenAllAsqnIsHigher() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var expectedRecord = journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
 
@@ -231,11 +284,17 @@ final class JournalReaderTest {
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
     assertThat(reader.next().asqn()).isEqualTo(5);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirstIfLowerThanFirst() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -250,11 +309,17 @@ final class JournalReaderTest {
     assertThat(record.asqn()).isEqualTo(1);
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.data()).isEqualTo(data);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekAfterTruncate() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     long lastIndex = -1;
     for (int i = 1; i <= ENTRIES; i++) {
       lastIndex = journal.append(i, recordDataWriter).index();
@@ -269,11 +334,17 @@ final class JournalReaderTest {
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(nextIndex);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekAfterCompact() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     journal.append(1, recordDataWriter).index();
     journal.append(2, recordDataWriter).index();
     journal.append(3, recordDataWriter).index();
@@ -288,11 +359,17 @@ final class JournalReaderTest {
     assertThat(next.index()).isEqualTo(nextIndex);
     assertThat(next.asqn()).isEqualTo(3);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToIndex() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     long asqn = 1;
     JournalRecord lastRecordWritten = null;
     for (int i = 1; i <= ENTRIES; i++) {
@@ -308,31 +385,51 @@ final class JournalReaderTest {
     // then
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(nextIndex);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWithEmptyJournal() {
+    // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     // when
     final long nextIndex = reader.seekToFirst();
 
     // then
     assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToLastWithEmptyJournal() {
+    // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     // when
     final long nextIndex = reader.seekToLast();
 
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex());
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWhenNoRecordsWithValidAsqnExists() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter);
     }
@@ -344,5 +441,7 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().asqn()).isEqualTo(ASQN_IGNORE);
+
+    journal.close();
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -38,54 +40,55 @@ final class JournalTest {
 
   @TempDir Path directory;
 
-  private byte[] entry = "TestData".getBytes();
-  private final DirectBufferWriter recordDataWriter =
-      new DirectBufferWriter().wrap(new UnsafeBuffer(entry));
-  private final DirectBufferWriter otherRecordDataWriter =
-      new DirectBufferWriter().wrap(new UnsafeBuffer("TestData".getBytes()));
+  private byte[] entry;
+  private final DirectBufferWriter recordDataWriter = new DirectBufferWriter();
+  private final DirectBufferWriter otherRecordDataWriter = new DirectBufferWriter();
+  private Journal journal;
+
+  @BeforeEach
+  void setup() {
+    entry = "TestData".getBytes();
+    recordDataWriter.wrap(new UnsafeBuffer(entry));
+
+    final var entryOther = "TestData".getBytes();
+    otherRecordDataWriter.wrap(new UnsafeBuffer(entryOther));
+
+    journal = openJournal();
+  }
+
+  @AfterEach
+  void teardown() throws Exception {
+    journal.close();
+  }
 
   @Test
   void shouldBeEmpty() {
-    // given
-    final var journal = openJournal();
-
     // when-then
     assertThat(journal.isEmpty()).isTrue();
-
-    journal.close();
   }
 
   @Test
   void shouldNotBeEmpty() {
     // given
-    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when-then
     assertThat(journal.isEmpty()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldAppendData() {
-    // given
-    final var journal = openJournal();
-
     // when
     final var recordAppended = journal.append(1, recordDataWriter);
 
     // then
     assertThat(recordAppended.index()).isEqualTo(1);
     assertThat(recordAppended.asqn()).isEqualTo(1);
-
-    journal.close();
   }
 
   @Test
   void shouldReadRecord() {
     // given
-    final var journal = openJournal();
     final var recordAppended = journal.append(1, recordDataWriter);
 
     // when
@@ -94,15 +97,10 @@ final class JournalTest {
 
     // then
     assertThat(recordRead).isEqualTo(recordAppended);
-
-    journal.close();
   }
 
   @Test
   void shouldAppendMultipleData() {
-    // given
-    final var journal = openJournal();
-
     // when
     final var firstRecord = journal.append(10, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
@@ -113,14 +111,11 @@ final class JournalTest {
 
     assertThat(secondRecord.index()).isEqualTo(2);
     assertThat(secondRecord.asqn()).isEqualTo(20);
-
-    journal.close();
   }
 
   @Test
   void shouldReadMultipleRecord() {
     // given
-    final var journal = openJournal();
     final var firstRecord = journal.append(1, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
 
@@ -132,15 +127,10 @@ final class JournalTest {
     // then
     assertThat(firstRecordRead).isEqualTo(firstRecord);
     assertThat(secondRecordRead).isEqualTo(secondRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldAppendAndReadMultipleRecordsInOrder() {
-    // given
-    final var journal = openJournal();
-
     // when
     for (int i = 0; i < 10; i++) {
       final var recordAppended = journal.append(i + 10, recordDataWriter);
@@ -158,17 +148,13 @@ final class JournalTest {
       assertThat(recordRead.asqn()).isEqualTo(i + 10);
       assertThat(data).containsExactly(entry);
     }
-
-    journal.close();
   }
 
   @Test
   void shouldAppendAndReadMultipleRecords() {
-    // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
-
     for (int i = 0; i < 10; i++) {
+      // given
       entry = ("TestData" + i).getBytes();
       recordDataWriter.wrap(new UnsafeBuffer(entry));
 
@@ -185,14 +171,11 @@ final class JournalTest {
       assertThat(recordRead.asqn()).isEqualTo(i + 10);
       assertThat(data).containsExactly(entry);
     }
-
-    journal.close();
   }
 
   @Test
   void shouldReset() {
     // given
-    final var journal = openJournal();
     long asqn = 1;
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(asqn++, recordDataWriter);
@@ -206,14 +189,11 @@ final class JournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(1);
     final var record = journal.append(asqn, recordDataWriter);
     assertThat(record.index()).isEqualTo(2);
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadAfterJournalResetWithoutReaderReset() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     long asqn = 1;
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -228,14 +208,11 @@ final class JournalTest {
 
     // then
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldWriteToTruncatedIndex() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -256,14 +233,11 @@ final class JournalTest {
 
     final var newRecord = reader.next();
     assertThat(newRecord).isEqualTo(record);
-
-    journal.close();
   }
 
   @Test
   void shouldTruncate() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -278,14 +252,11 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntries() {
     // given
-    final var journal = openJournal();
     final int totalWrites = 10;
     final int truncateIndex = 5;
     int asqn = 1;
@@ -322,14 +293,11 @@ final class JournalTest {
       final var record = reader.next();
       assertThat(record).isEqualTo(written.get(readerIndex));
     }
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderPastTruncateIndex() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -345,14 +313,11 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderAtTruncateIndex() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -368,14 +333,11 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(2);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderBeforeTruncateIndex() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -391,14 +353,11 @@ final class JournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(2);
     reader.next();
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldAppendJournalRecord() {
     // given
-    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -414,27 +373,21 @@ final class JournalTest {
     assertThat(reader.hasNext()).isTrue();
     final var actual = reader.next();
     assertThat(expected).isEqualTo(actual);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithAlreadyAppendedIndex() {
     // given
-    final var journal = openJournal();
     final var record = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithGapInIndex() {
     // given
-    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -445,38 +398,29 @@ final class JournalTest {
 
     // when/then
     assertThatThrownBy(() -> receiverJournal.append(record)).isInstanceOf(InvalidIndex.class);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendLastRecord() {
     // given
-    final var journal = openJournal();
     final var record = journal.append(1, recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
-
-    journal.close();
   }
 
   @Test
   void shouldAppendRecordWithASqnToIgnore() {
     // given
-    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when/then
     journal.append(ASQN_IGNORE, recordDataWriter);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithInvalidChecksum() {
     // given
-    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -491,27 +435,21 @@ final class JournalTest {
     // then
     assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
         .isInstanceOf(InvalidChecksum.class);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithTooLowASqn() {
     // given
-    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
     assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithTooLowASqnIfPreviousRecordIsIgnoreASqn() {
     // given
-    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when
@@ -520,45 +458,30 @@ final class JournalTest {
     // then
     assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
     assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
-
-    journal.close();
   }
 
   @Test
   void shouldReturnFirstIndex() {
-    // given
-    final var journal = openJournal();
-
     // when
     final long firstIndex = journal.append(recordDataWriter).index();
     journal.append(recordDataWriter);
 
     // then
     assertThat(journal.getFirstIndex()).isEqualTo(firstIndex);
-
-    journal.close();
   }
 
   @Test
   void shouldReturnLastIndex() {
-    // given
-    final var journal = openJournal();
-
     // when
     journal.append(recordDataWriter);
     final long lastIndex = journal.append(recordDataWriter).index();
 
     // then
     assertThat(journal.getLastIndex()).isEqualTo(lastIndex);
-
-    journal.close();
   }
 
   @Test
-  void shouldOpenAndClose() {
-    // given
-    final var journal = openJournal();
-
+  void shouldOpenAndClose() throws Exception {
     // when/then
     assertThat(journal.isOpen()).isTrue();
     journal.close();
@@ -568,56 +491,44 @@ final class JournalTest {
   @Test
   void shouldReopenJournalWithExistingRecords() throws Exception {
     // given
-    final long lastIndexBeforeClose;
-    try (var journal = openJournal()) {
-      journal.append(recordDataWriter);
-      journal.append(recordDataWriter);
-      lastIndexBeforeClose = journal.getLastIndex();
-      assertThat(lastIndexBeforeClose).isEqualTo(2);
-    }
+    journal.append(recordDataWriter);
+    journal.append(recordDataWriter);
+    final long lastIndexBeforeClose = journal.getLastIndex();
+    assertThat(lastIndexBeforeClose).isEqualTo(2);
+    journal.close();
 
     // when
-    final var journal = openJournal();
+    journal = openJournal();
 
     // then
     assertThat(journal.isOpen()).isTrue();
     assertThat(journal.getLastIndex()).isEqualTo(lastIndexBeforeClose);
-
-    journal.close();
   }
 
   @Test
   void shouldReadReopenedJournal() throws Exception {
     // given
-    final PersistedJournalRecord appendedRecord;
-    final JournalReader reader;
-    try (var journal = openJournal()) {
-      appendedRecord = copyRecord(journal.append(recordDataWriter));
-    }
+    final var appendedRecord = copyRecord(journal.append(recordDataWriter));
+    journal.close();
 
     // when
-    final var journal = openJournal();
-    reader = journal.openReader();
+    journal = openJournal();
+    final JournalReader reader = journal.openReader();
 
     // then
     assertThat(journal.isOpen()).isTrue();
-
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(appendedRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldWriteToReopenedJournalAtNextIndex() throws Exception {
     // given
-    final PersistedJournalRecord firstRecord;
-    try (var journal = openJournal()) {
-      firstRecord = copyRecord(journal.append(recordDataWriter));
-    }
+    final var firstRecord = copyRecord(journal.append(recordDataWriter));
+    journal.close();
 
     // when
-    final var journal = openJournal();
+    journal = openJournal();
     final var secondRecord = journal.append(recordDataWriter);
 
     // then
@@ -630,14 +541,11 @@ final class JournalTest {
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(secondRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadDeletedEntries() {
     // given
-    final var journal = openJournal();
     final var firstRecord = journal.append(recordDataWriter);
     journal.append(recordDataWriter);
     journal.append(recordDataWriter);
@@ -657,14 +565,11 @@ final class JournalTest {
     assertThat(reader.next()).isEqualTo(newSecondRecord);
 
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
-  void shouldInvalidateAllEntries() {
+  void shouldInvalidateAllEntries() throws Exception {
     // given
-    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
 
@@ -677,20 +582,18 @@ final class JournalTest {
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
 
     journal.close();
-    final var newJournal = openJournal();
+    journal = openJournal();
 
     // then
-    final var reader = newJournal.openReader();
+    final var reader = journal.openReader();
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.next()).isEqualTo(secondRecord);
     assertThat(reader.hasNext()).isFalse();
-    newJournal.close();
   }
 
   @Test
   void shouldDetectCorruptedEntry() throws Exception {
     // given
-    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     journal.append(recordDataWriter);
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
@@ -702,15 +605,14 @@ final class JournalTest {
     assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
 
     // then
-    //noinspection resource
-    assertThatThrownBy(() -> openJournal(b -> b.withLastWrittenIndex(secondRecord.index())))
+    assertThatThrownBy(
+            () -> journal = openJournal(b -> b.withLastWrittenIndex(secondRecord.index())))
         .isInstanceOf(CorruptedJournalException.class);
   }
 
   @Test
   void shouldDeletePartiallyWrittenEntry() throws Exception {
     // given
-    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
@@ -720,16 +622,14 @@ final class JournalTest {
     // when
     journal.close();
     assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
-    final var newJournal = openJournal(b -> b.withLastWrittenIndex(firstRecord.index()));
+    journal = openJournal(b -> b.withLastWrittenIndex(firstRecord.index()));
     recordDataWriter.wrap(new UnsafeBuffer("111".getBytes(StandardCharsets.UTF_8)));
-    final var lastRecord = newJournal.append(recordDataWriter);
-    final var reader = newJournal.openReader();
+    final var lastRecord = journal.append(recordDataWriter);
+    final var reader = journal.openReader();
 
     // then
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.next()).isEqualTo(lastRecord);
-
-    newJournal.close();
   }
 
   // TODO: do not rely on implementation detail to compare records

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,8 +58,8 @@ final class JournalTest {
   }
 
   @AfterEach
-  void teardown() throws Exception {
-    journal.close();
+  void teardown() {
+    CloseHelper.quietClose(journal);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -42,7 +42,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-@SuppressWarnings("resource")
 class SegmentedJournalTest {
   private static final String JOURNAL_NAME = "journal";
 
@@ -71,6 +70,8 @@ class SegmentedJournalTest {
     // then
     assertThat(journal.getJournalIndex().lookup(journalIndexDensity)).isNull();
     assertThat(journal.getJournalIndex().lookup(2 * journalIndexDensity)).isNull();
+
+    journal.close();
   }
 
   @Test
@@ -91,6 +92,8 @@ class SegmentedJournalTest {
     final IndexInfo lookup = journal.getJournalIndex().lookup(entriesPerSegment - 1);
     assertThat(lookup).isNull();
     assertThat(journal.getJournalIndex().lookup(3 * entriesPerSegment)).isNotNull();
+
+    journal.close();
   }
 
   @Test
@@ -114,6 +117,8 @@ class SegmentedJournalTest {
     assertThat(journal.getJournalIndex().lookup(journalIndexDensity)).isNotNull();
     assertThat(journal.getJournalIndex().lookup(2 * journalIndexDensity).index())
         .isEqualTo(journalIndexDensity);
+
+    journal.close();
   }
 
   @Test
@@ -139,6 +144,8 @@ class SegmentedJournalTest {
       assertThat(entry.asqn()).isEqualTo(asqn + i);
       assertThat(entry.data()).isEqualTo(data);
     }
+
+    journal.close();
   }
 
   @Test
@@ -162,6 +169,8 @@ class SegmentedJournalTest {
       assertThat(entry.asqn()).isEqualTo(asqn + i);
       assertThat(entry.data()).isEqualTo(data);
     }
+
+    journal.close();
   }
 
   @Test
@@ -181,6 +190,8 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(secondRecord);
+
+    journal.close();
   }
 
   @Test
@@ -199,6 +210,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -217,6 +230,8 @@ class SegmentedJournalTest {
     // then
     assertThat(reader.hasNext()).isFalse();
     assertThat(journal.getLastIndex()).isEqualTo(0);
+
+    journal.close();
   }
 
   @Test
@@ -234,6 +249,8 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.hasNext()).isFalse();
     assertThat(journal.getLastIndex()).isEqualTo(firstRecord.index());
+
+    journal.close();
   }
 
   @Test
@@ -253,6 +270,8 @@ class SegmentedJournalTest {
     assertThat(reader.seek(lastIndex - 1)).isEqualTo(lastIndex - 1);
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
     assertThat(journal.getLastIndex()).isEqualTo(lastIndex - 1);
+
+    journal.close();
   }
 
   @Test
@@ -273,6 +292,8 @@ class SegmentedJournalTest {
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
     reader.seekToFirst();
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
+
+    journal.close();
   }
 
   @Test
@@ -293,6 +314,8 @@ class SegmentedJournalTest {
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
     reader.seekToFirst();
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
+
+    journal.close();
   }
 
   @Test
@@ -309,6 +332,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
+
+    journal.close();
   }
 
   @Test
@@ -330,6 +355,8 @@ class SegmentedJournalTest {
     assertThat(first).isEqualTo(lastRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(lastRecord);
+
+    journal.close();
   }
 
   @Test
@@ -353,6 +380,8 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(secondRecord);
     assertThat(reader.next()).isEqualTo(thirdRecord);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -383,6 +412,8 @@ class SegmentedJournalTest {
         .isEqualTo(indexBeforeClose.lookup(firstIndexedPosition).position());
     assertThat(indexAfterRestart.lookup(secondIndexedPosition).position())
         .isEqualTo(indexBeforeClose.lookup(secondIndexedPosition).position());
+
+    journal.close();
   }
 
   @Test
@@ -403,6 +434,8 @@ class SegmentedJournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(record.index());
     assertThat(reader.next()).isEqualTo(record);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -425,6 +458,8 @@ class SegmentedJournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(record.index());
     assertThat(reader.next()).isEqualTo(record);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -458,6 +493,8 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(copiedFirstRecord);
     assertThat(reader.next()).isEqualTo(lastRecord);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -478,6 +515,8 @@ class SegmentedJournalTest {
         .isDirectoryContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+
+    journal.close();
   }
 
   @Test
@@ -504,6 +543,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue();
+
+    journal.close();
   }
 
   // Regression test for https://github.com/camunda/zeebe/issues/7962
@@ -533,6 +574,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue();
+
+    journal.close();
   }
 
   @Test
@@ -552,6 +595,8 @@ class SegmentedJournalTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+
+    journal.close();
   }
 
   @Test
@@ -569,6 +614,8 @@ class SegmentedJournalTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+
+    journal.close();
   }
 
   @Test
@@ -594,6 +641,8 @@ class SegmentedJournalTest {
     assertThat(
             logDirectory.listFiles(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName())))
         .hasSize(1);
+
+    journal.close();
   }
 
   @Test
@@ -622,6 +671,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+    journal.close();
   }
 
   @Test
@@ -675,6 +726,8 @@ class SegmentedJournalTest {
     Assertions.assertThatThrownBy(() -> journal.append(1, recordDataWriter))
         .isInstanceOf(InvalidAsqn.class);
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -694,6 +747,8 @@ class SegmentedJournalTest {
         .isInstanceOf(InvalidAsqn.class);
 
     assertThat(journal.getFirstSegment()).isNotEqualTo(journal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -715,6 +770,8 @@ class SegmentedJournalTest {
         .isInstanceOf(InvalidAsqn.class);
 
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -737,6 +794,8 @@ class SegmentedJournalTest {
         .isInstanceOf(InvalidAsqn.class);
 
     assertThat(reopenedJournal.getFirstSegment()).isNotEqualTo(reopenedJournal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -752,6 +811,8 @@ class SegmentedJournalTest {
     // then
     assertThat(journal.getFirstSegment().lastAsqn()).isEqualTo(initalAsqn);
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -769,6 +830,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getLastSegment().lastAsqn()).isEqualTo(expectedLastAsqn);
+
+    journal.close();
   }
 
   @Test
@@ -782,6 +845,8 @@ class SegmentedJournalTest {
 
     // then
     journal.append(1, recordDataWriter);
+
+    journal.close();
   }
 
   @Test
@@ -796,6 +861,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getLastSegment().lastAsqn()).isEqualTo(firstJournalRecord.asqn());
+
+    journal.close();
   }
 
   @Test
@@ -810,6 +877,8 @@ class SegmentedJournalTest {
 
     // then
     journal.append(2, recordDataWriter);
+
+    journal.close();
   }
 
   private SegmentedJournal openJournal(final float entriesPerSegment) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.Assertions;
@@ -57,9 +58,7 @@ class SegmentedJournalTest {
 
   @AfterEach
   void teardown() {
-    if (journal != null) {
-      journal.close();
-    }
+    CloseHelper.quietClose(journal);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -39,9 +39,11 @@ import java.util.concurrent.TimeUnit;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+@SuppressWarnings("resource")
 class SegmentedJournalTest {
   private static final String JOURNAL_NAME = "journal";
 
@@ -51,10 +53,19 @@ class SegmentedJournalTest {
   private final BufferWriter recordDataWriter = new DirectBufferWriter().wrap(data);
   private final int entrySize = getSerializedSize(data);
 
+  private SegmentedJournal journal;
+
+  @AfterEach
+  void teardown() {
+    if (journal != null) {
+      journal.close();
+    }
+  }
+
   @Test
   void shouldDeleteIndexMappingsOnReset() {
     // given
-    final SegmentedJournal journal = openJournal(10);
+    journal = openJournal(10);
 
     long asqn = 1;
     // append until there are two index mappings
@@ -70,8 +81,6 @@ class SegmentedJournalTest {
     // then
     assertThat(journal.getJournalIndex().lookup(journalIndexDensity)).isNull();
     assertThat(journal.getJournalIndex().lookup(2 * journalIndexDensity)).isNull();
-
-    journal.close();
   }
 
   @Test
@@ -79,7 +88,7 @@ class SegmentedJournalTest {
     // given
     final int entriesPerSegment = 10;
     long asqn = 1;
-    final SegmentedJournal journal = openJournal(entriesPerSegment);
+    journal = openJournal(entriesPerSegment);
     for (int i = 0; i < 3 * entriesPerSegment; i++) {
       journal.append(asqn++, recordDataWriter);
     }
@@ -92,8 +101,6 @@ class SegmentedJournalTest {
     final IndexInfo lookup = journal.getJournalIndex().lookup(entriesPerSegment - 1);
     assertThat(lookup).isNull();
     assertThat(journal.getJournalIndex().lookup(3 * entriesPerSegment)).isNotNull();
-
-    journal.close();
   }
 
   @Test
@@ -101,7 +108,7 @@ class SegmentedJournalTest {
     // given
     final int entriesPerSegment = 10;
     long asqn = 1;
-    final SegmentedJournal journal = openJournal(entriesPerSegment);
+    journal = openJournal(entriesPerSegment);
     for (int i = 0; i < 2 * journalIndexDensity; i++) {
       journal.append(asqn++, recordDataWriter);
     }
@@ -117,8 +124,6 @@ class SegmentedJournalTest {
     assertThat(journal.getJournalIndex().lookup(journalIndexDensity)).isNotNull();
     assertThat(journal.getJournalIndex().lookup(2 * journalIndexDensity).index())
         .isEqualTo(journalIndexDensity);
-
-    journal.close();
   }
 
   @Test
@@ -126,7 +131,7 @@ class SegmentedJournalTest {
     // given
     final int asqn = 1;
     // one entry fits but not two
-    final SegmentedJournal journal = openJournal(1.5f);
+    journal = openJournal(1.5f);
 
     final JournalReader reader = journal.openReader();
 
@@ -144,15 +149,13 @@ class SegmentedJournalTest {
       assertThat(entry.asqn()).isEqualTo(asqn + i);
       assertThat(entry.data()).isEqualTo(data);
     }
-
-    journal.close();
   }
 
   @Test
   void shouldNotTruncateIfIndexIsHigherThanLast() {
     // given
     final int asqn = 1;
-    final SegmentedJournal journal = openJournal(1);
+    journal = openJournal(1);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -169,15 +172,13 @@ class SegmentedJournalTest {
       assertThat(entry.asqn()).isEqualTo(asqn + i);
       assertThat(entry.data()).isEqualTo(data);
     }
-
-    journal.close();
   }
 
   @Test
   void shouldNotCompactIfIndexIsLowerThanFirst() {
     // given
     final int asqn = 1;
-    final SegmentedJournal journal = openJournal(1.5f);
+    journal = openJournal(1.5f);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -190,14 +191,12 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(secondRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldTruncateNextEntry() {
     // given
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -210,14 +209,12 @@ class SegmentedJournalTest {
 
     // then
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldTruncateReadEntry() {
     // given
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -230,14 +227,12 @@ class SegmentedJournalTest {
     // then
     assertThat(reader.hasNext()).isFalse();
     assertThat(journal.getLastIndex()).isEqualTo(0);
-
-    journal.close();
   }
 
   @Test
   void shouldTruncateNextSegment() {
     // given
-    final SegmentedJournal journal = openJournal(1);
+    journal = openJournal(1);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -249,14 +244,12 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.hasNext()).isFalse();
     assertThat(journal.getLastIndex()).isEqualTo(firstRecord.index());
-
-    journal.close();
   }
 
   @Test
   void shouldReadSegmentStartAfterMidSegmentTruncate() {
     final int entryPerSegment = 2;
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -270,14 +263,12 @@ class SegmentedJournalTest {
     assertThat(reader.seek(lastIndex - 1)).isEqualTo(lastIndex - 1);
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
     assertThat(journal.getLastIndex()).isEqualTo(lastIndex - 1);
-
-    journal.close();
   }
 
   @Test
   void shouldCompactUpToStartOfSegment() {
     final int entryPerSegment = 2;
-    final SegmentedJournal journal = openJournal(entryPerSegment);
+    journal = openJournal(entryPerSegment);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -292,14 +283,12 @@ class SegmentedJournalTest {
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
     reader.seekToFirst();
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
-
-    journal.close();
   }
 
   @Test
   void shouldNotCompactTheLastSegmentWhenNonExistingHigherIndex() {
     final int entryPerSegment = 2;
-    final SegmentedJournal journal = openJournal(entryPerSegment);
+    journal = openJournal(entryPerSegment);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -314,14 +303,12 @@ class SegmentedJournalTest {
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
     reader.seekToFirst();
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
-
-    journal.close();
   }
 
   @Test
   void shouldReturnCorrectFirstIndexAfterCompaction() {
     final int entryPerSegment = 2;
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
 
     // when
     long lastIndex = -1;
@@ -332,13 +319,11 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
-
-    journal.close();
   }
 
   @Test
   void shouldWriteAndReadAfterTruncate() {
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     final JournalReader reader = journal.openReader();
 
     // when
@@ -355,8 +340,6 @@ class SegmentedJournalTest {
     assertThat(first).isEqualTo(lastRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(lastRecord);
-
-    journal.close();
   }
 
   @Test
@@ -380,8 +363,6 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(secondRecord);
     assertThat(reader.next()).isEqualTo(thirdRecord);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
@@ -389,7 +370,7 @@ class SegmentedJournalTest {
     // given
     final int entriesPerSegment = 10;
     long asqn = 1;
-    SegmentedJournal journal = openJournal(entriesPerSegment);
+    journal = openJournal(entriesPerSegment);
     for (int i = 0; i < 2 * journalIndexDensity; i++) {
       journal.append(asqn++, recordDataWriter);
     }
@@ -412,8 +393,6 @@ class SegmentedJournalTest {
         .isEqualTo(indexBeforeClose.lookup(firstIndexedPosition).position());
     assertThat(indexAfterRestart.lookup(secondIndexedPosition).position())
         .isEqualTo(indexBeforeClose.lookup(secondIndexedPosition).position());
-
-    journal.close();
   }
 
   @Test
@@ -425,7 +404,7 @@ class SegmentedJournalTest {
     assertThat(emptyLog.createNewFile()).isTrue();
 
     // when
-    final var journal = openJournal(10);
+    journal = openJournal(10);
     final var reader = journal.openReader();
     final var record = journal.append(recordDataWriter);
 
@@ -434,14 +413,12 @@ class SegmentedJournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(record.index());
     assertThat(reader.next()).isEqualTo(record);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldContinueWritingAfterDetectingCorruptedDescriptorWithOutAckEntries() throws Exception {
     // given
-    var journal = openJournal(1);
+    journal = openJournal(1);
     journal.close();
     final File dataFile = directory.resolve("data").toFile();
     final File logFile =
@@ -458,14 +435,12 @@ class SegmentedJournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(record.index());
     assertThat(reader.next()).isEqualTo(record);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldHandleCorruptionAtDescriptorWithSomeAckedEntries() throws Exception {
     // given
-    var journal = openJournal(1);
+    journal = openJournal(1);
     final var firstRecord = (PersistedJournalRecord) journal.append(recordDataWriter);
     final var copiedFirstRecord =
         new PersistedJournalRecord(
@@ -493,14 +468,12 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(copiedFirstRecord);
     assertThat(reader.next()).isEqualTo(lastRecord);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotDeleteSegmentFileImmediately() {
     // given
-    final var journal = openJournal(2);
+    journal = openJournal(2);
     journal.append(recordDataWriter);
     journal.append(recordDataWriter);
     final var reader = journal.openReader();
@@ -515,15 +488,13 @@ class SegmentedJournalTest {
         .isDirectoryContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
-
-    journal.close();
   }
 
   @Test
   void shouldNotFailOnResetAndOpeningReaderConcurrently() throws InterruptedException {
     // given
     final var latch = new CountDownLatch(2);
-    final var journal = openJournal(2);
+    journal = openJournal(2);
     journal.append(recordDataWriter);
     journal.append(recordDataWriter);
 
@@ -543,8 +514,6 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue();
-
-    journal.close();
   }
 
   // Regression test for https://github.com/camunda/zeebe/issues/7962
@@ -552,7 +521,7 @@ class SegmentedJournalTest {
   void shouldNotFailOnDeleteAndOpeningReaderConcurrently() throws InterruptedException {
     // given
     final var latch = new CountDownLatch(2);
-    final var journal = openJournal(2);
+    journal = openJournal(2);
     for (int i = 0; i < 10; i++) {
       journal.append(recordDataWriter);
     }
@@ -574,14 +543,12 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue();
-
-    journal.close();
   }
 
   @Test
   void shouldDeleteSegmentFileWhenReaderIsClosed() {
     // given
-    final var journal = openJournal(2);
+    journal = openJournal(2);
     journal.append(recordDataWriter);
     final var reader = journal.openReader();
     journal.reset(100);
@@ -595,14 +562,12 @@ class SegmentedJournalTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
-
-    journal.close();
   }
 
   @Test
   void shouldDeleteSegmentFileImmediatelyWhenThereAreNoReaders() {
     // given
-    final var journal = openJournal(2);
+    journal = openJournal(2);
     journal.append(recordDataWriter);
 
     // when
@@ -614,14 +579,12 @@ class SegmentedJournalTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
-
-    journal.close();
   }
 
   @Test
   void shouldBeAbleToResetAgainWhileThePreviousFileIsNotDeleted() {
     // given
-    final var journal = openJournal(2);
+    journal = openJournal(2);
     journal.append(recordDataWriter);
     journal.openReader(); // Keep the reader opened so that the file is not deleted.
     journal.reset(100);
@@ -641,15 +604,13 @@ class SegmentedJournalTest {
     assertThat(
             logDirectory.listFiles(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName())))
         .hasSize(1);
-
-    journal.close();
   }
 
   @Test
   void shouldReleaseReadLock() throws InterruptedException {
     // given
     final var latch = new CountDownLatch(1);
-    final var journal = openJournal(5);
+    journal = openJournal(5);
 
     // delete first segment so that it closes
     final var segment = journal.getFirstSegment();
@@ -671,8 +632,6 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
-
-    journal.close();
   }
 
   @Test
@@ -719,22 +678,20 @@ class SegmentedJournalTest {
   void shouldValidateAsqnBeforeCreatingNewSegment() {
     // given
     // one entry fits but not two
-    final SegmentedJournal journal = openJournal(1.5f);
+    journal = openJournal(1.5f);
     journal.append(1, recordDataWriter);
 
     // when/then
     Assertions.assertThatThrownBy(() -> journal.append(1, recordDataWriter))
         .isInstanceOf(InvalidAsqn.class);
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
-
-    journal.close();
   }
 
   @Test
   void shouldValidateAsqnWhenWritingToNewSegment() {
     // given
     // one entry fits but not two
-    final SegmentedJournal journal = openJournal(1.5f);
+    journal = openJournal(1.5f);
     journal.append(1, recordDataWriter);
 
     // when
@@ -747,8 +704,6 @@ class SegmentedJournalTest {
         .isInstanceOf(InvalidAsqn.class);
 
     assertThat(journal.getFirstSegment()).isNotEqualTo(journal.getLastSegment());
-
-    journal.close();
   }
 
   @Test
@@ -756,7 +711,7 @@ class SegmentedJournalTest {
     // given
     // one entry fits but not two
     final float entriesPerSegment = 5;
-    SegmentedJournal journal = openJournal(entriesPerSegment);
+    journal = openJournal(entriesPerSegment);
 
     journal.append(1, recordDataWriter);
 
@@ -770,8 +725,6 @@ class SegmentedJournalTest {
         .isInstanceOf(InvalidAsqn.class);
 
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
-
-    journal.close();
   }
 
   @Test
@@ -779,7 +732,7 @@ class SegmentedJournalTest {
     // given
     // one entry fits but not two
     final float entriesPerSegment = 1.5f;
-    final SegmentedJournal journal = openJournal(entriesPerSegment);
+    journal = openJournal(entriesPerSegment);
 
     journal.append(1, recordDataWriter);
 
@@ -787,21 +740,19 @@ class SegmentedJournalTest {
     // force creation of new segment with an asqn ignore entry
     journal.append(ASQN_IGNORE, recordDataWriter);
     journal.close();
-    final SegmentedJournal reopenedJournal = openJournal(entriesPerSegment);
 
     // then
-    Assertions.assertThatThrownBy(() -> reopenedJournal.append(1, recordDataWriter))
-        .isInstanceOf(InvalidAsqn.class);
-
-    assertThat(reopenedJournal.getFirstSegment()).isNotEqualTo(reopenedJournal.getLastSegment());
-
-    journal.close();
+    try (final var reopenedJournal = openJournal(entriesPerSegment)) {
+      Assertions.assertThatThrownBy(() -> reopenedJournal.append(1, recordDataWriter))
+          .isInstanceOf(InvalidAsqn.class);
+      assertThat(reopenedJournal.getFirstSegment()).isNotEqualTo(reopenedJournal.getLastSegment());
+    }
   }
 
   @Test
   void shouldResetAsqnOnTruncateToLastAsqnOfPreviousSegment() {
     // given
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     final long initalAsqn = journal.getFirstSegment().lastAsqn();
     journal.append(1, recordDataWriter);
 
@@ -811,14 +762,12 @@ class SegmentedJournalTest {
     // then
     assertThat(journal.getFirstSegment().lastAsqn()).isEqualTo(initalAsqn);
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
-
-    journal.close();
   }
 
   @Test
   void shouldResetAsqnOnTruncateToLastAsqnOfPreviousSegmentWhenNewSegContainsAsqnIgnoreOnly() {
     // given
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     journal.append(1, recordDataWriter);
     final var expectedLastAsqn = journal.append(2, recordDataWriter).asqn();
     // write to second segment
@@ -830,14 +779,12 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getLastSegment().lastAsqn()).isEqualTo(expectedLastAsqn);
-
-    journal.close();
   }
 
   @Test
   void shouldSuceedToAppendWithPreviousAsqnAfterTruncateToIndexOfPreviousSegment() {
     // given
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     journal.append(1, recordDataWriter);
 
     // when
@@ -845,14 +792,12 @@ class SegmentedJournalTest {
 
     // then
     journal.append(1, recordDataWriter);
-
-    journal.close();
   }
 
   @Test
   void shouldResetAsqnOnTruncateToIndexWithinCurrentSegment() {
     // given
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     final JournalRecord firstJournalRecord = journal.append(1, recordDataWriter);
     journal.append(2, recordDataWriter);
 
@@ -861,14 +806,12 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getLastSegment().lastAsqn()).isEqualTo(firstJournalRecord.asqn());
-
-    journal.close();
   }
 
   @Test
   void shouldSucceedToAppendWithPreviousAsqnAfterTruncateToIndexWithinCurrentSegment() {
     // given
-    final SegmentedJournal journal = openJournal(2);
+    journal = openJournal(2);
     final JournalRecord firstJournalRecord = journal.append(1, recordDataWriter);
     journal.append(2, recordDataWriter);
 
@@ -877,8 +820,6 @@ class SegmentedJournalTest {
 
     // then
     journal.append(2, recordDataWriter);
-
-    journal.close();
   }
 
   private SegmentedJournal openJournal(final float entriesPerSegment) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -48,8 +48,9 @@ class SegmentsManagerTest {
     // when
     // if we close the current journal, it will delete the files on closing. So we cannot test this
     // scenario.
-    final var newSegments = createSegmentsManager(0);
-    newSegments.open();
+    try (var newSegments = createSegmentsManager(0)) {
+      newSegments.open();
+    }
 
     // then
     final File logDirectory = directory.resolve("data").toFile();
@@ -57,7 +58,6 @@ class SegmentsManagerTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
-    newSegments.close();
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -39,15 +39,17 @@ class SegmentsManagerTest {
   @Test
   void shouldDeleteFilesMarkedForDeletionsOnLoad() {
     // given
-    final var segments = createSegmentsManager(0);
-    segments.open();
-    segments.getFirstSegment().createReader();
-    segments.getFirstSegment().delete();
+    try (var segments = createSegmentsManager(0)) {
+      segments.open();
+      segments.getFirstSegment().createReader();
+      segments.getFirstSegment().delete();
+    }
 
     // when
     // if we close the current journal, it will delete the files on closing. So we cannot test this
     // scenario.
-    createSegmentsManager(0).open();
+    final var newSegments = createSegmentsManager(0);
+    newSegments.open();
 
     // then
     final File logDirectory = directory.resolve("data").toFile();
@@ -55,6 +57,7 @@ class SegmentsManagerTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+    newSegments.close();
   }
 
   @Test


### PR DESCRIPTION
* Ensures that closing the journal waits for async segment preparation to finish
* Closes the journal in all tests

This prevents flaky tests that fail because removing the temporary data folder fails which can occur when cleanup of segment files races with completion of the async preparation task.

fixes #11529