### PR TITLE
fix(ci): do not trim xml output before uploading artifacts

### DIFF
--- a/.github/actions/collect-test-artifacts/action.yml
+++ b/.github/actions/collect-test-artifacts/action.yml
@@ -11,23 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-
-    # MacOS sed is not compatible with the remove script, we need gnu sed instead
-  - name: Install GNU sed
-    if: runner.os == 'macOS'
-    shell: bash
-    run: |
-      brew install gnu-sed
-      echo "SED_BIN=gsed" >> $GITHUB_ENV
-
-    # Mitigate to large test output files by deleting the system-out element using sed
-    # Note: we cannot use XML tools like xmlstarlet as they all suffer the same libxml2 limitation
-    # Related to https://github.com/camunda/zeebe/issues/9959
-  - name: Remove system-out from test xml files
-    shell: bash
-    run: |
-      find . -iname TEST-*.xml -print0 | xargs -0 -r ${SED_BIN:-sed} '/<system-out>/,/<\/system-out>/d' -i
-
   - name: Archive Test Results
     uses: actions/upload-artifact@v3
     with:

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -27,6 +27,10 @@ jobs:
             gh api $url > "$name.zip"
             unzip -d "$name" "$name.zip"
           done
+          # Mitigate to large test output files by deleting the system-out element using sed
+          # Note: we cannot use XML tools like xmlstarlet as they all suffer the same libxml2 limitation
+          # Related to https://github.com/camunda/zeebe/issues/9959
+          find . -iname TEST-*.xml -print0 | xargs -0 -r sed '/<system-out>/,/<\/system-out>/d' -i
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
## Description

When tests are run concurrently, the logs are interleaved in output.txt. It is not useful to debug when a test fails. It was not possible to debug #11633 because of this. 

The output from each test were removed from xml because large xml had caused issues when parsing the results. In this commit, we moved the trimming of xml files just before parsing the results. So if a test fails, full xml is still available in the uploaded artifact.

