### PR TITLE
Move cluster cfg error handling

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -38,14 +38,6 @@ public final class SystemContext {
   private static final String BROKER_ID_LOG_PROPERTY = "broker-id";
   private static final String NODE_ID_ERROR_MSG =
       "Node id %s needs to be non negative and smaller then cluster size %s.";
-  private static final String REPLICATION_FACTOR_ERROR_MSG =
-      "Replication factor %s needs to be larger then zero and not larger then cluster size %s.";
-  private static final String REPLICATION_FACTOR_WARN_MSG =
-      "Expected to have odd replication factor, but was even ({}). Even replication factor has no benefit over "
-          + "the previous odd value and is weaker than next odd. Quorum is calculated as:"
-          + " quorum = floor(replication factor / 2) + 1. In this current case the quorum will be"
-          + " quorum = {}. If you want to ensure high fault-tolerance and availability,"
-          + " make sure to use an odd replication factor.";
   private static final String SNAPSHOT_PERIOD_ERROR_MSG =
       "Snapshot period %s needs to be larger then or equals to one minute.";
   private static final String MAX_BATCH_SIZE_ERROR_MSG =
@@ -76,8 +68,6 @@ public final class SystemContext {
   private void validateConfiguration() {
     final ClusterCfg cluster = brokerCfg.getCluster();
 
-    validateClusterConfig(cluster);
-
     validateDataConfig(brokerCfg.getData());
 
     validateExperimentalConfigs(cluster, brokerCfg.getExperimental());
@@ -85,46 +75,6 @@ public final class SystemContext {
     final var security = brokerCfg.getNetwork().getSecurity();
     if (security.isEnabled()) {
       validateNetworkSecurityConfig(security);
-    }
-  }
-
-  private static void validateClusterConfig(final ClusterCfg cluster) {
-    final int partitionCount = cluster.getPartitionsCount();
-    if (partitionCount < 1) {
-      throw new IllegalArgumentException("Partition count must not be smaller then 1.");
-    }
-
-    final int clusterSize = cluster.getClusterSize();
-    final int nodeId = cluster.getNodeId();
-    if (nodeId < 0 || nodeId >= clusterSize) {
-      throw new IllegalArgumentException(String.format(NODE_ID_ERROR_MSG, nodeId, clusterSize));
-    }
-
-    final int replicationFactor = cluster.getReplicationFactor();
-    if (replicationFactor < 1 || replicationFactor > clusterSize) {
-      throw new IllegalArgumentException(
-          String.format(REPLICATION_FACTOR_ERROR_MSG, replicationFactor, clusterSize));
-    }
-
-    if (replicationFactor % 2 == 0) {
-      LOG.warn(REPLICATION_FACTOR_WARN_MSG, replicationFactor, (replicationFactor / 2) + 1);
-    }
-
-    final var heartbeatInterval = cluster.getHeartbeatInterval();
-    final var electionTimeout = cluster.getElectionTimeout();
-    if (heartbeatInterval.toMillis() < 1) {
-      throw new IllegalArgumentException(
-          String.format("heartbeatInterval %s must be at least 1ms", heartbeatInterval));
-    }
-    if (electionTimeout.toMillis() < 1) {
-      throw new IllegalArgumentException(
-          String.format("electionTimeout %s must be at least 1ms", electionTimeout));
-    }
-    if (electionTimeout.compareTo(heartbeatInterval) < 1) {
-      throw new IllegalArgumentException(
-          String.format(
-              "electionTimeout %s must be greater than heartbeatInterval %s",
-              electionTimeout, heartbeatInterval));
     }
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -32,68 +32,6 @@ import org.springframework.util.unit.DataUnit;
 final class SystemContextTest {
 
   @Test
-  void shouldThrowExceptionIfNodeIdIsNegative() {
-    // given
-    final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setNodeId(-1);
-
-    // when - then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Node id -1 needs to be non negative and smaller then cluster size 1.");
-  }
-
-  @Test
-  void shouldThrowExceptionIfNodeIdIsLargerThenClusterSize() {
-    // given
-    final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setNodeId(2);
-
-    // when - then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Node id 2 needs to be non negative and smaller then cluster size 1.");
-  }
-
-  @Test
-  void shouldThrowExceptionIfReplicationFactorIsNegative() {
-    // given
-    final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setReplicationFactor(-1);
-
-    // when - then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
-            "Replication factor -1 needs to be larger then zero and not larger then cluster size 1.");
-  }
-
-  @Test
-  void shouldThrowExceptionIfReplicationFactorIsLargerThenClusterSize() {
-    // given
-    final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setReplicationFactor(2);
-
-    // when - then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
-            "Replication factor 2 needs to be larger then zero and not larger then cluster size 1.");
-  }
-
-  @Test
-  void shouldThrowExceptionIfPartitionsCountIsNegative() {
-    // given
-    final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setPartitionsCount(-1);
-
-    // when - then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Partition count must not be smaller then 1.");
-  }
-
-  @Test
   void shouldThrowExceptionIfSnapshotPeriodIsNegative() {
     // given
     final BrokerCfg brokerCfg = new BrokerCfg();
@@ -155,43 +93,6 @@ final class SystemContextTest {
     // then
     assertThat(systemContext.getBrokerConfiguration().getData().getSnapshotPeriod())
         .isEqualTo(Duration.ofMinutes(1));
-  }
-
-  @Test
-  void shouldThrowExceptionIfHeartbeatIntervalIsSmallerThanOneMs() {
-    // given
-    final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setHeartbeatInterval(Duration.ofMillis(0));
-
-    // when - then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("heartbeatInterval PT0S must be at least 1ms");
-  }
-
-  @Test
-  void shouldThrowExceptionIfElectionTimeoutIsSmallerThanOneMs() {
-    // given
-    final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setElectionTimeout(Duration.ofMillis(0));
-
-    // when - then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("electionTimeout PT0S must be at least 1ms");
-  }
-
-  @Test
-  void shouldThrowExceptionIfElectionTimeoutIsSmallerThanHeartbeatInterval() {
-    // given
-    final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setElectionTimeout(Duration.ofSeconds(1));
-    brokerCfg.getCluster().setHeartbeatInterval(Duration.ofSeconds(2));
-
-    // when - then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("electionTimeout PT1S must be greater than heartbeatInterval PT2S");
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -8,10 +8,12 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ClusterCfgTest {
 
@@ -42,5 +44,97 @@ public final class ClusterCfgTest {
 
     // then
     assertThat(clusterCfg.getPartitionIds()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8);
+  }
+
+  @Test
+  void shouldThrowExceptionIfNodeIdIsNegative() {
+    // given
+    final var environment = Collections.singletonMap("zeebe.broker.cluster.nodeId", "-1");
+
+    // when - then
+    assertThatCode(() -> TestConfigReader.readConfig("default", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Node id -1 needs to be non negative and smaller then cluster size 1.");
+  }
+
+  @Test
+  void shouldThrowExceptionIfNodeIdIsLargerThenClusterSize() {
+    // given
+    final var environment = Collections.singletonMap("zeebe.broker.cluster.nodeId", "2");
+
+    // when - then
+    assertThatCode(() -> TestConfigReader.readConfig("default", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Node id 2 needs to be non negative and smaller then cluster size 1.");
+  }
+
+  @Test
+  void shouldThrowExceptionIfReplicationFactorIsNegative() {
+    // given
+    final var environment =
+        Collections.singletonMap("zeebe.broker.cluster.replicationFactor", "-1");
+
+    // when - then
+    assertThatCode(() -> TestConfigReader.readConfig("default", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Replication factor -1 needs to be larger then zero and not larger then cluster size 1.");
+  }
+
+  @Test
+  void shouldThrowExceptionIfReplicationFactorIsLargerThenClusterSize() {
+    // given
+    final var environment = Collections.singletonMap("zeebe.broker.cluster.replicationFactor", "2");
+
+    // when - then
+    assertThatCode(() -> TestConfigReader.readConfig("default", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Replication factor 2 needs to be larger then zero and not larger then cluster size 1.");
+  }
+
+  @Test
+  void shouldThrowExceptionIfPartitionsCountIsNegative() {
+    // given
+    final var environment = Collections.singletonMap("zeebe.broker.cluster.partitionsCount", "-1");
+
+    // when - then
+    assertThatCode(() -> TestConfigReader.readConfig("default", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Partition count must not be smaller then 1.");
+  }
+
+  @Test
+  void shouldThrowExceptionIfElectionTimeoutIsSmallerThanOneMs() {
+    // given
+    final var environment = Collections.singletonMap("zeebe.broker.cluster.electionTimeout", "0ms");
+
+    // when - then
+    assertThatCode(() -> TestConfigReader.readConfig("default", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("electionTimeout PT0S must be at least 1ms");
+  }
+
+  @Test
+  void shouldThrowExceptionIfElectionTimeoutIsSmallerThanHeartbeatInterval() {
+    // given
+    final var environment = Collections.singletonMap("zeebe.broker.cluster.electionTimeout", "1ms");
+
+    // when - then
+    assertThatCode(() -> TestConfigReader.readConfig("default", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("electionTimeout PT0.001S must be greater than heartbeatInterval PT0.25S");
+  }
+
+  @Test
+  void shouldThrowExceptionIfHeartbeatIntervalIsSmallerThanOneMs() {
+    // given
+    final var environment =
+        Collections.singletonMap("zeebe.broker.cluster.heartbeatInterval", "0ms");
+
+    // when - then
+    assertThatCode(() -> TestConfigReader.readConfig("default", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("heartbeatInterval PT0S must be at least 1ms");
   }
 }

--- a/broker/src/test/resources/system/specific-node-id.yaml
+++ b/broker/src/test/resources/system/specific-node-id.yaml
@@ -1,4 +1,5 @@
 zeebe:
   broker:
     cluster:
-      nodeId: 123
+      clusterSize: 4
+      nodeId: 2


### PR DESCRIPTION
## Description

Another controversial topic (maybe). @oleschoenburg and I stumbled over it during adding a new config for the batch processing and were wondering why the config error handling is not in the corresponding classes. This would make it more self-contained (and we thought it is easier to find and test).

@npepinpe would be interested in your opinion since you were also working in the space for a bit. If you agree we can do that also for the other configs.

**What the PR does:**

Moves the cluster parameter handling to the ClusterCfg, and out of the `SystemContext`. This makes it more self-contained and encapsulated.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
