### PR TITLE
chore(release): use new 8 core runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   release:
     name: Maven & Go Release
-    runs-on: n1-standard-16-netssd-preempt-quick
+    runs-on: n1-standard-8-netssd-preempt-quick
     timeout-minutes: 30
     outputs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}


### PR DESCRIPTION
## Description

Makes use of the new 8 core runner for the release, which is a more reasonable resource assignment.

Testrun: https://github.com/camunda/zeebe/actions/runs/4251631731/jobs/7394220967
The [error occurred there is unrelated to this change](https://camunda.slack.com/archives/CSQ2E3BT4/p1677142803378239), the fact that the maven release ran confirms this change is fine.
