### PR TITLE
Async Raft flush

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -128,20 +128,20 @@ public class DefaultRaftServer implements RaftServer {
       return CompletableFuture.completedFuture(null);
     }
 
-    return context
-        .getThreadContext()
-        .submit(
-            () -> {
-              stopped = true;
-              started = false;
-              context.transition(Role.INACTIVE);
-              context.close();
-            });
+    return CompletableFuture.runAsync(
+        () -> {
+          stopped = true;
+          started = false;
+          context.transition(Role.INACTIVE);
+          context.close();
+        },
+        context.getThreadContext());
   }
 
   @Override
   public CompletableFuture<Void> goInactive() {
-    return context.getThreadContext().submit(() -> context.transition(Role.INACTIVE));
+    return CompletableFuture.runAsync(
+        () -> context.transition(Role.INACTIVE), context.getThreadContext());
   }
 
   @Override
@@ -171,7 +171,8 @@ public class DefaultRaftServer implements RaftServer {
 
   @Override
   public CompletableFuture<Void> stepDown() {
-    return context.getThreadContext().submit(() -> context.transition(Role.FOLLOWER));
+    return CompletableFuture.runAsync(
+        () -> context.transition(Role.FOLLOWER), context.getThreadContext());
   }
 
   /** Starts the server. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -83,7 +83,6 @@ public class PassiveRole extends InactiveRole {
   private void truncateUncommittedEntries() {
     if (role() == RaftServer.Role.PASSIVE && raft.getLog().getLastIndex() > raft.getCommitIndex()) {
       raft.getLog().deleteAfter(raft.getCommitIndex());
-      raft.getLog().flush();
     }
   }
 
@@ -564,7 +563,6 @@ public class PassiveRole extends InactiveRole {
         // the log and append the leader's entry.
         if (lastEntry.term() != entry.term()) {
           raft.getLog().deleteAfter(index - 1);
-          raft.getLog().flush();
 
           failedToAppend = !appendEntry(index, entry, future);
         }
@@ -616,7 +614,6 @@ public class PassiveRole extends InactiveRole {
       // the log and append the leader's entry.
       if (existingEntry.term() != entry.term()) {
         raft.getLog().deleteAfter(index - 1);
-        raft.getLog().flush();
 
         return appendEntry(index, entry, future);
       }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -24,6 +24,7 @@ import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.atomix.raft.storage.system.MetaStore;
 import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
@@ -181,7 +182,7 @@ public final class RaftStorage {
    *
    * @return The opened log.
    */
-  public RaftLog openLog(final MetaStore metaStore, final ThreadContext flushContext) {
+  public RaftLog openLog(final MetaStore metaStore, final ThreadContextFactory threadFactory) {
 
     return RaftLog.builder()
         .withName(prefix)
@@ -192,7 +193,7 @@ public final class RaftStorage {
         .withJournalIndexDensity(journalIndexDensity)
         .withPreallocateSegmentFiles(preallocateSegmentFiles)
         .withMetaStore(metaStore)
-        .withFlusher(flusherFactory.createFlusher(flushContext))
+        .withFlusher(flusherFactory.createFlusher(threadFactory))
         .build();
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -10,14 +10,17 @@ package io.atomix.raft.storage.log;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
 import io.camunda.zeebe.journal.Journal;
+import io.camunda.zeebe.journal.JournalException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * An implementation of {@link RaftLogFlusher} which treats calls to {@link #flush(Journal,
- * FlushMetaStore)} as signals that there is data to be flushed. When that happens, an asynchronous
- * operation is scheduled with a predefined delay. If a flush was already scheduled, then the signal
- * is ignored.
+ * An implementation of {@link RaftLogFlusher} which treats calls to {@link #flush(Journal)} as
+ * signals that there is data to be flushed. When that happens, an asynchronous operation is
+ * scheduled with a predefined delay. If a flush was already scheduled, then the signal is ignored.
  *
  * <p>In other words, this implementation flushes at least every given period, if there is anything
  * to flush.
@@ -26,14 +29,18 @@ import java.util.Objects;
  * journal write path, e.g. the Raft thread.
  */
 public final class DelayedFlusher implements RaftLogFlusher {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DelayedFlusher.class);
   private final Scheduler scheduler;
   private final Duration delayTime;
 
+  private final Object scheduledMonitor = new Object();
   private Scheduled scheduledFlush;
+
   private boolean closed;
 
   public DelayedFlusher(final Scheduler scheduler, final Duration delayTime) {
-    this.scheduler = Objects.requireNonNull(scheduler, "must specify a thread context");
+    this.scheduler = Objects.requireNonNull(scheduler, "must specify a scheduler");
     this.delayTime = Objects.requireNonNull(delayTime, "must specify a valid flush delay");
   }
 
@@ -44,29 +51,47 @@ public final class DelayedFlusher implements RaftLogFlusher {
 
   @Override
   public void close() {
-    if (closed) {
-      return;
+    synchronized (scheduledMonitor) {
+      closed = true;
+
+      if (scheduledFlush != null) {
+        scheduledFlush.cancel();
+        scheduledFlush = null;
+      }
     }
 
-    closed = true;
-    if (scheduledFlush != null) {
-      scheduledFlush.cancel();
+    scheduler.close();
+  }
+
+  private void scheduleFlush(final Journal journal) {
+    synchronized (scheduledMonitor) {
+      if (closed) {
+        LOGGER.debug("Skipped scheduling flush due to flusher being closed");
+        return;
+      }
+
+      if (scheduledFlush == null) {
+        LOGGER.trace(
+            "Scheduling delayed flush in {} up to index {}", delayTime, journal.getLastIndex());
+        scheduledFlush = scheduler.schedule(delayTime, () -> asyncFlush(journal));
+      } else {
+        LOGGER.trace("Skipped scheduling flush as there is already a pending, scheduled flush");
+      }
     }
   }
 
   private void asyncFlush(final Journal journal) {
-    scheduledFlush = null;
-
-    if (closed || !journal.isOpen()) {
-      return;
+    synchronized (scheduledMonitor) {
+      scheduledFlush = null;
     }
 
-    journal.flush();
-  }
+    LOGGER.trace("Flushing journal after {}", delayTime);
 
-  private void scheduleFlush(final Journal journal) {
-    if (scheduledFlush == null) {
-      scheduledFlush = scheduler.schedule(delayTime, () -> asyncFlush(journal));
+    try {
+      journal.flush();
+    } catch (final JournalException | UncheckedIOException e) {
+      LOGGER.warn("Failed to flush journal, operation will be retried after {}", delayTime, e);
+      scheduleFlush(journal);
     }
   }
 
@@ -79,8 +104,6 @@ public final class DelayedFlusher implements RaftLogFlusher {
         + delayTime
         + ", scheduledFlush="
         + scheduledFlush
-        + ", closed="
-        + closed
         + '}';
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -7,7 +7,7 @@
  */
 package io.atomix.raft.storage.log;
 
-import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.util.CloseableSilently;
 
@@ -80,22 +80,6 @@ public interface RaftLogFlusher extends CloseableSilently {
   }
 
   /**
-   * Temporary interface to allow the flusher to update the last flushed index once we know a flush
-   * operation occurred. Ideally we will push this down into the journal, such that it becomes
-   * unnecessary in a later iteration.
-   */
-  @FunctionalInterface
-  interface FlushMetaStore {
-
-    /**
-     * Sets the last guaranteed flush index.
-     *
-     * @param lastIndex the last guaranteed flushed index
-     */
-    void storeLastFlushedIndex(final long lastIndex);
-  }
-
-  /**
    * Factory methods to create a new {@link RaftLogFlusher}. This is unfortunately required due to
    * the blackbox instantiation of the {@link io.atomix.raft.impl.RaftContext}.
    */
@@ -110,20 +94,21 @@ public interface RaftLogFlusher extends CloseableSilently {
 
     /**
      * Creates a new {@link RaftLogFlusher} which should use the given thread context for
-     * synchronization.
+     * synchronization. If any {@link io.atomix.utils.concurrent.ThreadContext} are created, they
+     * should be closed by the flusher.
      *
-     * @param flushContext the thread context for asynchronous operations
+     * @param threadFactory the thread context factory for asynchronous operations
      * @return a configured Flusher
      */
-    RaftLogFlusher createFlusher(final ThreadContext flushContext);
+    RaftLogFlusher createFlusher(final ThreadContextFactory threadFactory);
 
     /** Preset factory method which returns a shared {@link DirectFlusher} instance. */
-    static DirectFlusher direct(final ThreadContext ignored) {
+    static DirectFlusher direct(final ThreadContextFactory ignored) {
       return DIRECT;
     }
 
     /** Preset factory method which returns a shared {@link NoopFlusher} instance. */
-    static NoopFlusher noop(final ThreadContext ignored) {
+    static NoopFlusher noop(final ThreadContextFactory ignored) {
       return NOOP;
     }
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -40,11 +40,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Manages persistence of server configurations.
  *
- * <p>The server metastore is responsible for persisting server configurations according to the
- * configured {@link RaftStorage#storageLevel() storage level}. Each server persists their current
- * {@link #loadTerm() term} and last {@link #loadVote() vote} as is dictated by the Raft consensus
- * algorithm. Additionally, the metastore is responsible for storing the last know server {@link
- * Configuration}, including cluster membership.
+ * <p>The server metastore is responsible for persisting server configurations. Each server persists
+ * their current {@link #loadTerm() term} and last {@link #loadVote() vote} as is dictated by the
+ * Raft consensus algorithm. Additionally, the metastore is responsible for storing the last know
+ * server {@link Configuration}, including cluster membership.
  */
 public class MetaStore implements JournalMetaStore, AutoCloseable {
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -339,9 +339,8 @@ public final class RaftRule extends ExternalResource {
       final var raftContext = raftServer.getContext();
       final var serviceManager = raftContext.getLogCompactor();
       serviceManager.setCompactableIndex(persistedSnapshot.getIndex());
-      raftContext
-          .getThreadContext()
-          .submit(serviceManager::compactIgnoringReplicationThreshold)
+      CompletableFuture.runAsync(
+              serviceManager::compactIgnoringReplicationThreshold, raftContext.getThreadContext())
           .join();
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -43,7 +43,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.mockito.Mockito;
 
 public class PassiveRoleTest {
 
@@ -175,35 +174,5 @@ public class PassiveRoleTest {
 
     // then
     verify(log, times(1)).flush();
-  }
-
-  @Test
-  public void shouldFlushAfterTruncating() {
-    // given
-    final var orderedFlush = Mockito.inOrder(log);
-    final List<PersistedRaftRecord> entries =
-        List.of(
-            new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
-            new PersistedRaftRecord(1, 2, 2, 1, new byte[1]),
-            new PersistedRaftRecord(1, 3, 3, 1, new byte[1]));
-    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 0);
-
-    when(log.append(any(PersistedRaftRecord.class)))
-        .thenReturn(mock(IndexedRaftLogEntry.class))
-        .thenReturn(mock(IndexedRaftLogEntry.class))
-        .thenReturn(mock(IndexedRaftLogEntry.class));
-    when(ctx.getLog()).thenReturn(log);
-    role.handleAppend(request).join();
-    orderedFlush.verify(log, times(1)).flush();
-
-    // when - force truncation
-    when(log.getLastIndex()).thenReturn(3L);
-    when(ctx.getCommitIndex()).thenReturn(1L);
-
-    role = new PassiveRole(ctx);
-    role.start().join();
-
-    // then
-    orderedFlush.verify(log, times(1)).flush();
   }
 }

--- a/atomix/utils/src/main/java/io/atomix/utils/concurrent/Scheduler.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/concurrent/Scheduler.java
@@ -16,12 +16,13 @@
  */
 package io.atomix.utils.concurrent;
 
+import io.camunda.zeebe.util.CloseableSilently;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /** Scheduler. */
 @FunctionalInterface
-public interface Scheduler {
+public interface Scheduler extends CloseableSilently {
 
   /**
    * Schedules a runnable after a delay.
@@ -75,4 +76,7 @@ public interface Scheduler {
    * @return the scheduled callback
    */
   Scheduled schedule(Duration initialDelay, Duration interval, Runnable callback);
+
+  @Override
+  default void close() {}
 }

--- a/atomix/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
@@ -155,6 +155,13 @@ public class SingleThreadContext implements ThreadContext {
   @Override
   public void close() {
     executor.shutdownNow();
+
+    try {
+      //noinspection ResultOfMethodCallIgnored
+      executor.awaitTermination(30, TimeUnit.SECONDS);
+    } catch (final InterruptedException ignored) {
+      // as we're shutting down the thread, we can safely ignore this
+    }
   }
 
   class WrappedRunnable implements Runnable {

--- a/atomix/utils/src/main/java/io/atomix/utils/concurrent/ThreadContext.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/concurrent/ThreadContext.java
@@ -18,9 +18,7 @@ package io.atomix.utils.concurrent;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import io.camunda.zeebe.util.CheckedRunnable;
 import io.camunda.zeebe.util.CloseableSilently;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
@@ -58,27 +56,4 @@ public interface ThreadContext extends CloseableSilently, Executor, Scheduler {
   /** By default there are no resources to close. */
   @Override
   default void close() {}
-
-  /**
-   * Submits a new blocking task to the thread context, and returns a future which is completed only
-   * when the task finishes.
-   *
-   * @param task the task to await
-   * @return a future which is completed successfully when the task is finished, or with any thrown
-   *     exception
-   */
-  default CompletableFuture<Void> submit(final CheckedRunnable task) {
-    final CompletableFuture<Void> result = new CompletableFuture<>();
-    execute(
-        () -> {
-          try {
-            task.run();
-            result.complete(null);
-          } catch (final Exception e) {
-            result.completeExceptionally(e);
-          }
-        });
-
-    return result;
-  }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -120,7 +120,7 @@ public final class RaftPartitionGroupFactory {
         return RaftLogFlusher.Factory::direct;
       }
 
-      return context -> new DelayedFlusher(context, delayTime);
+      return threadFactory -> new DelayedFlusher(threadFactory.createContext(), delayTime);
     }
 
     Loggers.RAFT.warn(

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
@@ -74,7 +74,7 @@ final class PartitionManagerImplTest {
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
-    assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
+    assertThat(config.getStorageConfig().flusherFactory().createFlusher(NoopContext::new))
         .isInstanceOf(DelayedFlusher.class)
         .asInstanceOf(InstanceOfAssertFactories.type(DelayedFlusher.class))
         .hasFieldOrPropertyWithValue("delayTime", Duration.ofSeconds(5));
@@ -102,7 +102,7 @@ final class PartitionManagerImplTest {
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
-    assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
+    assertThat(config.getStorageConfig().flusherFactory().createFlusher(() -> null))
         .isInstanceOf(DirectFlusher.class);
   }
 
@@ -128,7 +128,7 @@ final class PartitionManagerImplTest {
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
-    assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
+    assertThat(config.getStorageConfig().flusherFactory().createFlusher(() -> null))
         .isInstanceOf(NoopFlusher.class);
   }
 
@@ -155,7 +155,7 @@ final class PartitionManagerImplTest {
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
-    assertThat(config.getStorageConfig().flusherFactory().createFlusher(new NoOpContext()))
+    assertThat(config.getStorageConfig().flusherFactory().createFlusher(() -> null))
         .isInstanceOf(NoopFlusher.class);
   }
 
@@ -171,15 +171,16 @@ final class PartitionManagerImplTest {
     return config;
   }
 
-  private static class NoOpContext implements ThreadContext {
-
+  private static final class NoopContext implements ThreadContext {
     @Override
     public Scheduled schedule(
         final Duration initialDelay, final Duration interval, final Runnable callback) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
-    public void execute(final Runnable command) {}
+    public void execute(final Runnable command) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/FlushableSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/FlushableSegment.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+/** The minimum API a segment has to implement to be flush-able. */
+interface FlushableSegment {
+
+  /**
+   * The current last written index of the segment, giving a guaranteed lower bound for a flush
+   * index
+   */
+  long lastIndex();
+
+  /**
+   * Flushes any changes from the segment to its underlying storage.
+   *
+   * <p>If the method returns true, then it is guaranteed that the modified pages for this segment *
+   * have been flushed to disk (according to the underlying file system).
+   *
+   * @return true if the segment flushed successfully, false otherwise
+   */
+  boolean flush();
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -56,7 +56,7 @@ final class Segment implements AutoCloseable {
   // This need to be volatile because both the writer and the readers access it concurrently
   private volatile boolean markedForDeletion = false;
 
-  public Segment(
+  Segment(
       final SegmentFile file,
       final SegmentDescriptor descriptor,
       final MappedByteBuffer buffer,
@@ -77,7 +77,7 @@ final class Segment implements AutoCloseable {
    *
    * @return The segment ID.
    */
-  public long id() {
+  long id() {
     return descriptor.id();
   }
 
@@ -86,7 +86,7 @@ final class Segment implements AutoCloseable {
    *
    * @return The segment's starting index.
    */
-  public long index() {
+  long index() {
     return descriptor.index();
   }
 
@@ -95,7 +95,7 @@ final class Segment implements AutoCloseable {
    *
    * @return The last index in the segment.
    */
-  public long lastIndex() {
+  long lastIndex() {
     return writer.getLastIndex();
   }
 
@@ -104,7 +104,7 @@ final class Segment implements AutoCloseable {
    *
    * @return The last application sequence number in the segment.
    */
-  public long lastAsqn() {
+  long lastAsqn() {
     return writer.getLastAsqn();
   }
 
@@ -113,7 +113,7 @@ final class Segment implements AutoCloseable {
    *
    * @return The segment file.
    */
-  public SegmentFile file() {
+  SegmentFile file() {
     return file;
   }
 
@@ -122,7 +122,7 @@ final class Segment implements AutoCloseable {
    *
    * @return The segment descriptor.
    */
-  public SegmentDescriptor descriptor() {
+  SegmentDescriptor descriptor() {
     return descriptor;
   }
 
@@ -131,7 +131,7 @@ final class Segment implements AutoCloseable {
    *
    * @return Indicates whether the segment is empty.
    */
-  public boolean isEmpty() {
+  boolean isEmpty() {
     return length() == 0;
   }
 
@@ -140,7 +140,7 @@ final class Segment implements AutoCloseable {
    *
    * @return The segment length.
    */
-  public long length() {
+  long length() {
     return writer.getNextIndex() - index();
   }
 
@@ -149,7 +149,7 @@ final class Segment implements AutoCloseable {
    *
    * @return The segment writer.
    */
-  public SegmentWriter writer() {
+  SegmentWriter writer() {
     checkOpen();
     return writer;
   }
@@ -196,7 +196,7 @@ final class Segment implements AutoCloseable {
    *
    * @return indicates whether the segment is open
    */
-  public boolean isOpen() {
+  boolean isOpen() {
     return open;
   }
 
@@ -209,7 +209,7 @@ final class Segment implements AutoCloseable {
   }
 
   /** Deletes the segment. */
-  public void delete() {
+  void delete() {
     open = false;
     markForDeletion();
     if (readers.isEmpty()) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -82,10 +82,6 @@ final class SegmentWriter {
     return lastEntry != null ? lastEntry.index() : segment.index() - 1;
   }
 
-  JournalRecord getLastEntry() {
-    return lastEntry;
-  }
-
   long getNextIndex() {
     if (lastEntry != null) {
       return lastEntry.index() + 1;

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -52,7 +52,6 @@ final class SegmentWriter {
   private final long firstAsqn;
   private long lastAsqn;
   private JournalRecord lastEntry;
-  private boolean isOpen = true;
   private final JournalRecordReaderUtil recordUtil;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   private final JournalRecordSerializer serializer = new SBESerializer();
@@ -267,17 +266,6 @@ final class SegmentWriter {
     } else {
       reset(index, true);
       invalidateNextEntry(buffer.position());
-    }
-  }
-
-  void flush() {
-    buffer.force();
-  }
-
-  void close() {
-    if (isOpen) {
-      isOpen = false;
-      flush();
     }
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -58,7 +58,8 @@ public final class SegmentedJournal implements Journal {
 
     final var lastFlushedIndex = journalMetaStore.loadLastFlushedIndex();
     this.segments.open(lastFlushedIndex);
-    writer = new SegmentedJournalWriter(segments, lastFlushedIndex, journalMetrics);
+    writer =
+        new SegmentedJournalWriter(segments, new SegmentsFlusher(lastFlushedIndex), journalMetrics);
   }
 
   /**
@@ -155,7 +156,6 @@ public final class SegmentedJournal implements Journal {
     try (final var ignored = journalMetrics.observeJournalFlush()) {
       final var stamp = rwlock.readLock();
       try {
-        LOGGER.trace("Flushing journal up to {}", writer.getLastIndex());
         writer.flush(journalMetaStore);
       } finally {
         rwlock.unlockRead(stamp);

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -23,18 +23,19 @@ import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.JournalRecord;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.io.File;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.concurrent.locks.StampedLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A file based journal. The journal is split into multiple segments files. */
 public final class SegmentedJournal implements Journal {
   public static final long ASQN_IGNORE = -1;
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentedJournal.class);
   private final JournalMetrics journalMetrics;
-  private final File directory;
-  private final int maxSegmentSize;
   private final Collection<SegmentedJournalReader> readers = Sets.newConcurrentHashSet();
   private volatile boolean open = true;
   private final JournalIndex journalIndex;
@@ -45,22 +46,19 @@ public final class SegmentedJournal implements Journal {
   private final JournalMetaStore journalMetaStore;
 
   SegmentedJournal(
-      final File directory,
-      final int maxSegmentSize,
       final JournalIndex journalIndex,
       final SegmentsManager segments,
       final JournalMetrics journalMetrics,
       final JournalMetaStore journalMetaStore) {
-    this.directory = Objects.requireNonNull(directory, "must specify a journal directory");
-    this.maxSegmentSize = maxSegmentSize;
     this.journalMetrics = Objects.requireNonNull(journalMetrics, "must specify journal metrics");
     this.journalIndex = Objects.requireNonNull(journalIndex, "must specify a journal index");
     this.segments = Objects.requireNonNull(segments, "must specify a journal segments manager");
     this.journalMetaStore =
         Objects.requireNonNull(journalMetaStore, "must specify a journal meta store");
 
-    this.segments.open(journalMetaStore.loadLastFlushedIndex());
-    writer = new SegmentedJournalWriter(this);
+    final var lastFlushedIndex = journalMetaStore.loadLastFlushedIndex();
+    this.segments.open(lastFlushedIndex);
+    writer = new SegmentedJournalWriter(segments, lastFlushedIndex, journalMetrics);
   }
 
   /**
@@ -122,6 +120,10 @@ public final class SegmentedJournal implements Journal {
     try {
       journalIndex.clear();
       writer.reset(nextIndex);
+      // no need to update the meta store's last flushed index as usage is that we always reset
+      // with a greater index than what we previously had. it's fine if the stored last flushed
+      // index is lower than the real flushed index. every thing will be treated as a partial write
+      // until the next flush, which is fine
     } finally {
       rwlock.unlockWrite(stamp);
     }
@@ -145,8 +147,20 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public void flush() {
-    writer.flush();
-    journalMetaStore.storeLastFlushedIndex(getLastIndex());
+    if (!isOpen() || isEmpty()) {
+      LOGGER.debug("Skipped journal flush as it is either closed or empty");
+      return;
+    }
+
+    try (final var ignored = journalMetrics.observeJournalFlush()) {
+      final var stamp = rwlock.readLock();
+      try {
+        LOGGER.trace("Flushing journal up to {}", writer.getLastIndex());
+        writer.flush(journalMetaStore);
+      } finally {
+        rwlock.unlockRead(stamp);
+      }
+    }
   }
 
   @Override
@@ -168,6 +182,7 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public void close() {
+    flush();
     segments.close();
     open = false;
   }
@@ -179,14 +194,6 @@ public final class SegmentedJournal implements Journal {
    */
   private void assertOpen() {
     checkState(segments.getCurrentSegment() != null, "journal not open");
-  }
-
-  private long maxSegmentSize() {
-    return maxSegmentSize;
-  }
-
-  private File directory() {
-    return directory;
   }
 
   /**
@@ -207,11 +214,6 @@ public final class SegmentedJournal implements Journal {
   Segment getLastSegment() {
     assertOpen();
     return segments.getLastSegment();
-  }
-
-  Segment getNextSegment() {
-    assertOpen();
-    return segments.getNextSegment();
   }
 
   /**
@@ -240,24 +242,6 @@ public final class SegmentedJournal implements Journal {
   }
 
   /**
-   * Resets and returns the first segment in the journal.
-   *
-   * @param index the starting index of the journal
-   * @return the first segment
-   */
-  Segment resetSegments(final long index) {
-    return segments.resetSegments(index);
-  }
-
-  /**
-   * Removes a segment.
-   *
-   * @param segment The segment to remove.
-   */
-  synchronized void removeSegment(final Segment segment) {
-    segments.removeSegment(segment);
-  }
-  /**
    * Resets journal readers to the given index, if they are at a larger index.
    *
    * @param index The index at which to reset readers.
@@ -270,10 +254,6 @@ public final class SegmentedJournal implements Journal {
     }
   }
 
-  public JournalMetrics getJournalMetrics() {
-    return journalMetrics;
-  }
-
   public JournalIndex getJournalIndex() {
     return journalIndex;
   }
@@ -284,5 +264,11 @@ public final class SegmentedJournal implements Journal {
 
   void releaseReadlock(final long stamp) {
     rwlock.unlockRead(stamp);
+  }
+
+  @VisibleForTesting(
+      "The simplest way to guarantee certain methods acquire/release the write lock is to access directly")
+  StampedLock rwlock() {
+    return rwlock;
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -171,7 +171,6 @@ public class SegmentedJournalBuilder {
         new SegmentsManager(
             journalIndex, maxSegmentSize, directory, name, segmentLoader, journalMetrics);
 
-    return new SegmentedJournal(
-        directory, maxSegmentSize, journalIndex, segmentsManager, journalMetrics, journalMetaStore);
+    return new SegmentedJournal(journalIndex, segmentsManager, journalMetrics, journalMetaStore);
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -99,8 +99,8 @@ final class SegmentedJournalWriter {
 
     // Truncate down to the current index, such that the last index is `index`, and the next index
     // `index + 1`
-    currentWriter.truncate(index);
     flusher.setLastFlushedIndex(index);
+    currentWriter.truncate(index);
   }
 
   void flush() {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -84,9 +84,9 @@ final class SegmentedJournalWriter {
   }
 
   void reset(final long index) {
+    flusher.setLastFlushedIndex(index - 1);
     currentSegment = segments.resetSegments(index);
     currentWriter = currentSegment.writer();
-    flusher.setLastFlushedIndex(index - 1);
   }
 
   void deleteAfter(final long index) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -17,35 +17,44 @@
 package io.camunda.zeebe.journal.file;
 
 import io.camunda.zeebe.journal.JournalException.SegmentSizeTooSmall;
+import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-class SegmentedJournalWriter {
-  private final SegmentedJournal journal;
+final class SegmentedJournalWriter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentedJournalWriter.class);
+  private final SegmentsManager segments;
   private final JournalMetrics journalMetrics;
+
   private Segment currentSegment;
   private SegmentWriter currentWriter;
 
-  public SegmentedJournalWriter(final SegmentedJournal journal) {
-    this.journal = journal;
-    journalMetrics = journal.getJournalMetrics();
-    currentSegment = journal.getLastSegment();
+  // no need to make this volatile if callers always acquire the write-lock beforehand
+  private long lastFlushedIndex;
+
+  SegmentedJournalWriter(
+      final SegmentsManager segments,
+      final long lastFlushedIndex,
+      final JournalMetrics journalMetrics) {
+    this.segments = segments;
+    this.lastFlushedIndex = lastFlushedIndex;
+    this.journalMetrics = journalMetrics;
+
+    currentSegment = segments.getLastSegment();
     currentWriter = currentSegment.writer();
   }
 
-  public long getLastIndex() {
+  long getLastIndex() {
     return currentWriter.getLastIndex();
   }
 
-  public JournalRecord getLastEntry() {
-    return currentWriter.getLastEntry();
-  }
-
-  public long getNextIndex() {
+  long getNextIndex() {
     return currentWriter.getNextIndex();
   }
 
-  public JournalRecord append(final long asqn, final BufferWriter recordDataWriter) {
+  JournalRecord append(final long asqn, final BufferWriter recordDataWriter) {
     final var appendResult = currentWriter.append(asqn, recordDataWriter);
     if (appendResult.isRight()) {
       return appendResult.get();
@@ -63,7 +72,7 @@ class SegmentedJournalWriter {
     return appendResultOnNewSegment.get();
   }
 
-  public void append(final JournalRecord record) {
+  void append(final JournalRecord record) {
     final var appendResult = currentWriter.append(record);
     if (appendResult.isRight()) {
       return;
@@ -80,34 +89,69 @@ class SegmentedJournalWriter {
     }
   }
 
-  public void reset(final long index) {
-    currentSegment = journal.resetSegments(index);
+  void reset(final long index) {
+    currentSegment = segments.resetSegments(index);
     currentWriter = currentSegment.writer();
+    lastFlushedIndex = index - 1;
   }
 
-  public void deleteAfter(final long index) {
+  void deleteAfter(final long index) {
     // Delete all segments with first indexes greater than the given index.
-    while (index < currentSegment.index() && currentSegment != journal.getFirstSegment()) {
-      journal.removeSegment(currentSegment);
-      currentSegment = journal.getLastSegment();
+    while (index < currentSegment.index() && currentSegment != segments.getFirstSegment()) {
+      segments.removeSegment(currentSegment);
+      currentSegment = segments.getLastSegment();
       currentWriter = currentSegment.writer();
     }
 
     // Truncate the current index.
     currentWriter.truncate(index);
+    lastFlushedIndex = index - 1;
   }
 
-  public void flush() {
-    journalMetrics.observeSegmentFlush(currentWriter::flush);
-  }
+  /**
+   * Fetches all segments with a last index greater than or equal to current {@link
+   * #lastFlushedIndex}. These are then flushed in order. The {@link Segment#lastIndex()} of the
+   * last successful segment to be flushed will be stored in the given {@link JournalMetaStore}.
+   *
+   * @param metaStore where to store the last successfully flushed index
+   */
+  void flush(final JournalMetaStore metaStore) {
+    final var dirtySegments = segments.getSegments(lastFlushedIndex + 1);
+    final var segmentsCount = dirtySegments.size();
+    long flushedIndex = -1;
 
-  public void close() {
-    currentWriter.close();
+    if (segmentsCount == 0) {
+      LOGGER.debug(
+          "No segments to flush for index {} (last index = {}); there may be nothing to flush",
+          flushedIndex,
+          getLastIndex());
+      return;
+    }
+
+    try {
+      for (final var segment : dirtySegments) {
+        final long lastSegmentIndex = segment.lastIndex();
+        if (segment.flush()) {
+          flushedIndex = lastSegmentIndex;
+        }
+      }
+    } finally {
+      // store whatever we managed to flush to avoid doing it again
+      if (flushedIndex > lastFlushedIndex) {
+        lastFlushedIndex = flushedIndex;
+        metaStore.storeLastFlushedIndex(flushedIndex);
+
+        LOGGER.trace(
+            "Flushed {} segment(s), from index {} to index {}",
+            segmentsCount,
+            lastFlushedIndex,
+            flushedIndex);
+      }
+    }
   }
 
   private void createNewSegment() {
-    currentWriter.flush();
-    currentSegment = journal.getNextSegment();
+    currentSegment = segments.getNextSegment();
     currentWriter = currentSegment.writer();
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -20,26 +20,21 @@ import io.camunda.zeebe.journal.JournalException.SegmentSizeTooSmall;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class SegmentedJournalWriter {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentedJournalWriter.class);
   private final SegmentsManager segments;
+  private final SegmentsFlusher flusher;
   private final JournalMetrics journalMetrics;
 
   private Segment currentSegment;
   private SegmentWriter currentWriter;
 
-  // no need to make this volatile if callers always acquire the write-lock beforehand
-  private long lastFlushedIndex;
-
   SegmentedJournalWriter(
       final SegmentsManager segments,
-      final long lastFlushedIndex,
+      final SegmentsFlusher flusher,
       final JournalMetrics journalMetrics) {
     this.segments = segments;
-    this.lastFlushedIndex = lastFlushedIndex;
+    this.flusher = flusher;
     this.journalMetrics = journalMetrics;
 
     currentSegment = segments.getLastSegment();
@@ -92,7 +87,7 @@ final class SegmentedJournalWriter {
   void reset(final long index) {
     currentSegment = segments.resetSegments(index);
     currentWriter = currentSegment.writer();
-    lastFlushedIndex = index - 1;
+    flusher.resetLastFlushedIndex(index - 1);
   }
 
   void deleteAfter(final long index) {
@@ -105,49 +100,11 @@ final class SegmentedJournalWriter {
 
     // Truncate the current index.
     currentWriter.truncate(index);
-    lastFlushedIndex = index - 1;
+    flusher.resetLastFlushedIndex(index - 1);
   }
 
-  /**
-   * Fetches all segments with a last index greater than or equal to current {@link
-   * #lastFlushedIndex}. These are then flushed in order. The {@link Segment#lastIndex()} of the
-   * last successful segment to be flushed will be stored in the given {@link JournalMetaStore}.
-   *
-   * @param metaStore where to store the last successfully flushed index
-   */
   void flush(final JournalMetaStore metaStore) {
-    final var dirtySegments = segments.getSegments(lastFlushedIndex + 1);
-    final var segmentsCount = dirtySegments.size();
-    long flushedIndex = -1;
-
-    if (segmentsCount == 0) {
-      LOGGER.debug(
-          "No segments to flush for index {} (last index = {}); there may be nothing to flush",
-          flushedIndex,
-          getLastIndex());
-      return;
-    }
-
-    try {
-      for (final var segment : dirtySegments) {
-        final long lastSegmentIndex = segment.lastIndex();
-        if (segment.flush()) {
-          flushedIndex = lastSegmentIndex;
-        }
-      }
-    } finally {
-      // store whatever we managed to flush to avoid doing it again
-      if (flushedIndex > lastFlushedIndex) {
-        lastFlushedIndex = flushedIndex;
-        metaStore.storeLastFlushedIndex(flushedIndex);
-
-        LOGGER.trace(
-            "Flushed {} segment(s), from index {} to index {}",
-            segmentsCount,
-            lastFlushedIndex,
-            flushedIndex);
-      }
-    }
+    flusher.flush(metaStore, segments.getSegments(flusher.nextFlushIndex()));
   }
 
   private void createNewSegment() {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsFlusher.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsFlusher.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.JournalMetaStore;
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class SegmentsFlusher {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentsFlusher.class);
+  // no need to make this volatile if callers always acquire the write-lock beforehand
+  private long lastFlushedIndex;
+
+  SegmentsFlusher(final long lastFlushedIndex) {
+    resetLastFlushedIndex(lastFlushedIndex);
+  }
+
+  void resetLastFlushedIndex(final long lastFlushedIndex) {
+    this.lastFlushedIndex = lastFlushedIndex;
+  }
+
+  long nextFlushIndex() {
+    return lastFlushedIndex + 1;
+  }
+
+  /**
+   * Fetches all segments with a last index greater than or equal to current {@link
+   * #lastFlushedIndex}. These are then flushed in order. The {@link Segment#lastIndex()} of the
+   * last successful segment to be flushed will be stored in the given {@link JournalMetaStore}.
+   *
+   * @param metaStore where to store the last successfully flushed index
+   */
+  void flush(
+      final JournalMetaStore metaStore,
+      final Collection<? extends FlushableSegment> dirtySegments) {
+    final var segmentsCount = dirtySegments.size();
+    long flushedIndex = -1;
+
+    if (segmentsCount == 0) {
+      LOGGER.debug(
+          "No segments to flush for index {}; there may be nothing to flush", flushedIndex);
+      return;
+    }
+
+    try {
+      for (final var segment : dirtySegments) {
+        final long lastSegmentIndex = segment.lastIndex();
+        if (segment.flush()) {
+          flushedIndex = lastSegmentIndex;
+        }
+      }
+    } finally {
+      // store whatever we managed to flush to avoid doing it again
+      if (flushedIndex > lastFlushedIndex) {
+        lastFlushedIndex = flushedIndex;
+        metaStore.storeLastFlushedIndex(flushedIndex);
+
+        LOGGER.trace(
+            "Flushed {} segment(s), from index {} to index {}",
+            segmentsCount,
+            lastFlushedIndex,
+            flushedIndex);
+      }
+    }
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsFlusher.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsFlusher.java
@@ -9,21 +9,26 @@ package io.camunda.zeebe.journal.file;
 
 import io.camunda.zeebe.journal.JournalMetaStore;
 import java.util.Collection;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 final class SegmentsFlusher {
-
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentsFlusher.class);
+
+  private final JournalMetaStore metaStore;
+
   // no need to make this volatile if callers always acquire the write-lock beforehand
   private long lastFlushedIndex;
 
-  SegmentsFlusher(final long lastFlushedIndex) {
-    resetLastFlushedIndex(lastFlushedIndex);
+  SegmentsFlusher(final JournalMetaStore metaStore) {
+    this.metaStore = Objects.requireNonNull(metaStore, "must specify a meta store");
+    lastFlushedIndex = metaStore.loadLastFlushedIndex();
   }
 
-  void resetLastFlushedIndex(final long lastFlushedIndex) {
+  void setLastFlushedIndex(final long lastFlushedIndex) {
     this.lastFlushedIndex = lastFlushedIndex;
+    metaStore.storeLastFlushedIndex(lastFlushedIndex);
   }
 
   long nextFlushIndex() {
@@ -35,11 +40,9 @@ final class SegmentsFlusher {
    * #lastFlushedIndex}. These are then flushed in order. The {@link Segment#lastIndex()} of the
    * last successful segment to be flushed will be stored in the given {@link JournalMetaStore}.
    *
-   * @param metaStore where to store the last successfully flushed index
+   * @param dirtySegments the list of segments which need to be flushed
    */
-  void flush(
-      final JournalMetaStore metaStore,
-      final Collection<? extends FlushableSegment> dirtySegments) {
+  void flush(final Collection<? extends FlushableSegment> dirtySegments) {
     final var segmentsCount = dirtySegments.size();
     long flushedIndex = -1;
 
@@ -59,8 +62,7 @@ final class SegmentsFlusher {
     } finally {
       // store whatever we managed to flush to avoid doing it again
       if (flushedIndex > lastFlushedIndex) {
-        lastFlushedIndex = flushedIndex;
-        metaStore.storeLastFlushedIndex(flushedIndex);
+        setLastFlushedIndex(flushedIndex);
 
         LOGGER.trace(
             "Flushed {} segment(s), from index {} to index {}",

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -45,10 +45,6 @@ final class SegmentsManager implements AutoCloseable {
   private volatile Segment currentSegment;
   private CompletableFuture<UninitializedSegment> nextSegment = null;
 
-  // this needs to be volatile as it can be accessed from more than one thread if flushing is
-  // performed asynchronously
-  private final long lastFlushedIndex = -1;
-
   private final JournalIndex journalIndex;
   private final int maxSegmentSize;
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,10 @@ final class SegmentsManager implements AutoCloseable {
   private final NavigableMap<Long, Segment> segments = new ConcurrentSkipListMap<>();
   private volatile Segment currentSegment;
   private CompletableFuture<UninitializedSegment> nextSegment = null;
+
+  // this needs to be volatile as it can be accessed from more than one thread if flushing is
+  // performed asynchronously
+  private final long lastFlushedIndex = -1;
 
   private final JournalIndex journalIndex;
   private final int maxSegmentSize;
@@ -85,9 +90,9 @@ final class SegmentsManager implements AutoCloseable {
         LOG.warn(
             "Next segment preparation failed during close, ignoring and proceeding to close", e);
       }
+      nextSegment = null;
     }
 
-    nextSegment = null;
     currentSegment = null;
   }
 
@@ -232,6 +237,7 @@ final class SegmentsManager implements AutoCloseable {
    * @param segment The segment to remove.
    */
   void removeSegment(final Segment segment) {
+    //noinspection resource
     segments.remove(segment.index());
     journalMetrics.decSegmentCount();
     segment.delete();
@@ -302,6 +308,15 @@ final class SegmentsManager implements AutoCloseable {
     nextSegment = CompletableFuture.supplyAsync(() -> createUninitializedSegment(descriptor));
   }
 
+  Collection<Segment> getSegments(final long index) {
+    final var segment = getSegment(index);
+    if (segment == null) {
+      return Collections.emptySet();
+    }
+
+    return Collections.unmodifiableSortedMap(segments.tailMap(segment.index(), true)).values();
+  }
+
   private UninitializedSegment createUninitializedSegment(final SegmentDescriptor descriptor) {
     final var segmentFile = SegmentFile.createSegmentFile(name, directory, descriptor.id());
     return segmentLoader.createUninitializedSegment(segmentFile.toPath(), descriptor, journalIndex);
@@ -320,6 +335,7 @@ final class SegmentsManager implements AutoCloseable {
    */
   private Collection<Segment> loadSegments(final long lastFlushedIndex) {
     // Ensure log directories are created.
+    //noinspection ResultOfMethodCallIgnored
     directory.mkdirs();
     final List<Segment> segments = new ArrayList<>();
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -304,7 +304,7 @@ final class SegmentsManager implements AutoCloseable {
     nextSegment = CompletableFuture.supplyAsync(() -> createUninitializedSegment(descriptor));
   }
 
-  Collection<Segment> getSegments(final long index) {
+  Collection<Segment> getTailSegments(final long index) {
     final var segment = getSegment(index);
     if (segment == null) {
       return Collections.emptySet();

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -660,6 +660,19 @@ final class JournalTest {
     assertThat(reader.next()).isEqualTo(lastRecord);
   }
 
+  @Test
+  void shouldUpdateMetastoreAfterFlush() {
+    journal = openJournal();
+    journal.append(1, recordDataWriter);
+    final var lastWrittenIndex = journal.append(2, recordDataWriter).index();
+
+    // when
+    journal.flush();
+
+    // then
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(lastWrittenIndex);
+  }
+
   // TODO: do not rely on implementation detail to compare records
   private PersistedJournalRecord copyRecord(final JournalRecord record) {
     final RecordData data =

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -191,6 +191,7 @@ final class JournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(1);
     final var record = journal.append(asqn, recordDataWriter);
     assertThat(record.index()).isEqualTo(2);
+    assertThat(metaStore.loadLastFlushedIndex()).isOne();
   }
 
   @Test
@@ -253,6 +254,7 @@ final class JournalTest {
 
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
+    assertThat(metaStore.loadLastFlushedIndex()).isOne();
     assertThat(reader.hasNext()).isFalse();
   }
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 final class SegmentedJournalWriterTest {
   private final TestJournalFactory journalFactory = new TestJournalFactory();
-  private final SegmentsFlusher flusher = new SegmentsFlusher(-1L);
+  private final SegmentsFlusher flusher = new SegmentsFlusher(journalFactory.metaStore());
 
   private SegmentsManager segments;
   private SegmentedJournalWriter writer;
@@ -42,13 +42,14 @@ final class SegmentedJournalWriterTest {
     writer.append(2, journalFactory.entry());
     writer.append(3, journalFactory.entry());
     writer.append(4, journalFactory.entry());
-    writer.flush(journalFactory.metaStore());
+    writer.flush();
 
     // when
     writer.deleteAfter(2);
 
     // then
-    assertThat(flusher.nextFlushIndex()).isEqualTo(2L);
+    assertThat(flusher.nextFlushIndex()).isEqualTo(3L);
+    assertThat(journalFactory.metaStore().loadLastFlushedIndex()).isEqualTo(2L);
   }
 
   @Test
@@ -56,12 +57,13 @@ final class SegmentedJournalWriterTest {
     // given
     writer.append(1, journalFactory.entry());
     writer.append(2, journalFactory.entry());
-    writer.flush(journalFactory.metaStore());
+    writer.flush();
 
     // when
     writer.reset(8);
 
     // then
     assertThat(flusher.nextFlushIndex()).isEqualTo(8L);
+    assertThat(journalFactory.metaStore().loadLastFlushedIndex()).isEqualTo(7L);
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class SegmentedJournalWriterTest {
+  private final TestJournalFactory journalFactory = new TestJournalFactory();
+  private final SegmentsFlusher flusher = new SegmentsFlusher(-1L);
+
+  private SegmentsManager segments;
+  private SegmentedJournalWriter writer;
+
+  @BeforeEach
+  void beforeEach(final @TempDir Path tempDir) {
+    segments = journalFactory.segmentsManager(tempDir);
+    segments.open(-1L);
+    writer = new SegmentedJournalWriter(segments, flusher, journalFactory.metrics());
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietClose(segments);
+  }
+
+  @Test
+  void shouldResetLastFlushedIndexOnDeleteAfter() {
+    // given
+    writer.append(1, journalFactory.entry());
+    writer.append(2, journalFactory.entry());
+    writer.append(3, journalFactory.entry());
+    writer.append(4, journalFactory.entry());
+    writer.flush(journalFactory.metaStore());
+
+    // when
+    writer.deleteAfter(2);
+
+    // then
+    assertThat(flusher.nextFlushIndex()).isEqualTo(2L);
+  }
+
+  @Test
+  void shouldResetLastFlushedIndexOnReset() {
+    // given
+    writer.append(1, journalFactory.entry());
+    writer.append(2, journalFactory.entry());
+    writer.flush(journalFactory.metaStore());
+
+    // when
+    writer.reset(8);
+
+    // then
+    assertThat(flusher.nextFlushIndex()).isEqualTo(8L);
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsFlusherTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsFlusherTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.journal.util.MockJournalMetastore;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class SegmentsFlusherTest {
+  private final MockJournalMetastore metaStore = new MockJournalMetastore();
+  private final SegmentsFlusher flusher = new SegmentsFlusher(-1);
+
+  @Test
+  void shouldFlushAllSegments() {
+    // given
+    final var firstSegment = new TestSegment(15);
+    final var secondSegment = new TestSegment(30);
+
+    // when
+    flusher.flush(metaStore, List.of(firstSegment, secondSegment));
+
+    // then
+    assertThat(firstSegment.flushed).isTrue();
+    assertThat(secondSegment.flushed).isTrue();
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(30L);
+  }
+
+  @Test
+  void shouldStoreLastFlushedIndexOnPartialFlush() {
+    // given
+    final var dirtySegments = List.of(new TestSegment(15), new TestSegment(30, false));
+
+    // when
+    flusher.flush(metaStore, dirtySegments);
+
+    // then
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(15L);
+  }
+
+  @Test
+  void shouldStoreLastFlushedIndexOnPartialFailedFlush() {
+    // given
+    final var error = new UncheckedIOException(new IOException("Cannot allocate memory"));
+    final var dirtySegments = List.of(new TestSegment(15), new TestSegment(30, error));
+
+    // when
+    assertThatCode(() -> flusher.flush(metaStore, dirtySegments)).isSameAs(error);
+
+    // then
+    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(15L);
+  }
+
+  private static final class TestSegment implements FlushableSegment {
+    private final long lastIndex;
+    private final boolean shouldFlush;
+    private final RuntimeException flushError;
+    private boolean flushed;
+
+    private TestSegment(final long lastIndex) {
+      this(lastIndex, true);
+    }
+
+    private TestSegment(final long lastIndex, final boolean shouldFlush) {
+      this(lastIndex, shouldFlush, null);
+    }
+
+    private TestSegment(final long lastIndex, final RuntimeException flushError) {
+      this(lastIndex, true, flushError);
+    }
+
+    private TestSegment(
+        final long lastIndex, final boolean shouldFlush, final RuntimeException flushError) {
+      this.lastIndex = lastIndex;
+      this.shouldFlush = shouldFlush;
+      this.flushError = flushError;
+    }
+
+    @Override
+    public long lastIndex() {
+      return lastIndex;
+    }
+
+    @Override
+    public boolean flush() {
+      if (flushError != null) {
+        throw flushError;
+      }
+
+      flushed = shouldFlush;
+      return shouldFlush;
+    }
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsFlusherTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsFlusherTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 final class SegmentsFlusherTest {
   private final MockJournalMetastore metaStore = new MockJournalMetastore();
-  private final SegmentsFlusher flusher = new SegmentsFlusher(-1);
+  private final SegmentsFlusher flusher = new SegmentsFlusher(metaStore);
 
   @Test
   void shouldFlushAllSegments() {
@@ -27,7 +27,7 @@ final class SegmentsFlusherTest {
     final var secondSegment = new TestSegment(30);
 
     // when
-    flusher.flush(metaStore, List.of(firstSegment, secondSegment));
+    flusher.flush(List.of(firstSegment, secondSegment));
 
     // then
     assertThat(firstSegment.flushed).isTrue();
@@ -41,7 +41,7 @@ final class SegmentsFlusherTest {
     final var dirtySegments = List.of(new TestSegment(15), new TestSegment(30, false));
 
     // when
-    flusher.flush(metaStore, dirtySegments);
+    flusher.flush(dirtySegments);
 
     // then
     assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(15L);
@@ -54,7 +54,7 @@ final class SegmentsFlusherTest {
     final var dirtySegments = List.of(new TestSegment(15), new TestSegment(30, error));
 
     // when
-    assertThatCode(() -> flusher.flush(metaStore, dirtySegments)).isSameAs(error);
+    assertThatCode(() -> flusher.flush(dirtySegments)).isSameAs(error);
 
     // then
     assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(15L);

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.record.RecordData;
+import io.camunda.zeebe.journal.record.SBESerializer;
+import io.camunda.zeebe.journal.util.MockJournalMetastore;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * A small utility to create controllable {@link SegmentedJournal} with fixed size segments. Knowing
+ * beforehand how many entries will be present per segment is very useful to assert predictable
+ * results on journal operations.
+ *
+ * <p>The number of entries per segment is predicated on every entry having the same data, and thus
+ * all entries having the same fixed size. Use {@link #entry()} when appending as data to ensure
+ * this always holds.
+ *
+ * <p>Most external dependencies are reused (e.g. {@link JournalMetrics}, {@link
+ * MockJournalMetastore}), but the {@link SegmentsManager} and {@link SegmentedJournal} are always
+ * recreated. Make sure to close either of them after creation.
+ *
+ * <p>By default, the string "test" is the entry data, and there is one entry per segment.
+ */
+final class TestJournalFactory {
+  private final MockJournalMetastore metaStore = new MockJournalMetastore();
+  private final JournalMetrics metrics = new JournalMetrics("test");
+  private final JournalIndex index = new SparseJournalIndex(1);
+
+  private final int maxEntryCount;
+  private final DirectBuffer entryData;
+  private final BufferWriter entry;
+  private final int size;
+  private final SegmentLoader loader;
+
+  TestJournalFactory() {
+    this(1);
+  }
+
+  TestJournalFactory(final int maxEntryCount) {
+    this("test", maxEntryCount);
+  }
+
+  /**
+   * A test factory with custom entry data (used to compute the size of the segment) and a custom
+   * max entry count.
+   *
+   * @param data the entry data
+   * @param maxEntryCount the max number of entries per segment
+   */
+  TestJournalFactory(final String data, final int maxEntryCount) {
+    entryData = BufferUtil.wrapString(data);
+    entry = new DirectBufferWriter().wrap(entryData);
+    size = getSerializedSize(entryData);
+    this.maxEntryCount = maxEntryCount;
+
+    loader = new SegmentLoader(2 * maxSegmentSize(), metrics);
+  }
+
+  int serializedEntrySize() {
+    return size;
+  }
+
+  BufferWriter entry() {
+    return entry;
+  }
+
+  int maxSegmentSize() {
+    return (maxEntryCount * serializedEntrySize()) + SegmentDescriptor.getEncodingLength();
+  }
+
+  SegmentLoader segmentLoader() {
+    return loader;
+  }
+
+  MockJournalMetastore metaStore() {
+    return metaStore;
+  }
+
+  SegmentsManager segmentsManager(final Path directory) {
+    return new SegmentsManager(
+        index,
+        maxSegmentSize(),
+        directory.resolve("data").toFile(),
+        "journal",
+        segmentLoader(),
+        metrics);
+  }
+
+  SegmentedJournal journal(final SegmentsManager segments) {
+    return new SegmentedJournal(index, segments, metrics, metaStore);
+  }
+
+  DirectBuffer entryData() {
+    return entryData;
+  }
+
+  JournalMetrics metrics() {
+    return metrics;
+  }
+
+  private int getSerializedSize(final DirectBuffer data) {
+    final var record = new RecordData(1, 1, data);
+    final var serializer = new SBESerializer();
+    final ByteBuffer buffer = ByteBuffer.allocate(128);
+    return serializer.writeData(record, new UnsafeBuffer(buffer), 0).get()
+        + FrameUtil.getLength()
+        + serializer.getMetadataLength();
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/util/MockJournalMetastore.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/util/MockJournalMetastore.java
@@ -10,16 +10,25 @@ package io.camunda.zeebe.journal.util;
 import io.camunda.zeebe.journal.JournalMetaStore;
 
 public final class MockJournalMetastore implements JournalMetaStore {
+  private volatile Runnable onStoreFlushedIndex;
 
   private long lastFlushedIndex = -1;
 
   @Override
   public void storeLastFlushedIndex(final long index) {
+    if (onStoreFlushedIndex != null) {
+      onStoreFlushedIndex.run();
+    }
+
     lastFlushedIndex = index;
   }
 
   @Override
   public long loadLastFlushedIndex() {
     return lastFlushedIndex;
+  }
+
+  public void setOnStoreFlushedIndex(final Runnable onStoreFlushedIndex) {
+    this.onStoreFlushedIndex = onStoreFlushedIndex;
   }
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -132,8 +132,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "orange",
-                    "value": null
+                    "color": "orange"
                   }
                 ]
               }
@@ -287,8 +286,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -780,8 +778,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "#EAB839",
@@ -955,8 +952,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1032,8 +1028,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1199,8 +1194,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1642,8 +1636,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1740,8 +1733,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1992,8 +1984,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2319,8 +2310,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8592,7 +8582,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 20
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 278,
@@ -8715,7 +8705,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8731,7 +8722,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 27
+            "y": 19
           },
           "id": 373,
           "options": {
@@ -8810,7 +8801,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8826,7 +8818,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 27
           },
           "id": 363,
           "options": {
@@ -8905,7 +8897,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8921,7 +8914,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 27
           },
           "id": 406,
           "options": {
@@ -9000,7 +8993,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9016,7 +9010,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 34
           },
           "id": 368,
           "options": {
@@ -9095,7 +9089,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9111,7 +9106,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 34
           },
           "id": 411,
           "options": {
@@ -9177,7 +9172,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 41
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9272,7 +9267,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 416,
@@ -9412,7 +9407,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 48
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9523,7 +9518,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 48
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9551,7 +9546,8 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "ge": 2,
+              "le": 0
             },
             "legend": {
               "show": false
@@ -9634,7 +9630,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 62
+            "y": 54
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9745,7 +9741,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 54
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9840,7 +9836,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 68
+            "y": 60
           },
           "hiddenSeries": false,
           "id": 283,
@@ -9935,7 +9931,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 67
           },
           "hiddenSeries": false,
           "id": 79,
@@ -10028,7 +10024,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 75
+            "y": 67
           },
           "hiddenSeries": false,
           "id": 114,
@@ -10108,8 +10104,10 @@
           },
           "dataFormat": "tsbuckets",
           "datasource": {
+            "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
           },
+          "description": "Overall latency distribution to flush the journal",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -10129,12 +10127,233 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 74
           },
           "heatmap": {},
           "hideZeroBuckets": true,
           "highlightCards": true,
           "id": 89,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#b4ff00",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Spectral",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "9.3.6",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le)",
+              "format": "heatmap",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Journal Flush Latency",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "format": "dtdurations",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Overall latency to flush the complete journal",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 74
+          },
+          "id": 300,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.3.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(atomix_journal_flush_time_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (pod) / sum(rate(atomix_journal_flush_time_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m]))  by (pod)",
+              "interval": "",
+              "legendFormat": "Avg {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[1m])) by (le))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Median",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Journal Flush Latency",
+          "type": "timeseries"
+        },
+        {
+          "cards": {},
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Overall latency distribution to flush a single segment",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 81
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 426,
           "legend": {
             "show": false
           },
@@ -10207,48 +10426,84 @@
           "yBucketBound": "auto"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "description": "Overall latency of flushing a single segment",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 81
           },
-          "hiddenSeries": false,
-          "id": 300,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
+          "id": 427,
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
           "pluginVersion": "9.3.6",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10272,35 +10527,8 @@
               "refId": "C"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Segment Flush Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "cards": {},
@@ -10334,7 +10562,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 88
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -10427,7 +10655,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 88
           },
           "hiddenSeries": false,
           "id": 305,
@@ -10540,7 +10768,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 96
+            "y": 95
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -10639,7 +10867,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 96
+            "y": 95
           },
           "hiddenSeries": false,
           "id": 72,
@@ -10735,7 +10963,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 104
+            "y": 103
           },
           "hiddenSeries": false,
           "id": 95,
@@ -10822,98 +11050,6 @@
           }
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 104
-          },
-          "hiddenSeries": false,
-          "id": 180,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "9.3.6",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "expr": "atomix_segment_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
-              "interval": "",
-              "legendFormat": "{{pod}} {{partition}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Number of log segements",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
           "columns": [
             {
               "text": "Current",
@@ -10928,7 +11064,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 112
+            "y": 111
           },
           "id": 205,
           "maxPerRow": 6,
@@ -10996,7 +11132,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 117
+            "y": 116
           },
           "id": 209,
           "maxPerRow": 6,
@@ -11077,7 +11213,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 122
+            "y": 121
           },
           "id": 215,
           "options": {
@@ -11111,6 +11247,98 @@
           "type": "gauge"
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 121
+          },
+          "hiddenSeries": false,
+          "id": 180,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.3.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "atomix_segment_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{pod}} {{partition}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Number of log segements",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
           "datasource": {
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
@@ -11138,7 +11366,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 122
+            "y": 129
           },
           "id": 396,
           "options": {
@@ -14603,6 +14831,6 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 8,
+  "version": 9,
   "weekStart": ""
 }

--- a/util/src/main/java/io/camunda/zeebe/util/VisibleForTesting.java
+++ b/util/src/main/java/io/camunda/zeebe/util/VisibleForTesting.java
@@ -24,4 +24,8 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.SOURCE)
 @Documented
-public @interface VisibleForTesting {}
+public @interface VisibleForTesting {
+
+  /** An optional justification as to why something was made visible for testing */
+  String value() default "";
+}


### PR DESCRIPTION
## Description

First draft for asynchronous Raft flush. A second iteration could potentially simplify things further push down the flush strategy pattern to the journal, and introduce the concept of a background executor for the journal, useful for compaction, for segment creation, etc.

As a first step here, we just make sure the flush path is thread-safe, and we still provide a way to flush synchronously on the Raft thread if required.

The thread-safety relies on two things: the fact the segments map is thread-safe already, and a new volatile last flushed index that the `SegmentedJournalWriter` keeps track of.

By keeping track of what was the last successfully flushed index, we don't need to flush the moving to the next segment on write. Instead, on flush, we'll just pick up all the segments whose last index is greater than or equal to the last known flushed index, and flush them. At the end, we store the last successfully flushed index. This means we sometimes will flush a little more than what we need to, but that's fine.

This needs to be polished a little more, but I wanted to get some early feedback.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11519 
closes #11488 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
