### PR TITLE
chore(gha): input to control camunda maven mirror usage

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
     default: "default"
     required: false
+  maven-use-camunda-mirror:
+    description: Controls whether the camunda maven repo is configured as a mirror to download from.
+    default: "true"
+    required: false
   secret_vault_address:
     description: 'secret vault url'
     required: true
@@ -45,7 +49,8 @@ outputs: {}
 runs:
   using: composite
   steps:
-    - name: Import Secrets
+    - if: ${{ inputs.maven-use-camunda-mirror == 'true' }}
+      name: Import Secrets
       id: secrets
       uses: hashicorp/vault-action@v2.4.3
       with:
@@ -69,7 +74,8 @@ runs:
       with:
         maven-version: '3.8.6'
     # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
-    - name: 'Create settings.xml'
+    - if: ${{ inputs.maven-use-camunda-mirror == 'true' }}
+      name: 'Create settings.xml'
       uses: s4u/maven-settings-action@v2.8.0
       with:
         githubServer: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,13 +192,16 @@ jobs:
       matrix:
         os: [ macos, windows, linux ]
         arch: [ amd64 ]
+        maven-use-maven-mirror: [ true ]
         include:
           - os: macos
             runner: macos-latest
+            use-camunda-maven-mirror: false
           - os: windows
             runner: windows-latest
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
+            use-camunda-maven-mirror: false
           - os: linux
             runner: [ self-hosted, linux, arm64, "4" ]
             arch: arm64
@@ -211,6 +214,7 @@ jobs:
           go: false
           # setting up maven often times out on macOS
           maven: ${{ runner.os != 'macOS' }}
+          maven-use-camunda-mirror: ${{ matrix.use-camunda-maven-mirror }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -288,9 +292,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
         with:
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          maven-use-camunda-mirror: "false"
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       # Once we're on Go 1.18, use the official gorelease to do this
@@ -325,9 +327,7 @@ jobs:
           go: false
           maven-cache: 'true'
           maven-cache-key-modifier: java-client
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          maven-use-camunda-mirror: "false"
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -408,9 +408,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           java: false
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          maven-use-camunda-mirror: "false"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -425,11 +423,9 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+          maven-use-camunda-mirror: "false"
           maven-cache: 'true'
           maven-cache-key-modifier: java-checks
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify
   docker-checks:
     name: Docker checks
@@ -459,9 +455,7 @@ jobs:
           sarif_file: ./hadolint.sarif
       - uses: ./.github/actions/setup-zeebe
         with:
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          maven-use-camunda-mirror: "false"
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-docker


### PR DESCRIPTION
## Description

This change allows to disable the usage of the camunda maven repo and applies this to all ci jobs that make use of github hosted runners.
In cases where we run github actions on github hosted runners the camunda repo does not yield any speed or traffic cost benefits as initially aimed for with #11498 .

Is this inline with the initial intent of #11498 @cmur2 ?