### PR TITLE
fix(journal): check for null while closing

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -78,10 +78,13 @@ final class SegmentsManager implements AutoCloseable {
               segment.close();
             });
 
-    try {
-      nextSegment.join();
-    } catch (final Exception e) {
-      LOG.warn("Next segment preparation failed during close, ignoring and proceeding to close", e);
+    if (nextSegment != null) {
+      try {
+        nextSegment.join();
+      } catch (final Exception e) {
+        LOG.warn(
+            "Next segment preparation failed during close, ignoring and proceeding to close", e);
+      }
     }
 
     nextSegment = null;


### PR DESCRIPTION
## Description

Observed NPE in journal while closing.
```
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.CompletableFuture.join()" because "this.nextSegment" is null
	at io.camunda.zeebe.journal.file.SegmentsManager.close(SegmentsManager.java:82) ~[classes/:?]
	at io.camunda.zeebe.journal.file.SegmentedJournal.close(SegmentedJournal.java:171) ~[classes/:?]
	at org.agrona.CloseHelper.close(CloseHelper.java:111) ~[agrona-1.17.1.jar:1.17.1]
	at io.atomix.raft.storage.log.RaftLog.close(RaftLog.java:193) ~[classes/:?]
	at io.atomix.raft.impl.RaftContext.close(RaftContext.java:776) ~[classes/:?]
```
