### PR TITLE
Improve Record related toString methods

### DIFF
--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -39,11 +39,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private final RecordMetadataEncoder encoder = new RecordMetadataEncoder();
   private final RecordMetadataDecoder decoder = new RecordMetadataDecoder();
 
-  private long requestId;
-  private ValueType valueType = ValueType.NULL_VAL;
   private RecordType recordType = RecordType.NULL_VAL;
-  private short intentValue = Intent.NULL_VAL;
+  private ValueType valueType = ValueType.NULL_VAL;
   private Intent intent = null;
+  private long requestId;
+  private short intentValue = Intent.NULL_VAL;
   private int requestStreamId;
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
@@ -242,29 +242,17 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   @Override
-  public String toString() {
-    return "RecordMetadata{"
-        + "recordType="
-        + recordType
-        + ", intentValue="
-        + intentValue
-        + ", intent="
-        + intent
-        + ", requestStreamId="
-        + requestStreamId
-        + ", requestId="
-        + requestId
-        + ", protocolVersion="
-        + protocolVersion
-        + ", valueType="
-        + valueType
-        + ", rejectionType="
-        + rejectionType
-        + ", rejectionReason="
-        + BufferUtil.bufferAsString(rejectionReason)
-        + ", brokerVersion="
-        + brokerVersion
-        + '}';
+  public int hashCode() {
+    return Objects.hash(
+        requestId,
+        valueType,
+        recordType,
+        intentValue,
+        requestStreamId,
+        rejectionType,
+        rejectionReason,
+        protocolVersion,
+        brokerVersion);
   }
 
   @Override
@@ -288,16 +276,28 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(
-        requestId,
-        valueType,
-        recordType,
-        intentValue,
-        requestStreamId,
-        rejectionType,
-        rejectionReason,
-        protocolVersion,
-        brokerVersion);
+  public String toString() {
+    // The toString is intentionally cut-down to the only important properties for debugging
+    // (mostly for tests).
+    // If the record is already written to the log (in production) we have other ways to make
+    // it readable again.
+    final var builder =
+        new StringBuilder(
+            "RecordMetadata{"
+                + "recordType="
+                + recordType
+                + ", valueType="
+                + valueType
+                + ", intent="
+                + intent);
+    if (!rejectionType.equals(RejectionType.NULL_VAL)) {
+      builder.append(", rejectionType=").append(rejectionType);
+    }
+    if (rejectionReason.capacity() > 0) {
+      builder.append(", rejectionReason=").append(BufferUtil.bufferAsString(rejectionReason));
+    }
+
+    builder.append('}');
+    return builder.toString();
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -56,13 +56,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
       new LongProperty("parentElementInstanceKey", -1L);
 
   public ProcessInstanceRecord() {
-    declareProperty(bpmnProcessIdProp)
+    declareProperty(bpmnElementTypeProp)
+        .declareProperty(elementIdProp)
+        .declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processInstanceKeyProp)
-        .declareProperty(elementIdProp)
         .declareProperty(flowScopeKeyProp)
-        .declareProperty(bpmnElementTypeProp)
         .declareProperty(bpmnEventTypeProp)
         .declareProperty(parentProcessInstanceKeyProp)
         .declareProperty(parentElementInstanceKeyProp);

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatchEntry.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatchEntry.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public record RecordBatchEntry(
-    long key, int sourceIndex, RecordMetadata recordMetadata, UnifiedRecordValue unifiedRecordValue)
+    RecordMetadata recordMetadata, long key, int sourceIndex, UnifiedRecordValue unifiedRecordValue)
     implements LogAppendEntry {
 
   @Override
@@ -55,6 +55,6 @@ public record RecordBatchEntry(
         ReflectUtil.newInstance(EVENT_REGISTRY.get(recordMetadata.getValueType()));
     unifiedRecordValue.wrap(recordValueBuffer, 0, recordValueBuffer.capacity());
 
-    return new RecordBatchEntry(key, sourceIndex, recordMetadata, unifiedRecordValue);
+    return new RecordBatchEntry(recordMetadata, key, sourceIndex, unifiedRecordValue);
   }
 }


### PR DESCRIPTION

## Description

In the past, I had quite often a hard time _during debugging_ taking a look at the current batch of records and to understand what is part of it. Especially because the `toString` is so verbose and the properties are not in a good order to keep track of what is happening.

I tried to improve the situation, but this might be a bit _controversial_ how I did it, so I guess it make sense to review this by multiple people.

**What I did:**

* Reduce RecordMetadata toString to important properties (I see it only for a debugging use case), not print properties if they are null
* Move properties in declaration of the ProcessInstanceRecord to print some important properties earlier
* Move properties in RecordBatchEntry to move metadata to the front

**Before:**

```
RecordBatchEntry[key=2251799813685251, sourceIndex=-1, recordMetadata=RecordMetadata{recordType=COMMAND, intentValue=8, intent=ACTIVATE_ELEMENT, requestStreamId=-2147483648, requestId=-1, protocolVersion=3, valueType=PROCESS_INSTANCE, rejectionType=NULL_VAL, rejectionReason=, brokerVersion=8.2.0}, unifiedRecordValue={"bpmnProcessId":"process","version":1,"processDefinitionKey":2251799813685249,"processInstanceKey":2251799813685251,"elementId":"process","flowScopeKey":-1,"bpmnElementType":"PROCESS","bpmnEventType":"UNSPECIFIED","parentProcessInstanceKey":-1,"parentElementInstanceKey":-1}]
```

![notuseful2](https://user-images.githubusercontent.com/2758593/217258332-526b04a0-64f7-4050-a476-55b7e1c83896.png)


**After**

```
RecordBatchEntry[recordMetadata=RecordMetadata{recordType=COMMAND, valueType=PROCESS_INSTANCE, intent=ACTIVATE_ELEMENT}, key=2251799813685251, sourceIndex=-1, unifiedRecordValue={"bpmnElementType":"PROCESS","elementId":"process","bpmnProcessId":"process","version":1,"processDefinitionKey":2251799813685249,"processInstanceKey":2251799813685251,"flowScopeKey":-1,"bpmnEventType":"UNSPECIFIED","parentProcessInstanceKey":-1,"parentElementInstanceKey":-1}]
```

![moreuseful](https://user-images.githubusercontent.com/2758593/217258438-e37a0cfb-9f68-4339-9c9b-5c5d29bd819e.png)


I'm happy to also reduce more (like the duplication of the words `recordMetadata` etc. ) but I guess first I want to get an understanding what others think and feel about that.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
