### PR TITLE
Add new API to schedule async Task on ScheduleService

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
@@ -9,15 +9,15 @@ package io.camunda.zeebe.stream.api.scheduling;
 
 import java.time.Duration;
 
-public interface ProcessingScheduleService extends SimpleProcessingScheduleService {
+public interface SimpleProcessingScheduleService {
+
+  void runDelayed(Duration delay, Runnable task);
+
+  void runDelayed(Duration delay, Task task);
 
   /**
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
    * the task is executed, it is rescheduled with the same delay again.
-   *
-   * <p>The execution of the scheduled task is running asynchron/concurrent to other scheduled
-   * tasks. Other methods will guarantee ordering of scheduled tasks and running always in same
-   * thread, these guarantees don't apply to this method.
    *
    * <p>Note that time-traveling in tests only affects the delay of the currently scheduled next
    * task and not any of the iterations after. This is because the next task is scheduled with the
@@ -27,5 +27,17 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * @param delay The delay to wait initially and between each run
    * @param task The task to execute at the fixed rate
    */
-  void runAtFixedRateAsync(final Duration delay, final Task task);
+  default void runAtFixedRate(final Duration delay, final Runnable task) {
+    runDelayed(
+        delay,
+        () -> {
+          try {
+            task.run();
+          } finally {
+            runAtFixedRate(delay, task);
+          }
+        });
+  }
+
+  void runAtFixedRate(final Duration delay, final Task task);
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.Task;
+import java.time.Duration;
+
+public class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
+
+  private final SimpleProcessingScheduleService processorActorService;
+  private final SimpleProcessingScheduleService differentActorService;
+
+  public ExtendedProcessingScheduleServiceImpl(
+      final SimpleProcessingScheduleService processorActorService,
+      final SimpleProcessingScheduleService differentActorService) {
+    this.processorActorService = processorActorService;
+    this.differentActorService = differentActorService;
+  }
+
+  @Override
+  public void runAtFixedRateAsync(final Duration delay, final Task task) {
+    differentActorService.runAtFixedRate(delay, task);
+  }
+
+  @Override
+  public void runDelayed(final Duration delay, final Runnable task) {
+    processorActorService.runDelayed(delay, task);
+  }
+
+  @Override
+  public void runDelayed(final Duration delay, final Task task) {
+    processorActorService.runDelayed(delay, task);
+  }
+
+  @Override
+  public void runAtFixedRate(final Duration delay, final Task task) {
+    processorActorService.runAtFixedRate(delay, task);
+  }
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl;
 
-import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
@@ -16,24 +16,24 @@ import java.time.Duration;
 public class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
 
   private final SimpleProcessingScheduleService processorActorService;
-  private final SimpleProcessingScheduleService differentActorService;
-  private final ActorControl differentActor;
+  private final SimpleProcessingScheduleService asyncActorService;
+  private final ConcurrencyControl concurrencyControl;
 
   public ExtendedProcessingScheduleServiceImpl(
       final SimpleProcessingScheduleService processorActorService,
-      final SimpleProcessingScheduleService differentActorService,
-      final ActorControl differentActor) {
+      final SimpleProcessingScheduleService asyncActorService,
+      final ConcurrencyControl concurrencyControl) {
     this.processorActorService = processorActorService;
-    this.differentActorService = differentActorService;
-    this.differentActor = differentActor;
+    this.asyncActorService = asyncActorService;
+    this.concurrencyControl = concurrencyControl;
   }
 
   @Override
   public void runAtFixedRateAsync(final Duration delay, final Task task) {
-    differentActor.call(
+    concurrencyControl.run(
         () -> {
           // we must run in different actor in order to schedule task
-          differentActorService.runAtFixedRate(delay, task);
+          asyncActorService.runAtFixedRate(delay, task);
         });
   }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
-import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import java.time.Duration;
@@ -24,7 +24,8 @@ import org.slf4j.Logger;
  * Here the implementation is just a suggestion to amke the engine abstraction work. Can be whatever
  * PDT team thinks is best to work with
  */
-public class ProcessingScheduleServiceImpl implements ProcessingScheduleService, AutoCloseable {
+public class ProcessingScheduleServiceImpl
+    implements SimpleProcessingScheduleService, AutoCloseable {
 
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
   private final Supplier<StreamProcessor.Phase> streamProcessorPhaseSupplier;

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -170,9 +170,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               streamProcessorContext::getStreamProcessorPhase, // this is volatile
               () -> false, // we will just stop the actor in this case, no need to provide this
               logStream::newLogStreamWriter);
+      differentActor = new DifferentProcessingScheduleServiceActor(differentScheduleService);
       final var extendedProcessingScheduleService =
           new ExtendedProcessingScheduleServiceImpl(
-              processorActorService, differentScheduleService);
+              processorActorService, differentScheduleService, differentActor.getActorControl());
       streamProcessorContext.scheduleService(extendedProcessingScheduleService);
 
       initRecordProcessors();
@@ -263,7 +264,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private void tearDown() {
     processorActorService.close();
-    differentActor.close();
+    differentActor.closeAsync();
     differentScheduleService.close();
     streamProcessorContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
@@ -273,6 +274,24 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void healthCheckTick() {
     lastTickTime = ActorClock.currentTimeMillis();
     actor.runDelayed(HEALTH_CHECK_TICK_DURATION, this::healthCheckTick);
+  }
+
+  void chainSteps(final int index, final Step[] steps, final Runnable last) {
+    if (index == steps.length) {
+      last.run();
+      return;
+    }
+
+    final Step step = steps[index];
+    step.run()
+        .onComplete(
+            (v, t) -> {
+              if (t == null) {
+                chainSteps(index + 1, steps, last);
+              } else {
+                onFailure(t);
+              }
+            });
   }
 
   private void onRetrievingWriter(
@@ -285,35 +304,13 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
       streamProcessorContext.streamProcessorPhase(Phase.PROCESSING);
 
-      final var scheduleServiceOpenFuture = processorActorService.open(actor);
-      scheduleServiceOpenFuture.onComplete(
-          (v, failure) -> {
-            if (failure == null) {
-
-              differentActor = new DifferentProcessingScheduleServiceActor();
-              final var submitActorFuture = actorSchedulingService.submitActor(differentActor);
-
-              submitActorFuture.onComplete(
-                  (v2, failure2) -> {
-                    if (failure2 == null) {
-                      final var differentScheduleServiceOpenFuture =
-                          differentScheduleService.open(differentActor.getActorControl());
-                      differentScheduleServiceOpenFuture.onComplete(
-                          (v3, failure3) -> {
-                            if (failure3 == null) {
-                              startProcessing(lastProcessingPositions);
-                            } else {
-                              onFailure(failure3);
-                            }
-                          });
-                    } else {
-                      onFailure(failure2);
-                    }
-                  });
-            } else {
-              onFailure(failure);
-            }
-          });
+      chainSteps(
+          0,
+          new Step[] {
+            () -> processorActorService.open(actor),
+            () -> actorSchedulingService.submitActor(differentActor)
+          },
+          () -> startProcessing(lastProcessingPositions));
     } else {
       onFailure(errorOnReceivingWriter);
     }
@@ -560,17 +557,41 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     actor.run(processingStateMachine::readNextRecord);
   }
 
+  private static final class DifferentProcessingScheduleServiceActor extends Actor {
+
+    private final ProcessingScheduleServiceImpl scheduleService;
+
+    public DifferentProcessingScheduleServiceActor(
+        final ProcessingScheduleServiceImpl scheduleService) {
+      this.scheduleService = scheduleService;
+    }
+
+    @Override
+    protected void onActorStarting() {
+      final ActorFuture<Void> actorFuture = scheduleService.open(actor);
+      actor.runOnCompletionBlockingCurrentPhase(
+          actorFuture,
+          (v, t) -> {
+            if (t != null) {
+              actor.fail(t);
+            }
+          });
+    }
+
+    public ActorControl getActorControl() {
+      return actor;
+    }
+  }
+
+  public interface Step {
+    ActorFuture<Void> run();
+  }
+
   public enum Phase {
     INITIAL,
     REPLAY,
     PROCESSING,
     FAILED,
     PAUSED,
-  }
-
-  private final class DifferentProcessingScheduleServiceActor extends Actor {
-    public ActorControl getActorControl() {
-      return actor;
-    }
   }
 }

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
@@ -294,7 +295,7 @@ class ProcessingScheduleServiceTest {
    * not thread safe, so this need to happen on the same thread, meaning on the same actor.
    */
   private static final class TestScheduleServiceActorDecorator extends Actor
-      implements ProcessingScheduleService {
+      implements SimpleProcessingScheduleService {
     private final ProcessingScheduleServiceImpl processingScheduleService;
 
     public TestScheduleServiceActorDecorator(

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -32,10 +33,12 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.api.EmptyProcessingResult;
 import io.camunda.zeebe.stream.api.PostCommitTask;
 import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -43,7 +46,10 @@ import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.stream.util.Records;
 import io.camunda.zeebe.util.exception.RecoverableException;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.AssertionsForClassTypes;
@@ -62,6 +68,8 @@ public final class StreamProcessorTest {
 
   @SuppressWarnings("unused") // injected by the extension
   private StreamPlatform streamPlatform;
+
+  private ControlledActorClock actorClock;
 
   @Test
   public void shouldCallStreamProcessorLifecycle() throws Exception {
@@ -369,6 +377,145 @@ public final class StreamProcessorTest {
     assertThat(logStreamReader.next().getSourceEventPosition()).isEqualTo(firstRecordPosition);
     assertThat(logStreamReader.hasNext()).isTrue();
     assertThat(logStreamReader.next().getSourceEventPosition()).isEqualTo(firstRecordPosition);
+  }
+
+  @Test
+  public void shouldBlockProcessingIfSchedulingBlocks() throws InterruptedException {
+    // given
+    final var mockProcessorLifecycleAware = streamPlatform.getMockProcessorLifecycleAware();
+    final CountDownLatch asyncServiceLatch = new CountDownLatch(1);
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    doAnswer(
+            (invocationOnMock) -> {
+              final var context = (ReadonlyStreamProcessorContext) invocationOnMock.getArgument(0);
+
+              context
+                  .getScheduleService()
+                  .runAtFixedRate(
+                      Duration.ZERO,
+                      (taskResultBuilder) -> {
+                        try {
+                          asyncServiceLatch.countDown();
+                          countDownLatch.await();
+                        } catch (final InterruptedException e) {
+                          throw new RuntimeException(e);
+                        }
+                        return taskResultBuilder.build();
+                      });
+
+              return invocationOnMock.callRealMethod();
+            })
+        .when(mockProcessorLifecycleAware)
+        .onRecovered(any());
+
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    streamPlatform.startStreamProcessor();
+
+    // when
+    assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultRecordProcessor, timeout(500).times(0)).process(any(), any());
+    // free processor
+    countDownLatch.countDown();
+  }
+
+  @Test
+  public void shouldProcessEvenIfAsyncSchedulingBlocks() throws InterruptedException {
+    // given
+    final var mockProcessorLifecycleAware = streamPlatform.getMockProcessorLifecycleAware();
+    final CountDownLatch asyncServiceLatch = new CountDownLatch(1);
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    doAnswer(
+            (invocationOnMock) -> {
+              final var context = (ReadonlyStreamProcessorContext) invocationOnMock.getArgument(0);
+
+              context
+                  .getScheduleService()
+                  .runAtFixedRateAsync(
+                      Duration.ZERO,
+                      (taskResultBuilder) -> {
+                        try {
+                          asyncServiceLatch.countDown();
+                          countDownLatch.await();
+                        } catch (final InterruptedException e) {
+                          throw new RuntimeException(e);
+                        }
+                        return taskResultBuilder.build();
+                      });
+
+              return invocationOnMock.callRealMethod();
+            })
+        .when(mockProcessorLifecycleAware)
+        .onRecovered(any());
+
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    streamPlatform.startStreamProcessor();
+
+    // when
+    assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultRecordProcessor, TIMEOUT.times(1)).process(any(), any());
+    // free schedule service
+    countDownLatch.countDown();
+  }
+
+  @Test
+  public void shouldRunAsyncSchedulingEvenIfProcessingIsBlocked() throws InterruptedException {
+    // given
+    final var mockProcessorLifecycleAware = streamPlatform.getMockProcessorLifecycleAware();
+    final CountDownLatch asyncServiceLatch = new CountDownLatch(1);
+    final CountDownLatch processorLatch = new CountDownLatch(1);
+    final CountDownLatch waitLatch = new CountDownLatch(1);
+    doAnswer(
+            (invocationOnMock) -> {
+              final var context = (ReadonlyStreamProcessorContext) invocationOnMock.getArgument(0);
+
+              context
+                  .getScheduleService()
+                  .runAtFixedRateAsync(
+                      Duration.ofMinutes(1),
+                      (taskResultBuilder) -> {
+                        asyncServiceLatch.countDown();
+                        return taskResultBuilder.build();
+                      });
+
+              return invocationOnMock.callRealMethod();
+            })
+        .when(mockProcessorLifecycleAware)
+        .onRecovered(any());
+
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    doAnswer(
+            (invocationOnMock -> {
+              try {
+                processorLatch.countDown();
+                waitLatch.await();
+              } catch (final InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+              return invocationOnMock.callRealMethod();
+            }))
+        .when(defaultRecordProcessor)
+        .process(any(), any());
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+    assertThat(processorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+    actorClock.addTime(Duration.ofMinutes(2));
+
+    // then
+    assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
+    verify(defaultRecordProcessor, TIMEOUT).process(any(), any());
+    // free schedule service
+    waitLatch.countDown();
   }
 
   @Test


### PR DESCRIPTION
## Description

- Introduce a new simple interface for normal scheduling methods.
- Extend SimpleProcessingScheduleService in ProcessingScheduleService, in order to extend with more methods.
- Add new method to schedule task on different thread (async/concurrent).

```
 * <p>The execution of the scheduled task is running asynchron/concurrent to other scheduled
   * tasks. Other methods will guarantee ordering of scheduled tasks and running always in same
   * thread, these guarantees don't apply to this method.
   *
```


Introduce a new implementation for `ProcessingScheduleService` where we use two objects of the old ScheduleService impl, this allows to reuse old code, and without duplicating to much of the code. Furthermore we don't need to take care of different actor controls and running in different actors in the same schedule service, which make things more complicated. We have just a simple extra implementation that just delegates to two different schedule services.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->
related to https://github.com/camunda/zeebe/issues/11761

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
