### PR TITLE
[Backport stable/8.1] Asynchronously prepare next segment to reduce peak write latency

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
@@ -73,7 +73,12 @@ public final class SegmentFile {
     return fileName.startsWith(journalName);
   }
 
-  /** Returns the segment's id or -1 if the log segment name was not correctly formatted. */
+  /**
+   * Returns the segment's file id or -1 if the log segment name was not correctly formatted. Please
+   * note that this is not the same as the actual id of the segment that can be found in the {@link
+   * SegmentDescriptor}. Due to async preparation of the next segment before use, the file id can be
+   * larger than the actual id.
+   */
   static int getSegmentIdFromPath(final String name) {
     checkNotNull(name, "name cannot be null");
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -106,7 +106,11 @@ final class SegmentLoader {
           e);
     }
     return new UninitializedSegment(
-        new SegmentFile(segmentFile.toFile()), descriptor, mappedSegment, journalIndex);
+        new SegmentFile(segmentFile.toFile()),
+        descriptor.id(),
+        descriptor.maxSegmentSize(),
+        mappedSegment,
+        journalIndex);
   }
 
   Segment loadExistingSegment(

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -149,13 +149,13 @@ public class SegmentedJournalBuilder {
     final var journalIndex = new SparseJournalIndex(journalIndexDensity);
     final var segmentAllocator =
         preallocateSegmentFiles ? SegmentAllocator.fill() : SegmentAllocator.noop();
-    final var segmentLoader = new SegmentLoader(segmentAllocator);
+    final var segmentLoader = new SegmentLoader(segmentAllocator, freeDiskSpace);
     final var segmentsManager =
         new SegmentsManager(
             journalIndex, maxSegmentSize, directory, lastWrittenIndex, name, segmentLoader);
     final var journalMetrics = new JournalMetrics(name);
 
     return new SegmentedJournal(
-        directory, maxSegmentSize, freeDiskSpace, journalIndex, segmentsManager, journalMetrics);
+        directory, maxSegmentSize, journalIndex, segmentsManager, journalMetrics);
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Create new segments. Load existing segments from the disk. Keep track of all segments. */
-final class SegmentsManager {
+final class SegmentsManager implements AutoCloseable {
 
   private static final long FIRST_SEGMENT_ID = 1;
   private static final long INITIAL_INDEX = 1;
@@ -71,7 +71,8 @@ final class SegmentsManager {
     this.segmentLoader = segmentLoader;
   }
 
-  void close() {
+  @Override
+  public void close() {
     segments
         .values()
         .forEach(

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.SortedMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentSkipListMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +42,7 @@ final class SegmentsManager {
   private final JournalMetrics journalMetrics;
   private final NavigableMap<Long, Segment> segments = new ConcurrentSkipListMap<>();
   private volatile Segment currentSegment;
+  private CompletableFuture<UninitializedSegment> nextSegment = null;
 
   private final JournalIndex journalIndex;
   private final int maxSegmentSize;
@@ -102,15 +105,28 @@ final class SegmentsManager {
   Segment getNextSegment() {
 
     final Segment lastSegment = getLastSegment();
+    final var lastWrittenAsqn = lastSegment != null ? lastSegment.lastAsqn() : INITIAL_ASQN;
+    final var nextSegmentIndex = currentSegment.lastIndex() + 1;
     final SegmentDescriptor descriptor =
         SegmentDescriptor.builder()
             .withId(lastSegment != null ? lastSegment.descriptor().id() + 1 : 1)
-            .withIndex(currentSegment.lastIndex() + 1)
+            .withIndex(nextSegmentIndex)
             .withMaxSegmentSize(maxSegmentSize)
             .build();
-
-    currentSegment =
-        createSegment(descriptor, lastSegment != null ? lastSegment.lastAsqn() : INITIAL_ASQN);
+    if (nextSegment != null) {
+      try {
+        currentSegment =
+            nextSegment
+                .join()
+                .initializeForUse(nextSegmentIndex, lastWrittenAsqn, lastWrittenIndex);
+      } catch (final CompletionException e) {
+        LOG.error("Failed to acquire next segment, retrying synchronously now.", e);
+        currentSegment = createSegment(descriptor, lastWrittenAsqn);
+      }
+    } else {
+      currentSegment = createSegment(descriptor, lastWrittenAsqn);
+    }
+    prepareNextSegment();
 
     segments.put(descriptor.index(), currentSegment);
     journalMetrics.incSegmentCount();
@@ -263,6 +279,22 @@ final class SegmentsManager {
     // node was stopped. It is safe to delete it now since there are no readers opened for these
     // segments.
     deleteDeferredFiles();
+  }
+
+  private void prepareNextSegment() {
+    final var descriptor =
+        SegmentDescriptor.builder()
+            .withId(currentSegment.id() + 1)
+            .withIndex(INITIAL_INDEX)
+            .withMaxSegmentSize(maxSegmentSize)
+            .build();
+    nextSegment = CompletableFuture.supplyAsync(() -> createUninitializedSegment(descriptor));
+  }
+
+  private UninitializedSegment createUninitializedSegment(final SegmentDescriptor descriptor) {
+    final var segmentFile = SegmentFile.createSegmentFile(name, directory, descriptor.id());
+    return segmentLoader.createUninitializedSegment(
+        segmentFile.toPath(), descriptor, lastWrittenIndex, journalIndex);
   }
 
   private Segment createSegment(final SegmentDescriptor descriptor, final long lastWrittenAsqn) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -80,6 +80,14 @@ final class SegmentsManager implements AutoCloseable {
               LOG.debug("Closing segment: {}", segment);
               segment.close();
             });
+
+    try {
+      nextSegment.join();
+    } catch (final Exception e) {
+      LOG.warn("Next segment preparation failed during close, ignoring and proceeding to close", e);
+    }
+
+    nextSegment = null;
     currentSegment = null;
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/UninitializedSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/UninitializedSegment.java
@@ -15,7 +15,8 @@ import java.nio.MappedByteBuffer;
  */
 public record UninitializedSegment(
     SegmentFile file,
-    SegmentDescriptor initialDescriptor,
+    long segmentId,
+    int maxSegmentSize,
     MappedByteBuffer buffer,
     JournalIndex journalIndex) {
 
@@ -27,9 +28,9 @@ public record UninitializedSegment(
       final long index, final long lastWrittenAsqn, final long lastWrittenIndex) {
     final var updatedDescriptor =
         SegmentDescriptor.builder()
-            .withId(initialDescriptor.id())
+            .withId(segmentId)
             .withIndex(index)
-            .withMaxSegmentSize(initialDescriptor.maxSegmentSize())
+            .withMaxSegmentSize(maxSegmentSize)
             .build();
     updatedDescriptor.copyTo(buffer);
     return new Segment(

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/UninitializedSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/UninitializedSegment.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import java.nio.MappedByteBuffer;
+
+/**
+ * Holds a normal segment file that hasn't been written to and that has no {@link
+ * SegmentDescriptor}.
+ */
+public record UninitializedSegment(
+    SegmentFile file,
+    SegmentDescriptor initialDescriptor,
+    MappedByteBuffer buffer,
+    JournalIndex journalIndex) {
+
+  /**
+   * Creates a proper, initialized segment by writing a {@link SegmentDescriptor } with the given
+   * index.
+   */
+  public Segment initializeForUse(
+      final long index, final long lastWrittenAsqn, final long lastWrittenIndex) {
+    final var updatedDescriptor =
+        SegmentDescriptor.builder()
+            .withId(initialDescriptor.id())
+            .withIndex(index)
+            .withMaxSegmentSize(initialDescriptor.maxSegmentSize())
+            .build();
+    updatedDescriptor.copyTo(buffer);
+    return new Segment(
+        file, updatedDescriptor, buffer, lastWrittenIndex, lastWrittenAsqn, journalIndex);
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -15,25 +15,39 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 final class JournalReaderTest {
 
   private static final int ENTRIES = 4;
-  @TempDir File directory;
 
   private final UnsafeBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
   private final BufferWriter recordDataWriter = new DirectBufferWriter().wrap(data);
+  private JournalReader reader;
+  private SegmentedJournal journal;
+
+  @BeforeEach
+  public void setup(final @TempDir Path tempDir) {
+    final File directory = tempDir.resolve("data").toFile();
+
+    journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    reader = journal.openReader();
+  }
+
+  @AfterEach
+  public void teardown() {
+    journal.close();
+  }
 
   @Test
   void shouldSeek() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -49,17 +63,11 @@ final class JournalReaderTest {
       assertThat(record.data()).isEqualTo(data);
     }
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirst() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -74,17 +82,11 @@ final class JournalReaderTest {
     final JournalRecord record = reader.next();
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.asqn()).isEqualTo(1);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToLast() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -98,17 +100,11 @@ final class JournalReaderTest {
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.asqn()).isEqualTo(4);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadIfSeekIsHigherThanLast() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -119,17 +115,11 @@ final class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex() + 1);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldReadAppendedDataAfterSeek() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter).index();
     }
@@ -142,17 +132,10 @@ final class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex());
     assertThat(reader.hasNext()).isTrue();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToAsqn() {
-    // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     // given that all records with index i will have an asqn of startAsqn + i
     final long startAsqn = 10;
     for (int i = 0; i < ENTRIES; i++) {
@@ -170,17 +153,11 @@ final class JournalReaderTest {
     final JournalRecord next = reader.next();
     assertThat(next.index()).isEqualTo(nextIndex);
     assertThat(next.asqn()).isEqualTo(startAsqn + 2);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToHighestAsqnLowerThanProvidedAsqn() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(5, recordDataWriter);
 
@@ -191,17 +168,11 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToHighestAsqnWithinBoundIndex() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var firstIndex = journal.append(1, recordDataWriter).index();
     final var secondIndex = journal.append(4, recordDataWriter).index();
     final var thirdIndex = journal.append(recordDataWriter).index();
@@ -223,34 +194,22 @@ final class JournalReaderTest {
 
     assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(fourthIndex);
     assertThat(reader.next().asqn()).isEqualTo(5);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToLastAsqn() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var expectedRecord = journal.append(5, recordDataWriter);
     journal.append(recordDataWriter);
 
     // when - then
     assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(expectedRecord.index());
     assertThat(reader.next()).isEqualTo(expectedRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToHighestLowerAsqnSkippingRecordsWithNoAsqn() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
@@ -262,17 +221,11 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWhenAllAsqnIsHigher() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     final var expectedRecord = journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
 
@@ -284,17 +237,11 @@ final class JournalReaderTest {
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
     assertThat(reader.next().asqn()).isEqualTo(5);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirstIfLowerThanFirst() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -309,17 +256,11 @@ final class JournalReaderTest {
     assertThat(record.asqn()).isEqualTo(1);
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.data()).isEqualTo(data);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekAfterTruncate() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     long lastIndex = -1;
     for (int i = 1; i <= ENTRIES; i++) {
       lastIndex = journal.append(i, recordDataWriter).index();
@@ -334,17 +275,11 @@ final class JournalReaderTest {
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(nextIndex);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekAfterCompact() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     journal.append(1, recordDataWriter).index();
     journal.append(2, recordDataWriter).index();
     journal.append(3, recordDataWriter).index();
@@ -359,17 +294,11 @@ final class JournalReaderTest {
     assertThat(next.index()).isEqualTo(nextIndex);
     assertThat(next.asqn()).isEqualTo(3);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToIndex() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     long asqn = 1;
     JournalRecord lastRecordWritten = null;
     for (int i = 1; i <= ENTRIES; i++) {
@@ -385,51 +314,31 @@ final class JournalReaderTest {
     // then
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(nextIndex);
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWithEmptyJournal() {
-    // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     // when
     final long nextIndex = reader.seekToFirst();
 
     // then
     assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToLastWithEmptyJournal() {
-    // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     // when
     final long nextIndex = reader.seekToLast();
 
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex());
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWhenNoRecordsWithValidAsqnExists() {
     // given
-    final var journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    final var reader = journal.openReader();
-
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter);
     }
@@ -441,7 +350,5 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().asqn()).isEqualTo(ASQN_IGNORE);
-
-    journal.close();
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +43,7 @@ final class JournalReaderTest {
 
   @AfterEach
   public void teardown() {
-    journal.close();
+    CloseHelper.quietClose(journal);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -15,33 +15,25 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 final class JournalReaderTest {
 
   private static final int ENTRIES = 4;
+  @TempDir File directory;
 
   private final UnsafeBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
   private final BufferWriter recordDataWriter = new DirectBufferWriter().wrap(data);
-  private JournalReader reader;
-  private SegmentedJournal journal;
-
-  @BeforeEach
-  public void setup(final @TempDir Path tempDir) {
-    final File directory = tempDir.resolve("data").toFile();
-
-    journal =
-        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
-    reader = journal.openReader();
-  }
 
   @Test
   void shouldSeek() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -57,11 +49,17 @@ final class JournalReaderTest {
       assertThat(record.data()).isEqualTo(data);
     }
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirst() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -76,11 +74,17 @@ final class JournalReaderTest {
     final JournalRecord record = reader.next();
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.asqn()).isEqualTo(1);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToLast() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -94,11 +98,17 @@ final class JournalReaderTest {
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.asqn()).isEqualTo(4);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldNotReadIfSeekIsHigherThanLast() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -109,11 +119,17 @@ final class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex() + 1);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldReadAppendedDataAfterSeek() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter).index();
     }
@@ -126,10 +142,17 @@ final class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex());
     assertThat(reader.hasNext()).isTrue();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToAsqn() {
+    // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     // given that all records with index i will have an asqn of startAsqn + i
     final long startAsqn = 10;
     for (int i = 0; i < ENTRIES; i++) {
@@ -147,11 +170,17 @@ final class JournalReaderTest {
     final JournalRecord next = reader.next();
     assertThat(next.index()).isEqualTo(nextIndex);
     assertThat(next.asqn()).isEqualTo(startAsqn + 2);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToHighestAsqnLowerThanProvidedAsqn() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(5, recordDataWriter);
 
@@ -162,11 +191,17 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToHighestAsqnWithinBoundIndex() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var firstIndex = journal.append(1, recordDataWriter).index();
     final var secondIndex = journal.append(4, recordDataWriter).index();
     final var thirdIndex = journal.append(recordDataWriter).index();
@@ -188,22 +223,34 @@ final class JournalReaderTest {
 
     assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(fourthIndex);
     assertThat(reader.next().asqn()).isEqualTo(5);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToLastAsqn() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var expectedRecord = journal.append(5, recordDataWriter);
     journal.append(recordDataWriter);
 
     // when - then
     assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(expectedRecord.index());
     assertThat(reader.next()).isEqualTo(expectedRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToHighestLowerAsqnSkippingRecordsWithNoAsqn() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
@@ -215,11 +262,17 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWhenAllAsqnIsHigher() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     final var expectedRecord = journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
 
@@ -231,11 +284,17 @@ final class JournalReaderTest {
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(expectedRecord);
     assertThat(reader.next().asqn()).isEqualTo(5);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirstIfLowerThanFirst() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
     }
@@ -250,11 +309,17 @@ final class JournalReaderTest {
     assertThat(record.asqn()).isEqualTo(1);
     assertThat(record.index()).isEqualTo(nextIndex);
     assertThat(record.data()).isEqualTo(data);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekAfterTruncate() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     long lastIndex = -1;
     for (int i = 1; i <= ENTRIES; i++) {
       lastIndex = journal.append(i, recordDataWriter).index();
@@ -269,11 +334,17 @@ final class JournalReaderTest {
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(nextIndex);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekAfterCompact() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     journal.append(1, recordDataWriter).index();
     journal.append(2, recordDataWriter).index();
     journal.append(3, recordDataWriter).index();
@@ -288,11 +359,17 @@ final class JournalReaderTest {
     assertThat(next.index()).isEqualTo(nextIndex);
     assertThat(next.asqn()).isEqualTo(3);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToIndex() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     long asqn = 1;
     JournalRecord lastRecordWritten = null;
     for (int i = 1; i <= ENTRIES; i++) {
@@ -308,31 +385,51 @@ final class JournalReaderTest {
     // then
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().index()).isEqualTo(nextIndex);
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWithEmptyJournal() {
+    // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     // when
     final long nextIndex = reader.seekToFirst();
 
     // then
     assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToLastWithEmptyJournal() {
+    // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     // when
     final long nextIndex = reader.seekToLast();
 
     // then
     assertThat(nextIndex).isEqualTo(journal.getLastIndex());
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldSeekToFirstWhenNoRecordsWithValidAsqnExists() {
     // given
+    final var journal =
+        SegmentedJournal.builder().withDirectory(directory).withJournalIndexDensity(5).build();
+    final var reader = journal.openReader();
+
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter);
     }
@@ -344,5 +441,7 @@ final class JournalReaderTest {
     assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().asqn()).isEqualTo(ASQN_IGNORE);
+
+    journal.close();
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,8 +58,8 @@ final class JournalTest {
   }
 
   @AfterEach
-  void teardown() throws Exception {
-    journal.close();
+  void teardown() {
+    CloseHelper.quietClose(journal);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -39,50 +38,54 @@ final class JournalTest {
 
   @TempDir Path directory;
 
-  private byte[] entry;
-  private final DirectBufferWriter recordDataWriter = new DirectBufferWriter();
-  private final DirectBufferWriter otherRecordDataWriter = new DirectBufferWriter();
-  private Journal journal;
-
-  @BeforeEach
-  void setup() {
-    entry = "TestData".getBytes();
-    recordDataWriter.wrap(new UnsafeBuffer(entry));
-
-    final var entryOther = "TestData".getBytes();
-    otherRecordDataWriter.wrap(new UnsafeBuffer(entryOther));
-
-    journal = openJournal();
-  }
+  private byte[] entry = "TestData".getBytes();
+  private final DirectBufferWriter recordDataWriter =
+      new DirectBufferWriter().wrap(new UnsafeBuffer(entry));
+  private final DirectBufferWriter otherRecordDataWriter =
+      new DirectBufferWriter().wrap(new UnsafeBuffer("TestData".getBytes()));
 
   @Test
   void shouldBeEmpty() {
+    // given
+    final var journal = openJournal();
+
     // when-then
     assertThat(journal.isEmpty()).isTrue();
+
+    journal.close();
   }
 
   @Test
   void shouldNotBeEmpty() {
     // given
+    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when-then
     assertThat(journal.isEmpty()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldAppendData() {
+    // given
+    final var journal = openJournal();
+
     // when
     final var recordAppended = journal.append(1, recordDataWriter);
 
     // then
     assertThat(recordAppended.index()).isEqualTo(1);
     assertThat(recordAppended.asqn()).isEqualTo(1);
+
+    journal.close();
   }
 
   @Test
   void shouldReadRecord() {
     // given
+    final var journal = openJournal();
     final var recordAppended = journal.append(1, recordDataWriter);
 
     // when
@@ -91,10 +94,15 @@ final class JournalTest {
 
     // then
     assertThat(recordRead).isEqualTo(recordAppended);
+
+    journal.close();
   }
 
   @Test
   void shouldAppendMultipleData() {
+    // given
+    final var journal = openJournal();
+
     // when
     final var firstRecord = journal.append(10, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
@@ -105,11 +113,14 @@ final class JournalTest {
 
     assertThat(secondRecord.index()).isEqualTo(2);
     assertThat(secondRecord.asqn()).isEqualTo(20);
+
+    journal.close();
   }
 
   @Test
   void shouldReadMultipleRecord() {
     // given
+    final var journal = openJournal();
     final var firstRecord = journal.append(1, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
 
@@ -121,10 +132,15 @@ final class JournalTest {
     // then
     assertThat(firstRecordRead).isEqualTo(firstRecord);
     assertThat(secondRecordRead).isEqualTo(secondRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldAppendAndReadMultipleRecordsInOrder() {
+    // given
+    final var journal = openJournal();
+
     // when
     for (int i = 0; i < 10; i++) {
       final var recordAppended = journal.append(i + 10, recordDataWriter);
@@ -142,13 +158,17 @@ final class JournalTest {
       assertThat(recordRead.asqn()).isEqualTo(i + 10);
       assertThat(data).containsExactly(entry);
     }
+
+    journal.close();
   }
 
   @Test
   void shouldAppendAndReadMultipleRecords() {
+    // given
+    final var journal = openJournal();
     final var reader = journal.openReader();
+
     for (int i = 0; i < 10; i++) {
-      // given
       entry = ("TestData" + i).getBytes();
       recordDataWriter.wrap(new UnsafeBuffer(entry));
 
@@ -165,11 +185,14 @@ final class JournalTest {
       assertThat(recordRead.asqn()).isEqualTo(i + 10);
       assertThat(data).containsExactly(entry);
     }
+
+    journal.close();
   }
 
   @Test
   void shouldReset() {
     // given
+    final var journal = openJournal();
     long asqn = 1;
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(asqn++, recordDataWriter);
@@ -183,11 +206,14 @@ final class JournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(1);
     final var record = journal.append(asqn, recordDataWriter);
     assertThat(record.index()).isEqualTo(2);
+
+    journal.close();
   }
 
   @Test
   void shouldNotReadAfterJournalResetWithoutReaderReset() {
     // given
+    final var journal = openJournal();
     final var reader = journal.openReader();
     long asqn = 1;
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -202,11 +228,14 @@ final class JournalTest {
 
     // then
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldWriteToTruncatedIndex() {
     // given
+    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -227,11 +256,14 @@ final class JournalTest {
 
     final var newRecord = reader.next();
     assertThat(newRecord).isEqualTo(record);
+
+    journal.close();
   }
 
   @Test
   void shouldTruncate() {
     // given
+    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -246,11 +278,14 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntries() {
     // given
+    final var journal = openJournal();
     final int totalWrites = 10;
     final int truncateIndex = 5;
     int asqn = 1;
@@ -287,11 +322,14 @@ final class JournalTest {
       final var record = reader.next();
       assertThat(record).isEqualTo(written.get(readerIndex));
     }
+
+    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderPastTruncateIndex() {
     // given
+    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -307,11 +345,14 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderAtTruncateIndex() {
     // given
+    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -327,11 +368,14 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(2);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderBeforeTruncateIndex() {
     // given
+    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -347,11 +391,14 @@ final class JournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(2);
     reader.next();
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
   void shouldAppendJournalRecord() {
     // given
+    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -367,21 +414,27 @@ final class JournalTest {
     assertThat(reader.hasNext()).isTrue();
     final var actual = reader.next();
     assertThat(expected).isEqualTo(actual);
+
+    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithAlreadyAppendedIndex() {
     // given
+    final var journal = openJournal();
     final var record = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
+
+    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithGapInIndex() {
     // given
+    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -392,29 +445,38 @@ final class JournalTest {
 
     // when/then
     assertThatThrownBy(() -> receiverJournal.append(record)).isInstanceOf(InvalidIndex.class);
+
+    journal.close();
   }
 
   @Test
   void shouldNotAppendLastRecord() {
     // given
+    final var journal = openJournal();
     final var record = journal.append(1, recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
+
+    journal.close();
   }
 
   @Test
   void shouldAppendRecordWithASqnToIgnore() {
     // given
+    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when/then
     journal.append(ASQN_IGNORE, recordDataWriter);
+
+    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithInvalidChecksum() {
     // given
+    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -429,21 +491,27 @@ final class JournalTest {
     // then
     assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
         .isInstanceOf(InvalidChecksum.class);
+
+    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithTooLowASqn() {
     // given
+    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidASqn.class);
     assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidASqn.class);
+
+    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithTooLowASqnIfPreviousRecordIsIgnoreASqn() {
     // given
+    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when
@@ -452,30 +520,45 @@ final class JournalTest {
     // then
     assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidASqn.class);
     assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidASqn.class);
+
+    journal.close();
   }
 
   @Test
   void shouldReturnFirstIndex() {
+    // given
+    final var journal = openJournal();
+
     // when
     final long firstIndex = journal.append(recordDataWriter).index();
     journal.append(recordDataWriter);
 
     // then
     assertThat(journal.getFirstIndex()).isEqualTo(firstIndex);
+
+    journal.close();
   }
 
   @Test
   void shouldReturnLastIndex() {
+    // given
+    final var journal = openJournal();
+
     // when
     journal.append(recordDataWriter);
     final long lastIndex = journal.append(recordDataWriter).index();
 
     // then
     assertThat(journal.getLastIndex()).isEqualTo(lastIndex);
+
+    journal.close();
   }
 
   @Test
-  void shouldOpenAndClose() throws Exception {
+  void shouldOpenAndClose() {
+    // given
+    final var journal = openJournal();
+
     // when/then
     assertThat(journal.isOpen()).isTrue();
     journal.close();
@@ -485,44 +568,56 @@ final class JournalTest {
   @Test
   void shouldReopenJournalWithExistingRecords() throws Exception {
     // given
-    journal.append(recordDataWriter);
-    journal.append(recordDataWriter);
-    final long lastIndexBeforeClose = journal.getLastIndex();
-    assertThat(lastIndexBeforeClose).isEqualTo(2);
-    journal.close();
+    final long lastIndexBeforeClose;
+    try (var journal = openJournal()) {
+      journal.append(recordDataWriter);
+      journal.append(recordDataWriter);
+      lastIndexBeforeClose = journal.getLastIndex();
+      assertThat(lastIndexBeforeClose).isEqualTo(2);
+    }
 
     // when
-    journal = openJournal();
+    final var journal = openJournal();
 
     // then
     assertThat(journal.isOpen()).isTrue();
     assertThat(journal.getLastIndex()).isEqualTo(lastIndexBeforeClose);
+
+    journal.close();
   }
 
   @Test
   void shouldReadReopenedJournal() throws Exception {
     // given
-    final var appendedRecord = copyRecord(journal.append(recordDataWriter));
-    journal.close();
+    final PersistedJournalRecord appendedRecord;
+    final JournalReader reader;
+    try (var journal = openJournal()) {
+      appendedRecord = copyRecord(journal.append(recordDataWriter));
+    }
 
     // when
-    journal = openJournal();
-    final JournalReader reader = journal.openReader();
+    final var journal = openJournal();
+    reader = journal.openReader();
 
     // then
     assertThat(journal.isOpen()).isTrue();
+
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(appendedRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldWriteToReopenedJournalAtNextIndex() throws Exception {
     // given
-    final var firstRecord = copyRecord(journal.append(recordDataWriter));
-    journal.close();
+    final PersistedJournalRecord firstRecord;
+    try (var journal = openJournal()) {
+      firstRecord = copyRecord(journal.append(recordDataWriter));
+    }
 
     // when
-    journal = openJournal();
+    final var journal = openJournal();
     final var secondRecord = journal.append(recordDataWriter);
 
     // then
@@ -535,11 +630,14 @@ final class JournalTest {
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(secondRecord);
+
+    journal.close();
   }
 
   @Test
   void shouldNotReadDeletedEntries() {
     // given
+    final var journal = openJournal();
     final var firstRecord = journal.append(recordDataWriter);
     journal.append(recordDataWriter);
     journal.append(recordDataWriter);
@@ -559,11 +657,14 @@ final class JournalTest {
     assertThat(reader.next()).isEqualTo(newSecondRecord);
 
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
-  void shouldInvalidateAllEntries() throws Exception {
+  void shouldInvalidateAllEntries() {
     // given
+    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
 
@@ -576,18 +677,20 @@ final class JournalTest {
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
 
     journal.close();
-    journal = openJournal();
+    final var newJournal = openJournal();
 
     // then
-    final var reader = journal.openReader();
+    final var reader = newJournal.openReader();
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.next()).isEqualTo(secondRecord);
     assertThat(reader.hasNext()).isFalse();
+    newJournal.close();
   }
 
   @Test
   void shouldDetectCorruptedEntry() throws Exception {
     // given
+    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     journal.append(recordDataWriter);
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
@@ -599,14 +702,15 @@ final class JournalTest {
     assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
 
     // then
-    assertThatThrownBy(
-            () -> journal = openJournal(b -> b.withLastWrittenIndex(secondRecord.index())))
+    //noinspection resource
+    assertThatThrownBy(() -> openJournal(b -> b.withLastWrittenIndex(secondRecord.index())))
         .isInstanceOf(CorruptedJournalException.class);
   }
 
   @Test
   void shouldDeletePartiallyWrittenEntry() throws Exception {
     // given
+    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
@@ -616,14 +720,16 @@ final class JournalTest {
     // when
     journal.close();
     assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
-    journal = openJournal(b -> b.withLastWrittenIndex(firstRecord.index()));
+    final var newJournal = openJournal(b -> b.withLastWrittenIndex(firstRecord.index()));
     recordDataWriter.wrap(new UnsafeBuffer("111".getBytes(StandardCharsets.UTF_8)));
-    final var lastRecord = journal.append(recordDataWriter);
-    final var reader = journal.openReader();
+    final var lastRecord = newJournal.append(recordDataWriter);
+    final var reader = newJournal.openReader();
 
     // then
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.next()).isEqualTo(lastRecord);
+
+    newJournal.close();
   }
 
   // TODO: do not rely on implementation detail to compare records

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -38,54 +40,55 @@ final class JournalTest {
 
   @TempDir Path directory;
 
-  private byte[] entry = "TestData".getBytes();
-  private final DirectBufferWriter recordDataWriter =
-      new DirectBufferWriter().wrap(new UnsafeBuffer(entry));
-  private final DirectBufferWriter otherRecordDataWriter =
-      new DirectBufferWriter().wrap(new UnsafeBuffer("TestData".getBytes()));
+  private byte[] entry;
+  private final DirectBufferWriter recordDataWriter = new DirectBufferWriter();
+  private final DirectBufferWriter otherRecordDataWriter = new DirectBufferWriter();
+  private Journal journal;
+
+  @BeforeEach
+  void setup() {
+    entry = "TestData".getBytes();
+    recordDataWriter.wrap(new UnsafeBuffer(entry));
+
+    final var entryOther = "TestData".getBytes();
+    otherRecordDataWriter.wrap(new UnsafeBuffer(entryOther));
+
+    journal = openJournal();
+  }
+
+  @AfterEach
+  void teardown() throws Exception {
+    journal.close();
+  }
 
   @Test
   void shouldBeEmpty() {
-    // given
-    final var journal = openJournal();
-
     // when-then
     assertThat(journal.isEmpty()).isTrue();
-
-    journal.close();
   }
 
   @Test
   void shouldNotBeEmpty() {
     // given
-    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when-then
     assertThat(journal.isEmpty()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldAppendData() {
-    // given
-    final var journal = openJournal();
-
     // when
     final var recordAppended = journal.append(1, recordDataWriter);
 
     // then
     assertThat(recordAppended.index()).isEqualTo(1);
     assertThat(recordAppended.asqn()).isEqualTo(1);
-
-    journal.close();
   }
 
   @Test
   void shouldReadRecord() {
     // given
-    final var journal = openJournal();
     final var recordAppended = journal.append(1, recordDataWriter);
 
     // when
@@ -94,15 +97,10 @@ final class JournalTest {
 
     // then
     assertThat(recordRead).isEqualTo(recordAppended);
-
-    journal.close();
   }
 
   @Test
   void shouldAppendMultipleData() {
-    // given
-    final var journal = openJournal();
-
     // when
     final var firstRecord = journal.append(10, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
@@ -113,14 +111,11 @@ final class JournalTest {
 
     assertThat(secondRecord.index()).isEqualTo(2);
     assertThat(secondRecord.asqn()).isEqualTo(20);
-
-    journal.close();
   }
 
   @Test
   void shouldReadMultipleRecord() {
     // given
-    final var journal = openJournal();
     final var firstRecord = journal.append(1, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
 
@@ -132,15 +127,10 @@ final class JournalTest {
     // then
     assertThat(firstRecordRead).isEqualTo(firstRecord);
     assertThat(secondRecordRead).isEqualTo(secondRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldAppendAndReadMultipleRecordsInOrder() {
-    // given
-    final var journal = openJournal();
-
     // when
     for (int i = 0; i < 10; i++) {
       final var recordAppended = journal.append(i + 10, recordDataWriter);
@@ -158,17 +148,13 @@ final class JournalTest {
       assertThat(recordRead.asqn()).isEqualTo(i + 10);
       assertThat(data).containsExactly(entry);
     }
-
-    journal.close();
   }
 
   @Test
   void shouldAppendAndReadMultipleRecords() {
-    // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
-
     for (int i = 0; i < 10; i++) {
+      // given
       entry = ("TestData" + i).getBytes();
       recordDataWriter.wrap(new UnsafeBuffer(entry));
 
@@ -185,14 +171,11 @@ final class JournalTest {
       assertThat(recordRead.asqn()).isEqualTo(i + 10);
       assertThat(data).containsExactly(entry);
     }
-
-    journal.close();
   }
 
   @Test
   void shouldReset() {
     // given
-    final var journal = openJournal();
     long asqn = 1;
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(asqn++, recordDataWriter);
@@ -206,14 +189,11 @@ final class JournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(1);
     final var record = journal.append(asqn, recordDataWriter);
     assertThat(record.index()).isEqualTo(2);
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadAfterJournalResetWithoutReaderReset() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     long asqn = 1;
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -228,14 +208,11 @@ final class JournalTest {
 
     // then
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldWriteToTruncatedIndex() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -256,14 +233,11 @@ final class JournalTest {
 
     final var newRecord = reader.next();
     assertThat(newRecord).isEqualTo(record);
-
-    journal.close();
   }
 
   @Test
   void shouldTruncate() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -278,14 +252,11 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntries() {
     // given
-    final var journal = openJournal();
     final int totalWrites = 10;
     final int truncateIndex = 5;
     int asqn = 1;
@@ -322,14 +293,11 @@ final class JournalTest {
       final var record = reader.next();
       assertThat(record).isEqualTo(written.get(readerIndex));
     }
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderPastTruncateIndex() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -345,14 +313,11 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderAtTruncateIndex() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -368,14 +333,11 @@ final class JournalTest {
     // then
     assertThat(journal.getLastIndex()).isEqualTo(2);
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadTruncatedEntriesWhenReaderBeforeTruncateIndex() {
     // given
-    final var journal = openJournal();
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
     journal.append(1, recordDataWriter);
@@ -391,14 +353,11 @@ final class JournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(2);
     reader.next();
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
   void shouldAppendJournalRecord() {
     // given
-    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -414,27 +373,21 @@ final class JournalTest {
     assertThat(reader.hasNext()).isTrue();
     final var actual = reader.next();
     assertThat(expected).isEqualTo(actual);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithAlreadyAppendedIndex() {
     // given
-    final var journal = openJournal();
     final var record = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithGapInIndex() {
     // given
-    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -445,38 +398,29 @@ final class JournalTest {
 
     // when/then
     assertThatThrownBy(() -> receiverJournal.append(record)).isInstanceOf(InvalidIndex.class);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendLastRecord() {
     // given
-    final var journal = openJournal();
     final var record = journal.append(1, recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
-
-    journal.close();
   }
 
   @Test
   void shouldAppendRecordWithASqnToIgnore() {
     // given
-    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when/then
     journal.append(ASQN_IGNORE, recordDataWriter);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithInvalidChecksum() {
     // given
-    final var journal = openJournal();
     final var receiverJournal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data-2").toFile())
@@ -491,27 +435,21 @@ final class JournalTest {
     // then
     assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
         .isInstanceOf(InvalidChecksum.class);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithTooLowASqn() {
     // given
-    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when/then
     assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidASqn.class);
     assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidASqn.class);
-
-    journal.close();
   }
 
   @Test
   void shouldNotAppendRecordWithTooLowASqnIfPreviousRecordIsIgnoreASqn() {
     // given
-    final var journal = openJournal();
     journal.append(1, recordDataWriter);
 
     // when
@@ -520,45 +458,30 @@ final class JournalTest {
     // then
     assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidASqn.class);
     assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidASqn.class);
-
-    journal.close();
   }
 
   @Test
   void shouldReturnFirstIndex() {
-    // given
-    final var journal = openJournal();
-
     // when
     final long firstIndex = journal.append(recordDataWriter).index();
     journal.append(recordDataWriter);
 
     // then
     assertThat(journal.getFirstIndex()).isEqualTo(firstIndex);
-
-    journal.close();
   }
 
   @Test
   void shouldReturnLastIndex() {
-    // given
-    final var journal = openJournal();
-
     // when
     journal.append(recordDataWriter);
     final long lastIndex = journal.append(recordDataWriter).index();
 
     // then
     assertThat(journal.getLastIndex()).isEqualTo(lastIndex);
-
-    journal.close();
   }
 
   @Test
-  void shouldOpenAndClose() {
-    // given
-    final var journal = openJournal();
-
+  void shouldOpenAndClose() throws Exception {
     // when/then
     assertThat(journal.isOpen()).isTrue();
     journal.close();
@@ -568,56 +491,44 @@ final class JournalTest {
   @Test
   void shouldReopenJournalWithExistingRecords() throws Exception {
     // given
-    final long lastIndexBeforeClose;
-    try (var journal = openJournal()) {
-      journal.append(recordDataWriter);
-      journal.append(recordDataWriter);
-      lastIndexBeforeClose = journal.getLastIndex();
-      assertThat(lastIndexBeforeClose).isEqualTo(2);
-    }
+    journal.append(recordDataWriter);
+    journal.append(recordDataWriter);
+    final long lastIndexBeforeClose = journal.getLastIndex();
+    assertThat(lastIndexBeforeClose).isEqualTo(2);
+    journal.close();
 
     // when
-    final var journal = openJournal();
+    journal = openJournal();
 
     // then
     assertThat(journal.isOpen()).isTrue();
     assertThat(journal.getLastIndex()).isEqualTo(lastIndexBeforeClose);
-
-    journal.close();
   }
 
   @Test
   void shouldReadReopenedJournal() throws Exception {
     // given
-    final PersistedJournalRecord appendedRecord;
-    final JournalReader reader;
-    try (var journal = openJournal()) {
-      appendedRecord = copyRecord(journal.append(recordDataWriter));
-    }
+    final var appendedRecord = copyRecord(journal.append(recordDataWriter));
+    journal.close();
 
     // when
-    final var journal = openJournal();
-    reader = journal.openReader();
+    journal = openJournal();
+    final JournalReader reader = journal.openReader();
 
     // then
     assertThat(journal.isOpen()).isTrue();
-
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(appendedRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldWriteToReopenedJournalAtNextIndex() throws Exception {
     // given
-    final PersistedJournalRecord firstRecord;
-    try (var journal = openJournal()) {
-      firstRecord = copyRecord(journal.append(recordDataWriter));
-    }
+    final var firstRecord = copyRecord(journal.append(recordDataWriter));
+    journal.close();
 
     // when
-    final var journal = openJournal();
+    journal = openJournal();
     final var secondRecord = journal.append(recordDataWriter);
 
     // then
@@ -630,14 +541,11 @@ final class JournalTest {
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(secondRecord);
-
-    journal.close();
   }
 
   @Test
   void shouldNotReadDeletedEntries() {
     // given
-    final var journal = openJournal();
     final var firstRecord = journal.append(recordDataWriter);
     journal.append(recordDataWriter);
     journal.append(recordDataWriter);
@@ -657,14 +565,11 @@ final class JournalTest {
     assertThat(reader.next()).isEqualTo(newSecondRecord);
 
     assertThat(reader.hasNext()).isFalse();
-
-    journal.close();
   }
 
   @Test
-  void shouldInvalidateAllEntries() {
+  void shouldInvalidateAllEntries() throws Exception {
     // given
-    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
 
@@ -677,20 +582,18 @@ final class JournalTest {
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
 
     journal.close();
-    final var newJournal = openJournal();
+    journal = openJournal();
 
     // then
-    final var reader = newJournal.openReader();
+    final var reader = journal.openReader();
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.next()).isEqualTo(secondRecord);
     assertThat(reader.hasNext()).isFalse();
-    newJournal.close();
   }
 
   @Test
   void shouldDetectCorruptedEntry() throws Exception {
     // given
-    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     journal.append(recordDataWriter);
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
@@ -702,15 +605,14 @@ final class JournalTest {
     assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
 
     // then
-    //noinspection resource
-    assertThatThrownBy(() -> openJournal(b -> b.withLastWrittenIndex(secondRecord.index())))
+    assertThatThrownBy(
+            () -> journal = openJournal(b -> b.withLastWrittenIndex(secondRecord.index())))
         .isInstanceOf(CorruptedJournalException.class);
   }
 
   @Test
   void shouldDeletePartiallyWrittenEntry() throws Exception {
     // given
-    final var journal = openJournal();
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
@@ -720,16 +622,14 @@ final class JournalTest {
     // when
     journal.close();
     assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
-    final var newJournal = openJournal(b -> b.withLastWrittenIndex(firstRecord.index()));
+    journal = openJournal(b -> b.withLastWrittenIndex(firstRecord.index()));
     recordDataWriter.wrap(new UnsafeBuffer("111".getBytes(StandardCharsets.UTF_8)));
-    final var lastRecord = newJournal.append(recordDataWriter);
-    final var reader = newJournal.openReader();
+    final var lastRecord = journal.append(recordDataWriter);
+    final var reader = journal.openReader();
 
     // then
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.next()).isEqualTo(lastRecord);
-
-    newJournal.close();
   }
 
   // TODO: do not rely on implementation detail to compare records

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
@@ -27,7 +27,7 @@ final class SegmentLoaderTest {
     final var descriptor =
         SegmentDescriptor.builder().withId(1).withIndex(1).withMaxSegmentSize(segmentSize).build();
     final var lastWrittenIndex = descriptor.index() - 1;
-    final var segmentLoader = new SegmentLoader();
+    final var segmentLoader = new SegmentLoader(segmentSize * 2);
     final var segmentFile = tmpDir.resolve("segment.log");
 
     // when - the segment is "unused" if the lastWrittenIndex is less than the expected first index

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -25,8 +25,10 @@ import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -55,6 +57,11 @@ class SegmentedJournalReaderTest {
             .withJournalIndexDensity(5)
             .build();
     reader = journal.openReader();
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(reader, journal);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.Assertions;
@@ -57,9 +58,7 @@ class SegmentedJournalTest {
 
   @AfterEach
   void teardown() {
-    if (journal != null) {
-      journal.close();
-    }
+    CloseHelper.quietClose(journal);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -42,7 +42,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-@SuppressWarnings("resource")
 class SegmentedJournalTest {
   private static final String JOURNAL_NAME = "journal";
 
@@ -71,6 +70,8 @@ class SegmentedJournalTest {
     // then
     assertThat(journal.getJournalIndex().lookup(journalIndexDensity)).isNull();
     assertThat(journal.getJournalIndex().lookup(2 * journalIndexDensity)).isNull();
+
+    journal.close();
   }
 
   @Test
@@ -91,6 +92,8 @@ class SegmentedJournalTest {
     final IndexInfo lookup = journal.getJournalIndex().lookup(entriesPerSegment - 1);
     assertThat(lookup).isNull();
     assertThat(journal.getJournalIndex().lookup(3 * entriesPerSegment)).isNotNull();
+
+    journal.close();
   }
 
   @Test
@@ -114,6 +117,8 @@ class SegmentedJournalTest {
     assertThat(journal.getJournalIndex().lookup(journalIndexDensity)).isNotNull();
     assertThat(journal.getJournalIndex().lookup(2 * journalIndexDensity).index())
         .isEqualTo(journalIndexDensity);
+
+    journal.close();
   }
 
   @Test
@@ -139,6 +144,8 @@ class SegmentedJournalTest {
       assertThat(entry.asqn()).isEqualTo(asqn + i);
       assertThat(entry.data()).isEqualTo(data);
     }
+
+    journal.close();
   }
 
   @Test
@@ -162,6 +169,8 @@ class SegmentedJournalTest {
       assertThat(entry.asqn()).isEqualTo(asqn + i);
       assertThat(entry.data()).isEqualTo(data);
     }
+
+    journal.close();
   }
 
   @Test
@@ -181,6 +190,8 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(secondRecord);
+
+    journal.close();
   }
 
   @Test
@@ -199,6 +210,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -217,6 +230,8 @@ class SegmentedJournalTest {
     // then
     assertThat(reader.hasNext()).isFalse();
     assertThat(journal.getLastIndex()).isEqualTo(0);
+
+    journal.close();
   }
 
   @Test
@@ -234,6 +249,8 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.hasNext()).isFalse();
     assertThat(journal.getLastIndex()).isEqualTo(firstRecord.index());
+
+    journal.close();
   }
 
   @Test
@@ -253,6 +270,8 @@ class SegmentedJournalTest {
     assertThat(reader.seek(lastIndex - 1)).isEqualTo(lastIndex - 1);
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
     assertThat(journal.getLastIndex()).isEqualTo(lastIndex - 1);
+
+    journal.close();
   }
 
   @Test
@@ -273,6 +292,8 @@ class SegmentedJournalTest {
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
     reader.seekToFirst();
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
+
+    journal.close();
   }
 
   @Test
@@ -293,6 +314,8 @@ class SegmentedJournalTest {
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
     reader.seekToFirst();
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
+
+    journal.close();
   }
 
   @Test
@@ -309,6 +332,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
+
+    journal.close();
   }
 
   @Test
@@ -330,6 +355,8 @@ class SegmentedJournalTest {
     assertThat(first).isEqualTo(lastRecord.index());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next()).isEqualTo(lastRecord);
+
+    journal.close();
   }
 
   @Test
@@ -353,6 +380,8 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(secondRecord);
     assertThat(reader.next()).isEqualTo(thirdRecord);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -383,6 +412,8 @@ class SegmentedJournalTest {
         .isEqualTo(indexBeforeClose.lookup(firstIndexedPosition).position());
     assertThat(indexAfterRestart.lookup(secondIndexedPosition).position())
         .isEqualTo(indexBeforeClose.lookup(secondIndexedPosition).position());
+
+    journal.close();
   }
 
   @Test
@@ -403,6 +434,8 @@ class SegmentedJournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(record.index());
     assertThat(reader.next()).isEqualTo(record);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -425,6 +458,8 @@ class SegmentedJournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(record.index());
     assertThat(reader.next()).isEqualTo(record);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -458,6 +493,8 @@ class SegmentedJournalTest {
     assertThat(reader.next()).isEqualTo(copiedFirstRecord);
     assertThat(reader.next()).isEqualTo(lastRecord);
     assertThat(reader.hasNext()).isFalse();
+
+    journal.close();
   }
 
   @Test
@@ -478,6 +515,8 @@ class SegmentedJournalTest {
         .isDirectoryContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+
+    journal.close();
   }
 
   @Test
@@ -504,6 +543,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue();
+
+    journal.close();
   }
 
   // Regression test for https://github.com/camunda/zeebe/issues/7962
@@ -533,6 +574,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue();
+
+    journal.close();
   }
 
   @Test
@@ -552,6 +595,8 @@ class SegmentedJournalTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+
+    journal.close();
   }
 
   @Test
@@ -569,6 +614,8 @@ class SegmentedJournalTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+
+    journal.close();
   }
 
   @Test
@@ -594,6 +641,8 @@ class SegmentedJournalTest {
     assertThat(
             logDirectory.listFiles(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName())))
         .hasSize(1);
+
+    journal.close();
   }
 
   @Test
@@ -622,6 +671,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+    journal.close();
   }
 
   @Test
@@ -675,6 +726,8 @@ class SegmentedJournalTest {
     Assertions.assertThatThrownBy(() -> journal.append(1, recordDataWriter))
         .isInstanceOf(InvalidASqn.class);
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -694,6 +747,8 @@ class SegmentedJournalTest {
         .isInstanceOf(InvalidASqn.class);
 
     assertThat(journal.getFirstSegment()).isNotEqualTo(journal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -715,6 +770,8 @@ class SegmentedJournalTest {
         .isInstanceOf(InvalidASqn.class);
 
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -737,6 +794,8 @@ class SegmentedJournalTest {
         .isInstanceOf(InvalidASqn.class);
 
     assertThat(reopenedJournal.getFirstSegment()).isNotEqualTo(reopenedJournal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -752,6 +811,8 @@ class SegmentedJournalTest {
     // then
     assertThat(journal.getFirstSegment().lastAsqn()).isEqualTo(initalAsqn);
     assertThat(journal.getFirstSegment()).isEqualTo(journal.getLastSegment());
+
+    journal.close();
   }
 
   @Test
@@ -769,6 +830,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getLastSegment().lastAsqn()).isEqualTo(expectedLastAsqn);
+
+    journal.close();
   }
 
   @Test
@@ -782,6 +845,8 @@ class SegmentedJournalTest {
 
     // then
     journal.append(1, recordDataWriter);
+
+    journal.close();
   }
 
   @Test
@@ -796,6 +861,8 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getLastSegment().lastAsqn()).isEqualTo(firstJournalRecord.asqn());
+
+    journal.close();
   }
 
   @Test
@@ -810,6 +877,8 @@ class SegmentedJournalTest {
 
     // then
     journal.append(2, recordDataWriter);
+
+    journal.close();
   }
 
   private SegmentedJournal openJournal(final float entriesPerSegment) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -21,8 +21,10 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Objects;
+import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -36,12 +38,19 @@ class SegmentsManagerTest {
   private final BufferWriter recordDataWriter = new DirectBufferWriter().wrap(data);
   private final int entrySize = getSerializedSize(data);
 
+  private SegmentsManager segments;
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietClose(segments);
+  }
+
   @Test
   void shouldDeleteFilesMarkedForDeletionsOnLoad() {
     // given
-    final var segments = createSegmentsManager(0);
+    segments = createSegmentsManager(0);
     segments.open();
-    segments.getFirstSegment().createReader();
+    Objects.requireNonNull(segments.getFirstSegment()).createReader();
     segments.getFirstSegment().delete();
 
     // when
@@ -50,7 +59,7 @@ class SegmentsManagerTest {
     // will cause the segment to be deleted on close where we actually want to test that the file is
     // deleted when opening.
 
-    try (var newSegments = createSegmentsManager(0)) {
+    try (final var newSegments = createSegmentsManager(0)) {
       newSegments.open();
       // then
       final File logDirectory = directory.resolve("data").toFile();
@@ -59,62 +68,68 @@ class SegmentsManagerTest {
               file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
           .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
     }
-
-    segments.close();
   }
 
   @Test
   void shouldDetectCorruptionAtDescriptorWithAckedEntries() throws Exception {
     // given
-    final var journal = openJournal(1);
-    final long index = journal.append(recordDataWriter).index();
+    final long index;
+    try (final var journal = openJournal()) {
+      index = journal.append(recordDataWriter).index();
+    }
 
-    journal.close();
     final File dataFile = directory.resolve("data").toFile();
     final File logFile =
         Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
-    final var segments = createSegmentsManager(index);
+    segments = createSegmentsManager(index);
     assertThatThrownBy(segments::open).isInstanceOf(CorruptedJournalException.class);
   }
 
   @Test
   void shouldNotThrowExceptionWhenCorruptionAtNotAckEntries() throws Exception {
     // given
-    final var journal = openJournal(1);
-    final var index = journal.append(recordDataWriter).index();
-    journal.append(recordDataWriter);
+    final long index;
+    try (final var journal = openJournal()) {
+      index = journal.append(recordDataWriter).index();
+      journal.append(recordDataWriter);
+    }
 
-    journal.close();
     final File dataFile = directory.resolve("data").toFile();
     final File logFile =
         Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith("2.log")))[0];
     LogCorrupter.corruptDescriptor(logFile);
 
-    // when/then
-    final var segments = createSegmentsManager(index);
+    // when
+    segments = createSegmentsManager(index);
+
+    // then
     assertThatNoException().isThrownBy(segments::open);
-    assertThat(segments.getFirstSegment().index()).isEqualTo(index);
-    assertThat(segments.getLastSegment().index()).isEqualTo(index);
+    assertThat(segments.getFirstSegment())
+        .extracting(Segment::index, Segment::lastIndex)
+        .containsExactly(index, index);
   }
 
   @Test
   void shouldNotThrowExceptionWhenCorruptionAtDescriptorWithoutAckedEntries() throws Exception {
     // given
-    final var journal = openJournal(1);
+    final var journal = openJournal();
     journal.close();
     final File dataFile = directory.resolve("data").toFile();
     final File logFile =
         Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
     LogCorrupter.corruptDescriptor(logFile);
 
-    // when/then
-    final var segments = createSegmentsManager(0);
+    // when
+    segments = createSegmentsManager(0);
+
+    // then
     assertThatNoException().isThrownBy(segments::open);
-    assertThat(segments.getFirstSegment().index()).isEqualTo(1);
-    assertThat(segments.getFirstSegment().lastIndex()).isEqualTo(0);
+    assertThat(segments.getFirstSegment())
+        .extracting(Segment::index, Segment::lastIndex)
+        .containsExactly(1L, 0L);
   }
 
   @Test
@@ -126,12 +141,13 @@ class SegmentsManagerTest {
     assertThat(emptyLog.createNewFile()).isTrue();
 
     // when
-    final var segments = createSegmentsManager(0);
+    segments = createSegmentsManager(0);
 
     // then
     assertThatNoException().isThrownBy(segments::open);
-    assertThat(segments.getFirstSegment().index()).isEqualTo(1);
-    assertThat(segments.getFirstSegment().lastIndex()).isEqualTo(0);
+    assertThat(segments.getFirstSegment())
+        .extracting(Segment::index, Segment::lastIndex)
+        .containsExactly(1L, 0L);
   }
 
   private SegmentsManager createSegmentsManager(final long lastWrittenIndex) {
@@ -146,15 +162,14 @@ class SegmentsManagerTest {
         new SegmentLoader(2 * maxSegmentSize));
   }
 
-  private SegmentedJournal openJournal(final float entriesPerSegment) {
-    return openJournal(entriesPerSegment, entrySize);
+  private SegmentedJournal openJournal() {
+    return openJournal(entrySize);
   }
 
-  private SegmentedJournal openJournal(final float entriesPerSegment, final int entrySize) {
+  private SegmentedJournal openJournal(final int entrySize) {
     return SegmentedJournal.builder()
         .withDirectory(directory.resolve("data").toFile())
-        .withMaxSegmentSize(
-            (int) (entrySize * entriesPerSegment) + SegmentDescriptor.getEncodingLength())
+        .withMaxSegmentSize(entrySize + SegmentDescriptor.getEncodingLength())
         .withJournalIndexDensity(journalIndexDensity)
         .withName(JOURNAL_NAME)
         .build();

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -48,8 +48,9 @@ class SegmentsManagerTest {
     // when
     // if we close the current journal, it will delete the files on closing. So we cannot test this
     // scenario.
-    final var newSegments = createSegmentsManager(0);
-    newSegments.open();
+    try (var newSegments = createSegmentsManager(0)) {
+      newSegments.open();
+    }
 
     // then
     final File logDirectory = directory.resolve("data").toFile();
@@ -57,7 +58,6 @@ class SegmentsManagerTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
-    newSegments.close();
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -39,15 +39,17 @@ class SegmentsManagerTest {
   @Test
   void shouldDeleteFilesMarkedForDeletionsOnLoad() {
     // given
-    final var segments = createSegmentsManager(0);
-    segments.open();
-    segments.getFirstSegment().createReader();
-    segments.getFirstSegment().delete();
+    try (var segments = createSegmentsManager(0)) {
+      segments.open();
+      segments.getFirstSegment().createReader();
+      segments.getFirstSegment().delete();
+    }
 
     // when
     // if we close the current journal, it will delete the files on closing. So we cannot test this
     // scenario.
-    createSegmentsManager(0).open();
+    final var newSegments = createSegmentsManager(0);
+    newSegments.open();
 
     // then
     final File logDirectory = directory.resolve("data").toFile();
@@ -55,6 +57,7 @@ class SegmentsManagerTest {
         .isDirectoryNotContaining(
             file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
         .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+    newSegments.close();
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -130,13 +130,14 @@ class SegmentsManagerTest {
 
   private SegmentsManager createSegmentsManager(final long lastWrittenIndex) {
     final var journalIndex = new SparseJournalIndex(journalIndexDensity);
+    final var maxSegmentSize = entrySize + SegmentDescriptor.getEncodingLength();
     return new SegmentsManager(
         journalIndex,
-        entrySize + SegmentDescriptor.getEncodingLength(),
+        maxSegmentSize,
         directory.resolve("data").toFile(),
         lastWrittenIndex,
         JOURNAL_NAME,
-        new SegmentLoader());
+        new SegmentLoader(2 * maxSegmentSize));
   }
 
   private SegmentedJournal openJournal(final float entriesPerSegment) {


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/11489 + https://github.com/camunda/zeebe/pull/11552 + https://github.com/camunda/zeebe/pull/11589

closes #11444 