### PR TITLE
test: reliably fill journal for disk space recovery testing

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
@@ -68,7 +68,8 @@ final class DiskSpaceRecoveryIT {
         .newPublishMessageCommand()
         .messageName("test")
         .correlationKey(String.valueOf(1))
-        .variables(Map.of("key", "x".repeat(4096)))
+        .variables(Map.of("key", "abc".repeat(4096)))
+        .timeToLive(Duration.ZERO)
         .send()
         .join();
   }


### PR DESCRIPTION
This test would occasionally fail because after resuming exporting, the broker disk did not free up enough to resume processing.

To fix this, we now publish messages with a larger variable payload and with TTL=0. The larger payload fills up the disk faster while using TTL=0 ensures that it is only the journal that is using the majority of the disk space and that we don't accumulate too much state. This should help when resuming exporting because the journal can be compacted, freeing up disk space,  while the state cannot shrink (until the message expires).


While testing locally, I could reproduce the flaky test after 52 runs. With the fix here, the test has run > 100 (and counting) times without failure.

closes #11538