### PR TITLE
Make resource deployments atomic

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -84,31 +84,30 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   public void processRecord(final TypedRecord<DeploymentRecord> command) {
 
     final DeploymentRecord deploymentEvent = command.getValue();
-
     final Either<Failure, Void> result = deploymentTransformer.transform(deploymentEvent);
 
-    if (result.isRight()) {
-      try {
-        createTimerIfTimerStartEvent(command);
-      } catch (final RuntimeException e) {
-        final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
-        responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
-        rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
-        return;
-      }
-
-      final long key = keyGenerator.nextKey();
-
-      responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
-
-      stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
-
-      deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key);
-      // manage the top-level start event subscriptions except for timers
-      startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
-    } else {
+    if (result.isLeft()) {
       throw new ResourceTransformationFailedException(result.getLeft().getMessage());
     }
+
+    try {
+      createTimerIfTimerStartEvent(command);
+    } catch (final RuntimeException e) {
+      final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
+      responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
+      rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
+      return;
+    }
+
+    final long key = keyGenerator.nextKey();
+
+    responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
+
+    stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
+
+    deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key);
+    // manage the top-level start event subscriptions except for timers
+    startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistri
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer;
-import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer.ResourceTransformationFailedException;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -86,26 +85,30 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
 
     final DeploymentRecord deploymentEvent = command.getValue();
 
-    deploymentTransformer.transform(deploymentEvent);
+    final Either<Failure, Void> result = deploymentTransformer.transform(deploymentEvent);
 
-    try {
-      createTimerIfTimerStartEvent(command);
-    } catch (final RuntimeException e) {
-      final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
-      responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
-      rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
-      return;
+    if (result.isRight()) {
+      try {
+        createTimerIfTimerStartEvent(command);
+      } catch (final RuntimeException e) {
+        final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
+        responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
+        rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
+        return;
+      }
+
+      final long key = keyGenerator.nextKey();
+
+      responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
+
+      stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
+
+      deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key);
+      // manage the top-level start event subscriptions except for timers
+      startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
+    } else {
+      throw new ResourceTransformationFailedException(result.getLeft().getMessage());
     }
-
-    final long key = keyGenerator.nextKey();
-
-    responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
-
-    stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
-
-    deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key);
-    // manage the top-level start event subscriptions except for timers
-    startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
   }
 
   @Override
