### PR TITLE
Process Signal BROADCASTED events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -94,7 +94,9 @@ public final class ProcessProcessor
 
   private void activateStartEvent(
       final ExecutableFlowElementContainer element, final BpmnElementContext activated) {
-    if (element.hasMessageStartEvent() || element.hasTimerStartEvent()) {
+    if (element.hasMessageStartEvent()
+        || element.hasTimerStartEvent()
+        || element.hasSignalStartEvent()) {
       eventSubscriptionBehavior
           .getEventTriggerForProcessDefinition(activated.getProcessDefinitionKey())
           .filter(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowElementContainer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowElementContainer.java
@@ -53,4 +53,8 @@ public class ExecutableFlowElementContainer extends ExecutableActivity {
   public boolean hasTimerStartEvent() {
     return startEvents.stream().anyMatch(ExecutableCatchEventElement::isTimer);
   }
+
+  public boolean hasSignalStartEvent() {
+    return startEvents.stream().anyMatch(ExecutableCatchEventElement::isSignal);
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.signal;
+
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
+import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.SignalSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class SignalBroadcastProcessor implements TypedRecordProcessor<SignalRecord> {
+
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+  private final EventHandle eventHandle;
+  private final TypedResponseWriter responseWriter;
+  private final SignalSubscriptionState signalSubscriptionState;
+
+  public SignalBroadcastProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final EventScopeInstanceState eventScopeInstanceState,
+      final ProcessState processState,
+      final BpmnStateBehavior stateBehavior,
+      final EventTriggerBehavior eventTriggerBehavior,
+      final SignalSubscriptionState signalSubscriptionState) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    this.signalSubscriptionState = signalSubscriptionState;
+    this.keyGenerator = keyGenerator;
+    eventHandle =
+        new EventHandle(
+            keyGenerator,
+            eventScopeInstanceState,
+            writers,
+            processState,
+            eventTriggerBehavior,
+            stateBehavior);
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<SignalRecord> command) {
+    final var signalRecord = command.getValue();
+    final var key = command.getKey();
+    final var signalName = signalRecord.getSignalNameBuffer();
+    final var eventKey = key > -1 ? key : keyGenerator.nextKey();
+
+    stateWriter.appendFollowUpEvent(eventKey, SignalIntent.BROADCASTED, signalRecord);
+    responseWriter.writeEventOnCommand(eventKey, SignalIntent.BROADCASTED, signalRecord, command);
+
+    signalSubscriptionState.visitBySignalName(
+        signalName,
+        subscription -> {
+          final var subscriptionRecord = subscription.getRecord();
+          final var processDefinitionKey = subscriptionRecord.getProcessDefinitionKey();
+
+          if (subscriptionRecord.getCatchEventInstanceKey() == -1) {
+            eventHandle.activateProcessInstanceForStartEvent(
+                processDefinitionKey,
+                keyGenerator.nextKey(),
+                subscriptionRecord.getCatchEventIdBuffer(),
+                signalRecord.getVariablesBuffer());
+          }
+        });
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -151,6 +151,7 @@ public final class CreateProcessInstanceTest {
     processBuilder.startEvent("none-start").endEvent();
     processBuilder.startEvent("timer-start").timerWithCycle("R/PT1H").endEvent();
     processBuilder.startEvent("message-start").message("start").endEvent();
+    processBuilder.startEvent("signal-start").signal("signal").endEvent();
 
     ENGINE.deployment().withXmlResource(processBuilder.done()).deploy();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.engine.processing.signal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.SignalClient;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BroadcastSignalTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+  private static final String SIGNAL_NAME = "a";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private SignalClient signalClient;
+
+  @Before
+  public void init() {
+    signalClient = ENGINE_RULE.signal().withSignalName(SIGNAL_NAME);
+  }
+
+  @Test
+  public void shouldBroadcastSignal() {
+    // when
+    final Record<SignalRecordValue> record = signalClient.broadcast();
+
+    // then
+    assertThat(record.getValue().getVariables()).isEmpty();
+
+    Assertions.assertThat(record)
+        .hasIntent(SignalIntent.BROADCASTED)
+        .hasRecordType(RecordType.EVENT)
+        .hasValueType(ValueType.SIGNAL);
+
+    Assertions.assertThat(record.getValue()).hasSignalName(SIGNAL_NAME);
+  }
+
+  @Test
+  public void shouldBroadcastSignalWithVariables() {
+    // when
+    final Record<SignalRecordValue> record =
+        signalClient.withVariables("{'foo':'bar'}").broadcast();
+
+    // then
+    assertThat(record.getValue().getVariables()).containsExactly(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldBroadcastSignalWithDifferentName() {
+    // when
+    final Record<SignalRecordValue> firstRecord = signalClient.withSignalName("a").broadcast();
+
+    final Record<SignalRecordValue> secondRecord = signalClient.withSignalName("b").broadcast();
+
+    // then
+    assertThat(firstRecord.getKey()).isLessThan(secondRecord.getKey());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalStartEventTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.engine.processing.signal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SignalStartEventTest {
+
+  private static final String SIGNAL_NAME_1 = "a";
+  private static final String SIGNAL_NAME_2 = "b";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldBroadcastSignalToStartEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("wf")
+            .startEvent("start")
+            .signal(SIGNAL_NAME_1)
+            .endEvent()
+            .done();
+
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.signal().withSignalName(SIGNAL_NAME_1).broadcast();
+
+    // then
+    final var processInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .filterRootScope()
+            .getFirst();
+
+    final var startEvent =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.START_EVENT)
+            .getFirst();
+
+    Assertions.assertThat(startEvent.getValue())
+        .hasProcessDefinitionKey(processInstance.getValue().getProcessDefinitionKey())
+        .hasBpmnProcessId(processInstance.getValue().getBpmnProcessId())
+        .hasVersion(processInstance.getValue().getVersion())
+        .hasProcessInstanceKey(processInstance.getKey())
+        .hasBpmnEventType(BpmnEventType.SIGNAL)
+        .hasElementId("start")
+        .hasFlowScopeKey(processInstance.getKey());
+  }
+
+  @Test
+  public void shouldCreateNewInstanceWithSignalVariables() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("wf")
+            .startEvent("start")
+            .signal(SIGNAL_NAME_1)
+            .endEvent()
+            .done();
+
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.signal().withSignalName(SIGNAL_NAME_1).withVariables(Map.of("x", 1, "y", 2)).broadcast();
+
+    // then
+    assertThat(RecordingExporter.variableRecords().limit(2))
+        .extracting(Record::getValue)
+        .extracting(VariableRecordValue::getName, VariableRecordValue::getValue)
+        .hasSize(2)
+        .contains(tuple("x", "1"), tuple("y", "2"));
+  }
+
+  @Test
+  public void shouldApplyOutputMappings() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("wf")
+            .startEvent("start")
+            .zeebeOutputExpression("x", "y")
+            .signal(SIGNAL_NAME_1)
+            .endEvent()
+            .done();
+
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.signal().withSignalName(SIGNAL_NAME_1).withVariables(Map.of("x", 1, "y", 2)).broadcast();
+
+    // then
+    final var processInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst();
+
+    assertThat(RecordingExporter.variableRecords().withScopeKey(processInstance.getKey()).limit(1))
+        .extracting(Record::getValue)
+        .extracting(VariableRecordValue::getName, VariableRecordValue::getValue)
+        .contains(tuple("y", "1"));
+  }
+
+  @Test
+  public void shouldCreateInstanceOfLatestVersion() {
+    // given
+    final var process1 =
+        Bpmn.createExecutableProcess("wf").startEvent("v1").signal(SIGNAL_NAME_1).endEvent().done();
+
+    final var process2 =
+        Bpmn.createExecutableProcess("wf").startEvent("v2").signal(SIGNAL_NAME_1).endEvent().done();
+    engine.deployment().withXmlResource(process1).deploy();
+
+    engine.deployment().withXmlResource(process2).deploy();
+
+    // when
+    engine.signal().withSignalName(SIGNAL_NAME_1).broadcast();
+
+    // then
+    final var startEvent =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.START_EVENT)
+            .getFirst();
+
+    Assertions.assertThat(startEvent.getValue()).hasElementId("v2");
+  }
+
+  @Test
+  public void shouldCreateNewInstanceWithMultipleStartEvents() {
+    // given
+    final var process = Bpmn.createExecutableProcess("wf");
+    process.startEvent().signal(SIGNAL_NAME_1).endEvent("end");
+    process.startEvent().signal(SIGNAL_NAME_2).connectTo("end");
+
+    engine.deployment().withXmlResource(process.done()).deploy();
+
+    // when
+    engine.signal().withSignalName(SIGNAL_NAME_1).withVariables(Map.of("x", 1)).broadcast();
+
+    engine.signal().withSignalName(SIGNAL_NAME_2).withVariables(Map.of("x", 2)).broadcast();
+
+    // then
+    assertThat(
+            RecordingExporter.variableRecords().withName("x").filterProcessInstanceScope().limit(2))
+        .extracting(r -> r.getValue().getValue())
+        .containsExactly("1", "2");
+  }
+
+  @Test
+  public void shouldTriggerOnlySignalStartEvent() {
+    // given
+    final var process = Bpmn.createExecutableProcess("process");
+    process.startEvent("none-start").endEvent();
+    process.startEvent("message-start").message("test").endEvent();
+    process.startEvent("signal-start").signal(SIGNAL_NAME_1).endEvent();
+    process.startEvent("timer-start").timerWithCycle("R/PT1H").endEvent();
+
+    engine.deployment().withXmlResource(process.done()).deploy();
+
+    // when
+    engine.signal().withSignalName(SIGNAL_NAME_1).broadcast();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.START_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsOnly("signal-start");
+  }
+
+  @Test
+  public void shouldCreateMultipleInstances() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("wf")
+            .startEvent("start")
+            .signal(SIGNAL_NAME_1)
+            .endEvent()
+            .done();
+
+    engine.deployment().withXmlResource(process).deploy();
+
+    engine.signal().withSignalName(SIGNAL_NAME_1).withVariables(Map.of("x", 1)).broadcast();
+
+    // when
+    engine.signal().withSignalName(SIGNAL_NAME_1).withVariables(Map.of("x", 2)).broadcast();
+
+    // then
+    assertThat(
+            RecordingExporter.variableRecords().withName("x").filterProcessInstanceScope().limit(2))
+        .extracting(r -> r.getValue().getValue())
+        .containsExactly("1", "2");
+  }
+
+  @Test
+  public void shouldCreateMultipleInstancesForDifferentResources() {
+    // given
+    final var process1 =
+        Bpmn.createExecutableProcess("wf_1")
+            .startEvent("start")
+            .signal(SIGNAL_NAME_1)
+            .endEvent()
+            .done();
+
+    final var process2 =
+        Bpmn.createExecutableProcess("wf_2")
+            .startEvent("start")
+            .signal(SIGNAL_NAME_1)
+            .endEvent()
+            .done();
+
+    engine.deployment().withXmlResource(process1).withXmlResource(process2).deploy();
+
+    engine.signal().withSignalName(SIGNAL_NAME_1).withVariables(Map.of("x", 1)).broadcast();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementType(BpmnElementType.START_EVENT)
+                .limit(2))
+        .extracting(r -> r.getValue().getBpmnProcessId())
+        .containsExactly("wf_1", "wf_2");
+  }
+
+  @Test
+  public void shouldNotCreateInstanceDirectly() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("SignalStartEventOnly")
+                .startEvent("signal-start")
+                .signal("start")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine.processInstance().ofBpmnProcessId("SignalStartEventOnly").expectRejection().create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .onlyCommandRejections()
+                .withBpmnProcessId("SignalStartEventOnly")
+                .getFirst())
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to create instance of process with none start event, but there is no such event");
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.util.client.JobClient;
 import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
 import io.camunda.zeebe.engine.util.client.PublishMessageClient;
 import io.camunda.zeebe.engine.util.client.ResourceDeletionClient;
+import io.camunda.zeebe.engine.util.client.SignalClient;
 import io.camunda.zeebe.engine.util.client.VariableClient;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
@@ -321,6 +322,10 @@ public final class EngineRule extends ExternalResource {
 
   public ResourceDeletionClient resourceDeletion() {
     return new ResourceDeletionClient(environmentRule);
+  }
+
+  public SignalClient signal() {
+    return new SignalClient(environmentRule);
   }
 
   public Record<JobRecordValue> createJob(final String type, final String processId) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.engine.util.StreamProcessorRule;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import java.util.function.Function;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class SignalClient {
+
+  private static final Function<Long, Record<SignalRecordValue>> SUCCESS_EXPECTATION =
+      (position) ->
+          RecordingExporter.signalRecords(SignalIntent.BROADCASTED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private final StreamProcessorRule environmentRule;
+  private final SignalRecord signalRecord = new SignalRecord();
+  private final Function<Long, Record<SignalRecordValue>> expectation = SUCCESS_EXPECTATION;
+
+  public SignalClient(final StreamProcessorRule environmentRule) {
+    this.environmentRule = environmentRule;
+  }
+
+  public SignalClient withSignalName(final String signalName) {
+    signalRecord.setSignalName(signalName);
+    return this;
+  }
+
+  public SignalClient withVariables(final String variables) {
+    signalRecord.setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variables)));
+    return this;
+  }
+
+  public SignalClient withVariables(final DirectBuffer variables) {
+    signalRecord.setVariables(variables);
+    return this;
+  }
+
+  public SignalClient withVariable(final String key, final Object value) {
+    signalRecord.setVariables(MsgPackUtil.asMsgPack(key, value));
+    return this;
+  }
+
+  public SignalClient withVariables(final Map<String, Object> variables) {
+    signalRecord.setVariables(MsgPackUtil.asMsgPack(variables));
+    return this;
+  }
+
+  public Record<SignalRecordValue> broadcast() {
+    final long position = environmentRule.writeCommand(SignalIntent.BROADCAST, signalRecord);
+    return expectation.apply(position);
+  }
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
@@ -76,6 +77,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.CHECKPOINT, CheckpointRecord.class);
     registry.put(ValueType.ESCALATION, EscalationRecord.class);
     registry.put(ValueType.SIGNAL_SUBSCRIPTION, SignalSubscriptionRecord.class);
+    registry.put(ValueType.SIGNAL, SignalRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 


### PR DESCRIPTION
## Description

This PR adds introduce new `Signal:Broadcast` command processor.

## Related issues
closes #11777

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
