### PR TITLE
ci: faster benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,32 +73,27 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
             secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
+      - name: Get image tag
+        id: image-tag
+        run: |
+          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Setup BuildKit
+        uses: docker/setup-buildx-action@v2
       - name: Login to GCR
         uses: docker/login-action@v2
         with:
           registry: gcr.io
           username: _json_key
           password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
-      - uses: ./.github/actions/setup-zeebe
+      - uses: docker/build-push-action@v3
         with:
-          maven-cache: 'true'
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-      - name: Get image tag
-        id: image-tag
-        run: |
-          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C
-      - uses: ./.github/actions/build-docker
-        with:
-          repository: gcr.io/zeebe-io/zeebe
-          version: ${{ steps.image-tag.outputs.image-tag }}
+          context: .
+          tags: gcr.io/zeebe-io/zeebe:${{ steps.image-tag.outputs.image-tag }}
           push: true
-          distball: ${{ steps.build-zeebe.outputs.distball }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: DIST=build
+          target: app
   deploy-benchmark-cluster:
     name: Deploy benchmark cluster
     needs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,19 +60,11 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - uses: google-github-actions/auth@v1
+        id: auth
         with:
+          token_format: 'access_token'
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v2
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
       - name: Get image tag
         id: image-tag
         run: |
@@ -83,8 +75,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: gcr.io
-          username: _json_key
-          password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
       - uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,18 +52,33 @@ jobs:
     timeout-minutes: 30
     outputs:
       image-tag: ${{ steps.image-tag.outputs.image-tag }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
       - uses: google-github-actions/auth@v1
         with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
-      - uses: google-github-actions/setup-gcloud@v1
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
         with:
-          project_id: zeebe-io
-          install_components: gke-gcloud-auth-plugin, kubectl
-      - run: gcloud auth configure-docker
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
+      - name: Login to GCR
+        uses: docker/login-action@v2
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
       - uses: ./.github/actions/setup-zeebe
         with:
           maven-cache: 'true'
@@ -90,22 +105,21 @@ jobs:
       - build-zeebe-image
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
       - uses: google-github-actions/auth@v1
         with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
-      - uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: zeebe-io
-          install_components: gke-gcloud-auth-plugin, kubectl
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v1.0.1
         with:
           cluster_name: ${{ inputs.cluster }}
           location: ${{ inputs.cluster-region }}
-      - uses: azure/setup-helm@v3
       - name: Add camunda helm repo
         run: |
           helm repo add zeebe-benchmark https://zeebe-io.github.io/benchmark-helm

--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -8,14 +8,14 @@ on:
 jobs:
   delete-old-benchmarks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: google-github-actions/auth@v1
         with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
-      - uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: zeebe-io
-          install_components: gke-gcloud-auth-plugin, kubectl
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v1.0.1
         with:
           cluster_name: zeebe-cluster

--- a/.github/workflows/pr-benchmark.yaml
+++ b/.github/workflows/pr-benchmark.yaml
@@ -23,7 +23,7 @@ jobs:
     if: github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark')
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
-    with:      
+    with:
       name: ${{github.event.pull_request.head.ref}}-benchmark
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
@@ -34,14 +34,14 @@ jobs:
       (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark')
       || (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: google-github-actions/auth@v1
         with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
-      - uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: zeebe-io
-          install_components: gke-gcloud-auth-plugin, kubectl
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v1.0.1
         with:
           cluster_name: zeebe-cluster


### PR DESCRIPTION
Simplifies the benchmark workflow a little bit.

- Start using workload identity federation to get credentials to GKE and GCR
- Don't setup gcloud and helm, both are not necessary
- Build Zeebe from sources instead of setting up a local dev env first

Before: https://github.com/camunda/zeebe/actions/runs/4104327356
After: https://github.com/camunda/zeebe/actions/runs/4192403414

relates to #11484