### PR TITLE
deps: remove explicit dependency on `snakeyaml`

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -79,7 +79,6 @@
     <version.sbe>1.27.0</version.sbe>
     <version.scala>2.13.10</version.scala>
     <version.slf4j>2.0.6</version.slf4j>
-    <version.snakeyaml>1.33</version.snakeyaml>
     <version.javax>1.3.2</version.javax>
     <version.wiremock>2.35.0</version.wiremock>
     <version.conscrypt>2.5.2</version.conscrypt>
@@ -690,12 +689,6 @@
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
         <version>${version.objenesis}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.yaml</groupId>
-        <artifactId>snakeyaml</artifactId>
-        <version>${version.snakeyaml}</version>
       </dependency>
 
       <dependency>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -100,11 +100,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
     </dependency>
@@ -142,18 +137,4 @@
     </dependency>
 
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- dependencies only packaged but not explicitly used -->
-          <usedDependencies>
-            <dependency>org.yaml:snakeyaml</dependency>
-          </usedDependencies>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Partially addresses GHSA-mjmj-j48q-9wg2 by removing the explicit dependency on `snakeyaml` which is not used directly.

`snakeyaml` is still present via `jackson-dataformat-yaml` though, which is only used for caching OAuth credentials in the client :shrug: 