### PR TITLE
chore(ci): resolve non camunda artifacts via central

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -91,6 +91,18 @@
   </dependencyManagement>
 
   <repositories>
+    <!-- This entry for central makes sure that artifacts are first resolved via central. -->
+    <!-- This ensures traffic for non-camunda artifacts is not routed through camunda repos. -->
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2</url>
+      <layout>default</layout>
+    </repository>
+
     <repository>
       <releases>
         <enabled>true</enabled>


### PR DESCRIPTION
## Description

Previously Maven would first query the zeebe repo as this was the first entry on the effective pom (see linked issue), this was especially not efficient if runners were used that are not co-located with our nexus mirror. (e.g. Github hosted runners)

[Before](https://github.com/camunda/zeebe/actions/runs/4174028252):
![image](https://user-images.githubusercontent.com/209518/218784088-43da2a61-dc34-41d7-a44e-468cb10d4d13.png)
[After](https://github.com/camunda/zeebe/actions/runs/4175334853):
![image](https://user-images.githubusercontent.com/209518/218784128-b06d05d7-3a03-434d-9169-fbbd7a0bed18.png)

Generally I think it's fine to enforce the order `first central then ours` explicitly via the repository config. In case we want to use ci local m2 caches we may just do that via setting up a central mirror [using the settings action](https://github.com/camunda/zeebe/blob/main/.github/actions/setup-zeebe/action.yml#L64).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11655 