### PR TITLE
chore(ci): enable native arm64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
           - os: linux
-            runner: [ self-hosted, linux, amd64 ]
+            runner: [ self-hosted, linux, arm64, "4" ]
             arch: arm64
     env:
       JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64M
@@ -229,7 +229,6 @@ jobs:
           push: false
       - name: Run smoke test on ${{ matrix.arch }}
         env:
-          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
           # For non Linux runners there is no container available for testing, see build-docker job
           EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
         run: >


### PR DESCRIPTION
## Description

Reenabling the native runners that got disabled with #11191 due to instability.

## Related issues

closes #11590

