### PR TITLE
[Backport stable/8.1] Make processing batch limit configurable in StreamProcessor

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -98,8 +98,6 @@ public final class ProcessingStateMachine {
 
   private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
 
-  private static final int COMMAND_LIMIT = 1;
-
   private static final MetadataFilter PROCESSING_FILTER =
       recordMetadata -> recordMetadata.getRecordType() == RecordType.COMMAND;
 
@@ -143,6 +141,7 @@ public final class ProcessingStateMachine {
   private RecordProcessor currentProcessor;
   private final LogStreamBatchWriter logStreamBatchWriter;
   private boolean inProcessing;
+  private final int processingBatchLimit;
 
   public ProcessingStateMachine(
       final StreamProcessorContext context,
@@ -157,6 +156,7 @@ public final class ProcessingStateMachine {
     transactionContext = context.getTransactionContext();
     abortCondition = context.getAbortCondition();
     lastProcessedPositionState = context.getLastProcessedPositionState();
+    processingBatchLimit = context.getProcessingBatchLimit();
 
     writeRetryStrategy = new AbortableRetryStrategy(actor);
     sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);
@@ -284,7 +284,7 @@ public final class ProcessingStateMachine {
     final var pendingCommands = new ArrayDeque<TypedRecord<?>>();
     pendingCommands.addLast(initialCommand);
 
-    while (!pendingCommands.isEmpty() && processedCommandsCount < COMMAND_LIMIT) {
+    while (!pendingCommands.isEmpty() && processedCommandsCount < processingBatchLimit) {
 
       final var command = pendingCommands.removeFirst();
 
@@ -345,7 +345,7 @@ public final class ProcessingStateMachine {
 
               final int potentialBatchSize = currentBatchSize + commandsToProcess.size();
               if (entry.recordMetadata().getRecordType() == RecordType.COMMAND
-                  && potentialBatchSize < COMMAND_LIMIT) {
+                  && potentialBatchSize < processingBatchLimit) {
                 commandsToProcess.add(
                     new UnwrittenRecord(
                         entry.key(),

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
@@ -135,4 +135,9 @@ public final class StreamProcessorBuilder {
           "No partition command sender provided");
     }
   }
+
+  public StreamProcessorBuilder processingBatchLimit(final int processingBatchLimit) {
+    streamProcessorContext.processingBatchLimit(processingBatchLimit);
+    return this;
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -26,6 +26,7 @@ import java.util.function.BooleanSupplier;
 
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
 
+  public static final int DEFAULT_PROCESSING_BATCH_LIMIT = 1;
   private static final StreamProcessorListener NOOP_LISTENER =
       new StreamProcessorListener() {
         @Override
@@ -34,7 +35,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
         @Override
         public void onSkipped(final LoggedEvent skippedRecord) {}
       };
-
   private ActorControl actor;
   private LogStream logStream;
   private LogStreamReader logStreamReader;
@@ -55,6 +55,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   // this is accessed outside, which is why we need to make sure that it is thread-safe
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
   private KeyGeneratorControls keyGeneratorControls;
+  private int processingBatchLimit = DEFAULT_PROCESSING_BATCH_LIMIT;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -195,5 +196,14 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public void streamProcessorPhase(final Phase phase) {
     this.phase = phase;
+  }
+
+  public StreamProcessorContext processingBatchLimit(final int processingBatchLimit) {
+    this.processingBatchLimit = processingBatchLimit;
+    return this;
+  }
+
+  public int getProcessingBatchLimit() {
+    return processingBatchLimit;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -104,6 +104,7 @@ public final class EngineRule extends ExternalResource {
       new Int2ObjectHashMap<>();
 
   private long lastProcessedPosition = -1L;
+  private int batchLimit;
 
   private EngineRule(final int partitionCount) {
     this(partitionCount, null);
@@ -403,6 +404,11 @@ public final class EngineRule extends ExternalResource {
 
   public boolean hasReachedEnd() {
     return getStreamProcessor(PARTITION_ID).hasProcessingReachedTheEnd().join();
+  }
+
+  public EngineRule processingBatchLimit(final int processingBatchLimit) {
+    environmentRule.processingBatchLimit(processingBatchLimit);
+    return this;
   }
 
   private static final class VersatileBlob implements DbKey, DbValue {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.streamprocessor.StreamProcessorContext;
 import io.camunda.zeebe.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.streamprocessor.state.MutableLastProcessedPositionState;
@@ -68,6 +69,7 @@ public final class StreamProcessorRule implements TestRule {
   private StreamProcessingComposite streamProcessingComposite;
   private ListLogStorage sharedStorage = null;
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
+  private int processingBatchLimit = StreamProcessorContext.DEFAULT_PROCESSING_BATCH_LIMIT;
 
   public StreamProcessorRule() {
     this(new TemporaryFolder());
@@ -325,6 +327,10 @@ public final class StreamProcessorRule implements TestRule {
     return streamProcessingComposite.getLastProcessedPositionState();
   }
 
+  public void processingBatchLimit(final int processingBatchLimit) {
+    this.processingBatchLimit = processingBatchLimit;
+  }
+
   private class SetupRule extends ExternalResource {
 
     private final int startPartitionId;
@@ -339,6 +345,7 @@ public final class StreamProcessorRule implements TestRule {
     protected void before() {
       streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
       streams.withStreamProcessorMode(streamProcessorMode);
+      streams.processingBatchLimit(processingBatchLimit);
 
       int partitionId = startPartitionId;
       for (int i = 0; i < partitionCount; i++) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.streamprocessor.StreamProcessorContext;
 import io.camunda.zeebe.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
@@ -90,6 +91,7 @@ public final class TestStreams {
 
   private Function<MutableZeebeState, EventApplier> eventApplierFactory = EventAppliers::new;
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
+  private int processingBatchLimit = StreamProcessorContext.DEFAULT_PROCESSING_BATCH_LIMIT;
 
   public TestStreams(
       final TemporaryFolder dataDirectory,
@@ -295,6 +297,7 @@ public final class TestStreams {
             .recordProcessors(List.of(new Engine(wrappedFactory)))
             .eventApplierFactory(eventApplierFactory)
             .streamProcessorMode(streamProcessorMode)
+            .processingBatchLimit(processingBatchLimit)
             .partitionCommandSender(mock(InterPartitionCommandSender.class));
 
     final StreamProcessor streamProcessor = builder.build();
@@ -360,6 +363,10 @@ public final class TestStreams {
           .done();
     }
     return logStreamBatchWriter;
+  }
+
+  public void processingBatchLimit(final int processingBatchLimit) {
+    this.processingBatchLimit = processingBatchLimit;
   }
 
   public static class FluentLogWriter {


### PR DESCRIPTION
Manual backport of #11527.

Some conflicts due to package restructuring but nothing major.