### PR TITLE
Add randomized test for dataloss scenario

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -528,7 +528,17 @@ public final class ControllableRaftContexts {
   }
 
   boolean hasReplicatedAllEntries() {
-    return raftServers.values().stream().map(this::getLastUncommittedEntry).distinct().count() == 1;
+    final boolean allReplicasHaveSameLastIndex =
+        raftServers.values().stream()
+                .map(RaftContext::getLog)
+                .map(RaftLog::getLastIndex)
+                .distinct()
+                .count()
+            == 1;
+    final boolean allReplicasHaveSameLastEntry =
+        raftServers.values().stream().map(this::getLastUncommittedEntry).distinct().count() == 1;
+    // should check both to cover cases where one log is empty
+    return allReplicasHaveSameLastIndex && allReplicasHaveSameLastEntry;
   }
 
   public void assertAllEntriesCommittedAndReplicatedToAll() {

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -395,7 +396,7 @@ public final class ControllableRaftContexts {
       FileUtil.deleteFolderIfExists(dataDirectory);
     } catch (final IOException e) {
       LOG.error("Failed to delete directory {} of member {}", dataDirectory, memberId.id());
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
     newContext.getCluster().bootstrap(raftServers.keySet());

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -33,10 +33,12 @@ import io.atomix.raft.snapshot.InMemorySnapshot;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.io.File;
 import java.io.IOException;
@@ -48,9 +50,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -87,7 +92,7 @@ public final class ControllableRaftContexts {
   private int nextEntry = 0;
 
   // Used only for verification. Map[term -> leader]
-  private final Map<Long, MemberId> leadersAtTerms = new HashMap<>();
+  private final NavigableMap<Long, MemberId> leadersAtTerms = new TreeMap<>();
   private final AppendListener appendListener = mock(AppendListener.class);
 
   public ControllableRaftContexts(final int nodeCount) {
@@ -157,16 +162,19 @@ public final class ControllableRaftContexts {
 
   private void createRaftContexts(final int nodeCount, final Random random) {
     for (int i = 0; i < nodeCount; i++) {
-      final var memberId = MemberId.from(String.valueOf(i));
-      final var snapshotStore = new TestSnapshotStore(new AtomicReference<>());
-      snapshotStores.put(memberId, snapshotStore);
-      raftServers.put(
-          memberId,
-          createRaftContext(
-              memberId,
-              random,
-              createStorage(memberId, cfg -> cfg.withSnapshotStore(snapshotStore))));
+      createRaftContextForMember(random, i);
     }
+  }
+
+  private RaftContext createRaftContextForMember(final Random random, final int nodeId) {
+    final var memberId = MemberId.from(String.valueOf(nodeId));
+    final var snapshotStore = new TestSnapshotStore(new AtomicReference<>());
+    snapshotStores.put(memberId, snapshotStore);
+    final RaftContext raftContext =
+        createRaftContext(
+            memberId, random, createStorage(memberId, cfg -> cfg.withSnapshotStore(snapshotStore)));
+    raftServers.put(memberId, raftContext);
+    return raftContext;
   }
 
   public RaftContext createRaftContext(
@@ -363,6 +371,78 @@ public final class ControllableRaftContexts {
     newContext.getCluster().bootstrap(raftServers.keySet());
 
     raftServers.put(memberId, newContext);
+  }
+
+  // This is a different from other operations, as it restarts the node and force operations on
+  // other
+  // nodes to wait until this node is ready. This is required because we can only tolerate data loss
+  // of one node at a time.
+  public void restartWithDataLoss(final MemberId memberId) {
+    LOG.info("Shutting down member {}", memberId.id());
+    raftServers.get(memberId).close();
+    deterministicExecutors.remove(memberId).close();
+    final var nodeBeforeRestart = raftServers.remove(memberId);
+
+    // Wait until the other two members become a quorum and elect a leader. Otherwise, the restarted
+    // node and the follower without the latest log can become a quorum and result in data loss.
+    waitUntilThereIsAnotherLeader(memberId);
+
+    // Restart the node with empty state
+    final var dataDirectory = nodeBeforeRestart.getStorage().directory().toPath();
+    LOG.info("Deleting directory {} of member {}", dataDirectory, memberId.id());
+    try {
+      FileUtil.deleteFolderIfExists(dataDirectory);
+    } catch (final IOException e) {
+      LOG.error("Failed to delete directory {} of member {}", dataDirectory, memberId.id());
+      throw new RuntimeException(e);
+    }
+    final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
+    newContext.getCluster().bootstrap(raftServers.keySet());
+
+    raftServers.put(memberId, newContext);
+
+    // Wait until member has recovered lost data and have caught up with the leader
+    waitUntilMembersIsReadyIn(newContext, 100);
+  }
+
+  private void waitUntilThereIsAnotherLeader(final MemberId memberId) {
+    int steps = 100;
+
+    while (steps-- > 0) {
+      final Entry<Long, MemberId> currentLeaderEntry = leadersAtTerms.lowerEntry(Long.MAX_VALUE);
+      final var currentLeader =
+          currentLeaderEntry != null ? currentLeaderEntry.getValue().id() : null;
+      // If the node was leader before restart, wait until new leader is elected &&
+      // Ensure that other nodes in the quorum is up-to-date. Otherwise, after restart this node
+      // can form a quorum with a follower which is not up-to-date.
+      if (!memberId.id().equals(currentLeader)
+          && hasLeaderAtTheLatestTerm()
+          && hasReplicatedAllEntries()) {
+        final var leader = leadersAtTerms.lowerEntry(Long.MAX_VALUE).getValue();
+        LOG.info("Current leader is {}. ", leader.id());
+        break;
+      } else {
+        tickHeartbeatTimeout();
+        processAllMessage();
+        runUntilDone();
+      }
+    }
+    assertThat(hasLeaderAtTheLatestTerm()).isTrue();
+    assertThat(hasReplicatedAllEntries()).isTrue();
+  }
+
+  private void waitUntilMembersIsReadyIn(final RaftContext member, final int steps) {
+    int iter = steps;
+    while (member.getState() != State.READY && iter-- > 0) {
+      runUntilDone();
+      processAllMessage();
+      tickHeartbeatTimeout();
+    }
+    assertThat(member.getState())
+        .describedAs(
+            "Member should be ready in %d steps, if there are no failures or timeouts"
+                .formatted(steps))
+        .isEqualTo(State.READY);
   }
 
   // ----------------------- Verifications -----------------------------

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -68,6 +68,14 @@ public final class RaftOperation {
     return operationsWithSnapshot;
   }
 
+  public static List<RaftOperation> getRaftOperationsWithSnapshotsAndRestartsWithDataLoss() {
+    final List<RaftOperation> operations = getRaftOperationsWithSnapshotsAndRestarts();
+    operations.add(
+        RaftOperation.of(
+            "Restart member with full data loss", ControllableRaftContexts::restartWithDataLoss));
+    return operations;
+  }
+
   public static List<RaftOperation> getDefaultRaftOperations() {
     final List<RaftOperation> defaultRaftOperation = new ArrayList<>();
     defaultRaftOperation.add(

--- a/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -195,32 +195,23 @@ public class RandomizedRaftTest {
 
     // when - no more message loss
 
-    // hoping that 100 iterations are enough to elect a new leader, since there are no more failures
-    int maxStepsUntilLeader = 100;
-    while (!raftContexts.hasLeaderAtTheLatestTerm() && maxStepsUntilLeader-- > 0) {
-      raftContexts.runUntilDone();
-      raftContexts.processAllMessage();
-      raftContexts.tickHeartbeatTimeout();
-      raftContexts.processAllMessage();
-      raftContexts.runUntilDone();
-    }
-
-    // then - eventually a leader should be elected
-    assertThat(raftContexts.hasLeaderAtTheLatestTerm())
-        .describedAs("Leader election should be completed if there are no messages lost.")
-        .isTrue();
-
-    // then - eventually all entries are replicated to all followers and all entries are committed
     // hoping that 2000 iterations are enough to replicate all entries
     int maxStepsToReplicateEntries = 2000;
-    while (!(raftContexts.hasReplicatedAllEntries() && raftContexts.hasCommittedAllEntries())
+    while (!(raftContexts.hasLeaderAtTheLatestTerm()
+            && raftContexts.hasReplicatedAllEntries()
+            && raftContexts.hasCommittedAllEntries())
         && maxStepsToReplicateEntries-- > 0) {
       raftContexts.runUntilDone();
       raftContexts.processAllMessage();
       raftContexts.tickHeartbeatTimeout();
-      raftContexts.processAllMessage();
-      raftContexts.runUntilDone();
     }
+
+    // then - eventually all entries are replicated to all followers and all entries are committed
+
+    // eventually a leader should be elected
+    assertThat(raftContexts.hasLeaderAtTheLatestTerm())
+        .describedAs("Leader election should be completed if there are no messages lost.")
+        .isTrue();
 
     // All member are be ready
     raftContexts.assertAllMembersAreReady();

--- a/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -47,6 +47,7 @@ public class RandomizedRaftTest {
   private List<RaftOperation> operationsWithSnapshot;
   private List<RaftOperation> operationsWithRestarts;
   private List<RaftOperation> operationsWithSnapshotsAndRestarts;
+  private List<RaftOperation> operationsWithSnapshotsAndRestartsWithDataLoss;
 
   private List<MemberId> raftMembers;
   private Path raftDataDirectory;
@@ -63,6 +64,8 @@ public class RandomizedRaftTest {
     operationsWithSnapshot = RaftOperation.getRaftOperationsWithSnapshot();
     operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
     operationsWithSnapshotsAndRestarts = RaftOperation.getRaftOperationsWithSnapshotsAndRestarts();
+    operationsWithSnapshotsAndRestartsWithDataLoss =
+        RaftOperation.getRaftOperationsWithSnapshotsAndRestartsWithDataLoss();
     raftMembers = servers;
   }
 
@@ -106,6 +109,17 @@ public class RandomizedRaftTest {
   @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
   void consistencyTestWithSnapshotsAndRestarts(
       @ForAll("raftOperationsWithSnapshotsAndRestarts") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+
+    consistencyTest(raftOperations, raftMembers, seed);
+  }
+
+  @Property(tries = 1, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+  void consistencyTestAfterDataLoss(
+      @ForAll("raftOperationsWithSnapshotsAndRestartsWithDataLoss")
+          final List<RaftOperation> raftOperations,
       @ForAll("raftMembers") final List<MemberId> raftMembers,
       @ForAll("seeds") final long seed)
       throws Exception {
@@ -245,6 +259,13 @@ public class RandomizedRaftTest {
   @Provide
   Arbitrary<List<RaftOperation>> raftOperationsWithSnapshotsAndRestarts() {
     return Arbitraries.of(operationsWithSnapshotsAndRestarts).list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<List<RaftOperation>> raftOperationsWithSnapshotsAndRestartsWithDataLoss() {
+    return Arbitraries.of(operationsWithSnapshotsAndRestartsWithDataLoss)
+        .list()
+        .ofSize(OPERATION_SIZE);
   }
 
   @Provide

--- a/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -189,6 +189,7 @@ public class RandomizedRaftTest {
     raftContexts.assertAllLogsEqual();
     raftContexts.assertNoGapsInLog();
     raftContexts.assertNoJournalAppendErrors();
+    raftContexts.assertNoDataLoss();
   }
 
   private void livenessTest(
@@ -235,6 +236,7 @@ public class RandomizedRaftTest {
     raftContexts.assertAllEntriesCommittedAndReplicatedToAll();
     raftContexts.assertNoGapsInLog();
     raftContexts.assertNoJournalAppendErrors();
+    raftContexts.assertNoDataLoss();
   }
 
   /** Basic raft operations without snapshotting, compaction or restart */


### PR DESCRIPTION
## Description

Add restart with dataloss to the set of input operations in randomized raft tests. The operations ensures that we can only inject data loss of one node at a time. It waits until the restarted node have recovered and caught up before proceeding with the other operations. 

This PR also adds additional verification to ensure that there is no dataloss, by keeping track of committed entries and verifying that it is not overwritten.

## Related issues

closes #9837 
