### PR TITLE
fix: don't re-wrap runtime exceptions thrown inside a transaction

### DIFF
--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -321,6 +321,10 @@ public final class StreamPlatform {
     processorContext.close();
   }
 
+  public ZeebeDb getZeebeDb() {
+    return processorContext.zeebeDb;
+  }
+
   public record LogContext(SynchronousLogStream logStream) implements AutoCloseable {
 
     public LogStreamWriter setupWriter() {

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -38,7 +38,9 @@ import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
+import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.stream.util.Records;
@@ -925,6 +927,46 @@ public final class StreamProcessorTest {
             () ->
                 assertThat(streamPlatform.getStreamProcessor().getLastWrittenPositionAsync().join())
                     .isEqualTo(-1));
+  }
+
+  @Test
+  public void shouldCallOnErrorWhenProcessingFailsWithExceedingBatchInTransaction() {
+    // given
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+
+    final var processingError =
+        new ExceededBatchRecordSizeException(mock(RecordBatchEntry.class), 10, 1, 1);
+
+    when(defaultRecordProcessor.process(any(), any()))
+        .then(
+            (invocationOnMock -> {
+              streamPlatform
+                  .getZeebeDb()
+                  .createContext()
+                  .runInTransaction(
+                      () -> {
+                        throw processingError;
+                      });
+              return null;
+            }));
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.event()
+            .processInstance(ELEMENT_ACTIVATING, Records.processInstance(1))
+            .causedBy(0));
+
+    // then
+    final var inOrder = inOrder(defaultRecordProcessor);
+    inOrder.verify(defaultRecordProcessor, TIMEOUT).init(any());
+    inOrder.verify(defaultRecordProcessor, TIMEOUT).accepts(ValueType.PROCESS_INSTANCE);
+    inOrder.verify(defaultRecordProcessor, TIMEOUT).process(any(), any());
+    inOrder
+        .verify(defaultRecordProcessor, TIMEOUT)
+        .onProcessingError(eq(processingError), any(), any());
+    inOrder.verifyNoMoreInteractions();
   }
 
   private static final class TestProcessor implements RecordProcessor {

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.TransactionOperation;
 import io.camunda.zeebe.db.ZeebeDbException;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
-import io.camunda.zeebe.util.exception.RecoverableException;
-import io.camunda.zeebe.util.exception.UnrecoverableException;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Status;
 
@@ -34,8 +32,8 @@ public final class DefaultTransactionContext implements TransactionContext {
       } else {
         runInNewTransaction(operations);
       }
-    } catch (final RecoverableException | UnrecoverableException reportableException) {
-      throw reportableException;
+    } catch (final RuntimeException e) {
+      throw e;
     } catch (final RocksDBException rdbex) {
       final String errorMessage = "Unexpected error occurred during RocksDB transaction.";
       if (isRocksDbExceptionRecoverable(rdbex)) {

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
@@ -219,9 +219,8 @@ public final class DbStringColumnFamilyTest {
                             columnFamily.whileEqualPrefix(key, (k2, v2) -> {});
                           });
                     }))
-        .hasRootCauseInstanceOf(IllegalStateException.class)
-        .hasMessage("Unexpected error occurred during zeebe db transaction operation.")
-        .hasStackTraceContaining(
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
             "Currently nested prefix iterations are not supported! This will cause unexpected behavior.");
   }
 


### PR DESCRIPTION
When a `RuntimeException` is thrown inside a transaction, we should never re-wrap this exception.

This change ensures that all`RuntimeException`s are re-thrown as is. This makes exception handling in the `ProcessingStateMachine` easier and more reliable.

This is especially important for batch processing where the `ProcessingStateMachine` must see a `ExceededBatchRecordSizeException` to rollback and retry processing. Without this fix, it would only see a generic `RuntimeException`  if `ExceededBatchRecordSizeException` would occur in a `ensureInOpenTransaction` lambda, as is the case when handling message subscriptions for example.

closes #11681