### PR TITLE
Allow configuring different Raft flush strategies

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -191,7 +191,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     lastVotedFor = meta.loadVote();
 
     // Construct the core log, reader, writer, and compactor.
-    raftLog = storage.openLog(threadContext);
+    raftLog = storage.openLog(meta.lastFlushedIndex(), threadContext);
 
     // Open the snapshot store.
     persistedSnapshotStore = storage.getPersistedSnapshotStore();
@@ -434,7 +434,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       if (isLeader()) {
         // leader counts itself in quorum, so in order to commit the leader must persist
         raftLog.flush();
-        setLastWrittenIndex(commitIndex);
+        setLastFlushedIndex(commitIndex);
       }
       final long configurationIndex = cluster.getConfiguration().index();
       if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
@@ -1063,9 +1063,9 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     }
   }
 
-  public void setLastWrittenIndex(final long index) {
-    try (final var ignored = raftRoleMetrics.observeLastWrittenIndexUpdate()) {
-      meta.storeLastWrittenIndex(index);
+  public void setLastFlushedIndex(final long index) {
+    try (final var ignored = raftRoleMetrics.observeLastFlushedIndexUpdate()) {
+      meta.storeLastFlushedIndex(index);
     }
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetrics.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.metrics;
+
+import io.prometheus.client.Histogram;
+import io.prometheus.client.Histogram.Timer;
+
+public final class MetaStoreMetrics extends RaftMetrics {
+  private static final Histogram LAST_FLUSHED_INDEX_UPDATE =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("last_flushed_index_update")
+          .help("Time it takes to update the last flushed index")
+          .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
+          .register();
+
+  private final Histogram.Child lastFlushedIndexUpdate;
+
+  public MetaStoreMetrics(final String partitionName) {
+    super(partitionName);
+
+    lastFlushedIndexUpdate = LAST_FLUSHED_INDEX_UPDATE.labels(partitionGroupName, partition);
+  }
+
+  public Timer observeLastFlushedIndexUpdate() {
+    return lastFlushedIndexUpdate.startTimer();
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
@@ -19,7 +19,6 @@ package io.atomix.raft.metrics;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
-import io.prometheus.client.Histogram.Timer;
 
 public class RaftRoleMetrics extends RaftMetrics {
 
@@ -54,19 +53,10 @@ public class RaftRoleMetrics extends RaftMetrics {
           .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
           .register();
 
-  private static final Histogram LAST_FLUSHED_INDEX_UPDATE =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("last_flushed_index_update")
-          .help("Time it takes to update the last flushed index")
-          .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
-
   private final Gauge.Child role;
   private final Counter.Child heartbeatMiss;
   private final Histogram.Child heartbeatTime;
   private final Gauge.Child electionLatency;
-  private final Histogram.Child lastFlushedIndexUpdate;
 
   public RaftRoleMetrics(final String partitionName) {
     super(partitionName);
@@ -75,7 +65,6 @@ public class RaftRoleMetrics extends RaftMetrics {
     heartbeatMiss = HEARTBEAT_MISS.labels(partitionGroupName, partition);
     heartbeatTime = HEARTBEAT_TIME.labels(partitionGroupName, partition);
     electionLatency = ELECTION_LATENCY.labels(partitionGroupName, partition);
-    lastFlushedIndexUpdate = LAST_FLUSHED_INDEX_UPDATE.labels(partitionGroupName, partition);
   }
 
   public void becomingFollower() {
@@ -104,9 +93,5 @@ public class RaftRoleMetrics extends RaftMetrics {
 
   public void setElectionLatency(final long latencyMs) {
     electionLatency.set(latencyMs);
-  }
-
-  public Timer observeLastFlushedIndexUpdate() {
-    return lastFlushedIndexUpdate.startTimer();
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
@@ -54,11 +54,11 @@ public class RaftRoleMetrics extends RaftMetrics {
           .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
           .register();
 
-  private static final Histogram LAST_WRITTEN_INDEX_UPDATE =
+  private static final Histogram LAST_FLUSHED_INDEX_UPDATE =
       Histogram.build()
           .namespace(NAMESPACE)
-          .name("last_written_index_update")
-          .help("Time it takes to update the last written index")
+          .name("last_flushed_index_update")
+          .help("Time it takes to update the last flushed index")
           .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
           .register();
 
@@ -66,7 +66,7 @@ public class RaftRoleMetrics extends RaftMetrics {
   private final Counter.Child heartbeatMiss;
   private final Histogram.Child heartbeatTime;
   private final Gauge.Child electionLatency;
-  private final Histogram.Child lastWrittenIndexUpdate;
+  private final Histogram.Child lastFlushedIndexUpdate;
 
   public RaftRoleMetrics(final String partitionName) {
     super(partitionName);
@@ -75,7 +75,7 @@ public class RaftRoleMetrics extends RaftMetrics {
     heartbeatMiss = HEARTBEAT_MISS.labels(partitionGroupName, partition);
     heartbeatTime = HEARTBEAT_TIME.labels(partitionGroupName, partition);
     electionLatency = ELECTION_LATENCY.labels(partitionGroupName, partition);
-    lastWrittenIndexUpdate = LAST_WRITTEN_INDEX_UPDATE.labels(partitionGroupName, partition);
+    lastFlushedIndexUpdate = LAST_FLUSHED_INDEX_UPDATE.labels(partitionGroupName, partition);
   }
 
   public void becomingFollower() {
@@ -106,7 +106,7 @@ public class RaftRoleMetrics extends RaftMetrics {
     electionLatency.set(latencyMs);
   }
 
-  public Timer observeLastWrittenIndexUpdate() {
-    return lastWrittenIndexUpdate.startTimer();
+  public Timer observeLastFlushedIndexUpdate() {
+    return lastFlushedIndexUpdate.startTimer();
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -30,7 +30,10 @@ import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.atomix.raft.zeebe.EntryValidator;
+import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
@@ -357,13 +360,14 @@ public final class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
-     * Sets whether to flush logs to disk on commit.
+     * Sets the {@link RaftLogFlusher.Factory} to create a new flushing strategy for the {@link
+     * RaftLog} when {@link io.atomix.raft.storage.RaftStorage#openLog(ThreadContext)}} is called.
      *
-     * @param flushExplicitly whether to flush logs to disk on commit
+     * @param flusherFactory factory to create the flushing strategy for the {@link RaftLog}
      * @return the Raft partition group builder
      */
-    public Builder withFlushExplicitly(final boolean flushExplicitly) {
-      config.getStorageConfig().setFlushExplicitly(flushExplicitly);
+    public Builder withFlusherFactory(final RaftLogFlusher.Factory flusherFactory) {
+      config.getStorageConfig().setFlusherFactory(flusherFactory);
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -326,7 +326,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
         .withPartitionId(partition.id().id())
         .withDirectory(partition.dataDirectory())
         .withMaxSegmentSize((int) storageConfig.getSegmentSize())
-        .withFlushExplicitly(storageConfig.shouldFlushExplicitly())
+        .withFlusherFactory(storageConfig.flusherFactory())
         .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
         .withSnapshotStore(persistedSnapshotStore)
         .withJournalIndexDensity(storageConfig.getJournalIndexDensity())

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -542,7 +542,7 @@ public class PassiveRole extends InactiveRole {
   }
 
   private void flush(final long lastWrittenIndex, final long previousEntryIndex) {
-    if (raft.getLog().shouldFlushExplicitly() && lastWrittenIndex > previousEntryIndex) {
+    if (raft.getLog().flushesDirectly() && lastWrittenIndex > previousEntryIndex) {
       raft.getLog().flush();
       raft.setLastWrittenIndex(lastWrittenIndex);
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -83,9 +83,7 @@ public class PassiveRole extends InactiveRole {
   private void truncateUncommittedEntries() {
     if (role() == RaftServer.Role.PASSIVE && raft.getLog().getLastIndex() > raft.getCommitIndex()) {
       raft.getLog().deleteAfter(raft.getCommitIndex());
-
       raft.getLog().flush();
-      raft.setLastFlushedIndex(raft.getCommitIndex());
     }
   }
 
@@ -544,7 +542,6 @@ public class PassiveRole extends InactiveRole {
   private void flush(final long lastFlushedIndex, final long previousEntryIndex) {
     if (lastFlushedIndex > previousEntryIndex) {
       raft.getLog().flush();
-      raft.setLastFlushedIndex(lastFlushedIndex);
     }
   }
 
@@ -568,7 +565,6 @@ public class PassiveRole extends InactiveRole {
         if (lastEntry.term() != entry.term()) {
           raft.getLog().deleteAfter(index - 1);
           raft.getLog().flush();
-          raft.setLastFlushedIndex(index - 1);
 
           failedToAppend = !appendEntry(index, entry, future);
         }
@@ -621,7 +617,6 @@ public class PassiveRole extends InactiveRole {
       if (existingEntry.term() != entry.term()) {
         raft.getLog().deleteAfter(index - 1);
         raft.getLog().flush();
-        raft.setLastFlushedIndex(index - 1);
 
         return appendEntry(index, entry, future);
       }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -85,7 +85,7 @@ public class PassiveRole extends InactiveRole {
       raft.getLog().deleteAfter(raft.getCommitIndex());
 
       raft.getLog().flush();
-      raft.setLastWrittenIndex(raft.getCommitIndex());
+      raft.setLastFlushedIndex(raft.getCommitIndex());
     }
   }
 
@@ -541,10 +541,10 @@ public class PassiveRole extends InactiveRole {
     succeedAppend(lastLogIndex, future);
   }
 
-  private void flush(final long lastWrittenIndex, final long previousEntryIndex) {
-    if (raft.getLog().flushesDirectly() && lastWrittenIndex > previousEntryIndex) {
+  private void flush(final long lastFlushedIndex, final long previousEntryIndex) {
+    if (lastFlushedIndex > previousEntryIndex) {
       raft.getLog().flush();
-      raft.setLastWrittenIndex(lastWrittenIndex);
+      raft.setLastFlushedIndex(lastFlushedIndex);
     }
   }
 
@@ -568,7 +568,7 @@ public class PassiveRole extends InactiveRole {
         if (lastEntry.term() != entry.term()) {
           raft.getLog().deleteAfter(index - 1);
           raft.getLog().flush();
-          raft.setLastWrittenIndex(index - 1);
+          raft.setLastFlushedIndex(index - 1);
 
           failedToAppend = !appendEntry(index, entry, future);
         }
@@ -621,7 +621,7 @@ public class PassiveRole extends InactiveRole {
       if (existingEntry.term() != entry.term()) {
         raft.getLog().deleteAfter(index - 1);
         raft.getLog().flush();
-        raft.setLastWrittenIndex(index - 1);
+        raft.setLastFlushedIndex(index - 1);
 
         return appendEntry(index, entry, future);
       }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -21,7 +21,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.atomix.raft.storage.system.MetaStore;
+import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
@@ -57,10 +59,10 @@ public final class RaftStorage {
   private final File directory;
   private final int maxSegmentSize;
   private final long freeDiskSpace;
-  private final boolean flushExplicitly;
   private final ReceivableSnapshotStore persistedSnapshotStore;
   private final int journalIndexDensity;
   private final boolean preallocateSegmentFiles;
+  private final RaftLogFlusher.Factory flusherFactory;
 
   private RaftStorage(
       final String prefix,
@@ -68,7 +70,7 @@ public final class RaftStorage {
       final File directory,
       final int maxSegmentSize,
       final long freeDiskSpace,
-      final boolean flushExplicitly,
+      final RaftLogFlusher.Factory flusherFactory,
       final ReceivableSnapshotStore persistedSnapshotStore,
       final int journalIndexDensity,
       final boolean preallocateSegmentFiles) {
@@ -77,7 +79,7 @@ public final class RaftStorage {
     this.directory = directory;
     this.maxSegmentSize = maxSegmentSize;
     this.freeDiskSpace = freeDiskSpace;
-    this.flushExplicitly = flushExplicitly;
+    this.flusherFactory = flusherFactory;
     this.persistedSnapshotStore = persistedSnapshotStore;
     this.journalIndexDensity = journalIndexDensity;
     this.preallocateSegmentFiles = preallocateSegmentFiles;
@@ -179,7 +181,7 @@ public final class RaftStorage {
    *
    * @return The opened log.
    */
-  public RaftLog openLog() {
+  public RaftLog openLog(final ThreadContext flushContext) {
     final long lastWrittenIndex;
     try (final MetaStore metaStore = openMetaStore()) {
       lastWrittenIndex = metaStore.loadLastWrittenIndex();
@@ -191,10 +193,10 @@ public final class RaftStorage {
         .withDirectory(directory)
         .withMaxSegmentSize(maxSegmentSize)
         .withFreeDiskSpace(freeDiskSpace)
-        .withFlushExplicitly(flushExplicitly)
         .withJournalIndexDensity(journalIndexDensity)
         .withLastWrittenIndex(lastWrittenIndex)
         .withPreallocateSegmentFiles(preallocateSegmentFiles)
+        .withFlusher(flusherFactory.createFlusher(flushContext))
         .build();
   }
 
@@ -208,7 +210,8 @@ public final class RaftStorage {
    *
    * <p>The storage directory is the directory to which all {@link RaftLog}s write files. Segment
    * files for multiple logs may be stored in the storage directory, and files for each log instance
-   * will be identified by the {@code name} provided when the log is {@link #openLog() opened}.
+   * will be identified by the {@code name} provided when the log is {@link #openLog(ThreadContext)
+   * opened}.
    *
    * @return The storage directory.
    */
@@ -239,7 +242,8 @@ public final class RaftStorage {
         System.getProperty("atomix.data", System.getProperty("user.dir"));
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
     private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024;
-    private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
+    private static final RaftLogFlusher.Factory DEFAULT_FLUSHER_FACTORY =
+        RaftLogFlusher.Factory::direct;
     private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
     private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
 
@@ -250,7 +254,7 @@ public final class RaftStorage {
     private File directory = new File(DEFAULT_DIRECTORY);
     private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
     private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
-    private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
+    private RaftLogFlusher.Factory flusherFactory = DEFAULT_FLUSHER_FACTORY;
     private ReceivableSnapshotStore persistedSnapshotStore;
     private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
     private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
@@ -318,14 +322,14 @@ public final class RaftStorage {
     }
 
     /**
-     * Sets whether to flush logs to disk to guarantee correctness. If true, followers will flush on
-     * every append, and the leader will flush on commit.
+     * Sets the {@link RaftLogFlusher.Factory} to create a new flushing strategy for the {@link
+     * RaftLog} when {@link #openLog(ThreadContext)} is called.
      *
-     * @param flushExplicitly whether to flush buffers to disk
+     * @param flusherFactory factory to create the flushing strategy for the {@link RaftLog}
      * @return the storage builder.
      */
-    public Builder withFlushExplicitly(final boolean flushExplicitly) {
-      this.flushExplicitly = flushExplicitly;
+    public Builder withFlusherFactory(final RaftLogFlusher.Factory flusherFactory) {
+      this.flusherFactory = flusherFactory;
       return this;
     }
 
@@ -382,7 +386,7 @@ public final class RaftStorage {
           directory,
           maxSegmentSize,
           freeDiskSpace,
-          flushExplicitly,
+          flusherFactory,
           persistedSnapshotStore,
           journalIndexDensity,
           preallocateSegmentFiles);

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -181,11 +181,7 @@ public final class RaftStorage {
    *
    * @return The opened log.
    */
-  public RaftLog openLog(final ThreadContext flushContext) {
-    final long lastWrittenIndex;
-    try (final MetaStore metaStore = openMetaStore()) {
-      lastWrittenIndex = metaStore.loadLastWrittenIndex();
-    }
+  public RaftLog openLog(final long lastFlushedIndex, final ThreadContext flushContext) {
 
     return RaftLog.builder()
         .withName(prefix)
@@ -194,7 +190,7 @@ public final class RaftStorage {
         .withMaxSegmentSize(maxSegmentSize)
         .withFreeDiskSpace(freeDiskSpace)
         .withJournalIndexDensity(journalIndexDensity)
-        .withLastWrittenIndex(lastWrittenIndex)
+        .withLastFlushedIndex(lastFlushedIndex)
         .withPreallocateSegmentFiles(preallocateSegmentFiles)
         .withFlusher(flusherFactory.createFlusher(flushContext))
         .build();

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -42,11 +42,6 @@ public final class DelayedFlusher implements RaftLogFlusher {
   }
 
   @Override
-  public boolean isDirect() {
-    return false;
-  }
-
-  @Override
   public void close() {
     if (closed) {
       return;

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.storage.log;
+
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.Scheduler;
+import io.camunda.zeebe.journal.Journal;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * An implementation of {@link RaftLogFlusher} which treats calls to {@link #flush(Journal)} as
+ * signals that there is data to be flushed. When that happens, an asynchronous operation is
+ * scheduled with a predefined delay. If a flush was already scheduled, then the signal is ignored.
+ *
+ * <p>In other words, this implementation flushes at least every given period, if there is anything
+ * to flush.
+ *
+ * <p>NOTE: this class is not thread safe, and is expected to run from the same thread as the
+ * journal write path, e.g. the Raft thread.
+ */
+public final class DelayedFlusher implements RaftLogFlusher {
+  private final Scheduler scheduler;
+  private final Duration delayTime;
+
+  private Scheduled scheduledFlush;
+  private boolean closed;
+
+  public DelayedFlusher(final Scheduler scheduler, final Duration delayTime) {
+    this.scheduler = Objects.requireNonNull(scheduler, "must specify a thread context");
+    this.delayTime = Objects.requireNonNull(delayTime, "must specify a valid flush delay");
+  }
+
+  @Override
+  public void flush(final Journal journal) {
+    scheduleFlush(journal);
+  }
+
+  @Override
+  public boolean isDirect() {
+    return false;
+  }
+
+  @Override
+  public void close() {
+    if (closed) {
+      return;
+    }
+
+    closed = true;
+    if (scheduledFlush != null) {
+      scheduledFlush.cancel();
+    }
+  }
+
+  private void asyncFlush(final Journal journal) {
+    scheduledFlush = null;
+
+    if (closed || !journal.isOpen()) {
+      return;
+    }
+
+    journal.flush();
+  }
+
+  private void scheduleFlush(final Journal journal) {
+    if (scheduledFlush == null) {
+      scheduledFlush = scheduler.schedule(delayTime, () -> asyncFlush(journal));
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "DelayedFlusher{"
+        + "scheduler="
+        + scheduler
+        + ", delay="
+        + delayTime
+        + ", scheduledFlush="
+        + scheduledFlush
+        + ", closed="
+        + closed
+        + '}';
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -19,6 +19,8 @@ package io.atomix.raft.storage.log;
 import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
+import io.atomix.raft.storage.log.RaftLogFlusher.FlushMetaStore;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
 import io.atomix.raft.storage.serializer.RaftEntrySerializer;
@@ -32,13 +34,18 @@ public final class RaftLog implements Closeable {
   private final RaftEntrySerializer serializer = new RaftEntrySBESerializer();
   private final Journal journal;
   private final RaftLogFlusher flusher;
+  private final FlushMetaStore flushMetaStore;
 
   private IndexedRaftLogEntry lastAppendedEntry;
   private volatile long commitIndex;
 
-  RaftLog(final Journal journal, final RaftLogFlusher flusher) {
+  RaftLog(
+      final Journal journal,
+      final RaftLogFlusher flusher,
+      final RaftLogFlusher.FlushMetaStore flushMetaStore) {
     this.journal = journal;
     this.flusher = flusher;
+    this.flushMetaStore = flushMetaStore;
   }
 
   /**
@@ -173,7 +180,7 @@ public final class RaftLog implements Closeable {
    * the configured {@link RaftLogFlusher}.
    */
   public void flush() {
-    flusher.flush(journal);
+    flusher.flush(journal, flushMetaStore);
   }
 
   /**
@@ -184,7 +191,7 @@ public final class RaftLog implements Closeable {
    * guarantees are required.
    */
   public void forceFlush() {
-    journal.flush();
+    Factory.DIRECT.flush(journal, flushMetaStore);
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -111,8 +111,8 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
     return this;
   }
 
-  public RaftLogBuilder withLastWrittenIndex(final long lastWrittenIndex) {
-    journalBuilder.withLastWrittenIndex(lastWrittenIndex);
+  public RaftLogBuilder withLastFlushedIndex(final long lastFlushedIndex) {
+    journalBuilder.withLastFlushedIndex(lastFlushedIndex);
     return this;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -16,6 +16,7 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
+import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
@@ -24,7 +25,7 @@ import java.io.File;
 public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
 
   private final SegmentedJournalBuilder journalBuilder = SegmentedJournal.builder();
-  private RaftLogFlusher flusher = RaftLogFlusher.DIRECT;
+  private RaftLogFlusher flusher = Factory.DIRECT;
 
   protected RaftLogBuilder() {}
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -17,6 +17,7 @@ package io.atomix.raft.storage.log;
 
 import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
 import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
+import io.atomix.raft.storage.log.RaftLogFlusher.FlushMetaStore;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
@@ -26,6 +27,7 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
 
   private final SegmentedJournalBuilder journalBuilder = SegmentedJournal.builder();
   private RaftLogFlusher flusher = Factory.DIRECT;
+  private RaftLogFlusher.FlushMetaStore flushMetaStore = lastIndex -> {};
 
   protected RaftLogBuilder() {}
 
@@ -141,9 +143,20 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
     return this;
   }
 
+  /**
+   * Temporary builder method to specify the logic for how to store the last flushed index.
+   *
+   * @param flushMetaStore the handler to store the last flushed index
+   * @return this builder for chaining
+   */
+  public RaftLogBuilder withFlushMetaStore(final FlushMetaStore flushMetaStore) {
+    this.flushMetaStore = flushMetaStore;
+    return this;
+  }
+
   @Override
   public RaftLog build() {
     final Journal journal = journalBuilder.build();
-    return new RaftLog(journal, flusher);
+    return new RaftLog(journal, flusher, flushMetaStore);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.storage.log;
+
+import io.atomix.utils.concurrent.ThreadContext;
+import io.camunda.zeebe.journal.Journal;
+import io.camunda.zeebe.util.CloseableSilently;
+
+/**
+ * Configurable flush strategy for the {@link io.atomix.raft.storage.log.RaftLog}. You can use its
+ * implementations to improve performance at the cost of safety.
+ *
+ * <p>The default strategy is {@link DirectFlusher}, which is the safest but slowest option.
+ *
+ * <p>The {@link NoOpFlusher} is the fastest but most dangerous option, as it will defer flushing to
+ * the operating system. It's then possible to run into data corruption or data loss issues. Please
+ * refer to the documentation regarding this.
+ *
+ * <p>{@link DelayedFlusher} can be configured to provide a trade-off between performance and
+ * safety. This will cause flushes to be performed in a delayed fashion. See its documentation for
+ * more. You should pick this if {@link DirectFlusher} does not provide the desired performance, but
+ * you still wish a lower likelihood of corruption issues than with {@link NoOpFlusher}. The
+ * recommended configuration would be to find the smallest possible delay with which you achieve
+ * your performance goals.
+ */
+@FunctionalInterface
+public interface RaftLogFlusher extends CloseableSilently {
+
+  /**
+   * Shared, thread-safe, reusable {@link DirectFlusher} instance. Use {@link
+   * Factory#direct(ThreadContext)} as its factory method.
+   */
+  DirectFlusher DIRECT = new DirectFlusher();
+
+  /**
+   * Shared, thread-safe, reusable {@link NoOpFlusher} instance. Use {@link
+   * Factory#noop(ThreadContext)} as its factory method.
+   */
+  NoOpFlusher NOOP = new NoOpFlusher();
+
+  /**
+   * Signals that there is data to be flushed in the journal. The implementation may or may not
+   * immediately flush this.
+   *
+   * @param journal the journal to flush
+   */
+  void flush(final Journal journal);
+
+  /**
+   * If this returns true, then any calls to {@link #flush(Journal)} are synchronous and immediate,
+   * and any guarantees offered by the implementation will hold after a call to {@link
+   * #flush(Journal)}.
+   */
+  default boolean isDirect() {
+    return true;
+  }
+
+  @Override
+  default void close() {}
+
+  /**
+   * An implementation of {@link RaftLogFlusher} which does nothing. When this is the configured
+   * implementation, the journal is flushed only before a snapshot is taken.
+   */
+  final class NoOpFlusher implements RaftLogFlusher {
+
+    @Override
+    public void flush(final Journal ignored) {}
+  }
+
+  /**
+   * An implementation of {@link RaftLogFlusher} which flushes immediately in a blocking fashion.
+   * After any calls to {@link #flush(Journal)}, any data written before the call is guaranteed to
+   * be on disk.
+   */
+  final class DirectFlusher implements RaftLogFlusher {
+
+    @Override
+    public void flush(final Journal journal) {
+      journal.flush();
+    }
+  }
+
+  /**
+   * Factory methods to create a new {@link RaftLogFlusher}. This is unfortunately required due to
+   * the blackbox instantiation of the {@link io.atomix.raft.impl.RaftContext}.
+   */
+  @FunctionalInterface
+  interface Factory {
+
+    /**
+     * Creates a new {@link RaftLogFlusher} which should use the given thread context for
+     * synchronization.
+     *
+     * @param flushContext the thread context for asynchronous operations
+     * @return a configured Flusher
+     */
+    RaftLogFlusher createFlusher(final ThreadContext flushContext);
+
+    /** Preset factory method which returns a shared {@link DirectFlusher} instance. */
+    static DirectFlusher direct(final ThreadContext ignored) {
+      return DIRECT;
+    }
+
+    /** Preset factory method which returns a shared {@link NoOpFlusher} instance. */
+    static NoOpFlusher noop(final ThreadContext ignored) {
+      return NOOP;
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
@@ -144,7 +144,7 @@ public class MetaStoreSerializer {
     return metaDecoder.votedFor();
   }
 
-  public long readLastWrittenIndex(final MutableDirectBuffer buffer, final int offset) {
+  public long readLastFlushedIndex(final MutableDirectBuffer buffer, final int offset) {
     headerDecoder.wrap(buffer, offset);
     metaDecoder.wrap(
         buffer,
@@ -152,10 +152,10 @@ public class MetaStoreSerializer {
         headerDecoder.blockLength(),
         headerDecoder.version());
 
-    return metaDecoder.lastWrittenIndex();
+    return metaDecoder.lastFlushedIndex();
   }
 
-  public void writeLastWrittenIndex(
+  public void writeLastFlushedIndex(
       final long index, final MutableDirectBuffer buffer, final int offset) {
     headerEncoder
         .wrap(buffer, offset)
@@ -165,6 +165,6 @@ public class MetaStoreSerializer {
         .version(metaEncoder.sbeSchemaVersion());
 
     metaEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
-    metaEncoder.lastWrittenIndex(index);
+    metaEncoder.lastFlushedIndex(index);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -100,11 +100,11 @@ public class MetaStore implements AutoCloseable {
 
   private void initializeMetaBuffer() {
     final var term = loadTerm();
-    final long index = loadLastWrittenIndex();
+    final long index = lastFlushedIndex();
     final var voted = loadVote();
     metaBuffer.put(0, VERSION);
     storeTerm(term);
-    storeLastWrittenIndex(index);
+    storeLastFlushedIndex(index);
     storeVote(voted);
   }
 
@@ -173,21 +173,21 @@ public class MetaStore implements AutoCloseable {
     return id.isEmpty() ? null : MemberId.from(id);
   }
 
-  public synchronized long loadLastWrittenIndex() {
+  public synchronized long lastFlushedIndex() {
     try {
       metaFileChannel.read(metaBuffer, 0);
       metaBuffer.position(0);
     } catch (final IOException e) {
       throw new StorageException(e);
     }
-    return serializer.readLastWrittenIndex(new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
+    return serializer.readLastFlushedIndex(new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
   }
 
-  public synchronized void storeLastWrittenIndex(final long index) {
+  public synchronized void storeLastFlushedIndex(final long index) {
     log.trace("Store last flushed index {}", index);
 
     try {
-      serializer.writeLastWrittenIndex(index, new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
+      serializer.writeLastFlushedIndex(index, new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
       metaFileChannel.write(metaBuffer, 0);
       metaBuffer.position(0);
     } catch (final IOException e) {

--- a/atomix/cluster/src/main/resources/raft-entry-schema.xml
+++ b/atomix/cluster/src/main/resources/raft-entry-schema.xml
@@ -67,7 +67,7 @@
 
   <sbe:message name="Meta" id="6">
     <field name="term" id="0" type="uint64"/>
-    <field name="lastWrittenIndex" id="1" type="uint64"/>
+    <field name="lastFlushedIndex" id="1" type="uint64"/>
     <data name="votedFor" id="2" type="varDataEncoding"/>
   </sbe:message>
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -154,7 +154,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldStoreLastWrittenIndex() {
+  public void shouldStoreLastFlushedIndex() {
     // given
     final List<PersistedRaftRecord> entries =
         List.of(new PersistedRaftRecord(1, 1, 1, 1, new byte[1]));
@@ -167,7 +167,7 @@ public class PassiveRoleTest {
     role.handleAppend(request).join();
 
     // then
-    verify(ctx).setLastWrittenIndex(eq(1L));
+    verify(ctx).setLastFlushedIndex(eq(1L));
   }
 
   @Test
@@ -190,11 +190,11 @@ public class PassiveRoleTest {
     role.handleAppend(request).join();
 
     // then
-    verify(ctx).setLastWrittenIndex(eq(2L));
+    verify(ctx).setLastFlushedIndex(eq(2L));
   }
 
   @Test
-  public void shouldResetLastWrittenIndexAfterTruncating() {
+  public void shouldResetLastFlushedIndexAfterTruncating() {
     // given
     final List<PersistedRaftRecord> entries =
         List.of(
@@ -209,7 +209,7 @@ public class PassiveRoleTest {
         .thenReturn(mock(IndexedRaftLogEntry.class));
     when(ctx.getLog()).thenReturn(log);
     role.handleAppend(request).join();
-    verify(ctx).setLastWrittenIndex(eq(3L));
+    verify(ctx).setLastFlushedIndex(eq(3L));
 
     // when - force truncation
     when(log.getLastIndex()).thenReturn(3L);
@@ -219,6 +219,6 @@ public class PassiveRoleTest {
     role.start().join();
 
     // then
-    verify(ctx).setLastWrittenIndex(eq(1L));
+    verify(ctx).setLastFlushedIndex(eq(1L));
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -17,9 +17,9 @@ package io.atomix.raft.roles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +43,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.mockito.Mockito;
 
 public class PassiveRoleTest {
 
@@ -110,7 +111,7 @@ public class PassiveRoleTest {
     final AppendResponse response = role.handleAppend(request).join();
 
     // then
-    verify(log).flush();
+    verify(log, times(1)).flush();
     assertThat(response.lastLogIndex()).isEqualTo(2);
   }
 
@@ -131,8 +132,8 @@ public class PassiveRoleTest {
     final AppendResponse response = role.handleAppend(request).join();
 
     // then
-    verify(log).flush();
-    assertThat(response.lastLogIndex()).isEqualTo(1);
+    verify(log, times(1)).flush();
+    assertThat(response.lastLogIndex()).isOne();
   }
 
   @Test
@@ -150,28 +151,11 @@ public class PassiveRoleTest {
 
     // then
     verify(log, never()).flush();
-    assertThat(response.lastLogIndex()).isEqualTo(0);
+    assertThat(response.lastLogIndex()).isZero();
   }
 
   @Test
-  public void shouldStoreLastFlushedIndex() {
-    // given
-    final List<PersistedRaftRecord> entries =
-        List.of(new PersistedRaftRecord(1, 1, 1, 1, new byte[1]));
-    final AppendRequest request = new AppendRequest(2, "", 0, 0, entries, 1);
-
-    when(log.append(any(PersistedRaftRecord.class))).thenReturn(mock(IndexedRaftLogEntry.class));
-    when(ctx.getLog()).thenReturn(log);
-
-    // when
-    role.handleAppend(request).join();
-
-    // then
-    verify(ctx).setLastFlushedIndex(eq(1L));
-  }
-
-  @Test
-  public void shouldStoreLastWrittenEvenWithFailure() {
+  public void shouldFlushEventWithFailure() {
     // given
     final List<PersistedRaftRecord> entries =
         List.of(
@@ -190,12 +174,13 @@ public class PassiveRoleTest {
     role.handleAppend(request).join();
 
     // then
-    verify(ctx).setLastFlushedIndex(eq(2L));
+    verify(log, times(1)).flush();
   }
 
   @Test
-  public void shouldResetLastFlushedIndexAfterTruncating() {
+  public void shouldFlushAfterTruncating() {
     // given
+    final var orderedFlush = Mockito.inOrder(log);
     final List<PersistedRaftRecord> entries =
         List.of(
             new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
@@ -209,7 +194,7 @@ public class PassiveRoleTest {
         .thenReturn(mock(IndexedRaftLogEntry.class));
     when(ctx.getLog()).thenReturn(log);
     role.handleAppend(request).join();
-    verify(ctx).setLastFlushedIndex(eq(3L));
+    orderedFlush.verify(log, times(1)).flush();
 
     // when - force truncation
     when(log.getLastIndex()).thenReturn(3L);
@@ -219,6 +204,6 @@ public class PassiveRoleTest {
     role.start().join();
 
     // then
-    verify(ctx).setLastFlushedIndex(eq(1L));
+    orderedFlush.verify(log, times(1)).flush();
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -56,7 +56,7 @@ public class PassiveRoleTest {
     ctx = mock(RaftContext.class);
 
     log = mock(RaftLog.class);
-    when(log.shouldFlushExplicitly()).thenReturn(true);
+    when(log.flushesDirectly()).thenReturn(true);
     when(ctx.getLog()).thenReturn(log);
 
     final PersistedSnapshot snapshot = mock(PersistedSnapshot.class);

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
@@ -18,6 +18,7 @@ package io.atomix.raft.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +47,7 @@ public class RaftStorageTest {
             .withDirectory(new File(PATH.toFile(), "foo"))
             .withMaxSegmentSize(1024 * 1024)
             .withFreeDiskSpace(100)
-            .withFlushExplicitly(false)
+            .withFlusherFactory(RaftLogFlusher.Factory::noop)
             .build();
     assertThat(storage.prefix()).isEqualTo("foo");
     assertThat(storage.directory()).isEqualTo(new File(PATH.toFile(), "foo"));

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.storage.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.Scheduler;
+import io.camunda.zeebe.journal.Journal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+final class DelayedFlusherTest {
+  private final TestScheduler scheduler = new TestScheduler();
+  private final DelayedFlusher flusher = new DelayedFlusher(scheduler, Duration.ofSeconds(5));
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietClose(flusher);
+  }
+
+  @Test
+  void shouldDelayFlushByInterval() {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+    Mockito.when(journal.isOpen()).thenReturn(true);
+
+    // when
+    flusher.flush(journal);
+
+    // then
+    assertThat(scheduler.operations).hasSize(1);
+
+    final var scheduled = scheduler.operations.get(0);
+    assertThat(scheduled)
+        .extracting(t -> t.initialDelay, t -> t.interval)
+        .containsExactly(Duration.ZERO, Duration.ofSeconds(5));
+    Mockito.verify(journal, Mockito.never()).flush();
+  }
+
+  @Test
+  void shouldFlushWhenScheduledTaskIsRun() {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+    Mockito.when(journal.isOpen()).thenReturn(true);
+
+    // when
+    flusher.flush(journal);
+
+    // then
+    final var scheduled = scheduler.operations.get(0);
+    scheduled.operation.run();
+    Mockito.verify(journal, Mockito.times(1)).flush();
+  }
+
+  @Test
+  void shouldNotScheduleIfAlreadyScheduled() {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+
+    // when
+    flusher.flush(journal);
+    flusher.flush(journal);
+    flusher.flush(journal);
+
+    // then
+    assertThat(scheduler.operations).hasSize(1);
+    final var scheduled = scheduler.operations.get(0);
+    assertThat(scheduled)
+        .extracting(t -> t.initialDelay, t -> t.interval)
+        .containsExactly(Duration.ZERO, Duration.ofSeconds(5));
+  }
+
+  @Test
+  void shouldCancelScheduledFlushOnClose() {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+
+    // when
+    flusher.flush(journal);
+    flusher.close();
+
+    // then
+    final var scheduled = scheduler.operations.get(0);
+    assertThat(scheduled.cancelled).isTrue();
+  }
+
+  @Test
+  void shouldNotFlushWhenFlusherIsClosed() {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+    Mockito.when(journal.isOpen()).thenReturn(true);
+
+    // when
+    flusher.flush(journal);
+    flusher.close();
+
+    // then
+    final var scheduled = scheduler.operations.get(0);
+    scheduled.operation.run();
+    Mockito.verify(journal, Mockito.never()).flush();
+  }
+
+  @Test
+  void shouldNotFlushIfJournalIsClosed() {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+    Mockito.when(journal.isOpen()).thenReturn(false);
+
+    // when
+    flusher.flush(journal);
+
+    // then
+    final var scheduled = scheduler.operations.get(0);
+    scheduled.operation.run();
+    Mockito.verify(journal, Mockito.never()).flush();
+  }
+
+  private static final class TestScheduled implements Scheduled {
+    private final Duration initialDelay;
+    private final Duration interval;
+    private final Runnable operation;
+
+    private boolean cancelled;
+
+    private TestScheduled(
+        final Duration initialDelay, final Duration interval, final Runnable operation) {
+      this.initialDelay = initialDelay;
+      this.interval = interval;
+      this.operation = operation;
+    }
+
+    @Override
+    public void cancel() {
+      cancelled = true;
+    }
+
+    @Override
+    public boolean isDone() {
+      return cancelled;
+    }
+  }
+
+  private static final class TestScheduler implements Scheduler {
+    private final List<TestScheduled> operations = new ArrayList<>();
+
+    @Override
+    public Scheduled schedule(
+        final Duration initialDelay, final Duration interval, final Runnable callback) {
+      final var scheduled = new TestScheduled(initialDelay, interval, callback);
+      operations.add(scheduled);
+      return scheduled;
+    }
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
@@ -9,6 +9,7 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.raft.storage.log.RaftLogFlusher.FlushMetaStore;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
 import io.camunda.zeebe.journal.Journal;
@@ -33,10 +34,11 @@ final class DelayedFlusherTest {
   void shouldDelayFlushByInterval() {
     // given
     final var journal = Mockito.mock(Journal.class);
+    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, flushMetaStore);
 
     // then
     assertThat(scheduler.operations).hasSize(1);
@@ -46,32 +48,38 @@ final class DelayedFlusherTest {
         .extracting(t -> t.initialDelay, t -> t.interval)
         .containsExactly(Duration.ZERO, Duration.ofSeconds(5));
     Mockito.verify(journal, Mockito.never()).flush();
+    Mockito.verify(flushMetaStore, Mockito.never()).storeLastFlushedIndex(Mockito.anyLong());
   }
 
   @Test
   void shouldFlushWhenScheduledTaskIsRun() {
     // given
     final var journal = Mockito.mock(Journal.class);
+    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
+    Mockito.when(journal.getLastIndex()).thenReturn(5L);
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, flushMetaStore);
 
     // then
     final var scheduled = scheduler.operations.get(0);
     scheduled.operation.run();
     Mockito.verify(journal, Mockito.times(1)).flush();
+    Mockito.verify(flushMetaStore, Mockito.times(1)).storeLastFlushedIndex(5L);
   }
 
   @Test
   void shouldNotScheduleIfAlreadyScheduled() {
     // given
     final var journal = Mockito.mock(Journal.class);
+    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
+    Mockito.when(journal.getLastIndex()).thenReturn(5L);
 
     // when
-    flusher.flush(journal);
-    flusher.flush(journal);
-    flusher.flush(journal);
+    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal, flushMetaStore);
 
     // then
     assertThat(scheduler.operations).hasSize(1);
@@ -85,9 +93,10 @@ final class DelayedFlusherTest {
   void shouldCancelScheduledFlushOnClose() {
     // given
     final var journal = Mockito.mock(Journal.class);
+    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, flushMetaStore);
     flusher.close();
 
     // then
@@ -99,31 +108,35 @@ final class DelayedFlusherTest {
   void shouldNotFlushWhenFlusherIsClosed() {
     // given
     final var journal = Mockito.mock(Journal.class);
+    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, flushMetaStore);
     flusher.close();
 
     // then
     final var scheduled = scheduler.operations.get(0);
     scheduled.operation.run();
     Mockito.verify(journal, Mockito.never()).flush();
+    Mockito.verify(flushMetaStore, Mockito.never()).storeLastFlushedIndex(Mockito.anyLong());
   }
 
   @Test
   void shouldNotFlushIfJournalIsClosed() {
     // given
     final var journal = Mockito.mock(Journal.class);
+    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.isOpen()).thenReturn(false);
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, flushMetaStore);
 
     // then
     final var scheduled = scheduler.operations.get(0);
     scheduled.operation.run();
     Mockito.verify(journal, Mockito.never()).flush();
+    Mockito.verify(flushMetaStore, Mockito.never()).storeLastFlushedIndex(Mockito.anyLong());
   }
 
   private static final class TestScheduled implements Scheduled {

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -27,7 +27,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
-import io.atomix.raft.storage.log.RaftLogFlusher.NoOpFlusher;
+import io.atomix.raft.storage.log.RaftLogFlusher.NoopFlusher;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
@@ -277,7 +277,7 @@ class RaftLogTest {
     void shouldDisableFlush() {
       // given
       final var journal = mock(Journal.class);
-      final var flusher = spy(new NoOpFlusher());
+      final var flusher = spy(new NoopFlusher());
       final var log = new RaftLog(journal, flusher);
 
       // when

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -17,16 +17,19 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
+import io.atomix.raft.storage.log.RaftLogFlusher.FlushMetaStore;
 import io.atomix.raft.storage.log.RaftLogFlusher.NoopFlusher;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
@@ -238,39 +241,46 @@ class RaftLogTest {
       // given
       final var journal = mock(Journal.class);
       final var flusher = mock(RaftLogFlusher.class);
-      final var log = new RaftLog(journal, flusher);
+      final var flushMetaStore = mock(FlushMetaStore.class);
+      final var log = new RaftLog(journal, flusher, flushMetaStore);
 
       // when
       log.flush();
 
       // then
-      verify(flusher, times(1)).flush(journal);
+      verify(flusher, times(1)).flush(journal, flushMetaStore);
     }
 
     @Test
     void shouldForceFlush() {
       final var journal = mock(Journal.class);
       final var flusher = mock(RaftLogFlusher.class);
-      final var log = new RaftLog(journal, flusher);
+      final var flushMetaStore = mock(FlushMetaStore.class);
+      final var log = new RaftLog(journal, flusher, flushMetaStore);
+      when(journal.getLastIndex()).thenReturn(3L);
 
       // when
       log.forceFlush();
 
       // then
       verify(journal, times(1)).flush();
+      verify(flushMetaStore, times(1)).storeLastFlushedIndex(3L);
     }
 
     @Test
     void shouldFlushDirectly() {
       // given
       final var journal = mock(Journal.class);
-      final var log = new RaftLog(journal, new DirectFlusher());
+      final var flushMetaStore = mock(FlushMetaStore.class);
+      final var log = new RaftLog(journal, new DirectFlusher(), flushMetaStore);
+      when(journal.getLastIndex()).thenReturn(3L);
 
       // when
       log.flush();
 
       // then
       verify(journal, times(1)).flush();
+      verify(flushMetaStore, times(1)).storeLastFlushedIndex(3L);
     }
 
     @Test
@@ -278,14 +288,16 @@ class RaftLogTest {
       // given
       final var journal = mock(Journal.class);
       final var flusher = spy(new NoopFlusher());
-      final var log = new RaftLog(journal, flusher);
+      final var flushMetaStore = mock(FlushMetaStore.class);
+      final var log = new RaftLog(journal, flusher, flushMetaStore);
 
       // when
       log.flush();
 
       // then
-      verify(flusher, times(1)).flush(journal);
+      verify(flusher, times(1)).flush(journal, flushMetaStore);
       verify(journal, never()).flush();
+      verify(flushMetaStore, never()).storeLastFlushedIndex(anyLong());
     }
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -218,58 +218,58 @@ public class MetaStoreTest {
   }
 
   @Test
-  public void shouldStoreAndLoadLastWrittenIndex() {
+  public void shouldStoreAndLoadLastFlushedIndex() {
     // given
-    metaStore.storeLastWrittenIndex(5L);
+    metaStore.storeLastFlushedIndex(5L);
 
     // when/then
-    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(5L);
+    assertThat(metaStore.lastFlushedIndex()).isEqualTo(5L);
   }
 
   @Test
-  public void shouldStoreAndLoadLastWrittenIndexAfterRestart() throws IOException {
+  public void shouldStoreAndLoadLastFlushedIndexAfterRestart() throws IOException {
     // given
-    metaStore.storeLastWrittenIndex(5L);
+    metaStore.storeLastFlushedIndex(5L);
 
     // when
     metaStore.close();
     metaStore = new MetaStore(storage);
 
     // then
-    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(5L);
+    assertThat(metaStore.lastFlushedIndex()).isEqualTo(5L);
   }
 
   @Test
   public void shouldLoadLatestWrittenIndex() throws IOException {
     // given
-    metaStore.storeLastWrittenIndex(5L);
+    metaStore.storeLastFlushedIndex(5L);
 
     // when
-    metaStore.storeLastWrittenIndex(7L);
+    metaStore.storeLastFlushedIndex(7L);
 
     // then
-    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(7L);
+    assertThat(metaStore.lastFlushedIndex()).isEqualTo(7L);
 
     // when
-    metaStore.storeLastWrittenIndex(8L);
+    metaStore.storeLastFlushedIndex(8L);
 
     metaStore.close();
     metaStore = new MetaStore(storage);
 
     // then
-    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(8L);
+    assertThat(metaStore.lastFlushedIndex()).isEqualTo(8L);
   }
 
   @Test
   public void shouldStoreAndLoadAllMetadata() {
     // when
     metaStore.storeTerm(1L);
-    metaStore.storeLastWrittenIndex(2L);
+    metaStore.storeLastFlushedIndex(2L);
     metaStore.storeVote(MemberId.from("a"));
 
     // then
     assertThat(metaStore.loadTerm()).isEqualTo(1L);
-    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(2L);
+    assertThat(metaStore.lastFlushedIndex()).isEqualTo(2L);
     assertThat(metaStore.loadVote()).isEqualTo(MemberId.from("a"));
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -91,7 +91,7 @@ public class ZeebeTestNode {
   }
 
   public RaftPartitionGroup getPartitionGroup() {
-    return this.dataPartitionGroup;
+    return dataPartitionGroup;
   }
 
   public MemberId getMemberId() {
@@ -119,7 +119,6 @@ public class ZeebeTestNode {
         .withMembers(members.toArray(new Member[0]))
         .withNumPartitions(1)
         .withPartitionSize(members.size())
-        .withFlushExplicitly(true)
         .withSegmentSize(1024L)
         .withSnapshotStoreFactory(
             (path, partition) -> new TestSnapshotStore(new AtomicReference<>()));

--- a/atomix/utils/src/main/java/io/atomix/utils/concurrent/Scheduler.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/concurrent/Scheduler.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /** Scheduler. */
+@FunctionalInterface
 public interface Scheduler {
 
   /**
@@ -41,7 +42,9 @@ public interface Scheduler {
    * @param callback the callback to run
    * @return the scheduled callback
    */
-  Scheduled schedule(Duration delay, Runnable callback);
+  default Scheduled schedule(final Duration delay, final Runnable callback) {
+    return schedule(Duration.ZERO, delay, callback);
+  }
 
   /**
    * Schedules a runnable at a fixed rate.

--- a/broker/src/main/java/io/camunda/zeebe/broker/Loggers.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Loggers.java
@@ -26,6 +26,7 @@ public final class Loggers {
       LoggerFactory.getLogger("io.camunda.zeebe.broker.exporter");
   public static final Logger DELETION_SERVICE =
       LoggerFactory.getLogger("io.camunda.zeebe.broker.logstreams.delete");
+  public static final Logger RAFT = LoggerFactory.getLogger("io.camunda.zeebe.broker.raft");
 
   public static Logger getExporterLogger(final String exporterId) {
     final String loggerName = String.format("io.camunda.zeebe.broker.exporter.%s", exporterId);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -44,9 +44,6 @@ public final class SystemContext {
       "Snapshot period %s needs to be larger then or equals to one minute.";
   private static final String MAX_BATCH_SIZE_ERROR_MSG =
       "Expected to have an append batch size maximum which is non negative and smaller then '%d', but was '%s'.";
-  private static final String REPLICATION_WITH_DISABLED_FLUSH_WARNING =
-      "Disabling explicit flushing is an experimental feature and can lead to inconsistencies "
-          + "and/or data loss! Please refer to the documentation whether or not you should use this!";
 
   private final BrokerCfg brokerCfg;
   private Map<String, String> diagnosticContext;
@@ -124,10 +121,6 @@ public final class SystemContext {
 
   private void validateExperimentalConfigs(
       final ClusterCfg cluster, final ExperimentalCfg experimental) {
-    if (experimental.isDisableExplicitRaftFlush()) {
-      LOG.warn(REPLICATION_WITH_DISABLED_FLUSH_WARNING);
-    }
-
     final var maxAppendBatchSize = experimental.getMaxAppendBatchSize();
     if (maxAppendBatchSize.isNegative() || maxAppendBatchSize.toBytes() >= Integer.MAX_VALUE) {
       throw new IllegalArgumentException(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
+import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import java.util.Optional;
 import org.springframework.util.unit.DataSize;
 
@@ -58,10 +59,21 @@ public class ExperimentalCfg implements ConfigurationEntry {
     return Optional.ofNullable(maxAppendBatchSize).orElse(DEFAULT_MAX_APPEND_BATCH_SIZE).toBytes();
   }
 
+  /**
+   * @deprecated Deprecated in favor of {@link RaftCfg#getFlush()}. The equivalent is a null
+   *     configuration, e.g. {@link new FlushConfig(null)}. Will be removed in 8.3.0.
+   */
+  @Deprecated(since = "8.2.0", forRemoval = true)
   public boolean isDisableExplicitRaftFlush() {
     return disableExplicitRaftFlush;
   }
 
+  /**
+   * @deprecated Deprecated in favor of {@link RaftCfg#setFlush(FlushConfig)}. To disable, you can
+   *     call {@link RaftCfg#setFlush(FlushConfig)} with a null configuration, e.g. {@code new
+   *     FlushConfig(null)}. Will be removed in 8.3.0.
+   */
+  @Deprecated(since = "8.2.0", forRemoval = true)
   public void setDisableExplicitRaftFlush(final boolean disableExplicitRaftFlush) {
     this.disableExplicitRaftFlush = disableExplicitRaftFlush;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -7,10 +7,16 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
+import java.time.Duration;
+import java.util.Objects;
+
 public final class RaftCfg implements ConfigurationEntry {
   public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = true;
+  private static final FlushConfig DEFAULT_FLUSH_CONFIG = new FlushConfig(true, Duration.ZERO);
 
   private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
+
+  private FlushConfig flush = DEFAULT_FLUSH_CONFIG;
 
   public boolean isEnablePriorityElection() {
     return enablePriorityElection;
@@ -20,8 +26,28 @@ public final class RaftCfg implements ConfigurationEntry {
     this.enablePriorityElection = enablePriorityElection;
   }
 
+  public FlushConfig getFlush() {
+    return flush;
+  }
+
+  public void setFlush(final FlushConfig flush) {
+    this.flush = flush;
+  }
+
   @Override
   public String toString() {
-    return "RaftCfg{" + "enablePriorityElection=" + enablePriorityElection + '}';
+    return "RaftCfg{"
+        + "enablePriorityElection="
+        + enablePriorityElection
+        + ", flushConfig="
+        + flush
+        + '}';
+  }
+
+  public record FlushConfig(boolean enabled, Duration delayTime) {
+    public FlushConfig(final boolean enabled, final Duration delayTime) {
+      this.enabled = enabled;
+      this.delayTime = Objects.requireNonNull(delayTime, "must specify a valid delay");
+    }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public final class PartitionManagerImplTest {
+final class PartitionManagerImplTest {
   private @TempDir Path tempDir;
   private Environment environment;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
@@ -15,7 +15,7 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.raft.partition.RaftPartitionGroupConfig;
 import io.atomix.raft.storage.log.DelayedFlusher;
 import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
-import io.atomix.raft.storage.log.RaftLogFlusher.NoOpFlusher;
+import io.atomix.raft.storage.log.RaftLogFlusher.NoopFlusher;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
@@ -129,7 +129,7 @@ final class PartitionManagerImplTest {
     // then
     final var config = getPartitionGroupConfig(partitionManager);
     assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
-        .isInstanceOf(NoOpFlusher.class);
+        .isInstanceOf(NoopFlusher.class);
   }
 
   @Test
@@ -156,7 +156,7 @@ final class PartitionManagerImplTest {
     // then
     final var config = getPartitionGroupConfig(partitionManager);
     assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
-        .isInstanceOf(NoOpFlusher.class);
+        .isInstanceOf(NoopFlusher.class);
   }
 
   private RaftPartitionGroupConfig getPartitionGroupConfig(

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
@@ -12,34 +12,40 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.ClusterMembershipService;
-import io.atomix.cluster.Member;
 import io.atomix.raft.partition.RaftPartitionGroupConfig;
+import io.atomix.raft.storage.log.DelayedFlusher;
+import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
+import io.atomix.raft.storage.log.RaftLogFlusher.NoOpFlusher;
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.util.Environment;
+import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class PartitionManagerImplTest {
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private @TempDir Path tempDir;
   private Environment environment;
 
   @Mock private ClusterServices mockClusterServices;
   @Mock private ClusterMembershipService mockMembershipService;
-  @Mock private Member mockMember;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     environment = new Environment();
 
@@ -47,10 +53,10 @@ public final class PartitionManagerImplTest {
   }
 
   @Test
-  public void shouldDisableExplicitFlush() {
+  void shouldUseDelayedFlushStrategy() {
     // given
     final var brokerConfig = newConfig();
-    brokerConfig.getExperimental().setDisableExplicitRaftFlush(true);
+    brokerConfig.getCluster().getRaft().setFlush(new FlushConfig(true, Duration.ofSeconds(5)));
 
     // when
     final var partitionManager =
@@ -68,14 +74,17 @@ public final class PartitionManagerImplTest {
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
-    assertThat(config.getStorageConfig().shouldFlushExplicitly()).isFalse();
+    assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
+        .isInstanceOf(DelayedFlusher.class)
+        .asInstanceOf(InstanceOfAssertFactories.type(DelayedFlusher.class))
+        .hasFieldOrPropertyWithValue("delayTime", Duration.ofSeconds(5));
   }
 
   @Test
-  public void shouldEnableExplicitFlush() {
+  void shouldUseDirectFlushStrategy() {
     // given
     final var brokerConfig = newConfig();
-    brokerConfig.getExperimental().setDisableExplicitRaftFlush(false);
+    brokerConfig.getCluster().getRaft().setFlush(new FlushConfig(true, Duration.ZERO));
 
     // when
     final var partitionManager =
@@ -90,9 +99,64 @@ public final class PartitionManagerImplTest {
             null,
             mock(ExporterRepository.class),
             null);
+
     // then
     final var config = getPartitionGroupConfig(partitionManager);
-    assertThat(config.getStorageConfig().shouldFlushExplicitly()).isTrue();
+    assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
+        .isInstanceOf(DirectFlusher.class);
+  }
+
+  @Test
+  void shouldUseNoOpFlushStrategy() {
+    // given
+    final var brokerConfig = newConfig();
+    brokerConfig.getCluster().getRaft().setFlush(new FlushConfig(false, Duration.ofSeconds(5)));
+
+    // when
+    final var partitionManager =
+        new PartitionManagerImpl(
+            mock(ActorSchedulingService.class),
+            brokerConfig,
+            new BrokerInfo(1, "dummy"),
+            mockClusterServices,
+            mock(BrokerHealthCheckService.class),
+            null,
+            new ArrayList<>(),
+            null,
+            mock(ExporterRepository.class),
+            null);
+
+    // then
+    final var config = getPartitionGroupConfig(partitionManager);
+    assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
+        .isInstanceOf(NoOpFlusher.class);
+  }
+
+  @Test
+  void shouldDisableExplicitFlush() {
+    // given
+    final var brokerConfig = newConfig();
+    brokerConfig.getExperimental().setDisableExplicitRaftFlush(true);
+    brokerConfig.getCluster().getRaft().setFlush(new FlushConfig(true, Duration.ofSeconds(5)));
+
+    // when
+    final var partitionManager =
+        new PartitionManagerImpl(
+            mock(ActorSchedulingService.class),
+            brokerConfig,
+            new BrokerInfo(1, "dummy"),
+            mockClusterServices,
+            mock(BrokerHealthCheckService.class),
+            null,
+            new ArrayList<>(),
+            null,
+            mock(ExporterRepository.class),
+            null);
+
+    // then
+    final var config = getPartitionGroupConfig(partitionManager);
+    assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
+        .isInstanceOf(NoOpFlusher.class);
   }
 
   private RaftPartitionGroupConfig getPartitionGroupConfig(
@@ -102,8 +166,20 @@ public final class PartitionManagerImplTest {
 
   private BrokerCfg newConfig() {
     final var config = new BrokerCfg();
-    config.init(temporaryFolder.getRoot().getAbsolutePath(), environment);
+    config.init(tempDir.toAbsolutePath().toString(), environment);
 
     return config;
+  }
+
+  private static class NoOpContext implements ThreadContext {
+
+    @Override
+    public Scheduled schedule(
+        final Duration initialDelay, final Duration interval, final Runnable callback) {
+      return null;
+    }
+
+    @Override
+    public void execute(final Runnable command) {}
   }
 }

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -389,7 +389,29 @@
         # As a result, it tries to distributed the leaders uniformly across the brokers. Note that it is only a best-effort strategy.
         # It is not guaranteed to be a strictly uniform distribution.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_ENABLEPRIORITYELECTION
-        # enablePriorityElection = true;
+        # enablePriorityElection = true
+
+        # Configures how often data is explicitly flushed to disk. By default, for a given
+        # partition, data is flushed on every leader commit, and every follower append. This is to
+        # ensure consistency across all replicas. Disabling this can cause inconsistencies, and at
+        # worst, data corruption or data loss scenarios.
+        #
+        # The default behavior is optimized for safety, and flushing occurs on every leader commit
+        # and follower append in a synchronous fashion. You can introduce a delay to reduce the
+        # performance penalty of flushing via `delayTime`.
+        flush:
+          # If false, explicit flushing of the Raft log is disabled, and flushing only occurs right
+          # before a snapshot is taken. You should only disable explicit flushing if you are willing
+          # to accept potential data loss at the expense of performance. Before disabling it, try
+          # the delayed options, which provide a trade-off between safety and performance.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_ENABLED
+          # enabled: true
+          # If the delay is > 0, then flush requests are delayed by at least the given period. It is
+          # recommended that you find the smallest delay here with which you achieve your
+          # performance goals. It's also likely that anything above 30s is not useful, as this is
+          # the typical default flush interval for the Linux OS.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_DELAYTIME
+          # delayTime: 0s
 
       # Configure parameters for SWIM protocol which is used to propagate cluster membership
       # information among brokers and gateways

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -321,7 +321,29 @@
         # As a result, it tries to distributed the leaders uniformly across the brokers. Note that it is only a best-effort strategy.
         # It is not guaranteed to be a strictly uniform distribution.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_ENABLEPRIORITYELECTION
-        # enablePriorityElection = true;
+        # enablePriorityElection = true
+
+        # Configures how often data is explicitly flushed to disk. By default, for a given
+        # partition, data is flushed on every leader commit, and every follower append. This is to
+        # ensure consistency across all replicas. Disabling this can cause inconsistencies, and at
+        # worst, data corruption or data loss scenarios.
+        #
+        # The default behavior is optimized for safety, and flushing occurs on every leader commit
+        # and follower append in a synchronous fashion. You can introduce a delay to reduce the
+        # performance penalty of flushing via `delayTime`.
+        flush:
+          # If false, explicit flushing of the Raft log is disabled, and flushing only occurs right
+          # before a snapshot is taken. You should only disable explicit flushing if you are willing
+          # to accept potential data loss at the expense of performance. Before disabling it, try
+          # the delayed options, which provide a trade-off between safety and performance.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_ENABLED
+          # enabled: true
+          # If the delay is > 0, then flush requests are delayed by at least the given period. It is
+          # recommended that you find the smallest delay here with which you achieve your
+          # performance goals. It's also likely that anything above 30s is not useful, as this is
+          # the typical default flush interval for the Linux OS.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_DELAYTIME
+          # delayTime: 0s
 
       # Configure parameters for SWIM protocol which is used to propagate cluster membership
       # information among brokers and gateways

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -55,7 +55,7 @@ final class Segment implements AutoCloseable {
       final SegmentFile file,
       final SegmentDescriptor descriptor,
       final MappedByteBuffer buffer,
-      final long lastWrittenIndex,
+      final long lastFlushedIndex,
       final long lastWrittenAsqn,
       final JournalIndex index,
       final JournalMetrics metrics) {
@@ -64,7 +64,7 @@ final class Segment implements AutoCloseable {
     this.buffer = buffer;
     this.index = index;
 
-    writer = createWriter(lastWrittenIndex, lastWrittenAsqn, metrics);
+    writer = createWriter(lastFlushedIndex, lastWrittenAsqn, metrics);
   }
 
   /**
@@ -163,8 +163,8 @@ final class Segment implements AutoCloseable {
   }
 
   private SegmentWriter createWriter(
-      final long lastWrittenIndex, final long lastWrittenAsqn, final JournalMetrics metrics) {
-    return new SegmentWriter(buffer, this, index, lastWrittenIndex, lastWrittenAsqn, metrics);
+      final long lastFlushedIndex, final long lastWrittenAsqn, final JournalMetrics metrics) {
+    return new SegmentWriter(buffer, this, index, lastFlushedIndex, lastWrittenAsqn, metrics);
   }
 
   /**

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -46,13 +46,13 @@ final class SegmentLoader {
   Segment createSegment(
       final Path segmentFile,
       final SegmentDescriptor descriptor,
-      final long lastWrittenIndex,
+      final long lastFlushedIndex,
       final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final MappedByteBuffer mappedSegment;
 
     try {
-      mappedSegment = mapNewSegment(segmentFile, descriptor, lastWrittenIndex);
+      mappedSegment = mapNewSegment(segmentFile, descriptor, lastFlushedIndex);
     } catch (final IOException e) {
       throw new JournalException(
           String.format("Failed to create new segment file %s", segmentFile), e);
@@ -81,18 +81,18 @@ final class SegmentLoader {
     }
 
     return loadSegment(
-        segmentFile, mappedSegment, descriptor, lastWrittenIndex, lastWrittenAsqn, journalIndex);
+        segmentFile, mappedSegment, descriptor, lastFlushedIndex, lastWrittenAsqn, journalIndex);
   }
 
   UninitializedSegment createUninitializedSegment(
       final Path segmentFile,
       final SegmentDescriptor descriptor,
-      final long lastWrittenIndex,
+      final long lastFlushedIndex,
       final JournalIndex journalIndex) {
     final MappedByteBuffer mappedSegment;
 
     try {
-      mappedSegment = mapNewSegment(segmentFile, descriptor, lastWrittenIndex);
+      mappedSegment = mapNewSegment(segmentFile, descriptor, lastFlushedIndex);
     } catch (final IOException e) {
       throw new JournalException(
           String.format("Failed to create new segment file %s", segmentFile), e);
@@ -118,7 +118,7 @@ final class SegmentLoader {
 
   Segment loadExistingSegment(
       final Path segmentFile,
-      final long lastWrittenIndex,
+      final long lastFlushedIndex,
       final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final var descriptor = readDescriptor(segmentFile);
@@ -133,7 +133,7 @@ final class SegmentLoader {
     }
 
     return loadSegment(
-        segmentFile, mappedSegment, descriptor, lastWrittenIndex, lastWrittenAsqn, journalIndex);
+        segmentFile, mappedSegment, descriptor, lastFlushedIndex, lastWrittenAsqn, journalIndex);
   }
 
   /* ---- Internal methods ------ */
@@ -141,12 +141,12 @@ final class SegmentLoader {
       final Path file,
       final MappedByteBuffer buffer,
       final SegmentDescriptor descriptor,
-      final long lastWrittenIndex,
+      final long lastFlushedIndex,
       final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final SegmentFile segmentFile = new SegmentFile(file.toFile());
     return new Segment(
-        segmentFile, descriptor, buffer, lastWrittenIndex, lastWrittenAsqn, journalIndex, metrics);
+        segmentFile, descriptor, buffer, lastFlushedIndex, lastWrittenAsqn, journalIndex, metrics);
   }
 
   private MappedByteBuffer mapSegment(final FileChannel channel, final long segmentSize)
@@ -216,7 +216,7 @@ final class SegmentLoader {
   }
 
   private MappedByteBuffer mapNewSegment(
-      final Path segmentPath, final SegmentDescriptor descriptor, final long lastWrittenIndex)
+      final Path segmentPath, final SegmentDescriptor descriptor, final long lastFlushedIndex)
       throws IOException {
     final var maxSegmentSize = descriptor.maxSegmentSize();
 
@@ -232,12 +232,12 @@ final class SegmentLoader {
       return mapSegment(channel, maxSegmentSize);
     } catch (final FileAlreadyExistsException e) {
       // do not reuse a segment into which we've already written!
-      if (lastWrittenIndex >= descriptor.index()) {
+      if (lastFlushedIndex >= descriptor.index()) {
         throw new JournalException(
             String.format(
                 "Failed to create journal segment %s, as it already exists, and the last written "
                     + "index %d indicates we've already written to it",
-                segmentPath, lastWrittenIndex),
+                segmentPath, lastFlushedIndex),
             e);
       }
 
@@ -246,7 +246,7 @@ final class SegmentLoader {
           segmentPath,
           e);
       Files.delete(segmentPath);
-      return mapNewSegment(segmentPath, descriptor, lastWrittenIndex);
+      return mapNewSegment(segmentPath, descriptor, lastFlushedIndex);
     }
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -41,7 +41,7 @@ public class SegmentedJournalBuilder {
 
   private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
-  private long lastWrittenIndex = -1L;
+  private long lastFlushedIndex = -1L;
   private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
   private int partitionId = DEFAULT_PARTITION_ID;
 
@@ -127,11 +127,11 @@ public class SegmentedJournalBuilder {
   /**
    * Writes the last index to have been persisted to the metastore.
    *
-   * @param lastWrittenIndex last index to have been persisted in the log
+   * @param lastFlushedIndex last index to have been persisted in the log
    * @return the storage builder
    */
-  public SegmentedJournalBuilder withLastWrittenIndex(final long lastWrittenIndex) {
-    this.lastWrittenIndex = lastWrittenIndex;
+  public SegmentedJournalBuilder withLastFlushedIndex(final long lastFlushedIndex) {
+    this.lastFlushedIndex = lastFlushedIndex;
     return this;
   }
 
@@ -172,7 +172,7 @@ public class SegmentedJournalBuilder {
             journalIndex,
             maxSegmentSize,
             directory,
-            lastWrittenIndex,
+            lastFlushedIndex,
             name,
             segmentLoader,
             journalMetrics);

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -51,7 +51,7 @@ final class SegmentsManager implements AutoCloseable {
 
   private final SegmentLoader segmentLoader;
 
-  private final long lastWrittenIndex;
+  private final long lastFlushedIndex;
 
   private final String name;
 
@@ -59,7 +59,7 @@ final class SegmentsManager implements AutoCloseable {
       final JournalIndex journalIndex,
       final int maxSegmentSize,
       final File directory,
-      final long lastWrittenIndex,
+      final long lastFlushedIndex,
       final String name,
       final SegmentLoader segmentLoader,
       final JournalMetrics journalMetrics) {
@@ -67,7 +67,7 @@ final class SegmentsManager implements AutoCloseable {
     this.journalIndex = journalIndex;
     this.maxSegmentSize = maxSegmentSize;
     this.directory = directory;
-    this.lastWrittenIndex = lastWrittenIndex;
+    this.lastFlushedIndex = lastFlushedIndex;
     this.segmentLoader = segmentLoader;
     this.journalMetrics = journalMetrics;
   }
@@ -129,7 +129,7 @@ final class SegmentsManager implements AutoCloseable {
             nextSegment
                 .join()
                 .initializeForUse(
-                    nextSegmentIndex, lastWrittenAsqn, lastWrittenIndex, journalMetrics);
+                    nextSegmentIndex, lastWrittenAsqn, lastFlushedIndex, journalMetrics);
       } catch (final CompletionException e) {
         LOG.error("Failed to acquire next segment, retrying synchronously now.", e);
         currentSegment = createSegment(descriptor, lastWrittenAsqn);
@@ -305,13 +305,13 @@ final class SegmentsManager implements AutoCloseable {
   private UninitializedSegment createUninitializedSegment(final SegmentDescriptor descriptor) {
     final var segmentFile = SegmentFile.createSegmentFile(name, directory, descriptor.id());
     return segmentLoader.createUninitializedSegment(
-        segmentFile.toPath(), descriptor, lastWrittenIndex, journalIndex);
+        segmentFile.toPath(), descriptor, lastFlushedIndex, journalIndex);
   }
 
   private Segment createSegment(final SegmentDescriptor descriptor, final long lastWrittenAsqn) {
     final var segmentFile = SegmentFile.createSegmentFile(name, directory, descriptor.id());
     return segmentLoader.createSegment(
-        segmentFile.toPath(), descriptor, lastWrittenIndex, lastWrittenAsqn, journalIndex);
+        segmentFile.toPath(), descriptor, lastFlushedIndex, lastWrittenAsqn, journalIndex);
   }
 
   /**
@@ -334,7 +334,7 @@ final class SegmentsManager implements AutoCloseable {
         final Segment segment =
             segmentLoader.loadExistingSegment(
                 file.toPath(),
-                lastWrittenIndex,
+                lastFlushedIndex,
                 previousSegment != null ? previousSegment.lastAsqn() : INITIAL_ASQN,
                 journalIndex);
 
@@ -375,13 +375,13 @@ final class SegmentsManager implements AutoCloseable {
       lastSegmentIndex = previousSegment.lastIndex();
     }
 
-    if (lastWrittenIndex > lastSegmentIndex) {
+    if (lastFlushedIndex > lastSegmentIndex) {
       return false;
     }
 
     LOG.debug(
         "Found corrupted segment after last ack'ed index {}. Deleting segments {} - {}",
-        lastWrittenIndex,
+        lastFlushedIndex,
         files.get(failedIndex).getName(),
         files.get(files.size() - 1).getName());
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/UninitializedSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/UninitializedSegment.java
@@ -27,7 +27,7 @@ public record UninitializedSegment(
   public Segment initializeForUse(
       final long index,
       final long lastWrittenAsqn,
-      final long lastWrittenIndex,
+      final long lastFlushedIndex,
       final JournalMetrics metrics) {
     final var updatedDescriptor =
         SegmentDescriptor.builder()
@@ -37,6 +37,6 @@ public record UninitializedSegment(
             .build();
     updatedDescriptor.copyTo(buffer);
     return new Segment(
-        file, updatedDescriptor, buffer, lastWrittenIndex, lastWrittenAsqn, journalIndex, metrics);
+        file, updatedDescriptor, buffer, lastFlushedIndex, lastWrittenAsqn, journalIndex, metrics);
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -607,7 +607,7 @@ final class JournalTest {
 
     // then
     assertThatThrownBy(
-            () -> journal = openJournal(b -> b.withLastWrittenIndex(secondRecord.index())))
+            () -> journal = openJournal(b -> b.withLastFlushedIndex(secondRecord.index())))
         .isInstanceOf(CorruptedJournalException.class);
   }
 
@@ -623,7 +623,7 @@ final class JournalTest {
     // when
     journal.close();
     assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
-    journal = openJournal(b -> b.withLastWrittenIndex(firstRecord.index()));
+    journal = openJournal(b -> b.withLastFlushedIndex(firstRecord.index()));
     recordDataWriter.wrap(new UnsafeBuffer("111".getBytes(StandardCharsets.UTF_8)));
     final var lastRecord = journal.append(recordDataWriter);
     final var reader = journal.openReader();

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
@@ -26,15 +26,15 @@ final class SegmentLoaderTest {
     final var segmentSize = 4 * 1024 * 1024;
     final var descriptor =
         SegmentDescriptor.builder().withId(1).withIndex(1).withMaxSegmentSize(segmentSize).build();
-    final var lastWrittenIndex = descriptor.index() - 1;
+    final var lastFlushedIndex = descriptor.index() - 1;
     final var segmentLoader = new SegmentLoader(segmentSize * 2, new JournalMetrics("1"));
     final var segmentFile = tmpDir.resolve("segment.log");
 
-    // when - the segment is "unused" if the lastWrittenIndex is less than the expected first index
+    // when - the segment is "unused" if the lastFlushedIndex is less than the expected first index
     // this can happen if we crashed in the middle of creating the new segment
     Files.writeString(segmentFile, "foo");
     segmentLoader.createSegment(
-        segmentFile, descriptor, lastWrittenIndex, 0, new SparseJournalIndex(1));
+        segmentFile, descriptor, lastFlushedIndex, 0, new SparseJournalIndex(1));
 
     // then
     PosixPathAssert.assertThat(segmentFile).hasRealSize(segmentSize);

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -150,7 +150,7 @@ class SegmentsManagerTest {
         .containsExactly(1L, 0L);
   }
 
-  private SegmentsManager createSegmentsManager(final long lastWrittenIndex) {
+  private SegmentsManager createSegmentsManager(final long lastFlushedIndex) {
     final var journalIndex = new SparseJournalIndex(journalIndexDensity);
     final var maxSegmentSize = entrySize + SegmentDescriptor.getEncodingLength();
     final var metrics = new JournalMetrics("1");
@@ -158,7 +158,7 @@ class SegmentsManagerTest {
         journalIndex,
         maxSegmentSize,
         directory.resolve("data").toFile(),
-        lastWrittenIndex,
+        lastFlushedIndex,
         JOURNAL_NAME,
         new SegmentLoader(2 * maxSegmentSize, metrics),
         metrics);

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -9800,7 +9800,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(atomix_last_written_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le)",
+              "expr": "sum(increase(atomix_last_flushed_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",

--- a/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -112,7 +112,7 @@ public class PartitionRestoreService {
         SegmentedJournal.builder()
             .withDirectory(dataDirectory.toFile())
             .withName(partition.name())
-            .withLastWrittenIndex(-1)
+            .withLastFlushedIndex(-1)
             .build()) {
 
       resetJournal(checkpointPosition, journal);


### PR DESCRIPTION
## Description

This PR introduce a new user facing configuration which allows user to configure different Raft flush strategies. This can help users for whom the default performance of Zeebe is insufficient by trading off safety for performance.

The configuration looks like this:

```yaml
zeebe:
  broker:
    cluster:
      # Configure raft properties
      # raft:
        # Configures how often data is explicitly flushed to disk. By default, for a given
        # partition, data is flushed on every leader commit, and every follower append. This is to
        # ensure consistency across all replicas. Disabling this can cause inconsistencies, and at
        # worst, data corruption or data loss scenarios.
        #
        # The default behavior is optimized for safety, and flushing occurs on every leader commit
        # and follower append in a synchronous fashion. You can introduce a delay to reduce the
        # performance penalty of flushing via `delayTime`.
        flush:
          # If false, explicit flushing of the Raft log is disabled, and flushing only occurs right
          # before a snapshot is taken. You should only disable explicit flushing if you are willing
          # to accept potential data loss at the expense of performance. Before disabling it, try
          # the delayed options, which provide a trade-off between safety and performance.
          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_ENABLED
          # enabled: true
          # If the delay is > 0, then flush requests are delayed by at least the given period. It is
          # recommended that you find the smallest delay here with which you achieve your
          # performance goals. It's also likely that anything above 30s is not useful, as this is
          # the typical default flush interval for the Linux OS.
          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_DELAYTIME
          # delayTime: 0s
```

There are 3 strategies:

- NoOp: calling `RaftLog#flush` will do nothing. This is the fastest, but most dangerous. You can enable this by configuring `ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_ENABLED=false`
- Direct: calling `RaftLog#flush` will flush the journal. This is the default configuration, and the safest, and what's currently in use. You can configure it by setting `ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_ENABLED=true` and `ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_DELAYTIME=0s`.
- Delayed: calling `RaftLog#flush` will signal the flusher there is something to flush. If nothing is scheduled yet, a flush operation is scheduled for the configured delay in `ZEEBE_BROKER_CLUSTER_RAFT_FLUSH_DELAYTIME`. If there is already a scheduled operation, then nothing happens. This means under constant load you would be flushing periodically with the delay as period. Under low load, then when there is nothing to flush, nothing happens.

Because flushing the journal is asynchronously is not thread safe at the moment, this PR flushes synchronously on the Raft thread, and some corners were cut. This will be tackled in a second PR to keep things manageable.

The old `disableExplicitRaftFlush` flag is still respected and will set the strategy to `NoOp`. It's marked as deprecated now and marked for removal in 8.3.0.

## Related issues

related to #11519 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
