### PR TITLE
Use partition ID for journal metrics

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -323,6 +323,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
     final RaftStorageConfig storageConfig = config.getStorageConfig();
     return RaftStorage.builder()
         .withPrefix(partition.name())
+        .withPartitionId(partition.id().id())
         .withDirectory(partition.dataDirectory())
         .withMaxSegmentSize((int) storageConfig.getSegmentSize())
         .withFlushExplicitly(storageConfig.shouldFlushExplicitly())

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -53,6 +53,7 @@ import java.nio.file.StandardOpenOption;
 public final class RaftStorage {
 
   private final String prefix;
+  private final int partitionId;
   private final File directory;
   private final int maxSegmentSize;
   private final long freeDiskSpace;
@@ -63,6 +64,7 @@ public final class RaftStorage {
 
   private RaftStorage(
       final String prefix,
+      final int partitionId,
       final File directory,
       final int maxSegmentSize,
       final long freeDiskSpace,
@@ -71,6 +73,7 @@ public final class RaftStorage {
       final int journalIndexDensity,
       final boolean preallocateSegmentFiles) {
     this.prefix = prefix;
+    this.partitionId = partitionId;
     this.directory = directory;
     this.maxSegmentSize = maxSegmentSize;
     this.freeDiskSpace = freeDiskSpace;
@@ -184,6 +187,7 @@ public final class RaftStorage {
 
     return RaftLog.builder()
         .withName(prefix)
+        .withPartitionId(partitionId)
         .withDirectory(directory)
         .withMaxSegmentSize(maxSegmentSize)
         .withFreeDiskSpace(freeDiskSpace)
@@ -239,6 +243,9 @@ public final class RaftStorage {
     private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
     private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
 
+    // impossible value to make it clear it's unset and there's an error
+    private static final int DEFAULT_PARTITION_ID = -1;
+
     private String prefix = DEFAULT_PREFIX;
     private File directory = new File(DEFAULT_DIRECTORY);
     private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
@@ -247,6 +254,7 @@ public final class RaftStorage {
     private ReceivableSnapshotStore persistedSnapshotStore;
     private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
     private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
+    private int partitionId = DEFAULT_PARTITION_ID;
 
     private Builder() {}
 
@@ -351,6 +359,17 @@ public final class RaftStorage {
     }
 
     /**
+     * The ID of the partition on which this storage resides.
+     *
+     * @param partitionId the storage's partition ID
+     * @return this builder for chaining
+     */
+    public Builder withPartitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    /**
      * Builds the {@link RaftStorage} object.
      *
      * @return The built storage configuration.
@@ -359,6 +378,7 @@ public final class RaftStorage {
     public RaftStorage build() {
       return new RaftStorage(
           prefix,
+          partitionId,
           directory,
           maxSegmentSize,
           freeDiskSpace,

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -131,6 +131,17 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
     return this;
   }
 
+  /**
+   * The ID of the partition on which this log resides.
+   *
+   * @param partitionId the log's partition ID
+   * @return this builder for chaining
+   */
+  public RaftLogBuilder withPartitionId(final int partitionId) {
+    journalBuilder.withPartitionId(partitionId);
+    return this;
+  }
+
   @Override
   public RaftLog build() {
     final Journal journal = journalBuilder.build();

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalMetrics.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalMetrics.java
@@ -104,20 +104,16 @@ final class JournalMetrics {
   private final Counter.Child appendRate;
   private final Counter.Child appendDataRate;
 
-  JournalMetrics(final String name) {
-    // hacky way of fetching the partition ID if the journal was created from a partition group; if
-    // not, the name is used as is
-    final var partition = name.substring(name.lastIndexOf('-') + 1);
-
-    segmentCreationTime = SEGMENT_CREATION_TIME.labels(partition);
-    segmentTruncateTime = SEGMENT_TRUNCATE_TIME.labels(partition);
-    segmentFlushTime = SEGMENT_FLUSH_TIME.labels(partition);
-    segmentCount = SEGMENT_COUNT.labels(partition);
-    journalOpenTime = JOURNAL_OPEN_DURATION.labels(partition);
-    segmentAllocationTime = SEGMENT_ALLOCATION_TIME.labels(partition);
-    appendLatency = APPEND_LATENCY.labels(partition);
-    appendRate = APPEND_RATE.labels(partition);
-    appendDataRate = APPEND_DATA_RATE.labels(partition);
+  JournalMetrics(final String partitionId) {
+    segmentCreationTime = SEGMENT_CREATION_TIME.labels(partitionId);
+    segmentTruncateTime = SEGMENT_TRUNCATE_TIME.labels(partitionId);
+    segmentFlushTime = SEGMENT_FLUSH_TIME.labels(partitionId);
+    segmentCount = SEGMENT_COUNT.labels(partitionId);
+    journalOpenTime = JOURNAL_OPEN_DURATION.labels(partitionId);
+    segmentAllocationTime = SEGMENT_ALLOCATION_TIME.labels(partitionId);
+    appendLatency = APPEND_LATENCY.labels(partitionId);
+    appendRate = APPEND_RATE.labels(partitionId);
+    appendDataRate = APPEND_DATA_RATE.labels(partitionId);
   }
 
   void observeSegmentCreation(final Runnable segmentCreation) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalMetrics.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalMetrics.java
@@ -104,16 +104,20 @@ final class JournalMetrics {
   private final Counter.Child appendRate;
   private final Counter.Child appendDataRate;
 
-  JournalMetrics(final String logName) {
-    segmentCreationTime = SEGMENT_CREATION_TIME.labels(logName);
-    segmentTruncateTime = SEGMENT_TRUNCATE_TIME.labels(logName);
-    segmentFlushTime = SEGMENT_FLUSH_TIME.labels(logName);
-    segmentCount = SEGMENT_COUNT.labels(logName);
-    journalOpenTime = JOURNAL_OPEN_DURATION.labels(logName);
-    segmentAllocationTime = SEGMENT_ALLOCATION_TIME.labels(logName);
-    appendLatency = APPEND_LATENCY.labels(logName);
-    appendRate = APPEND_RATE.labels(logName);
-    appendDataRate = APPEND_DATA_RATE.labels(logName);
+  JournalMetrics(final String name) {
+    // hacky way of fetching the partition ID if the journal was created from a partition group; if
+    // not, the name is used as is
+    final var partition = name.substring(name.lastIndexOf('-') + 1);
+
+    segmentCreationTime = SEGMENT_CREATION_TIME.labels(partition);
+    segmentTruncateTime = SEGMENT_TRUNCATE_TIME.labels(partition);
+    segmentFlushTime = SEGMENT_FLUSH_TIME.labels(partition);
+    segmentCount = SEGMENT_COUNT.labels(partition);
+    journalOpenTime = JOURNAL_OPEN_DURATION.labels(partition);
+    segmentAllocationTime = SEGMENT_ALLOCATION_TIME.labels(partition);
+    appendLatency = APPEND_LATENCY.labels(partition);
+    appendRate = APPEND_RATE.labels(partition);
+    appendDataRate = APPEND_DATA_RATE.labels(partition);
   }
 
   void observeSegmentCreation(final Runnable segmentCreation) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -153,7 +153,13 @@ public class SegmentedJournalBuilder {
     final var segmentLoader = new SegmentLoader(freeDiskSpace, journalMetrics, segmentAllocator);
     final var segmentsManager =
         new SegmentsManager(
-            journalIndex, maxSegmentSize, directory, lastWrittenIndex, name, segmentLoader);
+            journalIndex,
+            maxSegmentSize,
+            directory,
+            lastWrittenIndex,
+            name,
+            segmentLoader,
+            journalMetrics);
 
     return new SegmentedJournal(
         directory, maxSegmentSize, journalIndex, segmentsManager, journalMetrics);

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -32,6 +32,9 @@ public class SegmentedJournalBuilder {
   private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
   private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
 
+  // impossible value to make it clear it's unset
+  private static final int DEFAULT_PARTITION_ID = -1;
+
   protected String name = DEFAULT_NAME;
   protected File directory = new File(DEFAULT_DIRECTORY);
   protected int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
@@ -40,6 +43,7 @@ public class SegmentedJournalBuilder {
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
   private long lastWrittenIndex = -1L;
   private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
+  private int partitionId = DEFAULT_PARTITION_ID;
 
   protected SegmentedJournalBuilder() {}
 
@@ -145,9 +149,21 @@ public class SegmentedJournalBuilder {
     return this;
   }
 
+  /**
+   * The ID of the partition on which this journal resides. This is used primarily for
+   * observability, e.g. in {@link JournalMetrics}.
+   *
+   * @param partitionId the journal's partition ID
+   * @return this builder for chaining
+   */
+  public SegmentedJournalBuilder withPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
   public SegmentedJournal build() {
     final var journalIndex = new SparseJournalIndex(journalIndexDensity);
-    final var journalMetrics = new JournalMetrics(name);
+    final var journalMetrics = new JournalMetrics(String.valueOf(partitionId));
     final var segmentAllocator =
         preallocateSegmentFiles ? SegmentAllocator.fill() : SegmentAllocator.noop();
     final var segmentLoader = new SegmentLoader(freeDiskSpace, journalMetrics, segmentAllocator);

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -61,14 +61,15 @@ final class SegmentsManager implements AutoCloseable {
       final File directory,
       final long lastWrittenIndex,
       final String name,
-      final SegmentLoader segmentLoader) {
+      final SegmentLoader segmentLoader,
+      final JournalMetrics journalMetrics) {
     this.name = checkNotNull(name, "name cannot be null");
-    journalMetrics = new JournalMetrics(name);
     this.journalIndex = journalIndex;
     this.maxSegmentSize = maxSegmentSize;
     this.directory = directory;
     this.lastWrittenIndex = lastWrittenIndex;
     this.segmentLoader = segmentLoader;
+    this.journalMetrics = journalMetrics;
   }
 
   @Override

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -50,7 +50,7 @@ class SegmentsManagerTest {
     // will cause the segment to be deleted on close where we actually want to test that the file is
     // deleted when opening.
 
-    try (var newSegments = createSegmentsManager(0)) {
+    try (final var newSegments = createSegmentsManager(0)) {
       newSegments.open();
       // then
       final File logDirectory = directory.resolve("data").toFile();
@@ -137,13 +137,15 @@ class SegmentsManagerTest {
   private SegmentsManager createSegmentsManager(final long lastWrittenIndex) {
     final var journalIndex = new SparseJournalIndex(journalIndexDensity);
     final var maxSegmentSize = entrySize + SegmentDescriptor.getEncodingLength();
+    final var metrics = new JournalMetrics("1");
     return new SegmentsManager(
         journalIndex,
         maxSegmentSize,
         directory.resolve("data").toFile(),
         lastWrittenIndex,
         JOURNAL_NAME,
-        new SegmentLoader(2 * maxSegmentSize, new JournalMetrics("1")));
+        new SegmentLoader(2 * maxSegmentSize, metrics),
+        metrics);
   }
 
   private SegmentedJournal openJournal(final float entriesPerSegment) {

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -9343,7 +9343,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_log_appender_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[1m])) by (partition) / sum(rate(zeebe_log_appender_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[1m])) by (partition) ",
+              "expr": "sum(rate(atomix_journal_append_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[1m])) by (partition) / sum(rate(atomix_journal_append_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[1m])) by (partition) ",
               "hide": false,
               "interval": "",
               "legendFormat": "AVG partition {{partition}}",
@@ -14603,6 +14603,6 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 7,
+  "version": 8,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description

This PR fixes the journal labels so the partition correctly refers to the partition ID, and not the journal name. This means the journal metrics can be filtered on the dashboard just like all the others.

## Related issues

closes #11556 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
