### PR TITLE
fix(ci): use input branches to run qa/e2e tests

### DIFF
--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -85,4 +85,5 @@ jobs:
         \"fault\": ${{ inputs.fault || 'null' }}
         }
         }
+      branch: ${{ inputs.branch }}
     secrets: inherit

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -56,5 +56,4 @@ jobs:
         \"processId\": \"qa-protocol\"
         }
       branch: ${{ inputs.branch }}
-      generation: ${{ inputs.generation }}
     secrets: inherit

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -55,4 +55,6 @@ jobs:
         \"businessKey\": \"${{ needs.prepare.outputs.buildUrl }}\",
         \"processId\": \"qa-protocol\"
         }
+      branch: ${{ inputs.branch }}
+      generation: ${{ inputs.generation }}
     secrets: inherit

--- a/.github/workflows/testbench.yaml
+++ b/.github/workflows/testbench.yaml
@@ -11,6 +11,10 @@ on:
         description: 'Id of process to start in testbench (eg:- e2e-testbench-protocol)'
         required: true
         type: string
+      branch:
+        description: 'Branch to test'
+        required: true
+        type: string
 
 jobs:
   testbench:

--- a/.github/workflows/testbench.yaml
+++ b/.github/workflows/testbench.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: "${{ github.ref_name || 'main' }}"
+          ref: "${{ inputs.branch || 'main' }}"
 
       - name: Build and push docker
         id: build-docker


### PR DESCRIPTION
## Description

The tests for stable branches were running on main, because the input branch were not used. For example [here](https://bru-3.operate.ultrawombat.com/7b2cd3f5-cfcc-4a65-ab22-0ccaa071e68e/processes/4503599782848840) the run for stable/8.1 used version 8.2.0-SNAPSHOT. 

