### PR TITLE
[backport/stable8.1] Replace AIMD backpressure with StabilizingAIMD

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/PartitionAwareRequestLimiter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/PartitionAwareRequestLimiter.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.transport.backpressure;
 import static io.camunda.zeebe.broker.Broker.LOG;
 
 import com.netflix.concurrency.limits.Limit;
-import com.netflix.concurrency.limits.limit.AIMDLimit;
 import com.netflix.concurrency.limits.limit.FixedLimit;
 import com.netflix.concurrency.limits.limit.Gradient2Limit;
 import com.netflix.concurrency.limits.limit.GradientLimit;
@@ -113,12 +112,12 @@ public final class PartitionAwareRequestLimiter {
         .build();
   }
 
-  private static AIMDLimit getAIMD(final AIMDCfg aimdCfg) {
-    return AIMDLimit.newBuilder()
+  private static StabilizingAIMDLimit getAIMD(final AIMDCfg aimdCfg) {
+    return StabilizingAIMDLimit.newBuilder()
         .initialLimit(aimdCfg.getInitialLimit())
         .minLimit(aimdCfg.getMinLimit())
         .maxLimit(aimdCfg.getMaxLimit())
-        .timeout(aimdCfg.getRequestTimeout().toMillis(), TimeUnit.MILLISECONDS)
+        .expectedRTT(aimdCfg.getRequestTimeout().toMillis(), TimeUnit.MILLISECONDS)
         .backoffRatio(aimdCfg.getBackoffRatio())
         .build();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/StabilizingAIMDLimit.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/StabilizingAIMDLimit.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.backpressure;
+
+import com.google.common.base.Preconditions;
+import com.netflix.concurrency.limits.limit.AbstractLimit;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The limit is calculated purely based on the configured expectedRTT and observed rtt (round trip
+ * time). The algorithm tries to keep the rtts around expectedRTT. It is not guaranteed to be always
+ * less than that. But on an average, rtts will be less than the configured expectedRTT.
+ *
+ * <p>The implementation is based on {@link com.netflix.concurrency.limits.limit.AIMDLimit}.
+ * AIMDLimit has a limitation that the limit fluctuates between 1 and 2*X, where X is the optimal
+ * limit for the system. It rarely stabilizes at X. This results in always fluctuating throughput
+ * and latency. {@link StabilizingAIMDLimit} fixes this issue and attempts to keep the limit around
+ * X.
+ */
+public final class StabilizingAIMDLimit extends AbstractLimit {
+
+  private static final long DEFAULT_MAX_RTT = TimeUnit.SECONDS.toNanos(2);
+  private final int minLimit;
+  private final int maxLimit;
+  private final double backoffRatio;
+  private final long expectedRTT;
+
+  private StabilizingAIMDLimit(
+      final int initialLimit,
+      final int maxLimit,
+      final int minLimit,
+      final double backoffRatio,
+      final long expectedRTT) {
+    super(initialLimit);
+    this.maxLimit = maxLimit;
+    this.minLimit = minLimit;
+    this.backoffRatio = backoffRatio;
+    this.expectedRTT = expectedRTT;
+  }
+
+  @Override
+  protected int _update(
+      final long startTime, final long rtt, final int inflight, final boolean didDrop) {
+    int currentLimit = getLimit();
+
+    if ((didDrop || rtt > expectedRTT)) {
+      if (inflight <= currentLimit) {
+        currentLimit = (int) (currentLimit * backoffRatio);
+      }
+    } else if (inflight * 2 >= currentLimit) {
+      currentLimit = currentLimit + 1;
+    }
+
+    return Math.min(maxLimit, Math.max(minLimit, currentLimit));
+  }
+
+  @Override
+  public String toString() {
+    return "StabilizingAIMDLimit [limit=" + getLimit() + "]";
+  }
+
+  public static StabilizingAIMDLimit.Builder newBuilder() {
+    return new StabilizingAIMDLimit.Builder();
+  }
+
+  static final class Builder {
+    private int minLimit = 10;
+    private int initialLimit = 100;
+    private int maxLimit = 1000;
+    private double backoffRatio = 0.9;
+    private long expectedRtt = DEFAULT_MAX_RTT;
+
+    public StabilizingAIMDLimit.Builder initialLimit(final int initialLimit) {
+      this.initialLimit = initialLimit;
+      return this;
+    }
+
+    public StabilizingAIMDLimit.Builder minLimit(final int minLimit) {
+      this.minLimit = minLimit;
+      return this;
+    }
+
+    public StabilizingAIMDLimit.Builder maxLimit(final int maxLimit) {
+      this.maxLimit = maxLimit;
+      return this;
+    }
+
+    /**
+     * When the limit has to be reduced, the new limit is calculated as current limit *
+     * backoffRatio.
+     */
+    public StabilizingAIMDLimit.Builder backoffRatio(final double backoffRatio) {
+      Preconditions.checkArgument(
+          backoffRatio < 1.0 && backoffRatio >= 0.5,
+          "Backoff ratio must be in the range [0.5, 1.0)");
+      this.backoffRatio = backoffRatio;
+      return this;
+    }
+
+    /** When observed RTT exceeds this value, the limit will be reduced. */
+    public StabilizingAIMDLimit.Builder expectedRTT(final long timeout, final TimeUnit units) {
+      Preconditions.checkArgument(timeout > 0, "Timeout must be positive");
+      expectedRtt = units.toNanos(timeout);
+      return this;
+    }
+
+    public StabilizingAIMDLimit build() {
+      return new StabilizingAIMDLimit(initialLimit, maxLimit, minLimit, backoffRatio, expectedRtt);
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/StabilizingAIMDLimit.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/StabilizingAIMDLimit.java
@@ -19,8 +19,8 @@ import java.util.concurrent.TimeUnit;
  * <p>The implementation is based on {@link com.netflix.concurrency.limits.limit.AIMDLimit}.
  * AIMDLimit has a limitation that the limit fluctuates between 1 and 2*X, where X is the optimal
  * limit for the system. It rarely stabilizes at X. This results in always fluctuating throughput
- * and latency. {@link StabilizingAIMDLimit} fixes this issue and attempts to keep the limit around
- * X.
+ * and latency. {@link StabilizingAIMDLimit} fixes this issue, by not reducing the limit if the
+ * inflight is greater than the current limit. As a result it attempts to keep the limit around X.
  */
 final class StabilizingAIMDLimit extends AbstractLimit {
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/StabilizingAIMDLimit.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/StabilizingAIMDLimit.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  * and latency. {@link StabilizingAIMDLimit} fixes this issue and attempts to keep the limit around
  * X.
  */
-public final class StabilizingAIMDLimit extends AbstractLimit {
+final class StabilizingAIMDLimit extends AbstractLimit {
 
   private static final long DEFAULT_MAX_RTT = TimeUnit.SECONDS.toNanos(2);
   private final int minLimit;
@@ -64,8 +64,8 @@ public final class StabilizingAIMDLimit extends AbstractLimit {
     return "StabilizingAIMDLimit [limit=" + getLimit() + "]";
   }
 
-  public static StabilizingAIMDLimit.Builder newBuilder() {
-    return new StabilizingAIMDLimit.Builder();
+  public static Builder newBuilder() {
+    return new Builder();
   }
 
   static final class Builder {
@@ -75,17 +75,17 @@ public final class StabilizingAIMDLimit extends AbstractLimit {
     private double backoffRatio = 0.9;
     private long expectedRtt = DEFAULT_MAX_RTT;
 
-    public StabilizingAIMDLimit.Builder initialLimit(final int initialLimit) {
+    Builder initialLimit(final int initialLimit) {
       this.initialLimit = initialLimit;
       return this;
     }
 
-    public StabilizingAIMDLimit.Builder minLimit(final int minLimit) {
+    Builder minLimit(final int minLimit) {
       this.minLimit = minLimit;
       return this;
     }
 
-    public StabilizingAIMDLimit.Builder maxLimit(final int maxLimit) {
+    Builder maxLimit(final int maxLimit) {
       this.maxLimit = maxLimit;
       return this;
     }
@@ -94,7 +94,7 @@ public final class StabilizingAIMDLimit extends AbstractLimit {
      * When the limit has to be reduced, the new limit is calculated as current limit *
      * backoffRatio.
      */
-    public StabilizingAIMDLimit.Builder backoffRatio(final double backoffRatio) {
+    Builder backoffRatio(final double backoffRatio) {
       Preconditions.checkArgument(
           backoffRatio < 1.0 && backoffRatio >= 0.5,
           "Backoff ratio must be in the range [0.5, 1.0)");
@@ -103,13 +103,13 @@ public final class StabilizingAIMDLimit extends AbstractLimit {
     }
 
     /** When observed RTT exceeds this value, the limit will be reduced. */
-    public StabilizingAIMDLimit.Builder expectedRTT(final long timeout, final TimeUnit units) {
+    Builder expectedRTT(final long timeout, final TimeUnit units) {
       Preconditions.checkArgument(timeout > 0, "Timeout must be positive");
       expectedRtt = units.toNanos(timeout);
       return this;
     }
 
-    public StabilizingAIMDLimit build() {
+    StabilizingAIMDLimit build() {
       return new StabilizingAIMDLimit(initialLimit, maxLimit, minLimit, backoffRatio, expectedRtt);
     }
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/StabilizingAIMDLimitTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/StabilizingAIMDLimitTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.backpressure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class StabilizingAIMDLimitTest {
+
+  private final StabilizingAIMDLimit limit =
+      StabilizingAIMDLimit.newBuilder()
+          .initialLimit(10)
+          .minLimit(1)
+          .expectedRTT(1, TimeUnit.SECONDS)
+          .build();
+
+  @Test
+  void shouldIncreaseLimitOnLowerRtt() {
+    // when
+    limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(1), 9, false);
+    // then
+    assertThat(limit.getLimit()).isEqualTo(11);
+  }
+
+  @Test
+  void shouldNotIncreaseLimitWhenLowInflight() {
+    // when
+    limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(1), 2, false);
+    // then
+    assertThat(limit.getLimit()).isEqualTo(10);
+  }
+
+  @Test
+  void shouldDecreaseLimitOnHigherRtt() {
+    // when
+    limit.onSample(0, TimeUnit.SECONDS.toNanos(2), 9, false);
+    // then
+    assertThat(limit.getLimit()).isEqualTo(9);
+  }
+
+  @Test
+  void shouldNotDecreaseLimitWhenInflightGreaterThanLimit() {
+    // when
+    limit.onSample(0, TimeUnit.SECONDS.toNanos(2), 11, false);
+    // then
+    assertThat(limit.getLimit()).isEqualTo(10);
+  }
+}


### PR DESCRIPTION
## Description

Partial backport of #10747
- Adds StabilitzingAIMDLimit which fixes the issues with AIMD that results in constantly fluctuating limit.
- Replace AIMD with StabilizingAIMDLimit.
- Default algo is not changed.
- Default configuration of AIMD is also not changed, except that now when AIMD is configured it uses the new fixed algorithm.

## Related issues

closes #8298 

related to [support](https://jira.camunda.com/browse/SUPPORT-15888)

