### PR TITLE
Allow configuring runtime directory

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -42,6 +42,9 @@ public final class DataCfg implements ConfigurationEntry {
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     directory = ConfigurationUtil.toAbsolutePath(directory, brokerBase);
+    if (runtimeDirectory != null) {
+      runtimeDirectory = ConfigurationUtil.toAbsolutePath(runtimeDirectory, brokerBase);
+    }
 
     backup.init(globalConfig, brokerBase);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -23,6 +23,8 @@ public final class DataCfg implements ConfigurationEntry {
 
   private String directory = DEFAULT_DIRECTORY;
 
+  private String runtimeDirectory = null;
+
   private DataSize logSegmentSize = DEFAULT_DATA_SIZE;
 
   private Duration snapshotPeriod = Duration.ofMinutes(5);
@@ -85,6 +87,18 @@ public final class DataCfg implements ConfigurationEntry {
 
   public void setDirectory(final String directory) {
     this.directory = directory;
+  }
+
+  public String getRuntimeDirectory() {
+    return runtimeDirectory;
+  }
+
+  public void setRuntimeDirectory(final String runtimeDirectory) {
+    this.runtimeDirectory = runtimeDirectory;
+  }
+
+  public boolean useSeparateRuntimeDirectory() {
+    return runtimeDirectory != null && !runtimeDirectory.isEmpty();
   }
 
   public long getLogSegmentSizeInBytes() {
@@ -152,6 +166,9 @@ public final class DataCfg implements ConfigurationEntry {
     return "DataCfg{"
         + "directory='"
         + directory
+        + '\''
+        + ", stateDirectory='"
+        + runtimeDirectory
         + '\''
         + ", logSegmentSize="
         + logSegmentSize

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerDifferentRuntimeDirectoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerDifferentRuntimeDirectoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BrokerDifferentRuntimeDirectoryTest {
+  private static final String STATE = "state";
+
+  @Rule
+  public final EmbeddedBrokerRule brokerRule =
+      new EmbeddedBrokerRule(
+          cfg -> {
+            cfg.getCluster().setPartitionsCount(2);
+            cfg.getData().setRuntimeDirectory(STATE);
+          });
+
+  @Test
+  public void shouldUseConfiguredRuntimeDirectory() {
+    final var runtimeDirectory = brokerRule.getBrokerBase().resolve(STATE);
+
+    // then
+    assertThat(runtimeDirectory).isNotEmptyDirectory();
+
+    for (int i = 1; i <= 2; i++) {
+      assertThat(runtimeDirectory.resolve(String.valueOf(i)))
+          .describedAs(
+              "Runtime directory for the partition must be created and db must be initialized.")
+          .isNotEmptyDirectory();
+      final var partition =
+          (RaftPartition)
+              brokerRule
+                  .getBroker()
+                  .getBrokerContext()
+                  .getPartitionManager()
+                  .getPartitionGroup()
+                  .getPartition(i);
+      assertThat(partition.dataDirectory().toPath().resolve("runtime"))
+          .describedAs("No runtime directory is created in the data directory")
+          .doesNotExist();
+    }
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
@@ -75,7 +76,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
 
   protected long startTime;
   private AtomixCluster atomixCluster;
-  private File newTemporaryFolder;
+  private File brokerBase;
   private String dataDirectory;
   private SystemContext systemContext;
 
@@ -130,7 +131,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
 
   @Override
   public void before() {
-    newTemporaryFolder = Files.newTemporaryFolder();
+    brokerBase = Files.newTemporaryFolder();
     startTime = System.currentTimeMillis();
     startBroker();
     LOG.info("\n====\nBroker startup time: {}\n====\n", (System.currentTimeMillis() - startTime));
@@ -153,7 +154,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
       }
     } finally {
       try {
-        FileUtil.deleteFolder(newTemporaryFolder.getAbsolutePath());
+        FileUtil.deleteFolder(brokerBase.getAbsolutePath());
       } catch (final IOException e) {
         LOG.error("Unexpected error on deleting data.", e);
       }
@@ -207,6 +208,10 @@ public final class EmbeddedBrokerRule extends ExternalResource {
       systemContext = null;
       System.gc();
     }
+  }
+
+  public Path getBrokerBase() {
+    return brokerBase.toPath();
   }
 
   public void startBroker(final PartitionListener... listeners) {
@@ -285,7 +290,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     assignSocketAddresses(brokerCfg);
 
     // initialize configuration
-    brokerCfg.init(newTemporaryFolder.getAbsolutePath());
+    brokerCfg.init(brokerBase.getAbsolutePath());
   }
 
   public void purgeSnapshots() {

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -191,19 +191,27 @@
       # This section allows to configure Zeebe's data storage. Data is stored in
       # "partition folders". A partition folder has the following structure:
       #
-      # partition-0                       (root partition folder)
-      # ├── partition.json                (metadata about the partition)
-      # ├── segments                      (the actual data as segment files)
-      # │   ├── 00.data
-      # │   └── 01.data
-      # └── state                     	(stream processor state and snapshots)
-      #     └── stream-processor
-      #		  ├── runtime
-      #		  └── snapshots
+      # partitions
+      #  └── 1                       (root partition folder)
+      #      ├── 1.log
+      #      ├── 2.log
+      #      └── snapshots
+      #          └── <snapshot-id>
+      #     		      └── xx.sst
+      #    	 └── runtime
+      #          └── yy.sst
 
       # Specify the directory in which data is stored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.
       # directory: data
+
+      # Specify the directory in which runtime is stored.
+      # By default runtime is stored in `directory` for data.
+      # If runtimeDirectory is configured, then the configured directory will be used. It will have a subdirectory for each partition to store its runtime.
+      # There is no need to store runtime in a persistent storage. This configuration allows to split runtime to another disk to optimize for performance and disk usage.
+      # Note: If runtime is another disk than the data directory, files need to be copied to data directory while taking snapshot. This may impact disk i/o or performance during snapshotting.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_RUNTIMEDIRECTORY.
+      # runtimeDirectory: null
 
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -198,7 +198,7 @@
       #      └── snapshots
       #          └── <snapshot-id>
       #     		      └── xx.sst
-      #    	 └── runtime
+      #      └── runtime
       #          └── yy.sst
 
       # Specify the directory in which data is stored.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -123,19 +123,27 @@
       # This section allows to configure Zeebe's data storage. Data is stored in
       # "partition folders". A partition folder has the following structure:
       #
-      # partition-0                       (root partition folder)
-      # ├── partition.json                (metadata about the partition)
-      # ├── segments                      (the actual data as segment files)
-      # │   ├── 00.data
-      # │   └── 01.data
-      # └── state                     	(stream processor state and snapshots)
-      #     └── stream-processor
-      #		  ├── runtime
-      #		  └── snapshots
+      # partitions
+      #  └── 1                       (root partition folder)
+      #      ├── 1.log
+      #      ├── 2.log
+      #      └── snapshots
+      #          └── <snapshot-id>
+      #     		      └── xx.sst
+      #    	 └── runtime
+      #          └── yy.sst
 
       # Specify the directory in which data is stored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.
       # directory: data
+
+      # Specify the directory in which runtime is stored.
+      # By default runtime is stored in `directory` for data.
+      # If runtimeDirectory is configured, then the configured directory will be used. It will have a subdirectory for each partition to store its runtime.
+      # There is no need to store runtime in a persistent storage. This configuration allows to split runtime to another disk to optimize for performance and disk usage.
+      # Note: If runtime is another disk than the data directory, files need to be copied to data directory while taking snapshot. This may impact disk i/o or performance during snapshotting.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_RUNTIMEDIRECTORY.
+      # runtimeDirectory: null
 
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -130,7 +130,7 @@
       #      └── snapshots
       #          └── <snapshot-id>
       #     		      └── xx.sst
-      #    	 └── runtime
+      #      └── runtime
       #          └── yy.sst
 
       # Specify the directory in which data is stored.


### PR DESCRIPTION
## Description

Add new configuration for specifying runtime directory.
```
zeebe:
   broker:
      data:
         directory: data
         runtime: runtime
```

The default value for `zeebe.broker.data.runtime` is null. If it is null, runtime is stored in the same location as before in the data directory. If any other value is configured, it will be used in the following directory structure:
```
runtime/
├─ 1/
|  ├─ 001.sst/
|  ├─ 002.sst/
├─ 2/
|  ├─ 001.sst/
         
```
## Related issues

closes #6044 
