### PR TITLE
Replace role change with state time line and leader table with topology table

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -115,151 +115,127 @@
       "id": 56,
       "panels": [
         {
+          "id": 68,
+          "gridPos": {
+            "x": 0,
+            "y": 1,
+            "w": 8,
+            "h": 6
+          },
+          "type": "table",
+          "title": "Topology",
+          "transformations": [
+            {
+              "id": "joinByLabels",
+              "options": {
+                "join": [
+                  "pod"
+                ],
+                "value": "partition"
+              }
+            },
+            {
+              "id": "seriesToRows",
+              "options": {}
+            }
+          ],
           "datasource": {
+            "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
           },
-          "description": "Shows for each partition which broker is the leader",
+          "pluginVersion": "9.3.6",
+          "interval": "1s",
+          "description": "Displays the roles of each node per partition.",
+          "links": [],
           "fieldConfig": {
             "defaults": {
               "custom": {
                 "align": "auto",
-                "displayMode": "auto",
-                "filterable": false,
+                "displayMode": "color-background-solid",
                 "inspect": false
               },
-              "mappings": [],
+              "mappings": [
+                {
+                  "options": {
+                    "1": {
+                      "color": "super-light-orange",
+                      "index": 0,
+                      "text": "Follower"
+                    },
+                    "2": {
+                      "color": "super-light-purple",
+                      "index": 1,
+                      "text": "Candidate"
+                    },
+                    "3": {
+                      "color": "light-green",
+                      "index": 2,
+                      "text": "Leader"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "orange"
+                    "color": "red",
+                    "value": null
                   }
                 ]
-              }
+              },
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": []
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Partition"
+                  "options": "pod"
                 },
                 "properties": [
                   {
-                    "id": "custom.width",
-                    "value": 76
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Role"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 96
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Broker"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width"
+                    "id": "custom.displayMode",
+                    "value": "auto"
                   }
                 ]
               }
             ]
           },
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 0,
-            "y": 1
-          },
-          "id": 68,
-          "links": [],
           "options": {
+            "showHeader": true,
             "footer": {
-              "fields": "",
+              "show": false,
               "reducer": [
                 "sum"
               ],
-              "show": false
+              "fields": "",
+              "enablePagination": false
             },
-            "showHeader": true,
-            "sortBy": [
-              {
-                "desc": false,
-                "displayName": "Partition"
-              }
-            ]
+            "frameIndex": 0,
+            "sortBy": []
           },
-          "pluginVersion": "9.3.6",
           "targets": [
             {
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"} >= 3",
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
               "format": "time_series",
+              "hide": false,
               "instant": true,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} {{partitionGroupName}} {{partition}}",
+              "legendFormat": "{{pod}} p{{partition}} ",
+              "range": false,
               "refId": "A"
             }
-          ],
-          "title": "Current Partition Leader",
-          "transformations": [
-            {
-              "id": "labelsToFields",
-              "options": {}
-            },
-            {
-              "id": "merge",
-              "options": {}
-            },
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Time": true,
-                  "Value": true,
-                  "__name__": true,
-                  "endpoint": true,
-                  "instance": true,
-                  "job": true,
-                  "namespace": true,
-                  "partitionGroupName": true,
-                  "service": true
-                },
-                "indexByName": {
-                  "Time": 0,
-                  "Value": 10,
-                  "__name__": 1,
-                  "endpoint": 2,
-                  "instance": 3,
-                  "job": 4,
-                  "namespace": 5,
-                  "partition": 7,
-                  "partitionGroupName": 6,
-                  "pod": 8,
-                  "service": 9
-                },
-                "renameByName": {
-                  "Value": "Role",
-                  "partition": "Partition",
-                  "pod": "Broker"
-                }
-              }
-            }
-          ],
-          "type": "table"
+          ]
         },
         {
           "datasource": {

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -10918,6 +10918,120 @@
           }
         },
         {
+          "id": 432,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 103
+          },
+          "type": "state-timeline",
+          "title": "Role changes over time",
+          "transformations": [
+            {
+              "id": "convertFieldType",
+              "options": {
+                "conversions": [
+                  {
+                    "destinationType": "string",
+                    "targetField": "Value"
+                  }
+                ],
+                "fields": {}
+              }
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "pluginVersion": "9.3.6",
+          "interval": "1s",
+          "description": "Shows when a role change has happened",
+          "links": [],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 70,
+                "spanNulls": false
+              },
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "light-red",
+                      "index": 3,
+                      "text": "Inactive"
+                    },
+                    "1": {
+                      "color": "super-light-orange",
+                      "index": 2,
+                      "text": "Follower"
+                    },
+                    "2": {
+                      "color": "super-light-purple",
+                      "index": 1,
+                      "text": "Candidate"
+                    },
+                    "3": {
+                      "color": "light-green",
+                      "index": 0,
+                      "text": "Leader"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  }
+                ]
+              },
+              "links": []
+            },
+            "overrides": []
+          },
+          "options": {
+            "mergeValues": true,
+            "showValue": "auto",
+            "alignValue": "center",
+            "rowHeight": 0.9,
+            "legend": {
+              "showLegend": false,
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}} p{{partition}} ",
+              "refId": "A"
+            }
+          ]
+        },
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -10938,7 +11052,7 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
+            "x": 12,
             "y": 103
           },
           "hiddenSeries": false,
@@ -11040,7 +11154,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 111
+            "y": 112
           },
           "id": 205,
           "maxPerRow": 6,
@@ -11108,7 +11222,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 116
+            "y": 117
           },
           "id": 209,
           "maxPerRow": 6,
@@ -11189,7 +11303,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 121
+            "y": 122
           },
           "id": 215,
           "options": {
@@ -11242,9 +11356,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 121
+            "w": 24,
+            "x": 0,
+            "y": 104
           },
           "hiddenSeries": false,
           "id": 180,
@@ -11286,7 +11400,7 @@
           ],
           "thresholds": [],
           "timeRegions": [],
-          "title": "Number of log segements",
+          "title": "Number of log segments",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -11342,7 +11456,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 129
+            "y": 122
           },
           "id": 396,
           "options": {

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -14921,6 +14921,6 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 9,
+  "version": 10,
   "weekStart": ""
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -55,6 +55,12 @@
     },
     {
       "type": "panel",
+      "id": "state-timeline",
+      "name": "State timeline",
+      "version": ""
+    },
+    {
+      "type": "panel",
       "id": "table",
       "name": "Table",
       "version": ""


### PR DESCRIPTION
## Description

This PR replaces the leader table at the top with a topology table, and the Raft role change graph with a state timeline of the role changes.

> **Note** The role change timeline displays horribly when there are too many data points, but it looks great if you filter per namespace, so I think it's an acceptable improvement over the simple graph.

### Topology table

Before:

![image](https://user-images.githubusercontent.com/43373/219045212-ba1f4308-65fd-40af-8c32-f64db105b18f.png)

After:

![image](https://user-images.githubusercontent.com/43373/219045348-119a9e67-3fe0-4bc3-bfe4-bc10a223a85f.png)

### Raft role state timeline

Before:

![image](https://user-images.githubusercontent.com/43373/219045916-3aefb3a8-4b58-4220-a799-b45790f52c98.png)


After:

![image](https://user-images.githubusercontent.com/43373/219045643-9bd3cdfa-2e3b-482d-81d7-c93d94d9a4c5.png)


You can view it live here: https://grafana.dev.zeebe.io/goto/k12ltpJVz?orgId=1

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
