### PR TITLE
Process DecisionRequirements DELETED events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DecisionRequirementsDeletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DecisionRequirementsDeletedApplier.java
@@ -22,5 +22,7 @@ public final class DecisionRequirementsDeletedApplier
   }
 
   @Override
-  public void applyState(final long key, final DecisionRequirementsRecord value) {}
+  public void applyState(final long key, final DecisionRequirementsRecord value) {
+    decisionState.deleteDecisionRequirements(value);
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DecisionRequirementsDeletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DecisionRequirementsDeletedApplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+
+public final class DecisionRequirementsDeletedApplier
+    implements TypedEventApplier<DecisionRequirementsIntent, DecisionRequirementsRecord> {
+
+  private final MutableDecisionState decisionState;
+
+  public DecisionRequirementsDeletedApplier(final MutableDecisionState decisionState) {
+    this.decisionState = decisionState;
+  }
+
+  @Override
+  public void applyState(final long key, final DecisionRequirementsRecord value) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -71,9 +71,7 @@ public final class EventAppliers implements EventApplier {
     registerProcessEventAppliers(state);
 
     registerDecisionAppliers(state);
-    register(
-        DecisionRequirementsIntent.CREATED,
-        new DecisionRequirementsCreatedApplier(state.getDecisionState()));
+    registerDecisionRequirementsAppliers(state);
 
     registerSignalSubscriptionAppliers(state);
   }
@@ -263,6 +261,15 @@ public final class EventAppliers implements EventApplier {
   private void registerDecisionAppliers(final MutableZeebeState state) {
     register(DecisionIntent.CREATED, new DecisionCreatedApplier(state.getDecisionState()));
     register(DecisionIntent.DELETED, new DecisionDeletedApplier(state.getDecisionState()));
+  }
+
+  private void registerDecisionRequirementsAppliers(final MutableZeebeState state) {
+    register(
+        DecisionRequirementsIntent.CREATED,
+        new DecisionRequirementsCreatedApplier(state.getDecisionState()));
+    register(
+        DecisionRequirementsIntent.DELETED,
+        new DecisionRequirementsDeletedApplier(state.getDecisionState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -291,6 +291,11 @@ public final class DbDecisionState implements MutableDecisionState {
     decisionKeyByDecisionIdAndVersion.deleteExisting(decisionIdAndVersion);
   }
 
+  @Override
+  public void deleteDecisionRequirements(final DecisionRequirementsRecord record) {
+    // TODO
+  }
+
   private void updateLatestDecisionVersion(final DecisionRecord record) {
     findLatestDecisionById(record.getDecisionIdBuffer())
         .ifPresentOrElse(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDecisionState.java
@@ -35,4 +35,12 @@ public interface MutableDecisionState extends DecisionState {
    * @param record the record of the decision
    */
   void deleteDecision(DecisionRecord record);
+
+  /**
+   * Deletes a decision requirements from the state. Updates the latest version of the decision
+   * requirements if the deleted version is the latest version and a previous version is available.
+   *
+   * @param record the record of the decision requirements
+   */
+  void deleteDecisionRequirements(DecisionRequirementsRecord record);
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds an EventApplier for `DecisionRequirements ` events. The applier will delete the decision from the state.

Since we store the latest `decisionRequirementsKey` for a `decisionRequirementsId` in the `latestDecisionRequirementsKeysById` ColumnFamily we have a two scenarios here:

1. The deleted DRG is the lates. At this point we must figure out what to do. If there are DRGs with lower versions we must update this ColumnFamily to refer to the previous version. If there are no other versions we must delete the DRG from this ColumnFamily.
2. The deleted DRG is **not** the latest decision. We can completely ignore the `latestDecisionRequirementsKeysById`. This columnFamily refers to a DRG that is not related to the DRG we are deleting.

The DRG will be deleted from all other relevant ColumnFamilies.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9773 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
