### PR TITLE
[Backport 8.1] build: docker image can be built from sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,7 @@ jobs:
           format: sarif
           output-file: ./hadolint.sarif
           no-color: true
+          verbose: true
       - name: Upload Hadolint Results
         if: always()
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,7 @@ jobs:
           output-file: ./hadolint.sarif
           no-color: true
       - name: Upload Hadolint Results
+        if: always()
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ./hadolint.sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: hadolint/hadolint-action@v2.1.0
+      - uses: hadolint/hadolint-action@v3.1.0
         with:
           config: ./.hadolint.yaml
           dockerfile: ./Dockerfile

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,2 @@
 failure-threshold: warning
-format: tty
 ignored: []

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG DIST="distball"
 
 ### Init image containing tini and the startup script ###
 FROM ubuntu:jammy as init
-WORKDIR /
+WORKDIR /zeebe
 RUN --mount=type=cache,target=/var/apt/cache,rw \
     apt-get -qq update && \
     apt-get install -y --no-install-recommends tini=0.19.0-1 && \
@@ -16,7 +16,7 @@ COPY --link --chown=1000:0 docker/utils/startup.sh .
 
 ### Build zeebe from scratch ###
 FROM maven:3-eclipse-temurin-17 as build
-WORKDIR /
+WORKDIR /zeebe
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
 COPY --link . ./
 RUN --mount=type=cache,target=/root/.m2,rw mvn -B -am -pl dist package -T1C -D skipChecks -D skipTests
@@ -24,7 +24,7 @@ RUN mv dist/target/camunda-zeebe .
 
 ### Extract zeebe from distball ###
 FROM ubuntu:jammy as distball
-WORKDIR /
+WORKDIR /zeebe
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} zeebe.tar.gz
 RUN mkdir camunda-zeebe && tar xfvz zeebe.tar.gz --strip 1 -C camunda-zeebe
@@ -86,8 +86,8 @@ RUN groupadd -g 1000 zeebe && \
     mkdir ${ZB_HOME}/data && \
     chmod 0775 ${ZB_HOME}/data
 
-COPY --from=init --chown=1000:0 tini ${ZB_HOME}/bin/
-COPY --from=init --chown=1000:0 startup.sh /usr/local/bin/startup.sh
-COPY --from=dist --chown=1000:0 camunda-zeebe ${ZB_HOME}
+COPY --from=init --chown=1000:0 /zeebe/tini ${ZB_HOME}/bin/
+COPY --from=init --chown=1000:0 /zeebe/startup.sh /usr/local/bin/startup.sh
+COPY --from=dist --chown=1000:0 /zeebe/camunda-zeebe ${ZB_HOME}
 
 ENTRYPOINT ["tini", "--", "/usr/local/bin/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG DIST="distball"
 
 ### Init image containing tini and the startup script ###
 FROM ubuntu:jammy as init
+WORKDIR /
 RUN --mount=type=cache,target=/var/apt/cache,rw \
     apt-get -qq update && \
     apt-get install -y --no-install-recommends tini=0.19.0-1 && \
@@ -14,7 +15,8 @@ RUN --mount=type=cache,target=/var/apt/cache,rw \
 COPY --link --chown=1000:0 docker/utils/startup.sh .
 
 ### Build zeebe from scratch ###
-FROM maven as build
+FROM maven:3-eclipse-temurin-17 as build
+WORKDIR /
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
 COPY --link . ./
 RUN --mount=type=cache,target=/root/.m2,rw mvn -B -am -pl dist package -T1C -D skipChecks -D skipTests
@@ -22,11 +24,13 @@ RUN mv dist/target/camunda-zeebe .
 
 ### Extract zeebe from distball ###
 FROM ubuntu:jammy as distball
+WORKDIR /
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} zeebe.tar.gz
 RUN mkdir camunda-zeebe && tar xfvz zeebe.tar.gz --strip 1 -C camunda-zeebe
 
 ### Image containing the zeebe distribution ###
+# hadolint ignore=DL3006
 FROM ${DIST} as dist
 
 # Building application image


### PR DESCRIPTION
## Description

Backport of #11495. Needed for running the benchmark workflow for 8.1.
Also needed to cherry-pick hadolint changes and updates as violations were triggered.

Tested with this workflow invocation https://github.com/camunda/zeebe/actions/runs/4233894787/jobs/7355573235

