### PR TITLE
chore(dependabot): patch dependency updates for stable branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,10 @@ updates:
     open-pull-requests-limit: 5
     target-branch: main
     ignore:
-      # we will always manually update ES dependencies as we need to sync with the other teams
-      # before doing that
+      # we will always manually update ES dependencies to minor or major releases
+      # as we need to sync with the other teams before doing that
       - dependency-name: org.elasticsearch.client:*
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
 
   # Enable version updates for the go client
   - package-ecosystem: "gomod"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,9 @@ updates:
       # Ignore major and minor updates, for stable branches we only want to get patches
       - dependency-name: "*"
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    allow:
+      # Allow only production dependency updates for maintenance branches
+      - dependency-type: "production"
 
   # Enable version updates for the go client
   - package-ecosystem: "gomod"
@@ -127,6 +130,9 @@ updates:
       # Ignore major and minor updates, for stable branches we only want to get patches
       - dependency-name: "*"
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    allow:
+      # Allow only production dependency updates for maintenance branches
+      - dependency-type: "production"
 
   # Enable version updates for the go client
   - package-ecosystem: "gomod"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 updates:
+  ########
+  # main #
+  ########
   # Enable version updates for Java
   - package-ecosystem: "maven"
     directory: "/"
@@ -12,6 +15,7 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    target-branch: main
     ignore:
       # we will always manually update ES dependencies as we need to sync with the other teams
       # before doing that
@@ -29,6 +33,7 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    target-branch: main
 
   # Enable version updates for the github actions
   - package-ecosystem: "github-actions"
@@ -42,3 +47,118 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    target-branch: main
+
+  ##############
+  # stable/8.1 #
+  ##############
+  # Enable version updates for Java
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps(maven): "
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    target-branch: "stable/8.1"
+    ignore:
+      # Ignore major and minor updates, for stable branches we only want to get patches
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  # Enable version updates for the go client
+  - package-ecosystem: "gomod"
+    directory: "clients/go"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps(go): "
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    target-branch: "stable/8.1"
+    ignore:
+      # Ignore major and minor updates, for stable branches we only want to get patches
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  # Enable version updates for the github actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps(.github): "
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    target-branch: "stable/8.1"
+    ignore:
+      # Ignore major and minor updates, for stable branches we only want to get patches
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  ##############
+  # stable/8.0 #
+  ##############
+  # Enable version updates for Java
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps(maven): "
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    target-branch: "stable/8.0"
+    ignore:
+      # Ignore major and minor updates, for stable branches we only want to get patches
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  # Enable version updates for the go client
+  - package-ecosystem: "gomod"
+    directory: "clients/go"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps(go): "
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    target-branch: "stable/8.0"
+    ignore:
+      # Ignore major and minor updates, for stable branches we only want to get patches
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  # Enable version updates for the github actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    commit-message:
+      prefix: "deps(.github): "
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    target-branch: "stable/8.0"
+    ignore:
+      # Ignore major and minor updates, for stable branches we only want to get patches
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
## Description

This automates dependency updates for stable branches with dependabot, by only allowing PRs to be created for patch updates.

It's unfortunate that dependabot does not yet support patterns and/or multiple target-branches, see this issue https://github.com/dependabot/dependabot-core/issues/2511 . Thus we have to duplicate the config for every supported stable branch in the meantime.

This would thus require a follow-up to be reflected in the release process for minor releases (add new config, remove out of support branches).

Still I think it's worth the effort right now to automate eliminating vulnerabilities for which patched versions already exist. Ultimately preventing support effort caused by customers performing vulnerability analytics and raising issues like SEC-238.

## Related issues

relates to #10553