### PR TITLE
Introduce publish option for benchmark measurments

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,12 @@ on:
       benchmark-load:
         description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitary helm arguments, like --set starter.rate=100'
         required: false
+      publish:
+        description: 'Where to publish the results, can be "slack" or "comment"'
+        default: ""
+        type: string
+        required: false
+
   workflow_call:
     inputs:
       name:
@@ -43,6 +49,11 @@ on:
         required: false
       benchmark-load:
         description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitary helm arguments, like --set starter.rate=100'
+        type: string
+        required: false
+      publish:
+        description: 'Where to publish the results, can be "slack" or "comment"'
+        default: ""
         type: string
         required: false
 jobs:
@@ -94,6 +105,7 @@ jobs:
     with:
       name: measurement-${{ github.run_id }}
       chaos: network-latency-5
+      publish: ${{ inputs.publish }}
       helm-arguments: >
         --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
         --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -92,7 +92,7 @@ jobs:
       - build-zeebe-image
     uses: zeebe-io/zeebe-performance-test/.github/workflows/measure.yaml@main
     with:
-      name: ${{ inputs.name }}-measurement
+      name: measurement-${{ github.run_id }}
       chaos: network-latency-5
       helm-arguments: >
         --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -102,6 +102,7 @@ jobs:
     needs:
       - build-zeebe-image
     uses: zeebe-io/zeebe-performance-test/.github/workflows/measure.yaml@main
+    secrets: inherit
     with:
       name: measurement-${{ github.run_id }}
       chaos: network-latency-5

--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -56,6 +56,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
+      publish: "slack"
   setup-mixed-benchmark:
     name: Setup mixed benchmark
     uses: ./.github/workflows/benchmark.yml

--- a/.github/workflows/pr-benchmark.yaml
+++ b/.github/workflows/pr-benchmark.yaml
@@ -18,6 +18,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ github.event.pull_request.head.ref }}
+      publish: "comment"
   update-benchmark:
     name: Update PR benchmark
     if: github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark')
@@ -28,6 +29,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ github.event.pull_request.head.ref }}
+      publish: "comment"
   delete-benchmark:
     name: Delete PR benchmark
     if: >


### PR DESCRIPTION
## Description


Introduces and uses the new option to publish the benchmark measurement results either on slack or pull-request, via comment. 

Fixes some smaller issues on the way, like missing secrets in measurement workflow. Additional changes the benchmark name to a shorter but unique name, which follows always the same pattern `measurement-github-runner-id`.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11768 
closes #11769 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
