### PR TITLE
[Backport stable/8.1] test: reliably fill journal for disk space recovery testing

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
@@ -67,7 +67,8 @@ final class DiskSpaceRecoveryIT {
         .newPublishMessageCommand()
         .messageName("test")
         .correlationKey(String.valueOf(1))
-        .variables(Map.of("key", "x".repeat(4096)))
+        .variables(Map.of("key", "abc".repeat(4096)))
+        .timeToLive(Duration.ZERO)
         .send()
         .join();
   }


### PR DESCRIPTION
# Description
Backport of #11562 to `stable/8.1`.

relates to #11538