### PR TITLE
Update lastFlushedIndex in metastore in Journal

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -190,7 +190,6 @@ public final class RaftStorage {
         .withMaxSegmentSize(maxSegmentSize)
         .withFreeDiskSpace(freeDiskSpace)
         .withJournalIndexDensity(journalIndexDensity)
-        .withLastFlushedIndex(metaStore.loadLastFlushedIndex())
         .withPreallocateSegmentFiles(preallocateSegmentFiles)
         .withMetaStore(metaStore)
         .withFlusher(flusherFactory.createFlusher(flushContext))

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -192,7 +192,7 @@ public final class RaftStorage {
         .withJournalIndexDensity(journalIndexDensity)
         .withLastFlushedIndex(metaStore.loadLastFlushedIndex())
         .withPreallocateSegmentFiles(preallocateSegmentFiles)
-        .withFlushMetaStore(metaStore::storeLastFlushedIndex)
+        .withMetaStore(metaStore)
         .withFlusher(flusherFactory.createFlusher(flushContext))
         .build();
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -190,7 +190,7 @@ public final class RaftStorage {
         .withMaxSegmentSize(maxSegmentSize)
         .withFreeDiskSpace(freeDiskSpace)
         .withJournalIndexDensity(journalIndexDensity)
-        .withLastFlushedIndex(metaStore.lastFlushedIndex())
+        .withLastFlushedIndex(metaStore.loadLastFlushedIndex())
         .withPreallocateSegmentFiles(preallocateSegmentFiles)
         .withFlushMetaStore(metaStore::storeLastFlushedIndex)
         .withFlusher(flusherFactory.createFlusher(flushContext))

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -54,7 +54,7 @@ public final class DelayedFlusher implements RaftLogFlusher {
     }
   }
 
-  private void asyncFlush(final Journal journal, final long lastIndex) {
+  private void asyncFlush(final Journal journal) {
     scheduledFlush = null;
 
     if (closed || !journal.isOpen()) {
@@ -66,10 +66,7 @@ public final class DelayedFlusher implements RaftLogFlusher {
 
   private void scheduleFlush(final Journal journal) {
     if (scheduledFlush == null) {
-      // necessary if the flush is asynchronous, as last index may or may not be thread-safe
-      // TODO: re-evaluate this when implementing asynchronous flushing
-      final var lastIndex = journal.getLastIndex();
-      scheduledFlush = scheduler.schedule(delayTime, () -> asyncFlush(journal, lastIndex));
+      scheduledFlush = scheduler.schedule(delayTime, () -> asyncFlush(journal));
     }
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -38,8 +38,8 @@ public final class DelayedFlusher implements RaftLogFlusher {
   }
 
   @Override
-  public void flush(final Journal journal, final FlushMetaStore flushMetaStore) {
-    scheduleFlush(journal, flushMetaStore);
+  public void flush(final Journal journal) {
+    scheduleFlush(journal);
   }
 
   @Override
@@ -54,8 +54,7 @@ public final class DelayedFlusher implements RaftLogFlusher {
     }
   }
 
-  private void asyncFlush(
-      final Journal journal, final FlushMetaStore flushMetaStore, final long lastIndex) {
+  private void asyncFlush(final Journal journal, final long lastIndex) {
     scheduledFlush = null;
 
     if (closed || !journal.isOpen()) {
@@ -63,16 +62,14 @@ public final class DelayedFlusher implements RaftLogFlusher {
     }
 
     journal.flush();
-    flushMetaStore.storeLastFlushedIndex(lastIndex);
   }
 
-  private void scheduleFlush(final Journal journal, final FlushMetaStore flushMetaStore) {
+  private void scheduleFlush(final Journal journal) {
     if (scheduledFlush == null) {
       // necessary if the flush is asynchronous, as last index may or may not be thread-safe
       // TODO: re-evaluate this when implementing asynchronous flushing
       final var lastIndex = journal.getLastIndex();
-      scheduledFlush =
-          scheduler.schedule(delayTime, () -> asyncFlush(journal, flushMetaStore, lastIndex));
+      scheduledFlush = scheduler.schedule(delayTime, () -> asyncFlush(journal, lastIndex));
     }
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -20,7 +20,6 @@ import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
-import io.atomix.raft.storage.log.RaftLogFlusher.FlushMetaStore;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
 import io.atomix.raft.storage.serializer.RaftEntrySerializer;
@@ -34,18 +33,12 @@ public final class RaftLog implements Closeable {
   private final RaftEntrySerializer serializer = new RaftEntrySBESerializer();
   private final Journal journal;
   private final RaftLogFlusher flusher;
-  private final FlushMetaStore flushMetaStore;
-
   private IndexedRaftLogEntry lastAppendedEntry;
   private volatile long commitIndex;
 
-  RaftLog(
-      final Journal journal,
-      final RaftLogFlusher flusher,
-      final RaftLogFlusher.FlushMetaStore flushMetaStore) {
+  RaftLog(final Journal journal, final RaftLogFlusher flusher) {
     this.journal = journal;
     this.flusher = flusher;
-    this.flushMetaStore = flushMetaStore;
   }
 
   /**
@@ -180,7 +173,7 @@ public final class RaftLog implements Closeable {
    * the configured {@link RaftLogFlusher}.
    */
   public void flush() {
-    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal);
   }
 
   /**
@@ -191,7 +184,7 @@ public final class RaftLog implements Closeable {
    * guarantees are required.
    */
   public void forceFlush() {
-    Factory.DIRECT.flush(journal, flushMetaStore);
+    Factory.DIRECT.flush(journal);
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -27,7 +27,6 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
 
   private final SegmentedJournalBuilder journalBuilder = SegmentedJournal.builder();
   private RaftLogFlusher flusher = Factory.DIRECT;
-  private JournalMetaStore flushMetaStore;
 
   protected RaftLogBuilder() {}
 
@@ -143,7 +142,7 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
    * @return this builder for chaining
    */
   public RaftLogBuilder withMetaStore(final JournalMetaStore metaStore) {
-    flushMetaStore = metaStore;
+    journalBuilder.withMetaStore(metaStore);
     return this;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -114,11 +114,6 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
     return this;
   }
 
-  public RaftLogBuilder withLastFlushedIndex(final long lastFlushedIndex) {
-    journalBuilder.withLastFlushedIndex(lastFlushedIndex);
-    return this;
-  }
-
   /**
    * Sets whether segment files are pre-allocated at creation. If true, segment files are
    * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -17,8 +17,8 @@ package io.atomix.raft.storage.log;
 
 import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
 import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
-import io.atomix.raft.storage.log.RaftLogFlusher.FlushMetaStore;
 import io.camunda.zeebe.journal.Journal;
+import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
 import java.io.File;
@@ -27,7 +27,7 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
 
   private final SegmentedJournalBuilder journalBuilder = SegmentedJournal.builder();
   private RaftLogFlusher flusher = Factory.DIRECT;
-  private RaftLogFlusher.FlushMetaStore flushMetaStore = lastIndex -> {};
+  private JournalMetaStore flushMetaStore;
 
   protected RaftLogBuilder() {}
 
@@ -144,19 +144,17 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
   }
 
   /**
-   * Temporary builder method to specify the logic for how to store the last flushed index.
-   *
-   * @param flushMetaStore the handler to store the last flushed index
+   * @param metaStore A persisted JournalMetaStore that can store lastFlushedIndex.
    * @return this builder for chaining
    */
-  public RaftLogBuilder withFlushMetaStore(final FlushMetaStore flushMetaStore) {
-    this.flushMetaStore = flushMetaStore;
+  public RaftLogBuilder withMetaStore(final JournalMetaStore metaStore) {
+    flushMetaStore = metaStore;
     return this;
   }
 
   @Override
   public RaftLog build() {
     final Journal journal = journalBuilder.build();
-    return new RaftLog(journal, flusher, flushMetaStore);
+    return new RaftLog(journal, flusher);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -37,12 +37,12 @@ public interface RaftLogFlusher extends CloseableSilently {
    *
    * @param journal the journal to flush
    */
-  void flush(final Journal journal, final FlushMetaStore metaStore);
+  void flush(final Journal journal);
 
   /**
-   * If this returns true, then any calls to {@link #flush(Journal, FlushMetaStore)} are synchronous
-   * and immediate, and any guarantees offered by the implementation will hold after a call to
-   * {@link #flush(Journal, FlushMetaStore)}.
+   * If this returns true, then any calls to {@link #flush(Journal)} are synchronous and immediate,
+   * and any guarantees offered by the implementation will hold after a call to {@link
+   * #flush(Journal)}.
    */
   default boolean isDirect() {
     return false;
@@ -58,20 +58,19 @@ public interface RaftLogFlusher extends CloseableSilently {
   final class NoopFlusher implements RaftLogFlusher {
 
     @Override
-    public void flush(final Journal ignoredJournal, final FlushMetaStore ignoredMetaStore) {}
+    public void flush(final Journal ignoredJournal) {}
   }
 
   /**
    * An implementation of {@link RaftLogFlusher} which flushes immediately in a blocking fashion.
-   * After any calls to {@link #flush(Journal, FlushMetaStore)}, any data written before the call is
-   * guaranteed to be on disk.
+   * After any calls to {@link #flush(Journal)}, any data written before the call is guaranteed to
+   * be on disk.
    */
   final class DirectFlusher implements RaftLogFlusher {
 
     @Override
-    public void flush(final Journal journal, final FlushMetaStore metaStore) {
+    public void flush(final Journal journal) {
       journal.flush();
-      metaStore.storeLastFlushedIndex(journal.getLastIndex());
     }
 
     @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -23,6 +23,7 @@ import io.atomix.raft.metrics.MetaStoreMetrics;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.StorageException;
 import io.atomix.raft.storage.serializer.MetaStoreSerializer;
+import io.camunda.zeebe.journal.JournalMetaStore;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -45,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * algorithm. Additionally, the metastore is responsible for storing the last know server {@link
  * Configuration}, including cluster membership.
  */
-public class MetaStore implements AutoCloseable {
+public class MetaStore implements JournalMetaStore, AutoCloseable {
 
   private static final byte VERSION = 1;
   private static final int VERSION_LENGTH = Byte.BYTES;
@@ -104,7 +105,7 @@ public class MetaStore implements AutoCloseable {
 
   private void initializeMetaBuffer() {
     final var term = loadTerm();
-    final long index = lastFlushedIndex();
+    final long index = loadLastFlushedIndex();
     final var voted = loadVote();
     metaBuffer.put(0, VERSION);
     storeTerm(term);
@@ -177,16 +178,7 @@ public class MetaStore implements AutoCloseable {
     return id.isEmpty() ? null : MemberId.from(id);
   }
 
-  public synchronized long lastFlushedIndex() {
-    try {
-      metaFileChannel.read(metaBuffer, 0);
-      metaBuffer.position(0);
-    } catch (final IOException e) {
-      throw new StorageException(e);
-    }
-    return serializer.readLastFlushedIndex(new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
-  }
-
+  @Override
   public synchronized void storeLastFlushedIndex(final long index) {
     log.trace("Store last flushed index {}", index);
 
@@ -197,6 +189,17 @@ public class MetaStore implements AutoCloseable {
     } catch (final IOException e) {
       throw new StorageException(e);
     }
+  }
+
+  @Override
+  public synchronized long loadLastFlushedIndex() {
+    try {
+      metaFileChannel.read(metaBuffer, 0);
+      metaBuffer.position(0);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
+    return serializer.readLastFlushedIndex(new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
   }
 
   /**

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/MockJournalMetaStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/MockJournalMetaStore.java
@@ -9,9 +9,9 @@ package io.atomix.raft.storage;
 
 import io.camunda.zeebe.journal.JournalMetaStore;
 
-public class MockJournalMetaStore implements JournalMetaStore {
+public final class MockJournalMetaStore implements JournalMetaStore {
 
-  long index;
+  private long index;
 
   @Override
   public void storeLastFlushedIndex(final long index) {

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/MockJournalMetaStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/MockJournalMetaStore.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.storage;
+
+import io.camunda.zeebe.journal.JournalMetaStore;
+
+public class MockJournalMetaStore implements JournalMetaStore {
+
+  long index;
+
+  @Override
+  public void storeLastFlushedIndex(final long index) {
+    this.index = index;
+  }
+
+  @Override
+  public long loadLastFlushedIndex() {
+    return index;
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
@@ -9,7 +9,6 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.raft.storage.log.RaftLogFlusher.FlushMetaStore;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
 import io.camunda.zeebe.journal.Journal;
@@ -34,11 +33,10 @@ final class DelayedFlusherTest {
   void shouldDelayFlushByInterval() {
     // given
     final var journal = Mockito.mock(Journal.class);
-    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
 
     // when
-    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal);
 
     // then
     assertThat(scheduler.operations).hasSize(1);
@@ -48,38 +46,34 @@ final class DelayedFlusherTest {
         .extracting(t -> t.initialDelay, t -> t.interval)
         .containsExactly(Duration.ZERO, Duration.ofSeconds(5));
     Mockito.verify(journal, Mockito.never()).flush();
-    Mockito.verify(flushMetaStore, Mockito.never()).storeLastFlushedIndex(Mockito.anyLong());
   }
 
   @Test
   void shouldFlushWhenScheduledTaskIsRun() {
     // given
     final var journal = Mockito.mock(Journal.class);
-    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
     Mockito.when(journal.getLastIndex()).thenReturn(5L);
 
     // when
-    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal);
 
     // then
     final var scheduled = scheduler.operations.get(0);
     scheduled.operation.run();
     Mockito.verify(journal, Mockito.times(1)).flush();
-    Mockito.verify(flushMetaStore, Mockito.times(1)).storeLastFlushedIndex(5L);
   }
 
   @Test
   void shouldNotScheduleIfAlreadyScheduled() {
     // given
     final var journal = Mockito.mock(Journal.class);
-    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.getLastIndex()).thenReturn(5L);
 
     // when
-    flusher.flush(journal, flushMetaStore);
-    flusher.flush(journal, flushMetaStore);
-    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal);
+    flusher.flush(journal);
+    flusher.flush(journal);
 
     // then
     assertThat(scheduler.operations).hasSize(1);
@@ -93,10 +87,9 @@ final class DelayedFlusherTest {
   void shouldCancelScheduledFlushOnClose() {
     // given
     final var journal = Mockito.mock(Journal.class);
-    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
 
     // when
-    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal);
     flusher.close();
 
     // then
@@ -108,35 +101,31 @@ final class DelayedFlusherTest {
   void shouldNotFlushWhenFlusherIsClosed() {
     // given
     final var journal = Mockito.mock(Journal.class);
-    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
 
     // when
-    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal);
     flusher.close();
 
     // then
     final var scheduled = scheduler.operations.get(0);
     scheduled.operation.run();
     Mockito.verify(journal, Mockito.never()).flush();
-    Mockito.verify(flushMetaStore, Mockito.never()).storeLastFlushedIndex(Mockito.anyLong());
   }
 
   @Test
   void shouldNotFlushIfJournalIsClosed() {
     // given
     final var journal = Mockito.mock(Journal.class);
-    final var flushMetaStore = Mockito.mock(FlushMetaStore.class);
     Mockito.when(journal.isOpen()).thenReturn(false);
 
     // when
-    flusher.flush(journal, flushMetaStore);
+    flusher.flush(journal);
 
     // then
     final var scheduled = scheduler.operations.get(0);
     scheduled.operation.run();
     Mockito.verify(journal, Mockito.never()).flush();
-    Mockito.verify(flushMetaStore, Mockito.never()).storeLastFlushedIndex(Mockito.anyLong());
   }
 
   private static final class TestScheduled implements Scheduled {

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogCommittedReaderTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogCommittedReaderTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.raft.storage.MockJournalMetaStore;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import java.io.File;
@@ -37,7 +38,12 @@ class RaftLogCommittedReaderTest {
 
   @BeforeEach
   void setup(@TempDir final File directory) {
-    raftlog = RaftLog.builder().withDirectory(directory).withName("test").build();
+    raftlog =
+        RaftLog.builder()
+            .withDirectory(directory)
+            .withName("test")
+            .withMetaStore(new MockJournalMetaStore())
+            .build();
     committedReader = raftlog.openCommittedReader();
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -17,7 +17,6 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -29,7 +28,6 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
-import io.atomix.raft.storage.log.RaftLogFlusher.FlushMetaStore;
 import io.atomix.raft.storage.log.RaftLogFlusher.NoopFlusher;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
@@ -241,22 +239,20 @@ class RaftLogTest {
       // given
       final var journal = mock(Journal.class);
       final var flusher = mock(RaftLogFlusher.class);
-      final var flushMetaStore = mock(FlushMetaStore.class);
-      final var log = new RaftLog(journal, flusher, flushMetaStore);
+      final var log = new RaftLog(journal, flusher);
 
       // when
       log.flush();
 
       // then
-      verify(flusher, times(1)).flush(journal, flushMetaStore);
+      verify(flusher, times(1)).flush(journal);
     }
 
     @Test
     void shouldForceFlush() {
       final var journal = mock(Journal.class);
       final var flusher = mock(RaftLogFlusher.class);
-      final var flushMetaStore = mock(FlushMetaStore.class);
-      final var log = new RaftLog(journal, flusher, flushMetaStore);
+      final var log = new RaftLog(journal, flusher);
       when(journal.getLastIndex()).thenReturn(3L);
 
       // when
@@ -264,15 +260,13 @@ class RaftLogTest {
 
       // then
       verify(journal, times(1)).flush();
-      verify(flushMetaStore, times(1)).storeLastFlushedIndex(3L);
     }
 
     @Test
     void shouldFlushDirectly() {
       // given
       final var journal = mock(Journal.class);
-      final var flushMetaStore = mock(FlushMetaStore.class);
-      final var log = new RaftLog(journal, new DirectFlusher(), flushMetaStore);
+      final var log = new RaftLog(journal, new DirectFlusher());
       when(journal.getLastIndex()).thenReturn(3L);
 
       // when
@@ -280,7 +274,6 @@ class RaftLogTest {
 
       // then
       verify(journal, times(1)).flush();
-      verify(flushMetaStore, times(1)).storeLastFlushedIndex(3L);
     }
 
     @Test
@@ -288,16 +281,14 @@ class RaftLogTest {
       // given
       final var journal = mock(Journal.class);
       final var flusher = spy(new NoopFlusher());
-      final var flushMetaStore = mock(FlushMetaStore.class);
-      final var log = new RaftLog(journal, flusher, flushMetaStore);
+      final var log = new RaftLog(journal, flusher);
 
       // when
       log.flush();
 
       // then
-      verify(flusher, times(1)).flush(journal, flushMetaStore);
+      verify(flusher, times(1)).flush(journal);
       verify(journal, never()).flush();
-      verify(flushMetaStore, never()).storeLastFlushedIndex(anyLong());
     }
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.raft.storage.MockJournalMetaStore;
 import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
 import io.atomix.raft.storage.log.RaftLogFlusher.NoopFlusher;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
@@ -64,7 +65,12 @@ class RaftLogTest {
 
   @BeforeEach
   void setup(@TempDir final File directory) {
-    raftlog = RaftLog.builder().withDirectory(directory).withName("test").build();
+    raftlog =
+        RaftLog.builder()
+            .withDirectory(directory)
+            .withName("test")
+            .withMetaStore(new MockJournalMetaStore())
+            .build();
     reader = raftlog.openUncommittedReader();
   }
 
@@ -143,7 +149,11 @@ class RaftLogTest {
     final RaftLogEntry entry = new RaftLogEntry(1, firstApplicationEntry);
     final var persistedRaftRecord = raftlog.append(entry).getPersistedRaftRecord();
     final var raftlogFollower =
-        RaftLog.builder().withDirectory(directory).withName("test-follower").build();
+        RaftLog.builder()
+            .withDirectory(directory)
+            .withName("test-follower")
+            .withMetaStore(new MockJournalMetaStore())
+            .build();
 
     // when
     final var appended = raftlogFollower.append(persistedRaftRecord);

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.raft.storage.MockJournalMetaStore;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
@@ -38,7 +39,12 @@ class RaftLogUncommittedReaderTest {
 
   @BeforeEach
   void setup(@TempDir final File directory) {
-    raftlog = RaftLog.builder().withDirectory(directory).withName("test").build();
+    raftlog =
+        RaftLog.builder()
+            .withDirectory(directory)
+            .withName("test")
+            .withMetaStore(new MockJournalMetaStore())
+            .build();
     uncommittedReader = raftlog.openUncommittedReader();
     data.order(ByteOrder.LITTLE_ENDIAN).putInt(123456);
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -73,7 +73,7 @@ public class MetaStoreTest {
   }
 
   @Test
-  public void shouldStoreAndLoadTerm() throws IOException {
+  public void shouldStoreAndLoadTerm() {
     // when
     metaStore.storeTerm(2L);
 
@@ -223,7 +223,7 @@ public class MetaStoreTest {
     metaStore.storeLastFlushedIndex(5L);
 
     // when/then
-    assertThat(metaStore.lastFlushedIndex()).isEqualTo(5L);
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(5L);
   }
 
   @Test
@@ -236,7 +236,7 @@ public class MetaStoreTest {
     metaStore = new MetaStore(storage);
 
     // then
-    assertThat(metaStore.lastFlushedIndex()).isEqualTo(5L);
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(5L);
   }
 
   @Test
@@ -248,7 +248,7 @@ public class MetaStoreTest {
     metaStore.storeLastFlushedIndex(7L);
 
     // then
-    assertThat(metaStore.lastFlushedIndex()).isEqualTo(7L);
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(7L);
 
     // when
     metaStore.storeLastFlushedIndex(8L);
@@ -257,7 +257,7 @@ public class MetaStoreTest {
     metaStore = new MetaStore(storage);
 
     // then
-    assertThat(metaStore.lastFlushedIndex()).isEqualTo(8L);
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(8L);
   }
 
   @Test
@@ -269,7 +269,7 @@ public class MetaStoreTest {
 
     // then
     assertThat(metaStore.loadTerm()).isEqualTo(1L);
-    assertThat(metaStore.lastFlushedIndex()).isEqualTo(2L);
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(2L);
     assertThat(metaStore.loadVote()).isEqualTo(MemberId.from("a"));
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
@@ -8,11 +8,13 @@
 package io.camunda.zeebe.broker.logstreams;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
+import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -32,7 +34,11 @@ final class AtomixLogStorageReaderTest {
 
   @BeforeEach
   void beforeEach(@TempDir final File tempDir) {
-    log = RaftLog.builder().withDirectory(tempDir).build();
+    log =
+        RaftLog.builder()
+            .withDirectory(tempDir)
+            .withMetaStore(mock(JournalMetaStore.class))
+            .build();
     final Appender appender = new Appender();
     logStorage = new AtomixLogStorage(log::openUncommittedReader, appender);
     reader = logStorage.newReader();

--- a/journal/src/main/java/io/camunda/zeebe/journal/JournalMetaStore.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/JournalMetaStore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal;
+
+public interface JournalMetaStore {
+
+  /**
+   * Update lastFlushedIndex in metastore. This method can be expensive and blocking as the
+   * implementations of this may have to write to a database or a file.
+   *
+   * @param index last flushed index
+   */
+  void storeLastFlushedIndex(long index);
+
+  /**
+   * Read last flushed index from the metastore. This method might be expensive and blocking as the
+   * implementations of this may have to read from a database or file. It is recommended for the
+   * callers of this method to cache lastFlushedIndex and call this method only when necessary.
+   *
+   * @return last flushed index
+   */
+  long loadLastFlushedIndex();
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -58,7 +58,7 @@ public final class SegmentedJournal implements Journal {
     this.segments = Objects.requireNonNull(segments, "must specify a journal segments manager");
     this.journalMetaStore = journalMetaStore;
 
-    this.segments.open();
+    this.segments.open(journalMetaStore.loadLastFlushedIndex());
     writer = new SegmentedJournalWriter(this);
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.Sets;
 import io.camunda.zeebe.journal.Journal;
+import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -41,17 +42,21 @@ public final class SegmentedJournal implements Journal {
   private final StampedLock rwlock = new StampedLock();
   private final SegmentsManager segments;
 
+  private final JournalMetaStore journalMetaStore;
+
   SegmentedJournal(
       final File directory,
       final int maxSegmentSize,
       final JournalIndex journalIndex,
       final SegmentsManager segments,
-      final JournalMetrics journalMetrics) {
+      final JournalMetrics journalMetrics,
+      final JournalMetaStore journalMetaStore) {
     this.directory = Objects.requireNonNull(directory, "must specify a journal directory");
     this.maxSegmentSize = maxSegmentSize;
     this.journalMetrics = Objects.requireNonNull(journalMetrics, "must specify journal metrics");
     this.journalIndex = Objects.requireNonNull(journalIndex, "must specify a journal index");
     this.segments = Objects.requireNonNull(segments, "must specify a journal segments manager");
+    this.journalMetaStore = journalMetaStore;
 
     this.segments.open();
     writer = new SegmentedJournalWriter(this);
@@ -140,6 +145,7 @@ public final class SegmentedJournal implements Journal {
   @Override
   public void flush() {
     writer.flush();
+    journalMetaStore.storeLastFlushedIndex(getLastIndex());
   }
 
   @Override

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -56,7 +56,8 @@ public final class SegmentedJournal implements Journal {
     this.journalMetrics = Objects.requireNonNull(journalMetrics, "must specify journal metrics");
     this.journalIndex = Objects.requireNonNull(journalIndex, "must specify a journal index");
     this.segments = Objects.requireNonNull(segments, "must specify a journal segments manager");
-    this.journalMetaStore = journalMetaStore;
+    this.journalMetaStore =
+        Objects.requireNonNull(journalMetaStore, "must specify a journal meta store");
 
     this.segments.open(journalMetaStore.loadLastFlushedIndex());
     writer = new SegmentedJournalWriter(this);

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -42,7 +42,6 @@ public class SegmentedJournalBuilder {
 
   private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
-  private long lastFlushedIndex = -1L;
   private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
   private int partitionId = DEFAULT_PARTITION_ID;
 
@@ -128,17 +127,6 @@ public class SegmentedJournalBuilder {
   }
 
   /**
-   * Writes the last index to have been persisted to the metastore.
-   *
-   * @param lastFlushedIndex last index to have been persisted in the log
-   * @return the storage builder
-   */
-  public SegmentedJournalBuilder withLastFlushedIndex(final long lastFlushedIndex) {
-    this.lastFlushedIndex = lastFlushedIndex;
-    return this;
-  }
-
-  /**
    * Sets whether segment files are pre-allocated at creation. If true, segment files are
    * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
    * before any writes happen.
@@ -181,13 +169,7 @@ public class SegmentedJournalBuilder {
     final var segmentLoader = new SegmentLoader(freeDiskSpace, journalMetrics, segmentAllocator);
     final var segmentsManager =
         new SegmentsManager(
-            journalIndex,
-            maxSegmentSize,
-            directory,
-            lastFlushedIndex,
-            name,
-            segmentLoader,
-            journalMetrics);
+            journalIndex, maxSegmentSize, directory, name, segmentLoader, journalMetrics);
 
     return new SegmentedJournal(
         directory, maxSegmentSize, journalIndex, segmentsManager, journalMetrics, journalMetaStore);

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.journal.file;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.camunda.zeebe.journal.JournalMetaStore;
 import java.io.File;
 
 /** Raft log builder. */
@@ -44,6 +45,8 @@ public class SegmentedJournalBuilder {
   private long lastFlushedIndex = -1L;
   private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
   private int partitionId = DEFAULT_PARTITION_ID;
+
+  private JournalMetaStore journalMetaStore;
 
   protected SegmentedJournalBuilder() {}
 
@@ -161,6 +164,15 @@ public class SegmentedJournalBuilder {
     return this;
   }
 
+  /**
+   * @param metaStore journal metastore to update lastFlushedIndex
+   * @return this builder for chaining
+   */
+  public SegmentedJournalBuilder withMetaStore(final JournalMetaStore metaStore) {
+    journalMetaStore = metaStore;
+    return this;
+  }
+
   public SegmentedJournal build() {
     final var journalIndex = new SparseJournalIndex(journalIndexDensity);
     final var journalMetrics = new JournalMetrics(String.valueOf(partitionId));
@@ -178,6 +190,6 @@ public class SegmentedJournalBuilder {
             journalMetrics);
 
     return new SegmentedJournal(
-        directory, maxSegmentSize, journalIndex, segmentsManager, journalMetrics);
+        directory, maxSegmentSize, journalIndex, segmentsManager, journalMetrics, journalMetaStore);
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -51,7 +51,7 @@ final class SegmentsManager implements AutoCloseable {
 
   private final SegmentLoader segmentLoader;
 
-  private final long lastFlushedIndex;
+  private long lastFlushedIndex;
 
   private final String name;
 
@@ -59,7 +59,6 @@ final class SegmentsManager implements AutoCloseable {
       final JournalIndex journalIndex,
       final int maxSegmentSize,
       final File directory,
-      final long lastFlushedIndex,
       final String name,
       final SegmentLoader segmentLoader,
       final JournalMetrics journalMetrics) {
@@ -67,7 +66,6 @@ final class SegmentsManager implements AutoCloseable {
     this.journalIndex = journalIndex;
     this.maxSegmentSize = maxSegmentSize;
     this.directory = directory;
-    this.lastFlushedIndex = lastFlushedIndex;
     this.segmentLoader = segmentLoader;
     this.journalMetrics = journalMetrics;
   }
@@ -259,7 +257,8 @@ final class SegmentsManager implements AutoCloseable {
   }
 
   /** Loads existing segments from the disk * */
-  void open() {
+  void open(final long lastFlushedIndex) {
+    this.lastFlushedIndex = lastFlushedIndex;
     final var openDurationTimer = journalMetrics.startJournalOpenDurationTimer();
     // Load existing log segments from disk.
     for (final Segment segment : loadSegments()) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.journal.util.MockJournalMetastore;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
@@ -37,7 +38,11 @@ final class JournalReaderTest {
     final File directory = tempDir.resolve("data").toFile();
 
     journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+        SegmentedJournal.builder()
+            .withDirectory(directory)
+            .withJournalIndexDensity(5)
+            .withMetaStore(new MockJournalMetastore())
+            .build();
     reader = journal.openReader();
   }
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.record.SBESerializer;
+import io.camunda.zeebe.journal.util.MockJournalMetastore;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.nio.ByteBuffer;
@@ -55,6 +56,7 @@ class SegmentedJournalReaderTest {
             .withMaxSegmentSize(
                 entrySize * ENTRIES_PER_SEGMENT + SegmentDescriptor.getEncodingLength())
             .withJournalIndexDensity(5)
+            .withMetaStore(new MockJournalMetastore())
             .build();
     reader = journal.openReader();
   }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.journal.record.PersistedJournalRecord;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.record.SBESerializer;
+import io.camunda.zeebe.journal.util.MockJournalMetastore;
 import io.camunda.zeebe.journal.util.PosixPathAssert;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -641,7 +642,8 @@ class SegmentedJournalTest {
         SegmentedJournal.builder()
             .withPreallocateSegmentFiles(true)
             .withMaxSegmentSize(segmentSize)
-            .withDirectory(tmpDir.toFile());
+            .withDirectory(tmpDir.toFile())
+            .withMetaStore(new MockJournalMetastore());
     final File firstSegment;
 
     // when
@@ -661,7 +663,8 @@ class SegmentedJournalTest {
         SegmentedJournal.builder()
             .withPreallocateSegmentFiles(false)
             .withMaxSegmentSize(segmentSize)
-            .withDirectory(tmpDir.toFile());
+            .withDirectory(tmpDir.toFile())
+            .withMetaStore(new MockJournalMetastore());
     final File firstSegment;
 
     // when
@@ -832,6 +835,7 @@ class SegmentedJournalTest {
             (int) (entrySize * entriesPerSegment) + SegmentDescriptor.getEncodingLength())
         .withJournalIndexDensity(journalIndexDensity)
         .withName(JOURNAL_NAME)
+        .withMetaStore(new MockJournalMetastore())
         .build();
   }
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/util/MockJournalMetastore.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/util/MockJournalMetastore.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.util;
+
+import io.camunda.zeebe.journal.JournalMetaStore;
+
+public class MockJournalMetastore implements JournalMetaStore {
+
+  long lastFlushedIndex = -1;
+
+  @Override
+  public void storeLastFlushedIndex(final long index) {
+    lastFlushedIndex = index;
+  }
+
+  @Override
+  public long loadLastFlushedIndex() {
+    return lastFlushedIndex;
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/util/MockJournalMetastore.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/util/MockJournalMetastore.java
@@ -9,9 +9,9 @@ package io.camunda.zeebe.journal.util;
 
 import io.camunda.zeebe.journal.JournalMetaStore;
 
-public class MockJournalMetastore implements JournalMetaStore {
+public final class MockJournalMetastore implements JournalMetaStore {
 
-  long lastFlushedIndex = -1;
+  private long lastFlushedIndex = -1;
 
   @Override
   public void storeLastFlushedIndex(final long index) {

--- a/restore/pom.xml
+++ b/restore/pom.xml
@@ -66,6 +66,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
       <scope>test</scope>

--- a/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
@@ -112,6 +113,19 @@ public class PartitionRestoreService {
         SegmentedJournal.builder()
             .withDirectory(dataDirectory.toFile())
             .withName(partition.name())
+            .withMetaStore(
+                // A NoopMetastore
+                new JournalMetaStore() {
+                  @Override
+                  public void storeLastFlushedIndex(final long index) {
+                    // noop
+                  }
+
+                  @Override
+                  public long loadLastFlushedIndex() {
+                    return 0;
+                  }
+                })
             .build()) {
 
       resetJournal(checkpointPosition, journal);

--- a/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -112,7 +112,6 @@ public class PartitionRestoreService {
         SegmentedJournal.builder()
             .withDirectory(dataDirectory.toFile())
             .withName(partition.name())
-            .withLastFlushedIndex(-1)
             .build()) {
 
       resetJournal(checkpointPosition, journal);

--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -9,12 +9,14 @@ package io.camunda.zeebe.restore;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.management.BackupService;
+import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -97,6 +99,7 @@ class PartitionRestoreServiceTest {
         SegmentedJournal.builder()
             .withDirectory(dataDirectory.toFile())
             .withName(raftPartition.name())
+            .withMetaStore(mock(JournalMetaStore.class))
             .build();
   }
 


### PR DESCRIPTION
## Description

This PR is in preparation to allowing async flush #11488. 
- Updating `lastFlushedIndex` is moved to Journal. This is needed because with async/configurable flush interval RaftContext doesn't know when flush will be completed and cannot reliably update lastFlushedIndex.
- It still uses the same MetaStore as before, but is hidden under an interface which is provided to the Journal.

Temporarily, in this PR metastore is updated in `SegmentedJournal::flush`. This might change depending on the implementation of async flush. A followup PR will refactor the use of `lastFlushedIndex` in the journal to use it only on startup. The goal is not to pass it all around in segment and segment writers. 

## Related issues

related #11488 

