### PR TITLE
chore(ci): run arm64 smoke tests with emulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
           - os: linux
-            runner: [ self-hosted, linux, arm64, "4" ]
+            runner: [ self-hosted, linux, amd64 ]
             arch: arm64
     env:
       JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64M
@@ -231,6 +231,7 @@ jobs:
           push: false
       - name: Run smoke test on ${{ matrix.arch }}
         env:
+          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
           # For non Linux runners there is no container available for testing, see build-docker job
           EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
         run: >


### PR DESCRIPTION
## Description

Revert to use emulation instead of native runners, which recently experienced instability.