### PR TITLE
[Backport stable/8.1] feat: start db iteration at a specified key

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -70,7 +70,7 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
    * key. The visitor can indicate via the return value, whether the iteration should continue or
    * not. This means if the visitor returns false the iteration will stop.
    *
-   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exist it
+   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exists,
    * the first key-value-pair will contain the equal key as {@code startAtKey}. If the key doesn't
    * exist it will start after.
    *

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -70,6 +70,22 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
    * key. The visitor can indicate via the return value, whether the iteration should continue or
    * not. This means if the visitor returns false the iteration will stop.
    *
+   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exist it
+   * the first key-value-pair will contain the equal key as {@code startAtKey}. If the key doesn't
+   * exist it will start after.
+   *
+   * <p>Similar to {@link #whileTrue(KeyValuePairVisitor)}}.
+   *
+   * @param startAtKey indicates on which key the iteration should start
+   * @param visitor the visitor which visits the key-value pairs
+   */
+  void whileTrue(KeyType startAtKey, KeyValuePairVisitor<KeyType, ValueType> visitor);
+
+  /**
+   * Visits the key-value pairs, which are stored in the column family. The ordering depends on the
+   * key. The visitor can indicate via the return value, whether the iteration should continue or
+   * not. This means if the visitor returns false the iteration will stop.
+   *
    * <p>Similar to {@link #forEach(BiConsumer)}.
    *
    * @param visitor the visitor which visits the key-value pairs

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.db.impl.rocksdb.transaction;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.impl.ZeebeDbConstants;
+import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.function.ObjIntConsumer;
@@ -112,5 +113,14 @@ public class ColumnFamilyContext {
     } finally {
       prefixKeyBuffers.add(prefixKeyBuffer);
     }
+  }
+
+  ByteBuffer keyWithColumnFamily(DbKey key) {
+    final var bytes = ByteBuffer.allocate(Long.BYTES + key.getLength());
+    final var buffer = new UnsafeBuffer(bytes);
+
+    buffer.putLong(0, columnFamilyPrefix, ZeebeDbConstants.ZB_DB_BYTE_ORDER);
+    key.write(buffer, Long.BYTES);
+    return bytes;
   }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -168,6 +168,10 @@ class TransactionalColumnFamily<
   }
 
   @Override
+  public void whileTrue(
+      final KeyType startAtKey, final KeyValuePairVisitor<KeyType, ValueType> visitor) {}
+
+  @Override
   public void whileTrue(final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     ensureInOpenTransaction(transaction -> forEachInPrefix(new DbNullKey(), visitor));
   }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -317,6 +317,64 @@ public final class ColumnFamilyTest {
   }
 
   @Test
+  public void shouldUseWhileTrueWithStartAt() {
+    // given
+    final var startAt = new DbLong();
+    startAt.wrapLong(1213);
+
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    final List<Long> values = new ArrayList<>();
+    columnFamily.whileTrue(
+        startAt,
+        (key, value) -> {
+          keys.add(key.getValue());
+          values.add(value.getValue());
+
+          return key.getValue() != 4567;
+        });
+
+    // then
+    assertThat(keys).containsExactly(1213L, 4567L);
+    assertThat(values).containsExactly(255L, 123L);
+  }
+
+  @Test
+  public void shouldUseWhileTrueWithStartAtMissingKey() {
+    // given
+    final var startAt = new DbLong();
+    startAt.wrapLong(1212);
+
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    final List<Long> values = new ArrayList<>();
+    columnFamily.whileTrue(
+        startAt,
+        (key, value) -> {
+          keys.add(key.getValue());
+          values.add(value.getValue());
+
+          return key.getValue() != 4567;
+        });
+
+    // then
+    assertThat(keys).containsExactly(1213L, 4567L);
+    assertThat(values).containsExactly(255L, 123L);
+  }
+
+  @Test
   public void shouldCheckIfEmpty() {
     assertThat(columnFamily.isEmpty()).isTrue();
 

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
@@ -107,10 +107,10 @@ public final class DbStringColumnFamilyTest {
   public void shouldUseWhileTrue() {
     // given
     upsertKeyValuePair("foo", "baring");
-    upsertKeyValuePair("this is the one", "as you know");
     upsertKeyValuePair("hello", "world");
-    upsertKeyValuePair("another", "string");
     upsertKeyValuePair("might", "be good");
+    upsertKeyValuePair("another", "string");
+    upsertKeyValuePair("this is the one", "as you know");
 
     // when
     final List<String> keys = new ArrayList<>();
@@ -120,12 +120,40 @@ public final class DbStringColumnFamilyTest {
           keys.add(key.toString());
           values.add(value.toString());
 
-          return !value.toString().equalsIgnoreCase("world");
+          return !value.toString().equalsIgnoreCase("string");
         });
 
     // then
-    assertThat(values).containsExactly("baring", "world");
-    assertThat(keys).containsExactly("foo", "hello");
+    assertThat(values).containsExactly("baring", "world", "be good", "string");
+    assertThat(keys).containsExactly("foo", "hello", "might", "another");
+  }
+
+  @Test
+  public void shouldUseWhileTrueWithStartAtKey() {
+    // given
+    upsertKeyValuePair("foo", "baring");
+    upsertKeyValuePair("hello", "world");
+    upsertKeyValuePair("might", "be good");
+    upsertKeyValuePair("another", "string");
+    upsertKeyValuePair("this is the one", "as you know");
+    final var startAtKey = new DbString();
+    startAtKey.wrapString("hello");
+
+    // when
+    final List<String> keys = new ArrayList<>();
+    final List<String> values = new ArrayList<>();
+    columnFamily.whileTrue(
+        startAtKey,
+        (key, value) -> {
+          keys.add(key.toString());
+          values.add(value.toString());
+
+          return !value.toString().equalsIgnoreCase("string");
+        });
+
+    // then
+    assertThat(values).containsExactly("world", "be good", "string");
+    assertThat(keys).containsExactly("hello", "might", "another");
   }
 
   @Test


### PR DESCRIPTION
Adds an additional method to `ColumnFamily`, `whileTrue` with a `startAt` key.

relates to https://github.com/camunda/zeebe/issues/11762