### PR TITLE
Add benchmark to measure network latency

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -86,6 +86,20 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: DIST=build
           target: app
+  deploy-benchmark-measurement:
+    name: Deploy benchmark network latency measurement
+    needs:
+      - build-zeebe-image
+    uses: zeebe-io/zeebe-performance-test/.github/workflows/measure.yaml@main
+    with:
+      name: ${{ inputs.name }}-measurement
+      chaos: network-latency-5
+      helm-arguments: >
+        --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
+        --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
+        --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
+        --set camunda-platform.zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
+        ${{ inputs.benchmark-load }}
   deploy-benchmark-cluster:
     name: Deploy benchmark cluster
     needs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -87,7 +87,7 @@ jobs:
           build-args: DIST=build
           target: app
   deploy-benchmark-measurement:
-    name: Deploy benchmark network latency measurement
+    name: Measure network latency
     needs:
       - build-zeebe-image
     uses: zeebe-io/zeebe-performance-test/.github/workflows/measure.yaml@main


### PR DESCRIPTION
## Description

Adds a job, which deploys a separate benchmark to measure impact of network latency on process execution latency.

Example run:

https://github.com/camunda/zeebe/actions/runs/4223450471

```
Process Instance Execution Time: p99=2.4700183211192543 p90=2.200183211192538 p50=1.0009160559626915
Throughput: 100.00592590123621 PI/s
```

With delay
```
Process Instance Execution Time: p99=2.470174786372212 p90=2.201747863722117 p50=1.008739318610587
Throughput: 99.59351944444444 PI/s
```

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/zeebe/issues/11484
closes https://github.com/camunda/zeebe/issues/11760

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