@@ -170,6 +173,20 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
 
     if (timerBpmnId.equals(processMetadata.getBpmnProcessIdBuffer())) {
       catchEventBehavior.unsubscribeFromTimerEvent(timer);
+    }
+  }
+
+  /**
+   * Exception that can be thrown during processing of a command, in case the resource cannot
+   * be transformed successfully. This allows the platform to roll back any changes the engine made.
+   * This exception can be handled by the processor in {@link
+   * io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor#tryHandleError(
+   * TypedRecord, Throwable)}.
+   */
+  private static final class ResourceTransformationFailedException extends RuntimeException {
+
+    private ResourceTransformationFailedException(final String message) {
+      super(message);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistri
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer;
+import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer.ResourceTransformationFailedException;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -85,37 +86,40 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
 
     final DeploymentRecord deploymentEvent = command.getValue();
 
-    final boolean accepted = deploymentTransformer.transform(deploymentEvent);
-    if (accepted) {
-      final long key = keyGenerator.nextKey();
+    deploymentTransformer.transform(deploymentEvent);
 
-      try {
-        createTimerIfTimerStartEvent(command);
-      } catch (final RuntimeException e) {
-        final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
-        responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
-        rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
-        return;
-      }
-
-      responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
-
-      stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
-
-      deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key);
-      // manage the top-level start event subscriptions except for timers
-      startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
-
-    } else {
-      responseWriter.writeRejectionOnCommand(
-          command,
-          deploymentTransformer.getRejectionType(),
-          deploymentTransformer.getRejectionReason());
-      rejectionWriter.appendRejection(
-          command,
-          deploymentTransformer.getRejectionType(),
-          deploymentTransformer.getRejectionReason());
+    try {
+      createTimerIfTimerStartEvent(command);
+    } catch (final RuntimeException e) {
+      final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
+      responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
+      rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
+      return;
     }
+
+    final long key = keyGenerator.nextKey();
+
+    responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
+
+    stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
+
+    deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key);
+    // manage the top-level start event subscriptions except for timers
+    startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<DeploymentRecord> command, final Throwable error) {
+    if (error instanceof ResourceTransformationFailedException exception) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.INVALID_ARGUMENT, exception.getMessage());
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.INVALID_ARGUMENT, exception.getMessage());
+      return ProcessingError.EXPECTED_ERROR;
+    }
+
+    return ProcessingError.UNEXPECTED_ERROR;
   }
 
   private void createTimerIfTimerStartEvent(final TypedRecord<DeploymentRecord> record) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -177,8 +177,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   }
 
   /**
-   * Exception that can be thrown during processing of a command, in case the resource cannot
-   * be transformed successfully. This allows the platform to roll back any changes the engine made.
+   * Exception that can be thrown during processing of a command, in case the resource cannot be
+   * transformed successfully. This allows the platform to roll back any changes the engine made.
    * This exception can be handled by the processor in {@link
    * io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor#tryHandleError(
    * TypedRecord, Throwable)}.

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -103,8 +103,7 @@ public final class DeploymentTransformer {
       rejectionType = RejectionType.INVALID_ARGUMENT;
       rejectionReason =
           String.format(
-              "Expected to deploy new resources, but encountered the following errors:%s",
-              errors);
+              "Expected to deploy new resources, but encountered the following errors:%s", errors);
 
       throw new ResourceTransformationFailedException(rejectionReason);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.security.MessageDigest;
@@ -81,7 +82,7 @@ public final class DeploymentTransformer {
     return wrapArray(digestGenerator.digest(resource.getResource()));
   }
 
-  public boolean transform(final DeploymentRecord deploymentEvent) {
+  public void transform(final DeploymentRecord deploymentEvent) {
     final StringBuilder errors = new StringBuilder();
     boolean success = true;
 
@@ -89,7 +90,8 @@ public final class DeploymentTransformer {
     if (!resourceIterator.hasNext()) {
       rejectionType = RejectionType.INVALID_ARGUMENT;
       rejectionReason = "Expected to deploy at least one resource, but none given";
-      return false;
+
+      throw new ResourceTransformationFailedException(rejectionReason);
     }
 
     while (resourceIterator.hasNext()) {
@@ -101,10 +103,11 @@ public final class DeploymentTransformer {
       rejectionType = RejectionType.INVALID_ARGUMENT;
       rejectionReason =
           String.format(
-              "Expected to deploy new resources, but encountered the following errors:%s", errors);
-    }
+              "Expected to deploy new resources, but encountered the following errors:%s",
+              errors);
 
-    return success;
+      throw new ResourceTransformationFailedException(rejectionReason);
+    }
   }
 
   private boolean transformResource(
@@ -147,6 +150,19 @@ public final class DeploymentTransformer {
         .map(Entry::getValue)
         .findFirst()
         .orElse(UNKNOWN_RESOURCE);
+  }
+
+  /**
+   * Exception that can be thrown during processing of a command, in case the engine could not
+   * subscribe to an event. This exception can be handled by the processor in {@link
+   * io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor#tryHandleError(TypedRecord,
+   * Throwable)}.
+   */
+  public static final class ResourceTransformationFailedException extends RuntimeException {
+
+    public ResourceTransformationFailedException(final String message) {
+      super(message);
+    }
   }
 
   private static class UnknownResourceTransformer implements DeploymentResourceTransformer {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.security.MessageDigest;
@@ -82,7 +81,7 @@ public final class DeploymentTransformer {
     return wrapArray(digestGenerator.digest(resource.getResource()));
   }
 
-  public void transform(final DeploymentRecord deploymentEvent) {
+  public Either<Failure, Void> transform(final DeploymentRecord deploymentEvent) {
     final StringBuilder errors = new StringBuilder();
     boolean success = true;
 
@@ -91,7 +90,7 @@ public final class DeploymentTransformer {
       rejectionType = RejectionType.INVALID_ARGUMENT;
       rejectionReason = "Expected to deploy at least one resource, but none given";
 
-      throw new ResourceTransformationFailedException(rejectionReason);
+      return Either.left(new Failure(rejectionReason));
     }
 
     while (resourceIterator.hasNext()) {
@@ -105,8 +104,10 @@ public final class DeploymentTransformer {
           String.format(
               "Expected to deploy new resources, but encountered the following errors:%s", errors);
 
-      throw new ResourceTransformationFailedException(rejectionReason);
+      return Either.left(new Failure(rejectionReason));
     }
+
+    return Either.right(null);
   }
 
   private boolean transformResource(
@@ -149,20 +150,6 @@ public final class DeploymentTransformer {
         .map(Entry::getValue)
         .findFirst()
         .orElse(UNKNOWN_RESOURCE);
-  }
-
-  /**
-   * Exception that can be thrown during processing of a command, in case the resource cannot
-   * be transformed successfully. This allows the platform to roll back any changes the engine made.
-   * This exception can be handled by the processor in {@link
-   * io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor#tryHandleError(
-   * TypedRecord, Throwable)}.
-   */
-  public static final class ResourceTransformationFailedException extends RuntimeException {
-
-    public ResourceTransformationFailedException(final String message) {
-      super(message);
-    }
   }
 
   private static class UnknownResourceTransformer implements DeploymentResourceTransformer {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -152,10 +152,11 @@ public final class DeploymentTransformer {
   }
 
   /**
-   * Exception that can be thrown during processing of a command, in case the engine could not
-   * subscribe to an event. This exception can be handled by the processor in {@link
-   * io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor#tryHandleError(TypedRecord,
-   * Throwable)}.
+   * Exception that can be thrown during processing of a command, in case the resource cannot
+   * be transformed successfully. This allows the platform to roll back any changes the engine made.
+   * This exception can be handled by the processor in {@link
+   * io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor#tryHandleError(
+   * TypedRecord, Throwable)}.
    */
   public static final class ResourceTransformationFailedException extends RuntimeException {
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -241,17 +241,18 @@ public final class CreateDeploymentTest {
         Bpmn.createExecutableProcess(process2Id).startEvent().task().endEvent().done();
 
     // when
-    ENGINE.deployment()
-            .withXmlResource(process1)
-            .withXmlResource(process2)
-            .expectRejection()
-            .deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource(process1)
+        .withXmlResource(process2)
+        .expectRejection()
+        .deploy();
 
     // then
     assertThat(
-        RecordingExporter.records()
-            .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
-            .collect(Collectors.toList()))
+            RecordingExporter.records()
+                .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
+                .collect(Collectors.toList()))
         .extracting(Record::getIntent, Record::getRecordType)
         .doesNotContain(
             tuple(ProcessIntent.CREATED, RecordType.EVENT),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -20,8 +20,6 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
@@ -224,40 +222,6 @@ public final class CreateDeploymentTest {
         .extracting(DeploymentResource::getResource)
         .contains(
             Bpmn.convertToString(process).getBytes(), Bpmn.convertToString(process2).getBytes());
-  }
-
-  @Test
-  public void shouldDoAtomicDeployments() {
-    // given
-    final String process1Id = "process1";
-    final BpmnModelInstance process1 =
-        Bpmn.createExecutableProcess(process1Id)
-            .startEvent()
-            .businessRuleTask("invalid_business_rule_task_id")
-            .endEvent()
-            .done();
-    final String process2Id = "process2";
-    final BpmnModelInstance process2 =
-        Bpmn.createExecutableProcess(process2Id).startEvent().task().endEvent().done();
-
-    // when
-    ENGINE
-        .deployment()
-        .withXmlResource(process1)
-        .withXmlResource(process2)
-        .expectRejection()
-        .deploy();
-
-    // then
-    assertThat(
-            RecordingExporter.records()
-                .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
-                .collect(Collectors.toList()))
-        .extracting(Record::getIntent, Record::getRecordType)
-        .doesNotContain(
-            tuple(ProcessIntent.CREATED, RecordType.EVENT),
-            tuple(DeploymentIntent.CREATED, RecordType.EVENT),
-            tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -20,6 +20,8 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
@@ -222,6 +224,39 @@ public final class CreateDeploymentTest {
         .extracting(DeploymentResource::getResource)
         .contains(
             Bpmn.convertToString(process).getBytes(), Bpmn.convertToString(process2).getBytes());
+  }
+
+  @Test
+  public void shouldDoAtomicDeployments() {
+    // given
+    final String process1Id = "process1";
+    final BpmnModelInstance process1 =
+        Bpmn.createExecutableProcess(process1Id)
+            .startEvent()
+            .businessRuleTask("invalid_business_rule_task_id")
+            .endEvent()
+            .done();
+    final String process2Id = "process2";
+    final BpmnModelInstance process2 =
+        Bpmn.createExecutableProcess(process2Id).startEvent().task().endEvent().done();
+
+    // when
+    ENGINE.deployment()
+            .withXmlResource(process1)
+            .withXmlResource(process2)
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(
+        RecordingExporter.records()
+            .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
+            .collect(Collectors.toList()))
+        .extracting(Record::getIntent, Record::getRecordType)
+        .doesNotContain(
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -281,9 +281,9 @@ public class DeploymentRejectionTest {
 
     // then
     assertThat(
-        RecordingExporter.records()
-            .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
-            .collect(Collectors.toList()))
+          RecordingExporter.records()
+              .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
+              .collect(Collectors.toList()))
         .extracting(Record::getIntent, Record::getRecordType)
         .doesNotContain(
             tuple(ProcessIntent.CREATED, RecordType.EVENT),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -281,9 +281,9 @@ public class DeploymentRejectionTest {
 
     // then
     assertThat(
-          RecordingExporter.records()
-              .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
-              .collect(Collectors.toList()))
+            RecordingExporter.records()
+                .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
+                .collect(Collectors.toList()))
         .extracting(Record::getIntent, Record::getRecordType)
         .doesNotContain(
             tuple(ProcessIntent.CREATED, RecordType.EVENT),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -268,11 +268,7 @@ public class DeploymentRejectionTest {
     final BpmnModelInstance invalidProcess =
         Bpmn.createExecutableProcess("invalid_process_without_start_event").done();
     final BpmnModelInstance validProcess =
-        Bpmn.createExecutableProcess("valid_process")
-            .startEvent()
-            .task()
-            .endEvent()
-            .done();
+        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
 
     // when
     ENGINE

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -265,22 +265,17 @@ public class DeploymentRejectionTest {
   @Test
   public void shouldDoAtomicDeployments() {
     // given
-    final String process1Id = "process1";
-    final BpmnModelInstance process1 =
-        Bpmn.createExecutableProcess(process1Id)
-            .startEvent()
-            .businessRuleTask("invalid_business_rule_task_id")
-            .endEvent()
-            .done();
-    final String process2Id = "process2";
-    final BpmnModelInstance process2 =
-        Bpmn.createExecutableProcess(process2Id).startEvent().task().endEvent().done();
+    final String invalidProcessId = "invalid_process_without_start_event";
+    final BpmnModelInstance invalidProcess = Bpmn.createExecutableProcess(invalidProcessId).done();
+    final String validProcessId = "valid_process";
+    final BpmnModelInstance validProcess =
+        Bpmn.createExecutableProcess(validProcessId).startEvent().task().endEvent().done();
 
     // when
     ENGINE
         .deployment()
-        .withXmlResource(process1)
-        .withXmlResource(process2)
+        .withXmlResource(invalidProcess)
+        .withXmlResource(validProcess)
         .expectRejection()
         .deploy();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -18,9 +19,13 @@ import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -255,5 +260,39 @@ public class DeploymentRejectionTest {
 
     assertThat(deploymentRejection.getRejectionReason())
         .contains("Must contain at least one executable process");
+  }
+
+  @Test
+  public void shouldDoAtomicDeployments() {
+    // given
+    final String process1Id = "process1";
+    final BpmnModelInstance process1 =
+        Bpmn.createExecutableProcess(process1Id)
+            .startEvent()
+            .businessRuleTask("invalid_business_rule_task_id")
+            .endEvent()
+            .done();
+    final String process2Id = "process2";
+    final BpmnModelInstance process2 =
+        Bpmn.createExecutableProcess(process2Id).startEvent().task().endEvent().done();
+
+    // when
+    ENGINE
+        .deployment()
+        .withXmlResource(process1)
+        .withXmlResource(process2)
+        .expectRejection()
+        .deploy();
+
+    // then
+    assertThat(
+        RecordingExporter.records()
+            .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
+            .collect(Collectors.toList()))
+        .extracting(Record::getIntent, Record::getRecordType)
+        .doesNotContain(
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -265,11 +265,14 @@ public class DeploymentRejectionTest {
   @Test
   public void shouldDoAtomicDeployments() {
     // given
-    final String invalidProcessId = "invalid_process_without_start_event";
-    final BpmnModelInstance invalidProcess = Bpmn.createExecutableProcess(invalidProcessId).done();
-    final String validProcessId = "valid_process";
+    final BpmnModelInstance invalidProcess =
+        Bpmn.createExecutableProcess("invalid_process_without_start_event").done();
     final BpmnModelInstance validProcess =
-        Bpmn.createExecutableProcess(validProcessId).startEvent().task().endEvent().done();
+        Bpmn.createExecutableProcess("valid_process")
+            .startEvent()
+            .task()
+            .endEvent()
+            .done();
 
     // when
     ENGINE

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -282,7 +282,7 @@ public class DeploymentRejectionTest {
     // then
     assertThat(
             RecordingExporter.records()
-                .limit(r -> r.getRejectionType() == RejectionType.INVALID_ARGUMENT)
+                .limit(r -> r.getRecordType() == RecordType.COMMAND_REJECTION)
                 .collect(Collectors.toList()))
         .extracting(Record::getIntent, Record::getRecordType)
         .doesNotContain(


### PR DESCRIPTION
## Description

The current deployment process conflicts with our documentation in a way that we are not doing atomic deployments. This fix is utilizing our generic error handling mechanism to rollback any events or commands that may have been written.

## Related issues

closes #5723 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
