### PR TITLE
ci: enable CI workflow to run on merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - trying
       - staging
   pull_request: { }
+  merge_group: { }
   workflow_dispatch: { }
   workflow_call: { }
 


### PR DESCRIPTION
This adds another trigger to the CI workflow so that it runs for merge queues: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions