### PR TITLE
fix(ci): backport action from main to stable branch

### DIFF
--- a/.github/actions/build-push-docker-gcr/action.yml
+++ b/.github/actions/build-push-docker-gcr/action.yml
@@ -1,0 +1,86 @@
+name: Build and push images for given branch
+description: Builds the Zeebe Docker image with tag following SemVer and push it gcr.io/
+
+inputs:
+  branch:
+    description: 'Specifies the branch, for which the image should be build'
+    default: 'main'
+    required: false
+  secret_vault_address:
+    description: 'secret vault url'
+    required: true
+  secret_vault_roleId:
+    description: 'secret vault roleId'
+    required: true
+  secret_vault_secretId:
+    description: 'secret valut secret id'
+    required: true
+
+outputs:
+  image:
+    description: "Fully qualified image name"
+    value: ${{ steps.build-docker.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    # Dynamic environment variables are not supported by GHA
+    # https://brandur.org/fragments/github-actions-env-vars-in-env-vars
+    #
+    # Since we run the workflow either on demand or via schedule we need to assign some defaults
+    # Furthermore we have branches like stable/1.0 where we have to replace certain patterns, in order to use the branch name as docker image tag
+    - id: evaluate-inputs
+      name: Evaluate Inputs
+      shell: bash
+      run: |
+        branch=${BRANCH/\//-}
+        branch=${branch//\./-}
+        branch=${branch:-main}
+        echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
+      env:
+        BRANCH: "${{ inputs.branch }}"
+    # We need to check out the evaluated branch and setup java (incl. maven), so we can retrieve the current project version
+    # The version is necessary, since CC Saas only accepts SemVer for docker image tags (need to start with a version tag)
+    - uses: actions/checkout@v3
+      with:
+        ref: "${{ github.event.inputs.branch }}"
+    # Also setup java
+    - uses: ./.github/actions/setup-zeebe
+      with:
+        secret_vault_secretId: ${{ inputs.secret_vault_secretId }}
+        secret_vault_address: ${{ inputs.secret_vault_address }}
+        secret_vault_roleId: ${{ inputs.secret_vault_roleId }}
+    # Set further environment variables, which are needed for the QA Testbench run
+    - id: generate-tag
+      name: Generate image tag
+      shell: bash
+      run: |
+        version=$(mvn help:evaluate -q -DforceStdout -D"expression=project.version")
+        tag="$version-$BRANCH_NAME-${GITHUB_SHA::8}"
+        echo "TAG=$tag" >> $GITHUB_ENV
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2
+      with:
+        url: ${{ inputs.secret_vault_address }}
+        method: approle
+        roleId: ${{ inputs.secret_vault_roleId }}
+        secretId: ${{ inputs.secret_vault_secretId }}
+        secrets: |
+          secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
+    - name: Login to GCR
+      uses: docker/login-action@v2
+      with:
+        registry: gcr.io
+        username: _json_key
+        password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
+    - uses: ./.github/actions/build-zeebe
+      id: build-zeebe
+    - name: build-docker
+      id: build-docker
+      uses: ./.github/actions/build-docker
+      with:
+        repository: "gcr.io/zeebe-io/zeebe"
+        version: ${{ env.TAG }}
+        push: true
+        distball: ${{ steps.build-zeebe.outputs.distball }}


### PR DESCRIPTION
## Description

The action must be available in stable branches for the qa/e2e workflows from main to run successfully on the stable branches.

Related to #11651

QA was started successfully on this branch, with the fix https://github.com/camunda/zeebe/pull/11651 
https://github.com/camunda/zeebe/actions/runs/4173106758/jobs/7225043063

