### PR TITLE
Candidate steps down if election timesout with out success or failure

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -108,10 +108,9 @@ public final class CandidateRole extends ActiveRole {
 
     final AtomicBoolean complete = new AtomicBoolean();
     final Set<DefaultRaftMember> votingMembers =
-        new HashSet<>(
-            raft.getCluster().getActiveMemberStates().stream()
-                .map(RaftMemberContext::getMember)
-                .collect(Collectors.toList()));
+        raft.getCluster().getActiveMemberStates().stream()
+            .map(RaftMemberContext::getMember)
+            .collect(Collectors.toSet());
 
     // Send vote requests to all nodes. The vote request that is sent
     // to this node will be automatically successful.
@@ -120,7 +119,7 @@ public final class CandidateRole extends ActiveRole {
     final Quorum quorum =
         new Quorum(
             raft.getCluster().getQuorum(),
-            (elected) -> {
+            elected -> {
               if (!isRunning()) {
                 return;
               }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -31,7 +31,6 @@ import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.Quorum;
 import io.atomix.utils.concurrent.Scheduled;
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,6 +40,8 @@ import java.util.stream.Collectors;
 public final class CandidateRole extends ActiveRole {
 
   private Scheduled currentTimer;
+
+  private int votingRound = 0;
 
   public CandidateRole(final RaftContext context) {
     super(context);
@@ -85,6 +86,7 @@ public final class CandidateRole extends ActiveRole {
 
   /** Resets the election timer. */
   private void sendVoteRequests() {
+    votingRound++;
     raft.checkThread();
 
     // Because of asynchronous execution, the candidate state could have already been closed. In
@@ -144,16 +146,26 @@ public final class CandidateRole extends ActiveRole {
                   if (!complete.get()) {
                     // When the election times out, clear the previous majority vote
                     // check and restart the election.
-                    log.debug("Election timed out. Transitioning to follower");
                     quorum.cancel();
 
-                    // Transition to follower and re-send poll requests to become candidate again.
-                    // This delays the election because now this member has to wait for another
-                    // electionTimeout to send the poll requests. But assuming this is not the
-                    // common case, this delay is acceptable. The other option is to immediately
-                    // send new vote request here, but this resulted in an election loop in a very
-                    // specific scenario https://github.com/camunda/zeebe/issues/11665
-                    raft.transition(Role.FOLLOWER);
+                    final var shouldRetry = votingRound <= 1;
+                    if (shouldRetry) {
+                      // Attempt one more election to reduce election delay. If transition to
+                      // follower, then this member has to wait for another election timeout before
+                      // starting the election.
+                      log.debug("Election timed out. Restarting election.");
+                      sendVoteRequests();
+                      votingRound++;
+                    } else {
+                      // Transition to follower and re-send poll requests to become candidate again.
+                      // This delays the election because now this member has to wait for another
+                      // electionTimeout to send the poll requests. But assuming this is not the
+                      // common case, this delay is acceptable. The other option is to immediately
+                      // send new vote request here, but this resulted in an election loop in a very
+                      // specific scenario https://github.com/camunda/zeebe/issues/11665
+                      log.debug("Second round of election timed out. Transitioning to follower.");
+                      raft.transition(Role.FOLLOWER);
+                    }
                   }
                 });
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/CandidateRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/CandidateRoleTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.raft.ControllableRaftContexts;
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+class CandidateRoleTest {
+  private ControllableRaftContexts raftContexts;
+
+  @TempDir private Path raftDataDirectory;
+
+  @BeforeEach
+  public void before() throws Exception {
+    raftContexts = new ControllableRaftContexts(3);
+    raftContexts.setup(raftDataDirectory, new Random(1));
+  }
+
+  @AfterEach
+  public void shutdown() throws IOException {
+    raftContexts.shutdown();
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/11665")
+  void shouldTransitionToFollowerWhenElectionTimesOut() {
+    // given
+    final var chosenCandidate = 0; // chose any member as candidate
+    // Timeout on chosen candidate so that it can start election before other members
+    raftContexts.tickElectionTimeout(chosenCandidate);
+    raftContexts.tickHeartbeatTimeout(chosenCandidate);
+
+    // wait until chosen member becomes a candidate
+    int steps = 100;
+    while (!isCandidate(chosenCandidate)) {
+      raftContexts.tickHeartbeatTimeout();
+      raftContexts.processAllMessage();
+      raftContexts.runUntilDone();
+      if (steps-- < 0) {
+        break;
+      }
+    }
+
+    assertThat(isCandidate(chosenCandidate)).isTrue();
+
+    // when
+
+    // Allow enough time to run two rounds of vote request
+    steps = 100;
+    while (isCandidate(chosenCandidate)) {
+      raftContexts.tickHeartbeatTimeout(chosenCandidate);
+      // Other members do nothing so that the vote requests from the candidate can timeout
+      if (steps-- < 0) {
+        break;
+      }
+    }
+
+    // then
+    assertThat(raftContexts.getRaftContext(chosenCandidate).getRole()).isEqualTo(Role.FOLLOWER);
+  }
+
+  private boolean isCandidate(final int expectedCandidate) {
+    return raftContexts.getRaftContext(expectedCandidate).getRole() == Role.CANDIDATE;
+  }
+}


### PR DESCRIPTION
## Description

`RandomizedRaftTest` found a case where two nodes caught in a election loop #11665. In real world the probability of this happening is very less because there is a r[andomized delay](https://github.com/camunda/zeebe/blob/main/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java#L133) set for timeouts in Candidate Role. 
In this specific scenario, one node has longer log. The other node in candidate role always had higher term, because on timeout it immediately starts another round of election. This prevented other node with longer log to become a candidate. As a fix, we now make the candidate step down and re-starts election with poll requests. 

- https://github.com/camunda/zeebe/commit/a6cd0647358049186595867fb4689bea21641a1c Steps down immediately after vote request timesout.
- https://github.com/camunda/zeebe/commit/a7f6238d0260753f0378be6bb7460d7ee514bbd5 Adds an optimization, where the candidate attempts two rounds of election before stepping down. This is to prevent the delay caused by stepping down and waiting for another election timeout. We can discuss it if it is really required.
- A regression test using the infrastructure built for `RandomizedRaftTest` is also added. Writing a unit test of `CandidateRole` was messy because of hundreds of mocks. 

## Related issues

closes #11665 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

