### PR TITLE
[Backport stable/8.1] fix(journal): check for null while closing

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -81,10 +81,13 @@ final class SegmentsManager implements AutoCloseable {
               segment.close();
             });
 
-    try {
-      nextSegment.join();
-    } catch (final Exception e) {
-      LOG.warn("Next segment preparation failed during close, ignoring and proceeding to close", e);
+    if (nextSegment != null) {
+      try {
+        nextSegment.join();
+      } catch (final Exception e) {
+        LOG.warn(
+            "Next segment preparation failed during close, ignoring and proceeding to close", e);
+      }
     }
 
     nextSegment = null;


### PR DESCRIPTION
# Description
Backport of #11781 to `stable/8.1`.

relates to 