### PR TITLE
[Backport 8.1] Corrolate message directly with batch processing

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -67,6 +67,7 @@ public final class EngineProcessors {
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(zeebeState.getPartitionId());
 
+    subscriptionCommandSender.setWriters(writers);
     final BpmnBehaviorsImpl bpmnBehaviors =
         createBehaviors(
             zeebeState,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -57,6 +57,7 @@ public final class CatchEventBehavior {
   private final TimerRecord timerRecord = new TimerRecord();
   private final DueDateTimerChecker timerChecker;
   private final KeyGenerator keyGenerator;
+  private final int currentPartitionId;
 
   public CatchEventBehavior(
       final ZeebeState zeebeState,
@@ -79,6 +80,8 @@ public final class CatchEventBehavior {
 
     this.keyGenerator = keyGenerator;
     this.timerChecker = timerChecker;
+
+    currentPartitionId = zeebeState.getPartitionId();
   }
 
   /**
@@ -240,16 +243,14 @@ public final class CatchEventBehavior {
     stateWriter.appendFollowUpEvent(
         subscriptionKey, ProcessMessageSubscriptionIntent.CREATING, subscription);
 
-    sideEffectWriter.appendSideEffect(
-        () ->
-            sendOpenMessageSubscription(
-                subscriptionPartitionId,
-                processInstanceKey,
-                elementInstanceKey,
-                bpmnProcessId,
-                messageName,
-                correlationKey,
-                event.isInterrupting()));
+    sendOpenMessageSubscription(
+        subscriptionPartitionId,
+        processInstanceKey,
+        elementInstanceKey,
+        bpmnProcessId,
+        messageName,
+        correlationKey,
+        event.isInterrupting());
   }
 
   private void subscribeToTimerEvents(
@@ -342,10 +343,8 @@ public final class CatchEventBehavior {
 
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, subscription.getRecord());
-    sideEffectWriter.appendSideEffect(
-        () ->
-            sendCloseMessageSubscriptionCommand(
-                subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName));
+    sendCloseMessageSubscriptionCommand(
+        subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName);
   }
 
   private boolean sendCloseMessageSubscriptionCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -22,13 +22,16 @@ public final class MessageCorrelator {
   private final MessageState messageState;
   private final SubscriptionCommandSender commandSender;
   private final StateWriter stateWriter;
-  private SideEffectWriter sideEffectWriter;
+  private final SideEffectWriter sideEffectWriter;
+  private final int currentPartitionId;
 
   public MessageCorrelator(
+      final int currentPartitionId,
       final MessageState messageState,
       final SubscriptionCommandSender commandSender,
       final StateWriter stateWriter,
       final SideEffectWriter sideEffectWriter) {
+    this.currentPartitionId = currentPartitionId;
     this.messageState = messageState;
     this.commandSender = commandSender;
     this.stateWriter = stateWriter;
@@ -72,7 +75,7 @@ public final class MessageCorrelator {
       stateWriter.appendFollowUpEvent(
           subscriptionKey, MessageSubscriptionIntent.CORRELATING, subscriptionRecord);
 
-      sideEffectWriter.appendSideEffect(() -> sendCorrelateCommand(subscriptionRecord));
+      sendCorrelateCommand(subscriptionRecord);
     }
 
     return correlateMessage;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -45,6 +45,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE,
             MessageIntent.PUBLISH,
             new MessagePublishProcessor(
+                zeebeState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 startEventSubscriptionState,
@@ -61,12 +62,21 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CREATE,
             new MessageSubscriptionCreateProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers, keyGenerator))
+                zeebeState.getPartitionId(),
+                messageState,
+                subscriptionState,
+                subscriptionCommandSender,
+                writers,
+                keyGenerator))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
             new MessageSubscriptionCorrelateProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers))
+                zeebeState.getPartitionId(),
+                messageState,
+                subscriptionState,
+                subscriptionCommandSender,
+                writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.DELETE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -32,17 +32,21 @@ public final class MessageSubscriptionCorrelateProcessor
   private final MessageCorrelator messageCorrelator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
+  private final int partitionId;
 
   public MessageSubscriptionCorrelateProcessor(
+      final int partitionId,
       final MessageState messageState,
       final MessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender commandSender,
       final Writers writers) {
+    this.partitionId = partitionId;
     this.subscriptionState = subscriptionState;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     messageCorrelator =
-        new MessageCorrelator(messageState, commandSender, stateWriter, writers.sideEffect());
+        new MessageCorrelator(
+            partitionId, messageState, commandSender, stateWriter, writers.sideEffect());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -37,8 +37,6 @@ public final class MessageSubscriptionCreateProcessor
 
   private MessageSubscriptionRecord subscriptionRecord;
   private final TypedRejectionWriter rejectionWriter;
-  private final SideEffectWriter sideEffectWriter;
-  private final int currentPartitionId;
 
   public MessageSubscriptionCreateProcessor(
       final int partitionId,
@@ -51,12 +49,11 @@ public final class MessageSubscriptionCreateProcessor
     this.commandSender = commandSender;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
-    sideEffectWriter = writers.sideEffect();
+    final SideEffectWriter sideEffectWriter = writers.sideEffect();
     this.keyGenerator = keyGenerator;
     messageCorrelator =
         new MessageCorrelator(
             partitionId, messageState, commandSender, stateWriter, sideEffectWriter);
-    currentPartitionId = partitionId;
   }
 
   @Override
@@ -77,10 +74,10 @@ public final class MessageSubscriptionCreateProcessor
       return;
     }
 
-    handleNewSubscription(sideEffectWriter);
+    handleNewSubscription();
   }
 
-  private void handleNewSubscription(final SideEffectWriter sideEffectWriter) {
+  private void handleNewSubscription() {
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -64,7 +64,7 @@ public final class MessageSubscriptionDeleteProcessor
       rejectCommand(record);
     }
 
-    sideEffectWriter.appendSideEffect(this::sendAcknowledgeCommand);
+    sendAcknowledgeCommand();
   }
 
   private void rejectCommand(final TypedRecord<MessageSubscriptionRecord> record) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -93,8 +93,7 @@ public final class MessageSubscriptionRejectProcessor
                 subscription.getKey(),
                 MessageSubscriptionIntent.CORRELATING,
                 correlatingSubscription);
-
-            sideEffectWriter.appendSideEffect(() -> sendCorrelateCommand(correlatingSubscription));
+            sendCorrelateCommand(correlatingSubscription);
           }
           return !canBeCorrelated;
         });

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
@@ -36,22 +36,19 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
   private boolean sendCommand(final MessageSubscription subscription) {
     final var record = subscription.getRecord();
 
-    final boolean success =
-        commandSender.correlateProcessMessageSubscription(
-            record.getProcessInstanceKey(),
-            record.getElementInstanceKey(),
-            record.getBpmnProcessIdBuffer(),
-            record.getMessageNameBuffer(),
-            record.getMessageKey(),
-            record.getVariablesBuffer(),
-            record.getCorrelationKeyBuffer());
+    commandSender.sendDirectCorrelateProcessMessageSubscription(
+        record.getProcessInstanceKey(),
+        record.getElementInstanceKey(),
+        record.getBpmnProcessIdBuffer(),
+        record.getMessageNameBuffer(),
+        record.getMessageKey(),
+        record.getVariablesBuffer(),
+        record.getCorrelationKeyBuffer());
 
-    if (success) {
-      // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)
-      final var sentTime = ActorClock.currentTimeMillis();
-      transientState.updateCommandSentTime(subscription.getRecord(), sentTime);
-    }
+    // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)
+    final var sentTime = ActorClock.currentTimeMillis();
+    transientState.updateCommandSentTime(subscription.getRecord(), sentTime);
 
-    return success;
+    return true; // to continue visiting
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -100,7 +100,7 @@ public final class PendingProcessMessageSubscriptionChecker
   }
 
   private boolean sendOpenCommand(final ProcessMessageSubscription subscription) {
-    return commandSender.openMessageSubscription(
+    commandSender.sendDirectOpenMessageSubscription(
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
         subscription.getRecord().getElementInstanceKey(),
@@ -108,6 +108,7 @@ public final class PendingProcessMessageSubscriptionChecker
         subscription.getRecord().getMessageNameBuffer(),
         subscription.getRecord().getCorrelationKeyBuffer(),
         subscription.getRecord().isInterrupting());
+    return true;
   }
 
   private boolean sendCloseCommand(final ProcessMessageSubscription subscription) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -82,24 +82,20 @@ public final class PendingProcessMessageSubscriptionChecker
   }
 
   private boolean sendPendingCommand(final ProcessMessageSubscription subscription) {
-    final boolean success;
-
     // can only be opening/closing as an opened subscription is not indexed in the sent time column
     if (subscription.isOpening()) {
-      success = sendOpenCommand(subscription);
+      sendOpenCommand(subscription);
     } else {
-      success = sendCloseCommand(subscription);
+      sendCloseCommand(subscription);
     }
 
-    if (success) {
-      final var sentTime = ActorClock.currentTimeMillis();
-      pendingState.updateSentTime(subscription.getRecord(), sentTime);
-    }
+    final var sentTime = ActorClock.currentTimeMillis();
+    pendingState.updateSentTime(subscription.getRecord(), sentTime);
 
-    return success;
+    return true; // to continue visiting
   }
 
-  private boolean sendOpenCommand(final ProcessMessageSubscription subscription) {
+  private void sendOpenCommand(final ProcessMessageSubscription subscription) {
     commandSender.sendDirectOpenMessageSubscription(
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
@@ -108,15 +104,13 @@ public final class PendingProcessMessageSubscriptionChecker
         subscription.getRecord().getMessageNameBuffer(),
         subscription.getRecord().getCorrelationKeyBuffer(),
         subscription.getRecord().isInterrupting());
-    return true;
   }
 
-  private boolean sendCloseCommand(final ProcessMessageSubscription subscription) {
+  private void sendCloseCommand(final ProcessMessageSubscription subscription) {
     commandSender.sendDirectCloseMessageSubscription(
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getMessageNameBuffer());
-    return true;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -111,10 +111,11 @@ public final class PendingProcessMessageSubscriptionChecker
   }
 
   private boolean sendCloseCommand(final ProcessMessageSubscription subscription) {
-    return commandSender.closeMessageSubscription(
+    commandSender.sendDirectCloseMessageSubscription(
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getMessageNameBuffer());
+    return true;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -149,6 +149,42 @@ public class SubscriptionCommandSender {
             .setCorrelationKey(correlationKey));
   }
 
+  /**
+   * Sends the correlate process message subscription command directly to the subscribed partition.
+   * This differs to ${link correlateProcessMessageSubscription}, as the sending/writing is not
+   * delayed. Usually useful or used in scheduled tasks, which want to directly send commands.
+   *
+   * @param processInstanceKey the related process instance key
+   * @param elementInstanceKey the related element instance key
+   * @param bpmnProcessId the related process id
+   * @param messageName the name of the message for which the subscription should be correlated
+   * @param messageKey the key of the message for which the subscription should be correlated
+   * @param variables the variables of the message
+   * @param correlationKey the correlation key for which the message should be correlated
+   */
+  public void sendDirectCorrelateProcessMessageSubscription(
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final DirectBuffer bpmnProcessId,
+      final DirectBuffer messageName,
+      final long messageKey,
+      final DirectBuffer variables,
+      final DirectBuffer correlationKey) {
+    interPartitionCommandSender.sendCommand(
+        Protocol.decodePartitionId(processInstanceKey),
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+        ProcessMessageSubscriptionIntent.CORRELATE,
+        new ProcessMessageSubscriptionRecord()
+            .setSubscriptionPartitionId(senderPartition)
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageKey(messageKey)
+            .setMessageName(messageName)
+            .setVariables(variables)
+            .setCorrelationKey(correlationKey));
+  }
+
   public boolean correlateMessageSubscription(
       final int subscriptionPartitionId,
       final long processInstanceKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -148,6 +148,32 @@ public class SubscriptionCommandSender {
             .setMessageName(messageName));
   }
 
+  /**
+   * Sends the close message subscription command directly to the subscription partition. This
+   * differs to ${link closeMessageSubscription}, as the sending/writing is not delayed. Usually
+   * useful or used in scheduled tasks, which want to directly send commands.
+   *
+   * @param subscriptionPartitionId the partition Id which should receive the command
+   * @param processInstanceKey the related process instance key
+   * @param elementInstanceKey the related element instance key
+   * @param messageName the name of the message for which the subscription should be closed
+   */
+  public void sendDirectCloseMessageSubscription(
+      final int subscriptionPartitionId,
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final DirectBuffer messageName) {
+    interPartitionCommandSender.sendCommand(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.DELETE,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setMessageKey(-1L)
+            .setMessageName(messageName));
+  }
+
   public boolean closeProcessMessageSubscription(
       final long processInstanceKey,
       final long elementInstanceKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -73,6 +73,41 @@ public class SubscriptionCommandSender {
             .setInterrupting(closeOnCorrelate));
   }
 
+  /**
+   * Sends the open message subscription command directly to the subscription partition. This
+   * differs to ${link openMessageSubscription}, as the sending/writing is not delayed. Usually
+   * useful or used in scheduled tasks, which want to directly send commands.
+   *
+   * @param subscriptionPartitionId the partition Id which should receive the command
+   * @param processInstanceKey the related process instance key
+   * @param elementInstanceKey the related element instance key
+   * @param bpmnProcessId the related process id
+   * @param messageName the name of the message for which the subscription should be correlated
+   * @param correlationKey the correlation key for which the message should be correlated
+   * @param closeOnCorrelate indicates whether the subscription should be closed after correlation
+   */
+  public void sendDirectOpenMessageSubscription(
+      final int subscriptionPartitionId,
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final DirectBuffer bpmnProcessId,
+      final DirectBuffer messageName,
+      final DirectBuffer correlationKey,
+      final boolean closeOnCorrelate) {
+    interPartitionCommandSender.sendCommand(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.CREATE,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageKey(-1)
+            .setMessageName(messageName)
+            .setCorrelationKey(correlationKey)
+            .setInterrupting(closeOnCorrelate));
+  }
+
   public boolean openProcessMessageSubscription(
       final long processInstanceKey,
       final long elementInstanceKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.message.command;
 
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
@@ -40,6 +41,7 @@ import org.agrona.DirectBuffer;
 public class SubscriptionCommandSender {
   private final InterPartitionCommandSender interPartitionCommandSender;
   private final int senderPartition;
+  private Writers writers;
 
   public SubscriptionCommandSender(
       final int senderPartition, final InterPartitionCommandSender interPartitionCommandSender) {
@@ -56,18 +58,40 @@ public class SubscriptionCommandSender {
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate) {
 
-    interPartitionCommandSender.sendCommand(
-        subscriptionPartitionId,
-        ValueType.MESSAGE_SUBSCRIPTION,
-        MessageSubscriptionIntent.CREATE,
-        new MessageSubscriptionRecord()
-            .setProcessInstanceKey(processInstanceKey)
-            .setElementInstanceKey(elementInstanceKey)
-            .setBpmnProcessId(bpmnProcessId)
-            .setMessageKey(-1)
-            .setMessageName(messageName)
-            .setCorrelationKey(correlationKey)
-            .setInterrupting(closeOnCorrelate));
+    if (subscriptionPartitionId == senderPartition) {
+      writers
+          .command()
+          .appendNewCommand(
+              MessageSubscriptionIntent.CREATE,
+              new MessageSubscriptionRecord()
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey)
+                  .setBpmnProcessId(bpmnProcessId)
+                  .setMessageKey(-1)
+                  .setMessageName(messageName)
+                  .setCorrelationKey(correlationKey)
+                  .setInterrupting(closeOnCorrelate));
+    } else {
+
+      writers
+          .sideEffect()
+          .appendSideEffect(
+              () -> {
+                interPartitionCommandSender.sendCommand(
+                    subscriptionPartitionId,
+                    ValueType.MESSAGE_SUBSCRIPTION,
+                    MessageSubscriptionIntent.CREATE,
+                    new MessageSubscriptionRecord()
+                        .setProcessInstanceKey(processInstanceKey)
+                        .setElementInstanceKey(elementInstanceKey)
+                        .setBpmnProcessId(bpmnProcessId)
+                        .setMessageKey(-1)
+                        .setMessageName(messageName)
+                        .setCorrelationKey(correlationKey)
+                        .setInterrupting(closeOnCorrelate));
+                return true;
+              });
+    }
     return true;
   }
 
@@ -76,18 +100,38 @@ public class SubscriptionCommandSender {
       final long elementInstanceKey,
       final DirectBuffer messageName,
       final boolean closeOnCorrelate) {
-
-    interPartitionCommandSender.sendCommand(
-        Protocol.decodePartitionId(processInstanceKey),
-        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
-        ProcessMessageSubscriptionIntent.CREATE,
-        new ProcessMessageSubscriptionRecord()
-            .setSubscriptionPartitionId(senderPartition)
-            .setProcessInstanceKey(processInstanceKey)
-            .setElementInstanceKey(elementInstanceKey)
-            .setMessageKey(-1)
-            .setMessageName(messageName)
-            .setInterrupting(closeOnCorrelate));
+    final int receiverPartitionId = Protocol.decodePartitionId(processInstanceKey);
+    if (receiverPartitionId == senderPartition) {
+      writers
+          .command()
+          .appendNewCommand(
+              ProcessMessageSubscriptionIntent.CREATE,
+              new ProcessMessageSubscriptionRecord()
+                  .setSubscriptionPartitionId(senderPartition)
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey)
+                  .setMessageKey(-1)
+                  .setMessageName(messageName)
+                  .setInterrupting(closeOnCorrelate));
+    } else {
+      writers
+          .sideEffect()
+          .appendSideEffect(
+              () -> {
+                interPartitionCommandSender.sendCommand(
+                    receiverPartitionId,
+                    ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+                    ProcessMessageSubscriptionIntent.CREATE,
+                    new ProcessMessageSubscriptionRecord()
+                        .setSubscriptionPartitionId(senderPartition)
+                        .setProcessInstanceKey(processInstanceKey)
+                        .setElementInstanceKey(elementInstanceKey)
+                        .setMessageKey(-1)
+                        .setMessageName(messageName)
+                        .setInterrupting(closeOnCorrelate));
+                return true;
+              });
+    }
     return true;
   }
 
@@ -99,20 +143,42 @@ public class SubscriptionCommandSender {
       final long messageKey,
       final DirectBuffer variables,
       final DirectBuffer correlationKey) {
-
-    interPartitionCommandSender.sendCommand(
-        Protocol.decodePartitionId(processInstanceKey),
-        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
-        ProcessMessageSubscriptionIntent.CORRELATE,
-        new ProcessMessageSubscriptionRecord()
-            .setSubscriptionPartitionId(senderPartition)
-            .setProcessInstanceKey(processInstanceKey)
-            .setElementInstanceKey(elementInstanceKey)
-            .setBpmnProcessId(bpmnProcessId)
-            .setMessageKey(messageKey)
-            .setMessageName(messageName)
-            .setVariables(variables)
-            .setCorrelationKey(correlationKey));
+    final int receiverPartitionId = Protocol.decodePartitionId(processInstanceKey);
+    if (receiverPartitionId == senderPartition) {
+      writers
+          .command()
+          .appendNewCommand(
+              ProcessMessageSubscriptionIntent.CORRELATE,
+              new ProcessMessageSubscriptionRecord()
+                  .setSubscriptionPartitionId(senderPartition)
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey)
+                  .setBpmnProcessId(bpmnProcessId)
+                  .setMessageKey(messageKey)
+                  .setMessageName(messageName)
+                  .setVariables(variables)
+                  .setCorrelationKey(correlationKey));
+    } else {
+      writers
+          .sideEffect()
+          .appendSideEffect(
+              () -> {
+                interPartitionCommandSender.sendCommand(
+                    receiverPartitionId,
+                    ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+                    ProcessMessageSubscriptionIntent.CORRELATE,
+                    new ProcessMessageSubscriptionRecord()
+                        .setSubscriptionPartitionId(senderPartition)
+                        .setProcessInstanceKey(processInstanceKey)
+                        .setElementInstanceKey(elementInstanceKey)
+                        .setBpmnProcessId(bpmnProcessId)
+                        .setMessageKey(messageKey)
+                        .setMessageName(messageName)
+                        .setVariables(variables)
+                        .setCorrelationKey(correlationKey));
+                return true;
+              });
+    }
     return true;
   }
 
@@ -122,16 +188,35 @@ public class SubscriptionCommandSender {
       final long elementInstanceKey,
       final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName) {
-    interPartitionCommandSender.sendCommand(
-        subscriptionPartitionId,
-        ValueType.MESSAGE_SUBSCRIPTION,
-        MessageSubscriptionIntent.CORRELATE,
-        new MessageSubscriptionRecord()
-            .setProcessInstanceKey(processInstanceKey)
-            .setElementInstanceKey(elementInstanceKey)
-            .setBpmnProcessId(bpmnProcessId)
-            .setMessageKey(-1)
-            .setMessageName(messageName));
+    if (subscriptionPartitionId == senderPartition) {
+      writers
+          .command()
+          .appendNewCommand(
+              MessageSubscriptionIntent.CORRELATE,
+              new MessageSubscriptionRecord()
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey)
+                  .setBpmnProcessId(bpmnProcessId)
+                  .setMessageKey(-1)
+                  .setMessageName(messageName));
+    } else {
+      writers
+          .sideEffect()
+          .appendSideEffect(
+              () -> {
+                interPartitionCommandSender.sendCommand(
+                    subscriptionPartitionId,
+                    ValueType.MESSAGE_SUBSCRIPTION,
+                    MessageSubscriptionIntent.CORRELATE,
+                    new MessageSubscriptionRecord()
+                        .setProcessInstanceKey(processInstanceKey)
+                        .setElementInstanceKey(elementInstanceKey)
+                        .setBpmnProcessId(bpmnProcessId)
+                        .setMessageKey(-1)
+                        .setMessageName(messageName));
+                return true;
+              });
+    }
     return true;
   }
 
@@ -140,16 +225,33 @@ public class SubscriptionCommandSender {
       final long processInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer messageName) {
-
-    interPartitionCommandSender.sendCommand(
-        subscriptionPartitionId,
-        ValueType.MESSAGE_SUBSCRIPTION,
-        MessageSubscriptionIntent.DELETE,
-        new MessageSubscriptionRecord()
-            .setProcessInstanceKey(processInstanceKey)
-            .setElementInstanceKey(elementInstanceKey)
-            .setMessageKey(-1L)
-            .setMessageName(messageName));
+    if (subscriptionPartitionId == senderPartition) {
+      writers
+          .command()
+          .appendNewCommand(
+              ProcessMessageSubscriptionIntent.DELETE,
+              new MessageSubscriptionRecord()
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey)
+                  .setMessageKey(-1L)
+                  .setMessageName(messageName));
+    } else {
+      writers
+          .sideEffect()
+          .appendSideEffect(
+              () -> {
+                interPartitionCommandSender.sendCommand(
+                    subscriptionPartitionId,
+                    ValueType.MESSAGE_SUBSCRIPTION,
+                    MessageSubscriptionIntent.DELETE,
+                    new MessageSubscriptionRecord()
+                        .setProcessInstanceKey(processInstanceKey)
+                        .setElementInstanceKey(elementInstanceKey)
+                        .setMessageKey(-1L)
+                        .setMessageName(messageName));
+                return true;
+              });
+    }
     return true;
   }
 
@@ -157,16 +259,38 @@ public class SubscriptionCommandSender {
       final long processInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer messageName) {
-    interPartitionCommandSender.sendCommand(
-        Protocol.decodePartitionId(processInstanceKey),
-        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
-        ProcessMessageSubscriptionIntent.DELETE,
-        new ProcessMessageSubscriptionRecord()
-            .setSubscriptionPartitionId(senderPartition)
-            .setProcessInstanceKey(processInstanceKey)
-            .setElementInstanceKey(elementInstanceKey)
-            .setMessageKey(-1)
-            .setMessageName(messageName));
+
+    final int receiverPartitionId = Protocol.decodePartitionId(processInstanceKey);
+    if (receiverPartitionId == senderPartition) {
+      writers
+          .command()
+          .appendNewCommand(
+              ProcessMessageSubscriptionIntent.DELETE,
+              new ProcessMessageSubscriptionRecord()
+                  .setSubscriptionPartitionId(senderPartition)
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey)
+                  .setMessageKey(-1)
+                  .setMessageName(messageName));
+    } else {
+      writers
+          .sideEffect()
+          .appendSideEffect(
+              () -> {
+                interPartitionCommandSender.sendCommand(
+                    receiverPartitionId,
+                    ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+                    ProcessMessageSubscriptionIntent.DELETE,
+                    new ProcessMessageSubscriptionRecord()
+                        .setSubscriptionPartitionId(senderPartition)
+                        .setProcessInstanceKey(processInstanceKey)
+                        .setElementInstanceKey(elementInstanceKey)
+                        .setMessageKey(-1)
+                        .setMessageName(messageName));
+                return true;
+              });
+    }
+
     return true;
   }
 
@@ -177,18 +301,44 @@ public class SubscriptionCommandSender {
       final DirectBuffer messageName,
       final DirectBuffer correlationKey) {
 
-    interPartitionCommandSender.sendCommand(
-        Protocol.decodePartitionId(processInstanceKey),
-        ValueType.MESSAGE_SUBSCRIPTION,
-        MessageSubscriptionIntent.REJECT,
-        new MessageSubscriptionRecord()
-            .setProcessInstanceKey(processInstanceKey)
-            .setElementInstanceKey(-1L)
-            .setBpmnProcessId(bpmnProcessId)
-            .setMessageName(messageName)
-            .setCorrelationKey(correlationKey)
-            .setMessageKey(messageKey)
-            .setInterrupting(false));
+    final int receiverPartitionId = Protocol.decodePartitionId(processInstanceKey);
+    if (receiverPartitionId == senderPartition) {
+      writers
+          .command()
+          .appendNewCommand(
+              MessageSubscriptionIntent.REJECT,
+              new MessageSubscriptionRecord()
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setElementInstanceKey(-1L)
+                  .setBpmnProcessId(bpmnProcessId)
+                  .setMessageName(messageName)
+                  .setCorrelationKey(correlationKey)
+                  .setMessageKey(messageKey)
+                  .setInterrupting(false));
+    } else {
+      writers
+          .sideEffect()
+          .appendSideEffect(
+              () -> {
+                interPartitionCommandSender.sendCommand(
+                    receiverPartitionId,
+                    ValueType.MESSAGE_SUBSCRIPTION,
+                    MessageSubscriptionIntent.REJECT,
+                    new MessageSubscriptionRecord()
+                        .setProcessInstanceKey(processInstanceKey)
+                        .setElementInstanceKey(-1L)
+                        .setBpmnProcessId(bpmnProcessId)
+                        .setMessageName(messageName)
+                        .setCorrelationKey(correlationKey)
+                        .setMessageKey(messageKey)
+                        .setInterrupting(false));
+                return true;
+              });
+    }
     return true;
+  }
+
+  public void setWriters(final Writers writers) {
+    this.writers = writers;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
@@ -94,7 +94,7 @@ public final class MessageCorrelationMultiplePartitionsTest {
   }
 
   @Test
-  public void shouldCorrelateMessageOnDifferentPartitions() {
+  public void shouldCorrelateMessageOnDifferentPartitions() throws InterruptedException {
     // given
     engine.forEachPartition(
         partitionId ->

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -19,6 +19,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -31,8 +33,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
-import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
-import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import java.time.Duration;
 import org.agrona.DirectBuffer;
 import org.awaitility.Awaitility;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -153,6 +153,29 @@ public class SubscriptionCommandSenderTest {
   }
 
   @Test
+  public void shouldSendDirectCloseMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.sendDirectCloseMessageSubscription(
+        DIFFERENT_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockInterPartitionCommandSender)
+        .sendCommand(
+            eq(DIFFERENT_PARTITION),
+            eq(ValueType.MESSAGE_SUBSCRIPTION),
+            eq(MessageSubscriptionIntent.DELETE),
+            any());
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
   public void shouldSentFollowUpCommandForOpenMessageSubscription() {
     // given
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -215,6 +215,32 @@ public class SubscriptionCommandSenderTest {
   }
 
   @Test
+  public void shouldSendDirectOpenMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.sendDirectOpenMessageSubscription(
+        DIFFERENT_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_CORRELATION_KEY,
+        true);
+
+    // then
+    verify(mockInterPartitionCommandSender)
+        .sendCommand(
+            eq(DIFFERENT_PARTITION),
+            eq(ValueType.MESSAGE_SUBSCRIPTION),
+            eq(MessageSubscriptionIntent.CREATE),
+            any());
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
   public void shouldSentFollowUpCommandForOpenProcessMessageSubscription() {
     // given
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.message.command;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -17,6 +18,9 @@ import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -117,6 +121,32 @@ public class SubscriptionCommandSenderTest {
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
     verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldSendDirectCorrelateProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.sendDirectCorrelateProcessMessageSubscription(
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_MESSAGE_KEY,
+        DEFAULT_VARIABLES,
+        DEFAULT_CORRELATION_KEY);
+
+    // then
+    verify(mockInterPartitionCommandSender)
+        .sendCommand(
+            eq(DIFFERENT_PARTITION),
+            eq(ValueType.PROCESS_MESSAGE_SUBSCRIPTION),
+            eq(ProcessMessageSubscriptionIntent.CORRELATE),
+            any());
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.message.command;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SubscriptionCommandSenderTest {
+
+  private static final long DIFFERENT_RECEIVER_PARTITION_KEY = Protocol.encodePartitionId(2, 1);
+  private static final long SAME_RECEIVER_PARTITION_KEY = Protocol.encodePartitionId(1, 1);
+  private static final int SENDER_PARTITION = 1;
+
+  private static final long DEFAULT_ELEMENT_INSTANCE_KEY = 111;
+  private static final DirectBuffer DEFAULT_MESSAGE_NAME = BufferUtil.wrapString("msg");
+
+  private InterPartitionCommandSender mockInterPartitionCommandSender;
+  private SubscriptionCommandSender subscriptionCommandSender;
+  private ProcessingResultBuilder mockProcessingResultBuilder;
+
+  @BeforeEach
+  public void setup() {
+    mockInterPartitionCommandSender = mock(InterPartitionCommandSender.class);
+    subscriptionCommandSender =
+        new SubscriptionCommandSender(SENDER_PARTITION, mockInterPartitionCommandSender);
+    mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
+    final var writers =
+        new Writers(() -> mockProcessingResultBuilder, (key, intent, recordValue) -> {});
+    subscriptionCommandSender.setWriters(writers);
+  }
+
+  @Test
+  public void shouldSentFollowUpCommandForCloseProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.closeProcessMessageSubscription(
+        DIFFERENT_RECEIVER_PARTITION_KEY, DEFAULT_ELEMENT_INSTANCE_KEY, DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockProcessingResultBuilder).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWriteFollowUpCommandForCloseProcessMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.closeProcessMessageSubscription(
+        SAME_RECEIVER_PARTITION_KEY, DEFAULT_ELEMENT_INSTANCE_KEY, DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+}


### PR DESCRIPTION
## Description
Backports https://github.com/camunda/zeebe/pull/11549
Backports https://github.com/camunda/zeebe/pull/11805
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/11494

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
