### PR TITLE
Move corruption detection from SegmentWriter to SegmentManager

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -55,7 +55,6 @@ final class Segment implements AutoCloseable {
       final SegmentFile file,
       final SegmentDescriptor descriptor,
       final MappedByteBuffer buffer,
-      final long lastFlushedIndex,
       final long lastWrittenAsqn,
       final JournalIndex index,
       final JournalMetrics metrics) {
@@ -64,7 +63,7 @@ final class Segment implements AutoCloseable {
     this.buffer = buffer;
     this.index = index;
 
-    writer = createWriter(lastFlushedIndex, lastWrittenAsqn, metrics);
+    writer = createWriter(lastWrittenAsqn, metrics);
   }
 
   /**
@@ -162,9 +161,8 @@ final class Segment implements AutoCloseable {
     return reader;
   }
 
-  private SegmentWriter createWriter(
-      final long lastFlushedIndex, final long lastWrittenAsqn, final JournalMetrics metrics) {
-    return new SegmentWriter(buffer, this, index, lastFlushedIndex, lastWrittenAsqn, metrics);
+  private SegmentWriter createWriter(final long lastWrittenAsqn, final JournalMetrics metrics) {
+    return new SegmentWriter(buffer, this, index, lastWrittenAsqn, metrics);
   }
 
   /**

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -46,13 +46,12 @@ final class SegmentLoader {
   Segment createSegment(
       final Path segmentFile,
       final SegmentDescriptor descriptor,
-      final long lastFlushedIndex,
       final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final MappedByteBuffer mappedSegment;
 
     try {
-      mappedSegment = mapNewSegment(segmentFile, descriptor, lastFlushedIndex);
+      mappedSegment = mapNewSegment(segmentFile, descriptor);
     } catch (final IOException e) {
       throw new JournalException(
           String.format("Failed to create new segment file %s", segmentFile), e);
@@ -80,19 +79,15 @@ final class SegmentLoader {
           e);
     }
 
-    return loadSegment(
-        segmentFile, mappedSegment, descriptor, lastFlushedIndex, lastWrittenAsqn, journalIndex);
+    return loadSegment(segmentFile, mappedSegment, descriptor, lastWrittenAsqn, journalIndex);
   }
 
   UninitializedSegment createUninitializedSegment(
-      final Path segmentFile,
-      final SegmentDescriptor descriptor,
-      final long lastFlushedIndex,
-      final JournalIndex journalIndex) {
+      final Path segmentFile, final SegmentDescriptor descriptor, final JournalIndex journalIndex) {
     final MappedByteBuffer mappedSegment;
 
     try {
-      mappedSegment = mapNewSegment(segmentFile, descriptor, lastFlushedIndex);
+      mappedSegment = mapNewSegment(segmentFile, descriptor);
     } catch (final IOException e) {
       throw new JournalException(
           String.format("Failed to create new segment file %s", segmentFile), e);
@@ -117,10 +112,7 @@ final class SegmentLoader {
   }
 
   Segment loadExistingSegment(
-      final Path segmentFile,
-      final long lastFlushedIndex,
-      final long lastWrittenAsqn,
-      final JournalIndex journalIndex) {
+      final Path segmentFile, final long lastWrittenAsqn, final JournalIndex journalIndex) {
     final var descriptor = readDescriptor(segmentFile);
     final MappedByteBuffer mappedSegment;
 
@@ -132,8 +124,7 @@ final class SegmentLoader {
           String.format("Failed to load existing segment %s", segmentFile), e);
     }
 
-    return loadSegment(
-        segmentFile, mappedSegment, descriptor, lastFlushedIndex, lastWrittenAsqn, journalIndex);
+    return loadSegment(segmentFile, mappedSegment, descriptor, lastWrittenAsqn, journalIndex);
   }
 
   /* ---- Internal methods ------ */
@@ -144,8 +135,7 @@ final class SegmentLoader {
       final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final SegmentFile segmentFile = new SegmentFile(file.toFile());
-    return new Segment(
-        segmentFile, descriptor, buffer, lastFlushedIndex, lastWrittenAsqn, journalIndex, metrics);
+    return new Segment(segmentFile, descriptor, buffer, lastWrittenAsqn, journalIndex, metrics);
   }
 
   private MappedByteBuffer mapSegment(final FileChannel channel, final long segmentSize)
@@ -214,8 +204,7 @@ final class SegmentLoader {
     return buffer.get(0);
   }
 
-  private MappedByteBuffer mapNewSegment(
-      final Path segmentPath, final SegmentDescriptor descriptor, final long lastFlushedIndex)
+  private MappedByteBuffer mapNewSegment(final Path segmentPath, final SegmentDescriptor descriptor)
       throws IOException {
     final var maxSegmentSize = descriptor.maxSegmentSize();
 
@@ -235,7 +224,7 @@ final class SegmentLoader {
           segmentPath,
           e);
       Files.delete(segmentPath);
-      return mapNewSegment(segmentPath, descriptor, lastFlushedIndex);
+      return mapNewSegment(segmentPath, descriptor);
     }
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -141,7 +141,6 @@ final class SegmentLoader {
       final Path file,
       final MappedByteBuffer buffer,
       final SegmentDescriptor descriptor,
-      final long lastFlushedIndex,
       final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final SegmentFile segmentFile = new SegmentFile(file.toFile());
@@ -231,16 +230,6 @@ final class SegmentLoader {
       allocateSegment(maxSegmentSize, channel);
       return mapSegment(channel, maxSegmentSize);
     } catch (final FileAlreadyExistsException e) {
-      // do not reuse a segment into which we've already written!
-      if (lastFlushedIndex >= descriptor.index()) {
-        throw new JournalException(
-            String.format(
-                "Failed to create journal segment %s, as it already exists, and the last written "
-                    + "index %d indicates we've already written to it",
-                segmentPath, lastFlushedIndex),
-            e);
-      }
-
       LOGGER.warn(
           "Failed to create segment {}: an unused file already existed, and will be replaced",
           segmentPath,

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -76,7 +76,7 @@ final class SegmentWriter {
     firstAsqn = lastWrittenAsqn + 1;
     lastAsqn = lastWrittenAsqn;
     this.metrics = metrics;
-    reset(0, true);
+    reset(0, false);
   }
 
   long getLastIndex() {
@@ -208,7 +208,7 @@ final class SegmentWriter {
     FrameUtil.markAsIgnored(buffer, position);
   }
 
-  private void reset(final long index, final boolean detectCorruptionAsPartialWrite) {
+  private void reset(final long index, final boolean detectCorruption) {
     long nextIndex = firstIndex;
 
     // Clear the buffer indexes.
@@ -229,11 +229,10 @@ final class SegmentWriter {
     } catch (final BufferUnderflowException e) {
       // Reached end of the segment
     } catch (final CorruptedJournalException e) {
-      if (detectCorruptionAsPartialWrite) {
-        resetPartiallyWrittenEntry(e, position);
-      } else {
+      if (detectCorruption) {
         throw e;
       }
+      resetPartiallyWrittenEntry(e, position);
     } finally {
       buffer.reset();
     }
@@ -266,7 +265,7 @@ final class SegmentWriter {
       buffer.position(descriptorLength);
       invalidateNextEntry(descriptorLength);
     } else {
-      reset(index, false);
+      reset(index, true);
       invalidateNextEntry(buffer.position());
     }
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -37,9 +37,13 @@ import java.nio.BufferUnderflowException;
 import java.nio.MappedByteBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Segment writer. */
 final class SegmentWriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SegmentWriter.class);
 
   private final MappedByteBuffer buffer;
   private final Segment segment;
@@ -227,7 +231,7 @@ final class SegmentWriter {
       // Reached end of the segment
     } catch (final CorruptedJournalException e) {
       if (detectCorruptionAsPartialWrite) {
-        resetPartiallyWrittenEntry(position);
+        resetPartiallyWrittenEntry(e, position);
       } else {
         throw e;
       }
@@ -236,7 +240,11 @@ final class SegmentWriter {
     }
   }
 
-  private void resetPartiallyWrittenEntry(final int position) {
+  private void resetPartiallyWrittenEntry(final CorruptedJournalException e, final int position) {
+    LOG.debug(
+        "{} Found a corrupted or partially written entry at position {}. Considering it as a partially written entry and resetting the position.",
+        e.getMessage(),
+        position);
     FrameUtil.markAsIgnored(buffer, position);
     buffer.position(position);
     buffer.mark();

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -64,7 +64,6 @@ final class SegmentWriter {
       final MappedByteBuffer buffer,
       final Segment segment,
       final JournalIndex index,
-      final long lastFlushedIndex,
       final long lastWrittenAsqn,
       final JournalMetrics metrics) {
     this.segment = segment;

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -338,7 +338,15 @@ final class SegmentsManager implements AutoCloseable {
                 journalIndex);
 
         if (i > 0) {
+          // throws CorruptedJournalException if there is gap
           checkForIndexGaps(segments.get(i - 1), segment);
+        }
+
+        final boolean isLastSegment = i == files.size() - 1;
+        if (isLastSegment && segment.lastIndex() < lastFlushedIndex) {
+          throw new CorruptedJournalException(
+              "Expected to find records until index %d, but last index is %d"
+                  .formatted(lastFlushedIndex, segment.lastIndex()));
         }
 
         segments.add(segment);

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/UninitializedSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/UninitializedSegment.java
@@ -25,10 +25,7 @@ public record UninitializedSegment(
    * index.
    */
   public Segment initializeForUse(
-      final long index,
-      final long lastWrittenAsqn,
-      final long lastFlushedIndex,
-      final JournalMetrics metrics) {
+      final long index, final long lastWrittenAsqn, final JournalMetrics metrics) {
     final var updatedDescriptor =
         SegmentDescriptor.builder()
             .withId(segmentId)
@@ -36,7 +33,6 @@ public record UninitializedSegment(
             .withMaxSegmentSize(maxSegmentSize)
             .build();
     updatedDescriptor.copyTo(buffer);
-    return new Segment(
-        file, updatedDescriptor, buffer, lastFlushedIndex, lastWrittenAsqn, journalIndex, metrics);
+    return new Segment(file, updatedDescriptor, buffer, lastWrittenAsqn, journalIndex, metrics);
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
@@ -62,7 +62,8 @@ public final class JournalRecordReaderUtil {
     if (checksum != metadata.checksum()) {
       buffer.reset();
       throw new CorruptedJournalException(
-          "Record doesn't match checksum. Log segment may be corrupted.");
+          "Record's checksum (%d) doesn't match checksum stored in metadata (%d)."
+              .formatted(checksum, metadata.checksum()));
     }
 
     // Read record

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
@@ -26,15 +26,12 @@ final class SegmentLoaderTest {
     final var segmentSize = 4 * 1024 * 1024;
     final var descriptor =
         SegmentDescriptor.builder().withId(1).withIndex(1).withMaxSegmentSize(segmentSize).build();
-    final var lastFlushedIndex = descriptor.index() - 1;
     final var segmentLoader = new SegmentLoader(segmentSize * 2, new JournalMetrics("1"));
     final var segmentFile = tmpDir.resolve("segment.log");
 
-    // when - the segment is "unused" if the lastFlushedIndex is less than the expected first index
-    // this can happen if we crashed in the middle of creating the new segment
+    // when - "unused" segment can happen if we crashed in the middle of creating the new segment
     Files.writeString(segmentFile, "foo");
-    segmentLoader.createSegment(
-        segmentFile, descriptor, lastFlushedIndex, 0, new SparseJournalIndex(1));
+    segmentLoader.createSegment(segmentFile, descriptor, 0, new SparseJournalIndex(1));
 
     // then
     PosixPathAssert.assertThat(segmentFile).hasRealSize(segmentSize);

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -131,6 +132,44 @@ class SegmentsManagerTest {
     assertThat(segments.getFirstSegment())
         .extracting(Segment::index, Segment::lastIndex)
         .containsExactly(1L, 0L);
+  }
+
+  @Test
+  void shouldDetectCorruptionInIntermediateSegments() throws Exception {
+    // given
+    final var journal = openJournal();
+    final var indexInFirstSegment = journal.append(1, recordDataWriter).index();
+    final var lastFlushedIndex = journal.append(2, recordDataWriter).index();
+    final var firstSegmentFile = journal.getFirstSegment().file().file();
+    journal.close();
+
+    LogCorrupter.corruptRecord(firstSegmentFile, indexInFirstSegment);
+
+    // when
+    segments = createSegmentsManager();
+
+    // then
+    assertThatException()
+        .isThrownBy(() -> segments.open(lastFlushedIndex))
+        .isInstanceOf(CorruptedJournalException.class);
+  }
+
+  @Test
+  void shouldNotDetectCorruptionWithUnflushedIndexInIntermediateSegments() throws Exception {
+    // given
+    final var journal = openJournal();
+    final var indexInFirstSegment = journal.append(1, recordDataWriter).index();
+    journal.append(2, recordDataWriter).index();
+    final var firstSegmentFile = journal.getFirstSegment().file().file();
+    journal.close();
+
+    LogCorrupter.corruptRecord(firstSegmentFile, indexInFirstSegment);
+
+    // when
+    segments = createSegmentsManager();
+
+    // then
+    assertThatNoException().isThrownBy(() -> segments.open(0));
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -135,6 +135,22 @@ class SegmentsManagerTest {
   }
 
   @Test
+  void shouldDetectMissingEntryAsCorruption() throws Exception {
+    // given
+    final var journal = openJournal();
+    final var indexInFirstSegment = journal.append(1, recordDataWriter).index();
+    journal.close();
+
+    // when
+    segments = createSegmentsManager();
+
+    // then
+    assertThatException()
+        .isThrownBy(() -> segments.open(indexInFirstSegment + 1))
+        .isInstanceOf(CorruptedJournalException.class);
+  }
+
+  @Test
   void shouldDetectCorruptionInIntermediateSegments() throws Exception {
     // given
     final var journal = openJournal();


### PR DESCRIPTION
## Description

This PR is follow up of #11650 

`lastFlushedIndex` is only useful at the startup to detect corruption. But it was passed to segment and segment writer always because corruption was detected by the writer at the startup. This PR refactor this behavior and move the corruption check to segment loader. The writer treats corrupted entry as a partial writer. The loader will then see this as a missing entry if `lastFlushedIndex` is greater than this position. Thus, `lastFlushedIndex` is only needed during the startup.

This PR also removes the check for detecting unused segment  using `lastFlushedIndex`. This check was not useful because in-memory `lastFlushedIndex` is never updated after the startup. So I think that this change has no impact.

Moving corruption detection out of writer makes it less convenient for debugging. To have some context if a corruption is detected, the writer logs a debug message if it detects a corrupted/partially written entry on startup. Example debug log:
`
Record's checksum (810675654) doesn't match checksum stored in metadata (2636955287). Found a corrupted or partially written entry at position 97. Considering it as a partially written entry and resetting the position.
`

## Related issues

closes #7652 


