### PR TITLE
ci: better caching of docker image build

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -81,7 +81,8 @@ runs:
         tags: ${{ steps.get-image.outputs.result }}
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
-        no-cache: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         platforms: ${{ inputs.platforms }}
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ ARG DIST="distball"
 ### Init image containing tini and the startup script ###
 FROM ubuntu:jammy as init
 WORKDIR /zeebe
-RUN --mount=type=cache,target=/var/apt/cache,rw \
+RUN rm /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get -qq update && \
     apt-get install -y --no-install-recommends tini=0.19.0-1 && \
     cp /usr/bin/tini .


### PR DESCRIPTION
- Adds another cachable directory and ensures that apt does not clean up automatically because it detects it's running in docker.
- Enables GHA cache for `docker/build-push-action`