### PR TITLE
chore(docker): run with zeebe user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,10 +105,12 @@ VOLUME ${ZB_HOME}/data
 RUN groupadd -g 1000 zeebe && \
     adduser -u 1000 zeebe --system --ingroup zeebe && \
     chmod g=u /etc/passwd && \
-    chown 1000:0 ${ZB_HOME} && \
-    chmod 0775 ${ZB_HOME} && \
+    # These directories are potentially mounted by users, eagerly creating them and setting ownership
+    # to the zeebe user makes sure no permission issues occur due to default volume ownership.
     mkdir ${ZB_HOME}/data && \
-    chmod 0775 ${ZB_HOME}/data
+    mkdir ${ZB_HOME}/logs && \
+    chown -R 1000:0 ${ZB_HOME} && \
+    chmod -R 0775 ${ZB_HOME}
 
 COPY --from=init --chown=1000:0 /zeebe/tini ${ZB_HOME}/bin/
 COPY --from=init --chown=1000:0 /zeebe/startup.sh /usr/local/bin/startup.sh

--- a/docker/utils/startup.sh
+++ b/docker/utils/startup.sh
@@ -2,6 +2,14 @@
 
 HOST=$(hostname -i)
 
+if [ "$EUID" = "0" ]; then
+  # This is here for migration purpose to run the zeebe process with the zeebe user going forward,
+  # while in older releases it was run with root.
+  chown -R 1000:0 /usr/local/zeebe/
+  chmod -R 0775 /usr/local/zeebe/
+  su -s /bin/bash zeebe -
+fi
+
 if [ "$ZEEBE_STANDALONE_GATEWAY" = "true" ]; then
     export ZEEBE_GATEWAY_NETWORK_HOST=${ZEEBE_GATEWAY_NETWORK_HOST:-${HOST}}
     export ZEEBE_GATEWAY_CLUSTER_HOST=${ZEEBE_GATEWAY_CLUSTER_HOST:-${ZEEBE_GATEWAY_NETWORK_HOST}}


### PR DESCRIPTION
## Description

Runs the zeebe process with the zeebe user instead of root.

I couldn't make use of  `USER zeebe` right away as this would be breaking given a previous zeebe instance was running as root and thus file ownership being with root. I thus kept the initial user root but reapply file ownership to zeebe from the startup script and then switch to the zeebe user.

As a follow-up we could introduce the `USER zeebe` statement to the dockerfile and remove the added if block from the startup script. E.g. with zeebe 8.3.0.

The changes to the Dockerfile could be backported to 8.1/8.0 and would allow users to configure the `zeebe` user manually in a new setup and not have trouble with mounting the log directory due to [this](https://github.com/moby/moby/issues/2259). I would need to verify this on the stable branches though.

Note:

- thanks to @oleschoenburg for bringing this up, changes to the startup.sh are not applied to the helm chart, as there a [custom script is used](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform/charts/zeebe/templates/configmap.yaml)
- thanks to @Zelldon, t[he original startup.sh ](https://github.com/camunda-cloud/zeebe-controller-k8s/blob/main/templates/zeebe_configmap.yaml)is also not used by the SaaS controller

## Related issues

closes #11784