### PR TITLE
feat: run message TTL checker concurrently to processing

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -66,12 +66,15 @@ public class Engine implements RecordProcessor {
 
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
+    final var zeebeDb = recordProcessorContext.getZeebeDb();
     processingState =
         new ProcessingDbState(
             recordProcessorContext.getPartitionId(),
-            recordProcessorContext.getZeebeDb(),
+            zeebeDb,
             recordProcessorContext.getTransactionContext(),
             recordProcessorContext.getKeyGenerator());
+    final var scheduledTaskDbState = new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
+
     eventApplier = new EventAppliers(processingState);
 
     writers = new Writers(resultBuilderMutex, eventApplier);
@@ -81,6 +84,7 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getScheduleService(),
             processingState,
+            scheduledTaskDbState,
             writers,
             recordProcessorContext.getPartitionCommandSender());
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -15,7 +15,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFa
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.processing.DbBlackListState;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
@@ -47,7 +48,7 @@ public class Engine implements RecordProcessor {
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;
-  private ZeebeDbState zeebeState;
+  private ProcessingDbState processingState;
 
   private final ErrorRecord errorRecord = new ErrorRecord();
 
@@ -65,13 +66,13 @@ public class Engine implements RecordProcessor {
 
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
-    zeebeState =
-        new ZeebeDbState(
+    processingState =
+        new ProcessingDbState(
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getZeebeDb(),
             recordProcessorContext.getTransactionContext(),
             recordProcessorContext.getKeyGenerator());
-    eventApplier = new EventAppliers(zeebeState);
+    eventApplier = new EventAppliers(processingState);
 
     writers = new Writers(resultBuilderMutex, eventApplier);
 
@@ -79,7 +80,7 @@ public class Engine implements RecordProcessor {
         new TypedRecordProcessorContextImpl(
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getScheduleService(),
-            zeebeState,
+            processingState,
             writers,
             recordProcessorContext.getPartitionCommandSender());
 
@@ -122,7 +123,8 @@ public class Engine implements RecordProcessor {
         return processingResultBuilder.build();
       }
 
-      final boolean isNotOnBlacklist = !zeebeState.getBlackListState().isOnBlacklist(typedCommand);
+      final boolean isNotOnBlacklist =
+          !processingState.getBlackListState().isOnBlacklist(typedCommand);
       if (isNotOnBlacklist) {
         currentProcessor.processRecord(record);
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorCo
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationController;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -97,7 +98,12 @@ public final class EngineProcessors {
         deploymentDistributionCommandSender,
         processingState.getKeyGenerator());
     addMessageProcessors(
-        bpmnBehaviors, subscriptionCommandSender, processingState, typedRecordProcessors, writers);
+        bpmnBehaviors,
+        subscriptionCommandSender,
+        processingState,
+        typedRecordProcessorContext.getScheduledTaskDbState(),
+        typedRecordProcessors,
+        writers);
 
     final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor =
         addProcessProcessors(
@@ -214,10 +220,16 @@ public final class EngineProcessors {
       final BpmnBehaviorsImpl bpmnBehaviors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableProcessingState processingState,
+      final ScheduledTaskDbState scheduledTaskDbState,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers) {
     MessageEventProcessors.addMessageProcessors(
-        bpmnBehaviors, typedRecordProcessors, processingState, subscriptionCommandSender, writers);
+        bpmnBehaviors,
+        typedRecordProcessors,
+        processingState,
+        scheduledTaskDbState,
+        subscriptionCommandSender,
+        writers);
   }
 
   private static void addDecisionProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -40,17 +40,17 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
 
   public BpmnStreamProcessor(
       final BpmnBehaviors bpmnBehaviors,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final Writers writers,
       final ProcessEngineMetrics processEngineMetrics) {
-    processState = zeebeState.getProcessState();
+    processState = processingState.getProcessState();
 
     rejectionWriter = writers.rejection();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     stateTransitionGuard = bpmnBehaviors.stateTransitionGuard();
     stateTransitionBehavior =
         new BpmnStateTransitionBehavior(
-            zeebeState.getKeyGenerator(),
+            processingState.getKeyGenerator(),
             bpmnBehaviors.stateBehavior(),
             processEngineMetrics,
             this::getContainerProcessor,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.processing.variable.VariableStateEvaluationContextLookup;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
@@ -43,7 +43,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final ElementActivationBehavior elementActivationBehavior;
 
   public BpmnBehaviorsImpl(
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final Writers writers,
       final JobMetrics jobMetrics,
       final DecisionBehavior decisionBehavior,
@@ -53,16 +53,16 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     expressionBehavior =
         new ExpressionProcessor(
             ExpressionLanguageFactory.createExpressionLanguage(),
-            new VariableStateEvaluationContextLookup(zeebeState.getVariableState()));
+            new VariableStateEvaluationContextLookup(processingState.getVariableState()));
 
     variableBehavior =
         new VariableBehavior(
-            zeebeState.getVariableState(), writers.state(), zeebeState.getKeyGenerator());
+            processingState.getVariableState(), writers.state(), processingState.getKeyGenerator());
 
     catchEventBehavior =
         new CatchEventBehavior(
-            zeebeState,
-            zeebeState.getKeyGenerator(),
+            processingState,
+            processingState.getKeyGenerator(),
             expressionBehavior,
             subscriptionCommandSender,
             writers.state(),
@@ -72,45 +72,55 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     eventTriggerBehavior =
         new EventTriggerBehavior(
-            zeebeState.getKeyGenerator(), catchEventBehavior, writers, zeebeState);
+            processingState.getKeyGenerator(), catchEventBehavior, writers, processingState);
 
     bpmnDecisionBehavior =
         new BpmnDecisionBehavior(
             decisionBehavior,
-            zeebeState,
+            processingState,
             eventTriggerBehavior,
             writers.state(),
-            zeebeState.getKeyGenerator(),
+            processingState.getKeyGenerator(),
             expressionBehavior);
 
-    stateBehavior = new BpmnStateBehavior(zeebeState, variableBehavior);
+    stateBehavior = new BpmnStateBehavior(processingState, variableBehavior);
 
     stateTransitionGuard = new ProcessInstanceStateTransitionGuard(stateBehavior);
 
     variableMappingBehavior =
-        new BpmnVariableMappingBehavior(expressionBehavior, zeebeState, variableBehavior);
+        new BpmnVariableMappingBehavior(expressionBehavior, processingState, variableBehavior);
 
     eventSubscriptionBehavior =
-        new BpmnEventSubscriptionBehavior(catchEventBehavior, eventTriggerBehavior, zeebeState);
+        new BpmnEventSubscriptionBehavior(
+            catchEventBehavior, eventTriggerBehavior, processingState);
 
     incidentBehavior =
-        new BpmnIncidentBehavior(zeebeState, zeebeState.getKeyGenerator(), writers.state());
+        new BpmnIncidentBehavior(
+            processingState, processingState.getKeyGenerator(), writers.state());
 
     eventPublicationBehavior =
         new BpmnEventPublicationBehavior(
-            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, stateBehavior, writers);
+            processingState,
+            processingState.getKeyGenerator(),
+            eventTriggerBehavior,
+            stateBehavior,
+            writers);
 
     processResultSenderBehavior =
-        new BpmnProcessResultSenderBehavior(zeebeState, writers.response());
+        new BpmnProcessResultSenderBehavior(processingState, writers.response());
 
     bufferedMessageStartEventBehavior =
         new BpmnBufferedMessageStartEventBehavior(
-            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, stateBehavior, writers);
+            processingState,
+            processingState.getKeyGenerator(),
+            eventTriggerBehavior,
+            stateBehavior,
+            writers);
 
     jobBehavior =
         new BpmnJobBehavior(
-            zeebeState.getKeyGenerator(),
-            zeebeState.getJobState(),
+            processingState.getKeyGenerator(),
+            processingState.getJobState(),
             writers,
             expressionBehavior,
             stateBehavior,
@@ -122,10 +132,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     elementActivationBehavior =
         new ElementActivationBehavior(
-            zeebeState.getKeyGenerator(),
+            processingState.getKeyGenerator(),
             writers,
             catchEventBehavior,
-            zeebeState.getElementInstanceState());
+            processingState.getElementInstanceState());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -31,19 +31,19 @@ public final class BpmnBufferedMessageStartEventBehavior {
   private final EventHandle eventHandle;
 
   public BpmnBufferedMessageStartEventBehavior(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final KeyGenerator keyGenerator,
       final EventTriggerBehavior eventTriggerBehavior,
       final BpmnStateBehavior stateBehavior,
       final Writers writers) {
-    messageState = zeebeState.getMessageState();
-    processState = zeebeState.getProcessState();
-    messageStartEventSubscriptionState = zeebeState.getMessageStartEventSubscriptionState();
+    messageState = processingState.getMessageState();
+    processState = processingState.getProcessState();
+    messageStartEventSubscriptionState = processingState.getMessageStartEventSubscriptionState();
 
     eventHandle =
         new EventHandle(
             keyGenerator,
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getEventScopeInstanceState(),
             writers,
             processState,
             eventTriggerBehavior,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCalledDecision;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
@@ -41,13 +41,13 @@ public final class BpmnDecisionBehavior {
 
   public BpmnDecisionBehavior(
       final DecisionBehavior decisionBehavior,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final EventTriggerBehavior eventTriggerBehavior,
       final StateWriter stateWriter,
       final KeyGenerator keyGenerator,
       final ExpressionProcessor expressionBehavior) {
 
-    variableState = zeebeState.getVariableState();
+    variableState = processingState.getVariableState();
     this.decisionBehavior = decisionBehavior;
     this.eventTriggerBehavior = eventTriggerBehavior;
     this.stateWriter = stateWriter;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTuple;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
@@ -42,21 +42,22 @@ public final class BpmnEventPublicationBehavior {
   private final KeyGenerator keyGenerator;
 
   public BpmnEventPublicationBehavior(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final KeyGenerator keyGenerator,
       final EventTriggerBehavior eventTriggerBehavior,
       final BpmnStateBehavior stateBehavior,
       final Writers writers) {
-    elementInstanceState = zeebeState.getElementInstanceState();
+    elementInstanceState = processingState.getElementInstanceState();
     eventHandle =
         new EventHandle(
             keyGenerator,
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getEventScopeInstanceState(),
             writers,
-            zeebeState.getProcessState(),
+            processingState.getProcessState(),
             eventTriggerBehavior,
             stateBehavior);
-    catchEventAnalyzer = new CatchEventAnalyzer(zeebeState.getProcessState(), elementInstanceState);
+    catchEventAnalyzer =
+        new CatchEventAnalyzer(processingState.getProcessState(), elementInstanceState);
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -32,12 +32,12 @@ public final class BpmnEventSubscriptionBehavior {
   public BpmnEventSubscriptionBehavior(
       final CatchEventBehavior catchEventBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
-      final ZeebeState zeebeState) {
+      final ProcessingState processingState) {
     this.catchEventBehavior = catchEventBehavior;
     this.eventTriggerBehavior = eventTriggerBehavior;
 
-    processState = zeebeState.getProcessState();
-    eventScopeInstanceState = zeebeState.getEventScopeInstanceState();
+    processState = processingState.getProcessState();
+    eventScopeInstanceState = processingState.getEventScopeInstanceState();
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -26,8 +26,10 @@ public final class BpmnIncidentBehavior {
   private final KeyGenerator keyGenerator;
 
   public BpmnIncidentBehavior(
-      final ZeebeState zeebeState, final KeyGenerator keyGenerator, final StateWriter stateWriter) {
-    incidentState = zeebeState.getIncidentState();
+      final ProcessingState processingState,
+      final KeyGenerator keyGenerator,
+      final StateWriter stateWriter) {
+    incidentState = processingState.getIncidentState();
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.AwaitProcessInstanceResultMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -33,9 +33,9 @@ public final class BpmnProcessResultSenderBehavior {
   private final TypedResponseWriter responseWriter;
 
   public BpmnProcessResultSenderBehavior(
-      final ZeebeState zeebeState, final TypedResponseWriter responseWriter) {
-    elementInstanceState = zeebeState.getElementInstanceState();
-    variableState = zeebeState.getVariableState();
+      final ProcessingState processingState, final TypedResponseWriter responseWriter) {
+    elementInstanceState = processingState.getElementInstanceState();
+    variableState = processingState.getVariableState();
     this.responseWriter = responseWriter;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
@@ -32,13 +32,14 @@ public final class BpmnStateBehavior {
   private final ProcessState processState;
   private final VariableBehavior variableBehavior;
 
-  public BpmnStateBehavior(final ZeebeState zeebeState, final VariableBehavior variableBehavior) {
+  public BpmnStateBehavior(
+      final ProcessingState processingState, final VariableBehavior variableBehavior) {
     this.variableBehavior = variableBehavior;
 
-    processState = zeebeState.getProcessState();
-    elementInstanceState = zeebeState.getElementInstanceState();
-    variablesState = zeebeState.getVariableState();
-    jobState = zeebeState.getJobState();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
+    variablesState = processingState.getVariableState();
+    jobState = processingState.getJobState();
   }
 
   public ElementInstance getElementInstance(final BpmnElementContext context) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -34,13 +34,13 @@ public final class BpmnVariableMappingBehavior {
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final VariableBehavior variableBehavior) {
     this.expressionProcessor = expressionProcessor;
-    elementInstanceState = zeebeState.getElementInstanceState();
-    variablesState = zeebeState.getVariableState();
+    elementInstanceState = processingState.getElementInstanceState();
+    variablesState = processingState.getVariableState();
     this.variableBehavior = variableBehavior;
-    eventScopeInstanceState = zeebeState.getEventScopeInstanceState();
+    eventScopeInstanceState = processingState.getEventScopeInstanceState();
   }
 
   /**
@@ -141,8 +141,7 @@ public final class BpmnVariableMappingBehavior {
   }
 
   private boolean isConnectedToEventBasedGateway(final ExecutableFlowNode element) {
-    if (element instanceof ExecutableCatchEventElement) {
-      final var catchEvent = (ExecutableCatchEventElement) element;
+    if (element instanceof final ExecutableCatchEventElement catchEvent) {
       return catchEvent.isConnectedToEventBasedGateway();
     } else {
       return false;
@@ -150,8 +149,7 @@ public final class BpmnVariableMappingBehavior {
   }
 
   private boolean isErrorEvent(final ExecutableFlowNode element) {
-    if (element instanceof ExecutableCatchEventElement) {
-      final var catchEvent = (ExecutableCatchEventElement) element;
+    if (element instanceof final ExecutableCatchEventElement catchEvent) {
       return catchEvent.isError();
     } else {
       return false;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -21,8 +21,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
@@ -60,7 +60,7 @@ public final class CatchEventBehavior {
   private final int currentPartitionId;
 
   public CatchEventBehavior(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final KeyGenerator keyGenerator,
       final ExpressionProcessor expressionProcessor,
       final SubscriptionCommandSender subscriptionCommandSender,
@@ -74,14 +74,14 @@ public final class CatchEventBehavior {
     this.sideEffectWriter = sideEffectWriter;
     this.partitionsCount = partitionsCount;
 
-    timerInstanceState = zeebeState.getTimerState();
-    processMessageSubscriptionState = zeebeState.getProcessMessageSubscriptionState();
-    processState = zeebeState.getProcessState();
+    timerInstanceState = processingState.getTimerState();
+    processMessageSubscriptionState = processingState.getProcessMessageSubscriptionState();
+    processState = processingState.getProcessState();
 
     this.keyGenerator = keyGenerator;
     this.timerChecker = timerChecker;
 
-    currentPartitionId = zeebeState.getPartitionId();
+    currentPartitionId = processingState.getPartitionId();
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.EvaluatedDecisionRecord;
@@ -43,10 +43,10 @@ public class DecisionBehavior {
 
   public DecisionBehavior(
       final DecisionEngine decisionEngine,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final ProcessEngineMetrics metrics) {
 
-    decisionState = zeebeState.getDecisionState();
+    decisionState = processingState.getDecisionState();
     this.decisionEngine = decisionEngine;
     this.metrics = metrics;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
@@ -45,17 +45,17 @@ public class EventTriggerBehavior {
       final KeyGenerator keyGenerator,
       final CatchEventBehavior catchEventBehavior,
       final Writers writers,
-      final ZeebeState zeebeState) {
+      final ProcessingState processingState) {
     this.keyGenerator = keyGenerator;
     this.catchEventBehavior = catchEventBehavior;
     commandWriter = writers.command();
     stateWriter = writers.state();
 
-    elementInstanceState = zeebeState.getElementInstanceState();
-    eventScopeInstanceState = zeebeState.getEventScopeInstanceState();
+    elementInstanceState = processingState.getElementInstanceState();
+    eventScopeInstanceState = processingState.getEventScopeInstanceState();
 
     variableBehavior =
-        new VariableBehavior(zeebeState.getVariableState(), writers.state(), keyGenerator);
+        new VariableBehavior(processingState.getVariableState(), writers.state(), keyGenerator);
   }
 
   public void triggerEventSubProcess(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -25,8 +25,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -57,14 +57,14 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   private final TypedResponseWriter responseWriter;
 
   public DeploymentCreateProcessor(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final int partitionsCount,
       final Writers writers,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
       final KeyGenerator keyGenerator) {
-    processState = zeebeState.getProcessState();
-    timerInstanceState = zeebeState.getTimerState();
+    processState = processingState.getProcessState();
+    timerInstanceState = processingState.getTimerState();
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -72,8 +72,9 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     expressionProcessor = bpmnBehaviors.expressionBehavior();
     deploymentTransformer =
-        new DeploymentTransformer(stateWriter, zeebeState, expressionProcessor, keyGenerator);
-    startEventSubscriptionManager = new StartEventSubscriptionManager(zeebeState, keyGenerator);
+        new DeploymentTransformer(stateWriter, processingState, expressionProcessor, keyGenerator);
+    startEventSubscriptionManager =
+        new StartEventSubscriptionManager(processingState, keyGenerator);
     deploymentDistributionBehavior =
         new DeploymentDistributionBehavior(
             writers, partitionsCount, deploymentDistributionCommandSender);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SignalSubscriptionState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
@@ -41,10 +41,10 @@ public class StartEventSubscriptionManager {
   private final KeyGenerator keyGenerator;
 
   public StartEventSubscriptionManager(
-      final ZeebeState zeebeState, final KeyGenerator keyGenerator) {
-    processState = zeebeState.getProcessState();
-    messageStartEventSubscriptionState = zeebeState.getMessageStartEventSubscriptionState();
-    signalSubscriptionState = zeebeState.getSignalSubscriptionState();
+      final ProcessingState processingState, final KeyGenerator keyGenerator) {
+    processState = processingState.getProcessState();
+    messageStartEventSubscriptionState = processingState.getMessageStartEventSubscriptionState();
+    signalSubscriptionState = processingState.getSignalSubscriptionState();
     this.keyGenerator = keyGenerator;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManag
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -25,12 +25,13 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
   private final DeploymentDistributionCommandSender deploymentDistributionCommandSender;
 
   public DeploymentDistributeProcessor(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
       final Writers writers,
       final KeyGenerator keyGenerator) {
     this.deploymentDistributionCommandSender = deploymentDistributionCommandSender;
-    startEventSubscriptionManager = new StartEventSubscriptionManager(zeebeState, keyGenerator);
+    startEventSubscriptionManager =
+        new StartEventSubscriptionManager(processingState, keyGenerator);
     stateWriter = writers.state();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -44,7 +44,7 @@ public final class DeploymentTransformer {
 
   public DeploymentTransformer(
       final StateWriter stateWriter,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final ExpressionProcessor expressionProcessor,
       final KeyGenerator keyGenerator) {
 
@@ -64,11 +64,11 @@ public final class DeploymentTransformer {
             keyGenerator,
             stateWriter,
             this::getChecksum,
-            zeebeState.getProcessState(),
+            processingState.getProcessState(),
             expressionProcessor);
     final var dmnResourceTransformer =
         new DmnResourceTransformer(
-            keyGenerator, stateWriter, this::getChecksum, zeebeState.getDecisionState());
+            keyGenerator, stateWriter, this::getChecksum, processingState.getDecisionState());
 
     resourceTransformers =
         Map.ofEntries(
@@ -101,8 +101,7 @@ public final class DeploymentTransformer {
       rejectionType = RejectionType.INVALID_ARGUMENT;
       rejectionReason =
           String.format(
-              "Expected to deploy new resources, but encountered the following errors:%s",
-              errors.toString());
+              "Expected to deploy new resources, but encountered the following errors:%s", errors);
     }
 
     return success;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.incident;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -19,12 +19,12 @@ public final class IncidentEventProcessors {
 
   public static void addProcessors(
       final TypedRecordProcessors typedRecordProcessors,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
       final Writers writers) {
     typedRecordProcessors.onCommand(
         ValueType.INCIDENT,
         IncidentIntent.RESOLVE,
-        new ResolveIncidentProcessor(zeebeState, bpmnStreamProcessor, writers));
+        new ResolveIncidentProcessor(processingState, bpmnStreamProcessor, writers));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -42,15 +42,15 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
   private final TypedResponseWriter responseWriter;
 
   public ResolveIncidentProcessor(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
       final Writers writers) {
     this.bpmnStreamProcessor = bpmnStreamProcessor;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
-    incidentState = zeebeState.getIncidentState();
-    elementInstanceState = zeebeState.getElementInstanceState();
+    incidentState = processingState.getIncidentState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -41,7 +41,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
   public JobBatchActivateProcessor(
       final Writers writers,
-      final ZeebeState state,
+      final ProcessingState state,
       final KeyGenerator keyGenerator,
       final JobMetrics jobMetrics) {
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -23,7 +23,7 @@ public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
   private final JobState jobState;
   private final JobMetrics jobMetrics;
 
-  public JobCancelProcessor(final ZeebeState state, final JobMetrics jobMetrics) {
+  public JobCancelProcessor(final ProcessingState state, final JobMetrics jobMetrics) {
     jobState = state.getJobState();
     this.jobMetrics = jobMetrics;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -31,7 +31,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
   private final EventHandle eventHandle;
 
   public JobCompleteProcessor(
-      final ZeebeState state, final JobMetrics jobMetrics, final EventHandle eventHandle) {
+      final ProcessingState state, final JobMetrics jobMetrics, final EventHandle eventHandle) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
     defaultProcessor =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWr
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -42,7 +42,7 @@ public final class JobFailProcessor implements CommandProcessor<JobRecord> {
   private final SideEffectWriter sideEffectWriter;
 
   public JobFailProcessor(
-      final ZeebeState state,
+      final ProcessingState state,
       final Writers writers,
       final KeyGenerator keyGenerator,
       final JobMetrics jobMetrics,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -22,8 +22,8 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
       "Expected to back off failed job with key '%d', but %s";
   private final JobState jobState;
 
-  public JobRecurProcessor(final ZeebeState zeebeState) {
-    jobState = zeebeState.getJobState();
+  public JobRecurProcessor(final ProcessingState processingState) {
+    jobState = processingState.getJobState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTupl
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -54,7 +54,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
   private final JobMetrics jobMetrics;
 
   public JobThrowErrorProcessor(
-      final ZeebeState state,
+      final ProcessingState state,
       final BpmnEventPublicationBehavior eventPublicationBehavior,
       final KeyGenerator keyGenerator,
       final JobMetrics jobMetrics) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -23,7 +23,7 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
   private final JobState jobState;
   private final JobMetrics jobMetrics;
 
-  public JobTimeOutProcessor(final ZeebeState state, final JobMetrics jobMetrics) {
+  public JobTimeOutProcessor(final ProcessingState state, final JobMetrics jobMetrics) {
     jobState = state.getJobState();
     this.jobMetrics = jobMetrics;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -25,7 +25,7 @@ public final class JobUpdateRetriesProcessor implements CommandProcessor<JobReco
 
   private final JobState jobState;
 
-  public JobUpdateRetriesProcessor(final ZeebeState state) {
+  public JobUpdateRetriesProcessor(final ProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
@@ -27,6 +28,7 @@ public final class MessageEventProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
+      final ScheduledTaskDbState scheduledTaskDbState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers) {
 
@@ -89,7 +91,7 @@ public final class MessageEventProcessors {
                 messageState, subscriptionState, subscriptionCommandSender, writers))
         .withListener(
             new MessageObserver(
-                messageState,
+                scheduledTaskDbState.getMessageState(),
                 processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender));
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -26,26 +26,26 @@ public final class MessageEventProcessors {
   public static void addMessageProcessors(
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers) {
 
-    final MutableMessageState messageState = zeebeState.getMessageState();
+    final MutableMessageState messageState = processingState.getMessageState();
     final MutableMessageSubscriptionState subscriptionState =
-        zeebeState.getMessageSubscriptionState();
+        processingState.getMessageSubscriptionState();
     final MutableMessageStartEventSubscriptionState startEventSubscriptionState =
-        zeebeState.getMessageStartEventSubscriptionState();
+        processingState.getMessageStartEventSubscriptionState();
     final MutableEventScopeInstanceState eventScopeInstanceState =
-        zeebeState.getEventScopeInstanceState();
-    final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
-    final var processState = zeebeState.getProcessState();
+        processingState.getEventScopeInstanceState();
+    final KeyGenerator keyGenerator = processingState.getKeyGenerator();
+    final var processState = processingState.getProcessState();
 
     typedRecordProcessors
         .onCommand(
             ValueType.MESSAGE,
             MessageIntent.PUBLISH,
             new MessagePublishProcessor(
-                zeebeState.getPartitionId(),
+                processingState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 startEventSubscriptionState,
@@ -62,7 +62,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CREATE,
             new MessageSubscriptionCreateProcessor(
-                zeebeState.getPartitionId(),
+                processingState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 subscriptionCommandSender,
@@ -72,7 +72,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
             new MessageSubscriptionCorrelateProcessor(
-                zeebeState.getPartitionId(),
+                processingState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 subscriptionCommandSender,
@@ -90,7 +90,7 @@ public final class MessageEventProcessors {
         .withListener(
             new MessageObserver(
                 messageState,
-                zeebeState.getPendingMessageSubscriptionState(),
+                processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -39,7 +39,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
     final var scheduleService = context.getScheduleService();
     // it is safe to reuse the write because we running in the same actor/thread
     final MessageTimeToLiveChecker timeToLiveChecker = new MessageTimeToLiveChecker(messageState);
-    scheduleService.runAtFixedRate(MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, timeToLiveChecker);
+    scheduleService.runAtFixedRateAsync(MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, timeToLiveChecker);
 
     final PendingMessageSubscriptionChecker pendingSubscriptionChecker =
         new PendingMessageSubscriptionChecker(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -54,19 +54,19 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   public ProcessMessageSubscriptionCorrelateProcessor(
       final ProcessMessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender subscriptionCommandSender,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {
     this.subscriptionState = subscriptionState;
     this.subscriptionCommandSender = subscriptionCommandSender;
-    processState = zeebeState.getProcessState();
-    elementInstanceState = zeebeState.getElementInstanceState();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     eventHandle =
         new EventHandle(
-            zeebeState.getKeyGenerator(),
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getKeyGenerator(),
+            processingState.getEventScopeInstanceState(),
             writers,
             processState,
             bpmnBehaviors.eventTriggerBehavior(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 
@@ -18,7 +18,7 @@ public interface TypedRecordProcessorContext {
 
   ProcessingScheduleService getScheduleService();
 
-  MutableZeebeState getZeebeState();
+  MutableProcessingState getProcessingState();
 
   Writers getWriters();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
@@ -23,4 +24,6 @@ public interface TypedRecordProcessorContext {
   Writers getWriters();
 
   InterPartitionCommandSender getPartitionCommandSender();
+
+  ScheduledTaskDbState getScheduledTaskDbState();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -19,6 +19,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
   private final ProcessingDbState processingState;
+  private final ScheduledTaskDbState scheduledTaskDbState;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
 
@@ -26,11 +27,13 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
       final int partitionId,
       final ProcessingScheduleService scheduleService,
       final ProcessingDbState processingState,
+      final ScheduledTaskDbState scheduledTaskDbState,
       final Writers writers,
       final InterPartitionCommandSender partitionCommandSender) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.processingState = processingState;
+    this.scheduledTaskDbState = scheduledTaskDbState;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
   }
@@ -58,5 +61,10 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   @Override
   public InterPartitionCommandSender getPartitionCommandSender() {
     return partitionCommandSender;
+  }
+
+  @Override
+  public ScheduledTaskDbState getScheduledTaskDbState() {
+    return scheduledTaskDbState;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -8,8 +8,9 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 
@@ -17,19 +18,19 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
 
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
-  private final ZeebeDbState zeebeState;
+  private final ProcessingDbState processingState;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
 
   public TypedRecordProcessorContextImpl(
       final int partitionId,
       final ProcessingScheduleService scheduleService,
-      final ZeebeDbState zeebeState,
+      final ProcessingDbState processingState,
       final Writers writers,
       final InterPartitionCommandSender partitionCommandSender) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
-    this.zeebeState = zeebeState;
+    this.processingState = processingState;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
   }
@@ -45,8 +46,8 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   }
 
   @Override
-  public MutableZeebeState getZeebeState() {
-    return zeebeState;
+  public MutableProcessingState getProcessingState() {
+    return processingState;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -19,8 +19,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.model.bpmn.util.time.Interval;
 import io.camunda.zeebe.model.bpmn.util.time.RepeatingInterval;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
@@ -55,7 +55,7 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
   private final EventHandle eventHandle;
 
   public TriggerTimerProcessor(
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
@@ -63,14 +63,14 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
 
-    processState = zeebeState.getProcessState();
-    elementInstanceState = zeebeState.getElementInstanceState();
-    timerInstanceState = zeebeState.getTimerState();
-    keyGenerator = zeebeState.getKeyGenerator();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
+    timerInstanceState = processingState.getTimerState();
+    keyGenerator = processingState.getKeyGenerator();
     eventHandle =
         new EventHandle(
             keyGenerator,
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getEventScopeInstanceState(),
             writers,
             processState,
             bpmnBehaviors.eventTriggerBehavior(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -39,10 +39,10 @@ import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionSt
 import io.camunda.zeebe.engine.state.mutable.MutablePendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSignalSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.engine.state.processing.DbBlackListState;
 import io.camunda.zeebe.engine.state.signal.DbSignalSubscriptionState;
 import io.camunda.zeebe.engine.state.variable.DbVariableState;
@@ -52,7 +52,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
-public class ZeebeDbState implements MutableZeebeState {
+public class ProcessingDbState implements MutableProcessingState {
 
   private final ZeebeDb<ZbColumnFamilies> zeebeDb;
   private final KeyGenerator keyGenerator;
@@ -77,7 +77,7 @@ public class ZeebeDbState implements MutableZeebeState {
 
   private final int partitionId;
 
-  public ZeebeDbState(
+  public ProcessingDbState(
       final int partitionId,
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.message.DbMessageState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+
+/** Contains read-only state that can be accessed safely by scheduled tasks. */
+public final class ScheduledTaskDbState {
+  private final MessageState messageState;
+
+  public ScheduledTaskDbState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    this.messageState = new DbMessageState(zeebeDb, transactionContext);
+  }
+
+  public MessageState getMessageState() {
+    return messageState;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/TypedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/TypedEventApplier.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.engine.state;
 
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 
-/** Applies state changes for a specific event to the {@link MutableZeebeState}. */
+/** Applies state changes for a specific event to the {@link MutableProcessingState}. */
 public interface TypedEventApplier<I extends Intent, V extends RecordValue> {
 
   void applyState(final long key, final V value);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributionApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributionApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 
@@ -18,8 +18,8 @@ public class DeploymentDistributionApplier
 
   private final MutableDeploymentState deploymentState;
 
-  public DeploymentDistributionApplier(final MutableZeebeState zeebeState) {
-    deploymentState = zeebeState.getDeploymentState();
+  public DeploymentDistributionApplier(final MutableProcessingState processingState) {
+    deploymentState = processingState.getDeploymentState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Applies state changes from events to the {@link MutableZeebeState}.
+ * Applies state changes from events to the {@link MutableProcessingState}.
  *
  * <p>Finds the correct {@link TypedEventApplier} and delegates.
  */
@@ -49,7 +49,7 @@ public final class EventAppliers implements EventApplier {
 
   private final Map<Intent, TypedEventApplier> mapping = new HashMap<>();
 
-  public EventAppliers(final MutableZeebeState state) {
+  public EventAppliers(final MutableProcessingState state) {
     registerProcessInstanceEventAppliers(state);
     registerProcessInstanceCreationAppliers(state);
     registerProcessInstanceModificationAppliers(state);
@@ -76,13 +76,13 @@ public final class EventAppliers implements EventApplier {
     registerSignalSubscriptionAppliers(state);
   }
 
-  private void registerTimeEventAppliers(final MutableZeebeState state) {
+  private void registerTimeEventAppliers(final MutableProcessingState state) {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
   }
 
-  private void registerDeploymentAppliers(final MutableZeebeState state) {
+  private void registerDeploymentAppliers(final MutableProcessingState state) {
     register(DeploymentDistributionIntent.DISTRIBUTING, new DeploymentDistributionApplier(state));
     register(
         DeploymentDistributionIntent.COMPLETED,
@@ -97,13 +97,13 @@ public final class EventAppliers implements EventApplier {
         new DeploymentFullyDistributedApplier(state.getDeploymentState()));
   }
 
-  private void registerVariableEventAppliers(final MutableZeebeState state) {
+  private void registerVariableEventAppliers(final MutableProcessingState state) {
     final VariableApplier variableApplier = new VariableApplier(state.getVariableState());
     register(VariableIntent.CREATED, variableApplier);
     register(VariableIntent.UPDATED, variableApplier);
   }
 
-  private void registerProcessInstanceEventAppliers(final MutableZeebeState state) {
+  private void registerProcessInstanceEventAppliers(final MutableProcessingState state) {
     final var elementInstanceState = state.getElementInstanceState();
     final var eventScopeInstanceState = state.getEventScopeInstanceState();
     final var processState = state.getProcessState();
@@ -141,7 +141,7 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState, processState));
   }
 
-  private void registerProcessInstanceCreationAppliers(final MutableZeebeState state) {
+  private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {
     final var processState = state.getProcessState();
     final var elementInstanceState = state.getElementInstanceState();
 
@@ -150,14 +150,14 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceCreationCreatedApplier(processState, elementInstanceState));
   }
 
-  private void registerProcessInstanceModificationAppliers(final MutableZeebeState state) {
+  private void registerProcessInstanceModificationAppliers(final MutableProcessingState state) {
     register(
         ProcessInstanceModificationIntent.MODIFIED,
         new ProcessInstanceModifiedEventApplier(
             state.getElementInstanceState(), state.getProcessState()));
   }
 
-  private void registerJobIntentEventAppliers(final MutableZeebeState state) {
+  private void registerJobIntentEventAppliers(final MutableProcessingState state) {
     register(JobIntent.CANCELED, new JobCanceledApplier(state));
     register(JobIntent.COMPLETED, new JobCompletedApplier(state));
     register(JobIntent.CREATED, new JobCreatedApplier(state));
@@ -168,12 +168,12 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.RECURRED_AFTER_BACKOFF, new JobRecurredApplier(state));
   }
 
-  private void registerMessageAppliers(final MutableZeebeState state) {
+  private void registerMessageAppliers(final MutableProcessingState state) {
     register(MessageIntent.PUBLISHED, new MessagePublishedApplier(state.getMessageState()));
     register(MessageIntent.EXPIRED, new MessageExpiredApplier(state.getMessageState()));
   }
 
-  private void registerMessageSubscriptionAppliers(final MutableZeebeState state) {
+  private void registerMessageSubscriptionAppliers(final MutableProcessingState state) {
     register(
         MessageSubscriptionIntent.CREATED,
         new MessageSubscriptionCreatedApplier(state.getMessageSubscriptionState()));
@@ -192,7 +192,7 @@ public final class EventAppliers implements EventApplier {
         new MessageSubscriptionDeletedApplier(state.getMessageSubscriptionState()));
   }
 
-  private void registerMessageStartEventSubscriptionAppliers(final MutableZeebeState state) {
+  private void registerMessageStartEventSubscriptionAppliers(final MutableProcessingState state) {
     register(
         MessageStartEventSubscriptionIntent.CREATED,
         new MessageStartEventSubscriptionCreatedApplier(
@@ -206,7 +206,7 @@ public final class EventAppliers implements EventApplier {
             state.getMessageStartEventSubscriptionState()));
   }
 
-  private void registerIncidentEventAppliers(final MutableZeebeState state) {
+  private void registerIncidentEventAppliers(final MutableProcessingState state) {
     register(
         IncidentIntent.CREATED,
         new IncidentCreatedApplier(state.getIncidentState(), state.getJobState()));
@@ -216,7 +216,7 @@ public final class EventAppliers implements EventApplier {
             state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
   }
 
-  private void registerProcessMessageSubscriptionEventAppliers(final MutableZeebeState state) {
+  private void registerProcessMessageSubscriptionEventAppliers(final MutableProcessingState state) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         state.getProcessMessageSubscriptionState();
 
@@ -237,7 +237,7 @@ public final class EventAppliers implements EventApplier {
         new ProcessMessageSubscriptionDeletedApplier(subscriptionState));
   }
 
-  private void registerProcessEventAppliers(final MutableZeebeState state) {
+  private void registerProcessEventAppliers(final MutableProcessingState state) {
     register(
         ProcessEventIntent.TRIGGERING,
         new ProcessEventTriggeringApplier(
@@ -249,7 +249,7 @@ public final class EventAppliers implements EventApplier {
         new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
   }
 
-  private void registerSignalSubscriptionAppliers(final MutableZeebeState state) {
+  private void registerSignalSubscriptionAppliers(final MutableProcessingState state) {
     register(
         SignalSubscriptionIntent.CREATED,
         new SignalSubscriptionCreatedApplier(state.getSignalSubscriptionState()));
@@ -258,12 +258,12 @@ public final class EventAppliers implements EventApplier {
         new SignalSubscriptionDeletedApplier(state.getSignalSubscriptionState()));
   }
 
-  private void registerDecisionAppliers(final MutableZeebeState state) {
+  private void registerDecisionAppliers(final MutableProcessingState state) {
     register(DecisionIntent.CREATED, new DecisionCreatedApplier(state.getDecisionState()));
     register(DecisionIntent.DELETED, new DecisionDeletedApplier(state.getDecisionState()));
   }
 
-  private void registerDecisionRequirementsAppliers(final MutableZeebeState state) {
+  private void registerDecisionRequirementsAppliers(final MutableProcessingState state) {
     register(
         DecisionRequirementsIntent.CREATED,
         new DecisionRequirementsCreatedApplier(state.getDecisionState()));

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchActivatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchActivatedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -20,7 +20,7 @@ public class JobBatchActivatedApplier implements TypedEventApplier<JobBatchInten
 
   private final MutableJobState jobState;
 
-  public JobBatchActivatedApplier(final MutableZeebeState state) {
+  public JobBatchActivatedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,7 +17,7 @@ public class JobCanceledApplier implements TypedEventApplier<JobIntent, JobRecor
 
   private final MutableJobState jobState;
 
-  JobCanceledApplier(final MutableZeebeState state) {
+  JobCanceledApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplier.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -20,7 +20,7 @@ class JobCompletedApplier implements TypedEventApplier<JobIntent, JobRecord> {
   private final MutableJobState jobState;
   private final MutableElementInstanceState elementInstanceState;
 
-  JobCompletedApplier(final MutableZeebeState state) {
+  JobCompletedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -20,7 +20,7 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
   private final MutableElementInstanceState elementInstanceState;
   private final MutableJobState jobState;
 
-  JobCreatedApplier(final MutableZeebeState state) {
+  JobCreatedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobErrorThrownApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobErrorThrownApplier.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -21,7 +21,7 @@ public class JobErrorThrownApplier implements TypedEventApplier<JobIntent, JobRe
   private final MutableJobState jobState;
   private final MutableElementInstanceState elementInstanceState;
 
-  JobErrorThrownApplier(final MutableZeebeState state) {
+  JobErrorThrownApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobFailedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobFailedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,7 +17,7 @@ final class JobFailedApplier implements TypedEventApplier<JobIntent, JobRecord> 
 
   private final MutableJobState jobState;
 
-  JobFailedApplier(final MutableZeebeState state) {
+  JobFailedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobRecurredApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobRecurredApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,8 +17,8 @@ public class JobRecurredApplier implements TypedEventApplier<JobIntent, JobRecor
 
   private final MutableJobState jobState;
 
-  JobRecurredApplier(final MutableZeebeState zeebeState) {
-    jobState = zeebeState.getJobState();
+  JobRecurredApplier(final MutableProcessingState processingState) {
+    jobState = processingState.getJobState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobRetriesUpdatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobRetriesUpdatedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,7 +17,7 @@ public class JobRetriesUpdatedApplier implements TypedEventApplier<JobIntent, Jo
 
   private final MutableJobState jobState;
 
-  JobRetriesUpdatedApplier(final MutableZeebeState state) {
+  JobRetriesUpdatedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobTimedOutApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobTimedOutApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,7 +17,7 @@ public class JobTimedOutApplier implements TypedEventApplier<JobIntent, JobRecor
 
   private final MutableJobState jobState;
 
-  JobTimedOutApplier(final MutableZeebeState state) {
+  JobTimedOutApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 
@@ -17,7 +17,7 @@ public class ProcessCreatedApplier implements TypedEventApplier<ProcessIntent, P
 
   private final MutableProcessState processState;
 
-  public ProcessCreatedApplier(final MutableZeebeState state) {
+  public ProcessCreatedApplier(final MutableProcessingState state) {
     processState = state.getProcessState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 
-public interface ZeebeState extends StreamProcessorLifecycleAware {
+public interface ProcessingState extends StreamProcessorLifecycleAware {
 
   DeploymentState getDeploymentState();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionRequirementsMigration;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -33,20 +33,21 @@ public class DbMigratorImpl implements DbMigrator {
   // Be mindful of https://github.com/camunda/zeebe/issues/7248. In particular, that issue
   // should be solved first, before adding any migration that can take a long time
 
-  private final MutableZeebeState zeebeState;
+  private final MutableProcessingState processingState;
   private final Supplier<List<MigrationTask>> migrationSupplier;
   private boolean abortRequested = false;
 
   private MigrationTask currentMigration;
 
-  public DbMigratorImpl(final MutableZeebeState zeebeState) {
-    this(zeebeState, () -> MIGRATION_TASKS);
+  public DbMigratorImpl(final MutableProcessingState processingState) {
+    this(processingState, () -> MIGRATION_TASKS);
   }
 
   DbMigratorImpl(
-      final MutableZeebeState zeebeState, final Supplier<List<MigrationTask>> migrationSupplier) {
+      final MutableProcessingState processingState,
+      final Supplier<List<MigrationTask>> migrationSupplier) {
 
-    this.zeebeState = zeebeState;
+    this.processingState = processingState;
     this.migrationSupplier = migrationSupplier;
   }
 
@@ -107,7 +108,7 @@ public class DbMigratorImpl implements DbMigrator {
 
   private boolean handleMigrationTask(
       final MigrationTask migrationTask, final int index, final int total) {
-    if (migrationTask.needsToRun(zeebeState)) {
+    if (migrationTask.needsToRun(processingState)) {
       try {
         currentMigration = migrationTask;
         runMigration(migrationTask, index, total);
@@ -137,7 +138,7 @@ public class DbMigratorImpl implements DbMigrator {
     LOGGER.info(
         "Starting " + migrationTask.getIdentifier() + " migration (" + index + "/" + total + ")");
     final var startTime = System.currentTimeMillis();
-    migrationTask.runMigration(zeebeState);
+    migrationTask.runMigration(processingState);
     final var duration = System.currentTimeMillis() - startTime;
 
     LOGGER.debug(migrationTask.getIdentifier() + " migration completed in " + duration + " ms.");

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MessageSubscriptionSentTimeMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MessageSubscriptionSentTimeMigration.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 /**
@@ -23,16 +23,16 @@ public class MessageSubscriptionSentTimeMigration implements MigrationTask {
   }
 
   @Override
-  public boolean needsToRun(final ZeebeState zeebeState) {
-    return !zeebeState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME);
+  public boolean needsToRun(final ProcessingState processingState) {
+    return !processingState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME);
   }
 
   @Override
-  public void runMigration(final MutableZeebeState zeebeState) {
-    zeebeState
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState
         .getMigrationState()
         .migrateMessageSubscriptionSentTime(
-            zeebeState.getMessageSubscriptionState(),
-            zeebeState.getPendingMessageSubscriptionState());
+            processingState.getMessageSubscriptionState(),
+            processingState.getPendingMessageSubscriptionState());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 /**
  * Interface for migration tasks.
@@ -54,15 +54,15 @@ public interface MigrationTask {
   /**
    * Returns whether the migration needs to run
    *
-   * @param zeebeState the immutable Zeebe state
+   * @param processingState the immutable Zeebe state
    * @return whether the migration needs to run
    */
-  boolean needsToRun(final ZeebeState zeebeState);
+  boolean needsToRun(final ProcessingState processingState);
 
   /**
    * Implementations of this method perform the actual migration
    *
-   * @param zeebeState the mutable Zeebe state
+   * @param processingState the mutable Zeebe state
    */
-  void runMigration(final MutableZeebeState zeebeState);
+  void runMigration(final MutableProcessingState processingState);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/ProcessMessageSubscriptionSentTimeMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/ProcessMessageSubscriptionSentTimeMigration.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 /**
@@ -24,16 +24,16 @@ public class ProcessMessageSubscriptionSentTimeMigration implements MigrationTas
   }
 
   @Override
-  public boolean needsToRun(final ZeebeState zeebeState) {
-    return !zeebeState.isEmpty(ZbColumnFamilies.PROCESS_SUBSCRIPTION_BY_SENT_TIME);
+  public boolean needsToRun(final ProcessingState processingState) {
+    return !processingState.isEmpty(ZbColumnFamilies.PROCESS_SUBSCRIPTION_BY_SENT_TIME);
   }
 
   @Override
-  public void runMigration(final MutableZeebeState zeebeState) {
-    zeebeState
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState
         .getMigrationState()
         .migrateProcessMessageSubscriptionSentTime(
-            zeebeState.getProcessMessageSubscriptionState(),
-            zeebeState.getPendingProcessMessageSubscriptionState());
+            processingState.getProcessMessageSubscriptionState(),
+            processingState.getPendingProcessMessageSubscriptionState());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariableMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariableMigration.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 /** Reads out the temporary variable column and creates an EventTrigger for reach of them. */
@@ -20,15 +20,16 @@ public class TemporaryVariableMigration implements MigrationTask {
   }
 
   @Override
-  public boolean needsToRun(final ZeebeState zeebeState) {
-    return !zeebeState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE);
+  public boolean needsToRun(final ProcessingState processingState) {
+    return !processingState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE);
   }
 
   @Override
-  public void runMigration(final MutableZeebeState zeebeState) {
-    zeebeState
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState
         .getMigrationState()
         .migrateTemporaryVariables(
-            zeebeState.getEventScopeInstanceState(), zeebeState.getElementInstanceState());
+            processingState.getEventScopeInstanceState(),
+            processingState.getElementInstanceState());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_2/DecisionMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_2/DecisionMigration.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.engine.state.migration.to_8_2;
 
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.migration.MigrationTask;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 /**
@@ -25,14 +25,14 @@ public class DecisionMigration implements MigrationTask {
   }
 
   @Override
-  public boolean needsToRun(final ZeebeState zeebeState) {
-    return zeebeState.isEmpty(ZbColumnFamilies.DMN_DECISION_KEY_BY_DECISION_ID_AND_VERSION)
-        && !zeebeState.isEmpty(ZbColumnFamilies.DMN_DECISIONS);
+  public boolean needsToRun(final ProcessingState processingState) {
+    return processingState.isEmpty(ZbColumnFamilies.DMN_DECISION_KEY_BY_DECISION_ID_AND_VERSION)
+        && !processingState.isEmpty(ZbColumnFamilies.DMN_DECISIONS);
   }
 
   @Override
-  public void runMigration(final MutableZeebeState zeebeState) {
-    zeebeState
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState
         .getMigrationState()
         .migrateDecisionsPopulateDecisionVersionByDecisionIdAndDecisionKey();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_2/DecisionRequirementsMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_2/DecisionRequirementsMigration.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.engine.state.migration.to_8_2;
 
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.migration.MigrationTask;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 public class DecisionRequirementsMigration implements MigrationTask {
@@ -20,14 +20,14 @@ public class DecisionRequirementsMigration implements MigrationTask {
   }
 
   @Override
-  public boolean needsToRun(final ZeebeState zeebeState) {
-    return zeebeState.isEmpty(
+  public boolean needsToRun(final ProcessingState processingState) {
+    return processingState.isEmpty(
             ZbColumnFamilies.DMN_DECISION_REQUIREMENTS_KEY_BY_DECISION_REQUIREMENT_ID_AND_VERSION)
-        && !zeebeState.isEmpty(ZbColumnFamilies.DMN_DECISION_REQUIREMENTS);
+        && !processingState.isEmpty(ZbColumnFamilies.DMN_DECISION_REQUIREMENTS);
   }
 
   @Override
-  public void runMigration(final MutableZeebeState zeebeState) {
-    zeebeState.getMigrationState().migrateDrgPopulateDrgVersionByDrgIdAndKey();
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState.getMigrationState().migrateDrgPopulateDrgVersionByDrgIdAndKey();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.engine.state.mutable;
 
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
-public interface MutableZeebeState extends ZeebeState {
+public interface MutableProcessingState extends ProcessingState {
 
   @Override
   MutableDeploymentState getDeploymentState();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -8,10 +8,10 @@
 package io.camunda.zeebe.engine.state.query;
 
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.QueryService;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -22,7 +22,7 @@ import org.agrona.DirectBuffer;
 
 public final class StateQueryService implements QueryService {
   private volatile boolean isClosed;
-  private ZeebeState state;
+  private ProcessingState state;
   private final ZeebeDb<ZbColumnFamilies> zeebeDb;
 
   public StateQueryService(final ZeebeDb<ZbColumnFamilies> zeebeDb) {
@@ -67,7 +67,7 @@ public final class StateQueryService implements QueryService {
       // service is used for the first time, create state now
       // we don't need a key generator here, so we set it to unsupported
       state =
-          new ZeebeDbState(
+          new ProcessingDbState(
               Protocol.DEPLOYMENT_PARTITION,
               zeebeDb,
               zeebeDb.createContext(),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.engine.processing.job;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -41,14 +41,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 final class JobBatchCollectorTest {
   private static final String JOB_TYPE = "job";
 
   private final RecordLengthEvaluator lengthEvaluator = new RecordLengthEvaluator();
 
   @SuppressWarnings("unused") // injected by the extension
-  private MutableZeebeState state;
+  private MutableProcessingState state;
 
   private JobBatchCollector collector;
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -59,11 +59,11 @@ public final class MessageStreamProcessorTest {
 
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
-          final var zeebeState = processingContext.getZeebeState();
+          final var processingState = processingContext.getProcessingState();
           MessageEventProcessors.addMessageProcessors(
               mock(BpmnBehaviors.class),
               typedRecordProcessors,
-              zeebeState,
+              processingState,
               spySubscriptionCommandSender,
               processingContext.getWriters());
           return typedRecordProcessors;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -60,10 +60,12 @@ public final class MessageStreamProcessorTest {
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
           final var processingState = processingContext.getProcessingState();
+          final var scheduledTaskDbState = processingContext.getScheduledTaskDbState();
           MessageEventProcessors.addMessageProcessors(
               mock(BpmnBehaviors.class),
               typedRecordProcessors,
               processingState,
+              scheduledTaskDbState,
               spySubscriptionCommandSender,
               processingContext.getWriters());
           return typedRecordProcessors;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -11,11 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.engine.util.RecordingTypedEventWriter;
 import io.camunda.zeebe.engine.util.RecordingTypedEventWriter.RecordedEvent;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValueAssert;
@@ -29,13 +29,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 final class VariableBehaviorTest {
 
   private final RecordingTypedEventWriter eventWriter = new RecordingTypedEventWriter();
 
   @SuppressWarnings("unused") // injected by the extension
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   private MutableVariableState state;
   private VariableBehavior behavior;
@@ -43,10 +43,10 @@ final class VariableBehaviorTest {
   @BeforeEach
   void beforeEach() {
     final var stateWriter =
-        new EventApplyingStateWriter(eventWriter, new EventAppliers(zeebeState));
+        new EventApplyingStateWriter(eventWriter, new EventAppliers(processingState));
 
-    state = zeebeState.getVariableState();
-    behavior = new VariableBehavior(state, stateWriter, zeebeState.getKeyGenerator());
+    state = processingState.getVariableState();
+    behavior = new VariableBehavior(state, stateWriter, processingState.getKeyGenerator());
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/BlacklistInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/BlacklistInstanceTest.java
@@ -12,8 +12,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -47,7 +47,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public final class BlacklistInstanceTest {
 
-  @ClassRule public static final ZeebeStateRule ZEEBE_STATE_RULE = new ZeebeStateRule();
+  @ClassRule public static final ProcessingStateRule ZEEBE_STATE_RULE = new ProcessingStateRule();
   private static final AtomicLong KEY_GENERATOR = new AtomicLong(0);
 
   @Parameter(0)
@@ -214,14 +214,14 @@ public final class BlacklistInstanceTest {
     typedEvent.wrap(loggedEvent, metadata, new Value());
 
     // when
-    final MutableZeebeState zeebeState = ZEEBE_STATE_RULE.getZeebeState();
-    zeebeState.getBlackListState().tryToBlacklist(typedEvent, (processInstanceKey) -> {});
+    final MutableProcessingState processingState = ZEEBE_STATE_RULE.getProcessingState();
+    processingState.getBlackListState().tryToBlacklist(typedEvent, (processInstanceKey) -> {});
 
     // then
     metadata.intent(ProcessInstanceIntent.ELEMENT_ACTIVATING);
     metadata.valueType(ValueType.PROCESS_INSTANCE);
     typedEvent.wrap(null, metadata, new Value());
-    assertThat(zeebeState.getBlackListState().isOnBlacklist(typedEvent))
+    assertThat(processingState.getBlackListState().isOnBlacklist(typedEvent))
         .isEqualTo(expectedToBlacklist);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.state;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -21,13 +21,13 @@ import org.junit.Test;
 
 public final class KeyGeneratorTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private KeyGenerator keyGenerator;
 
   @Before
   public void setUp() throws Exception {
-    keyGenerator = stateRule.getZeebeState().getKeyGenerator();
+    keyGenerator = stateRule.getProcessingState().getKeyGenerator();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -11,7 +11,7 @@ import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.processing.message.MessageObserver;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -47,11 +47,11 @@ public final class ProcessExecutionCleanStateTest {
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 
-  private ZeebeState zeebeState;
+  private ProcessingState processingState;
 
   @Before
   public void init() {
-    zeebeState = engineRule.getZeebeState();
+    processingState = engineRule.getProcessingState();
 
     assertThatStateIsEmpty();
   }
@@ -789,7 +789,7 @@ public final class ProcessExecutionCleanStateTest {
               final var nonEmptyColumns =
                   Arrays.stream(ZbColumnFamilies.values())
                       .filter(not(IGNORE_NON_EMPTY_COLUMNS::contains))
-                      .filter(not(zeebeState::isEmpty))
+                      .filter(not(processingState::isEmpty))
                       .collect(Collectors.toList());
 
               assertThat(nonEmptyColumns).describedAs("Expected all columns to be empty").isEmpty();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -13,8 +13,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,15 +22,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 public final class DecisionStateTest {
 
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
   private MutableDecisionState decisionState;
 
   @BeforeEach
   public void setup() {
-    decisionState = zeebeState.getDecisionState();
+    decisionState = processingState.getDecisionState();
   }
 
   @DisplayName("should return empty if no decision is deployed")

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -26,14 +26,14 @@ import org.junit.Test;
 
 public class DeploymentStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableDeploymentState deploymentState;
 
   @Before
   public void setUp() {
-    final var zeebeState = stateRule.getZeebeState();
-    deploymentState = zeebeState.getDeploymentState();
+    final var processingState = stateRule.getProcessingState();
+    deploymentState = processingState.getDeploymentState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -13,8 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
@@ -32,15 +32,15 @@ public final class ProcessStateTest {
 
   private static final Long FIRST_PROCESS_KEY =
       Protocol.encodePartitionId(Protocol.DEPLOYMENT_PARTITION, 1);
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableProcessState processState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    processState = zeebeState.getProcessState();
+    processingState = stateRule.getProcessingState();
+    processState = processingState.getProcessState();
   }
 
   @Test
@@ -57,7 +57,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldGetProcessVersion() {
     // given
-    final var processRecord = creatingProcessRecord(zeebeState);
+    final var processRecord = creatingProcessRecord(processingState);
     processState.putProcess(processRecord.getKey(), processRecord);
 
     // when
@@ -70,10 +70,10 @@ public final class ProcessStateTest {
   @Test
   public void shouldIncrementProcessVersion() {
     // given
-    final var processRecord = creatingProcessRecord(zeebeState);
+    final var processRecord = creatingProcessRecord(processingState);
     processState.putProcess(processRecord.getKey(), processRecord);
 
-    final var processRecord2 = creatingProcessRecord(zeebeState);
+    final var processRecord2 = creatingProcessRecord(processingState);
     processState.putProcess(processRecord2.getKey(), processRecord2);
 
     // when
@@ -87,9 +87,9 @@ public final class ProcessStateTest {
   @Test
   public void shouldNotIncrementProcessVersionForDifferentProcessId() {
     // given
-    final var processRecord = creatingProcessRecord(zeebeState);
+    final var processRecord = creatingProcessRecord(processingState);
     processState.putProcess(processRecord.getKey(), processRecord);
-    final var processRecord2 = creatingProcessRecord(zeebeState, "other");
+    final var processRecord2 = creatingProcessRecord(processingState, "other");
 
     // when
     processState.putProcess(processRecord2.getKey(), processRecord2);
@@ -162,7 +162,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldPutDeploymentToState() {
     // given
-    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
+    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(processingState);
 
     // when
     processState.putDeployment(deploymentRecord);
@@ -177,7 +177,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldPutProcessToState() {
     // given
-    final var processRecord = creatingProcessRecord(zeebeState);
+    final var processRecord = creatingProcessRecord(processingState);
 
     // when
     processState.putProcess(processRecord.getKey(), processRecord);
@@ -205,7 +205,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldUpdateLatestDigestOnPutProcessToState() {
     // given
-    final var processRecord = creatingProcessRecord(zeebeState);
+    final var processRecord = creatingProcessRecord(processingState);
 
     // when
     processState.putProcess(processRecord.getKey(), processRecord);
@@ -218,7 +218,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldUpdateLatestProcessOnPutProcessToState() {
     // given
-    final var processRecord = creatingProcessRecord(zeebeState);
+    final var processRecord = creatingProcessRecord(processingState);
 
     // when
     processState.putProcess(processRecord.getKey(), processRecord);
@@ -238,7 +238,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldNotOverwritePreviousRecord() {
     // given
-    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
+    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(processingState);
 
     // when
     processState.putDeployment(deploymentRecord);
@@ -261,8 +261,8 @@ public final class ProcessStateTest {
     // given
 
     // when
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
 
     // then
     final DeployedProcess deployedProcess =
@@ -287,10 +287,10 @@ public final class ProcessStateTest {
   @Test
   public void shouldRestartVersionCountOnDifferentProcessId() {
     // given
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
 
     // when
-    processState.putDeployment(creatingDeploymentRecord(zeebeState, "otherId"));
+    processState.putDeployment(creatingDeploymentRecord(processingState, "otherId"));
 
     // then
     final DeployedProcess deployedProcess =
@@ -314,8 +314,8 @@ public final class ProcessStateTest {
   @Test
   public void shouldGetLatestDeployedProcess() {
     // given
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
 
     // when
     final DeployedProcess latestProcess =
@@ -349,12 +349,12 @@ public final class ProcessStateTest {
   @Test
   public void shouldGetLatestDeployedProcessAfterDeploymentWasAdded() {
     // given
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
     final DeployedProcess firstLatest =
         processState.getLatestProcessVersionByProcessId(wrapString("processId"));
 
     // when
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
 
     // then
     final DeployedProcess latestProcess =
@@ -377,7 +377,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldGetExecutableProcess() {
     // given
-    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
+    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(processingState);
     processState.putDeployment(deploymentRecord);
 
     // when
@@ -394,7 +394,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldGetExecutableProcessByKey() {
     // given
-    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
+    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(processingState);
     processState.putDeployment(deploymentRecord);
 
     // when
@@ -411,7 +411,7 @@ public final class ProcessStateTest {
   @Test
   public void shouldGetExecutableProcessByLatestProcess() {
     // given
-    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
+    final DeploymentRecord deploymentRecord = creatingDeploymentRecord(processingState);
     processState.putDeployment(deploymentRecord);
 
     // when
@@ -428,9 +428,9 @@ public final class ProcessStateTest {
   @Test
   public void shouldGetAllProcesses() {
     // given
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
-    processState.putDeployment(creatingDeploymentRecord(zeebeState, "otherId"));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
+    processState.putDeployment(creatingDeploymentRecord(processingState, "otherId"));
 
     // when
     final Collection<DeployedProcess> processes = processState.getProcesses();
@@ -450,8 +450,8 @@ public final class ProcessStateTest {
   @Test
   public void shouldGetAllProcessesWithProcessId() {
     // given
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
 
     // when
     final Collection<DeployedProcess> processes =
@@ -471,8 +471,8 @@ public final class ProcessStateTest {
   @Test
   public void shouldNotGetProcessesWithOtherProcessId() {
     // given
-    processState.putDeployment(creatingDeploymentRecord(zeebeState));
-    processState.putDeployment(creatingDeploymentRecord(zeebeState, "otherId"));
+    processState.putDeployment(creatingDeploymentRecord(processingState));
+    processState.putDeployment(creatingDeploymentRecord(processingState, "otherId"));
 
     // when
     final Collection<DeployedProcess> processes =
@@ -496,8 +496,8 @@ public final class ProcessStateTest {
   public void shouldReturnHighestVersionInsteadOfMostRecent() {
     // given
     final String processId = "process";
-    processState.putDeployment(creatingDeploymentRecord(zeebeState, processId, 2));
-    processState.putDeployment(creatingDeploymentRecord(zeebeState, processId, 1));
+    processState.putDeployment(creatingDeploymentRecord(processingState, processId, 2));
+    processState.putDeployment(creatingDeploymentRecord(processingState, processId, 1));
 
     // when
     final DeployedProcess latestProcess =
@@ -507,19 +507,20 @@ public final class ProcessStateTest {
     Assertions.assertThat(latestProcess.getVersion()).isEqualTo(2);
   }
 
-  public static DeploymentRecord creatingDeploymentRecord(final MutableZeebeState zeebeState) {
-    return creatingDeploymentRecord(zeebeState, "processId");
+  public static DeploymentRecord creatingDeploymentRecord(
+      final MutableProcessingState processingState) {
+    return creatingDeploymentRecord(processingState, "processId");
   }
 
   public static DeploymentRecord creatingDeploymentRecord(
-      final MutableZeebeState zeebeState, final String processId) {
-    final MutableProcessState processState = zeebeState.getProcessState();
+      final MutableProcessingState processingState, final String processId) {
+    final MutableProcessState processState = processingState.getProcessState();
     final int version = processState.getProcessVersion(processId) + 1;
-    return creatingDeploymentRecord(zeebeState, processId, version);
+    return creatingDeploymentRecord(processingState, processId, version);
   }
 
   public static DeploymentRecord creatingDeploymentRecord(
-      final MutableZeebeState zeebeState, final String processId, final int version) {
+      final MutableProcessingState processingState, final String processId, final int version) {
     final BpmnModelInstance modelInstance =
         Bpmn.createExecutableProcess(processId)
             .startEvent()
@@ -541,7 +542,7 @@ public final class ProcessStateTest {
         .setResourceName(wrapString(resourceName))
         .setResource(resource);
 
-    final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
+    final KeyGenerator keyGenerator = processingState.getKeyGenerator();
     final long key = keyGenerator.nextKey();
 
     deploymentRecord
@@ -556,19 +557,19 @@ public final class ProcessStateTest {
     return deploymentRecord;
   }
 
-  public static ProcessRecord creatingProcessRecord(final MutableZeebeState zeebeState) {
-    return creatingProcessRecord(zeebeState, "processId");
+  public static ProcessRecord creatingProcessRecord(final MutableProcessingState processingState) {
+    return creatingProcessRecord(processingState, "processId");
   }
 
   public static ProcessRecord creatingProcessRecord(
-      final MutableZeebeState zeebeState, final String processId) {
-    final MutableProcessState processState = zeebeState.getProcessState();
+      final MutableProcessingState processingState, final String processId) {
+    final MutableProcessState processState = processingState.getProcessState();
     final int version = processState.getProcessVersion(processId) + 1;
-    return creatingProcessRecord(zeebeState, processId, version);
+    return creatingProcessRecord(processingState, processId, version);
   }
 
   public static ProcessRecord creatingProcessRecord(
-      final MutableZeebeState zeebeState, final String processId, final int version) {
+      final MutableProcessingState processingState, final String processId, final int version) {
     final BpmnModelInstance modelInstance =
         Bpmn.createExecutableProcess(processId)
             .startEvent()
@@ -581,7 +582,7 @@ public final class ProcessStateTest {
     final var resource = wrapString(Bpmn.convertToString(modelInstance));
     final var checksum = wrapString("checksum");
 
-    final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
+    final KeyGenerator keyGenerator = processingState.getKeyGenerator();
     final long key = keyGenerator.nextKey();
 
     processRecord

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
@@ -16,8 +16,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.state.mutable.MutableBlackListState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -30,15 +30,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 public final class BlackListStateTest {
 
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
   private MutableBlackListState blackListState;
 
   @BeforeEach
   public void setup() {
-    blackListState = zeebeState.getBlackListState();
+    blackListState = processingState.getBlackListState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -12,8 +12,8 @@ import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -33,15 +33,15 @@ public final class ElementInstanceStateTest {
 
   private static final long PROCESS_KEY = 123;
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableElementInstanceState elementInstanceState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    elementInstanceState = zeebeState.getElementInstanceState();
+    processingState = stateRule.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Test
@@ -291,7 +291,7 @@ public final class ElementInstanceStateTest {
     final ElementInstance parentInstance =
         elementInstanceState.newInstance(
             parent, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
-    zeebeState
+    processingState
         .getVariableState()
         .setVariableLocal(
             1, parent, PROCESS_KEY, BufferUtil.wrapString("a"), MsgPackUtil.asMsgPack("1"));
@@ -299,7 +299,7 @@ public final class ElementInstanceStateTest {
     processInstanceRecord.setElementId("subProcess");
     elementInstanceState.newInstance(
         parentInstance, child, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
-    zeebeState
+    processingState
         .getVariableState()
         .setVariableLocal(
             2, child, PROCESS_KEY, BufferUtil.wrapString("b"), MsgPackUtil.asMsgPack("2"));
@@ -312,7 +312,7 @@ public final class ElementInstanceStateTest {
     final var nonEmptyColumns =
         Arrays.stream(ZbColumnFamilies.values())
             .filter(not(ZbColumnFamilies.KEY::equals))
-            .filter(not(zeebeState::isEmpty))
+            .filter(not(processingState::isEmpty))
             .collect(Collectors.toList());
 
     assertThat(nonEmptyColumns).describedAs("Expected all columns to be empty").isEmpty();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
@@ -13,8 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 public final class EventScopeInstanceStateTest {
 
   private static final int SCOPE_KEY = 123;
@@ -32,13 +32,13 @@ public final class EventScopeInstanceStateTest {
       Collections.emptySet();
   private static final Collection<DirectBuffer> NO_BOUNDARY_ELEMENT_IDS = Collections.emptySet();
 
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   private MutableEventScopeInstanceState state;
 
   @BeforeEach
   void setUp() {
-    state = zeebeState.getEventScopeInstanceState();
+    state = processingState.getEventScopeInstanceState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/IncidentStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/IncidentStateTest.java
@@ -14,8 +14,8 @@ import io.camunda.zeebe.engine.state.immutable.IncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -27,19 +27,19 @@ import org.junit.Test;
 
 public final class IncidentStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableIncidentState incidentState;
   private MutableElementInstanceState elementInstanceState;
   private MutableJobState jobState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    elementInstanceState = zeebeState.getElementInstanceState();
-    jobState = zeebeState.getJobState();
-    incidentState = zeebeState.getIncidentState();
+    processingState = stateRule.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
+    jobState = processingState.getJobState();
+    incidentState = processingState.getIncidentState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -14,8 +14,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.test.util.BufferAssert;
@@ -35,15 +35,15 @@ import org.junit.Test;
 
 public final class JobStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableJobState jobState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    jobState = zeebeState.getJobState();
+    processingState = stateRule.getProcessingState();
+    jobState = processingState.getJobState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/NumberOfTakenSequenceFlowsStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/NumberOfTakenSequenceFlowsStateTest.java
@@ -11,8 +11,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -30,15 +30,15 @@ public final class NumberOfTakenSequenceFlowsStateTest {
   private static final DirectBuffer SEQUENCE_FLOW_ELEMENT_ID = wrapString("flow-1");
   private static final DirectBuffer OTHER_SEQUENCE_FLOW_ELEMENT_ID = wrapString("flow-2");
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableElementInstanceState elementInstanceState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    elementInstanceState = zeebeState.getElementInstanceState();
+    processingState = stateRule.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Test
@@ -162,7 +162,7 @@ public final class NumberOfTakenSequenceFlowsStateTest {
         elementInstanceState.getNumberOfTakenSequenceFlows(FLOW_SCOPE_KEY, GATEWAY_ELEMENT_ID);
     assertThat(number).isZero();
 
-    assertThat(zeebeState.isEmpty(ZbColumnFamilies.NUMBER_OF_TAKEN_SEQUENCE_FLOWS))
+    assertThat(processingState.isEmpty(ZbColumnFamilies.NUMBER_OF_TAKEN_SEQUENCE_FLOWS))
         .describedAs("Expected the entries to be removed")
         .isTrue();
   }
@@ -185,7 +185,7 @@ public final class NumberOfTakenSequenceFlowsStateTest {
         elementInstanceState.getNumberOfTakenSequenceFlows(FLOW_SCOPE_KEY, GATEWAY_ELEMENT_ID);
     assertThat(number).isZero();
 
-    assertThat(zeebeState.isEmpty(ZbColumnFamilies.NUMBER_OF_TAKEN_SEQUENCE_FLOWS))
+    assertThat(processingState.isEmpty(ZbColumnFamilies.NUMBER_OF_TAKEN_SEQUENCE_FLOWS))
         .describedAs("Expected the entries to be removed")
         .isTrue();
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -9,9 +9,9 @@ package io.camunda.zeebe.engine.state.instance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import java.util.ArrayList;
@@ -23,14 +23,14 @@ import org.junit.Test;
 
 public final class TimerInstanceStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableTimerInstanceState state;
 
   @Before
   public void setUp() {
-    final MutableZeebeState zeebeState = stateRule.getZeebeState();
-    state = zeebeState.getTimerState();
+    final MutableProcessingState processingState = stateRule.getProcessingState();
+    state = processingState.getTimerState();
   }
 
   @Test
@@ -214,7 +214,7 @@ public final class TimerInstanceStateTest {
 
   private void createElementInstance(final long key) {
     stateRule
-        .getZeebeState()
+        .getProcessingState()
         .getElementInstanceState()
         .createInstance(
             new ElementInstance(

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscriptionStateTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
@@ -27,13 +27,13 @@ import org.junit.Test;
 
 public final class MessageStartEventSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageStartEventSubscriptionState state;
 
   @Before
   public void setUp() {
-    state = stateRule.getZeebeState().getMessageStartEventSubscriptionState();
+    state = stateRule.getProcessingState().getMessageStartEventSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -11,8 +11,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
@@ -24,15 +24,15 @@ import org.junit.Test;
 
 public final class MessageStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageState messageState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    messageState = zeebeState.getMessageState();
+    processingState = stateRule.getProcessingState();
+    messageState = processingState.getMessageState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageSubscriptionStateTest.java
@@ -11,8 +11,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,15 +22,15 @@ import org.junit.Test;
 
 public final class MessageSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageSubscriptionState state;
 
   @Before
   public void setUp() {
 
-    final MutableZeebeState zeebeState = stateRule.getZeebeState();
-    state = zeebeState.getMessageSubscriptionState();
+    final MutableProcessingState processingState = stateRule.getProcessingState();
+    state = processingState.getMessageSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingMessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingMessageSubscriptionStateTest.java
@@ -12,8 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.ArrayList;
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 public final class PendingMessageSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageSubscriptionState persistentState;
   private MutablePendingMessageSubscriptionState transientState;
@@ -33,9 +33,9 @@ public final class PendingMessageSubscriptionStateTest {
   @Before
   public void setUp() {
 
-    final MutableZeebeState zeebeState = stateRule.getZeebeState();
-    persistentState = zeebeState.getMessageSubscriptionState();
-    transientState = zeebeState.getPendingMessageSubscriptionState();
+    final MutableProcessingState processingState = stateRule.getProcessingState();
+    persistentState = processingState.getMessageSubscriptionState();
+    transientState = processingState.getPendingMessageSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingProcessMessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingProcessMessageSubscriptionStateTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutablePendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,15 +23,15 @@ import org.junit.Test;
 
 public final class PendingProcessMessageSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableProcessMessageSubscriptionState persistentState;
   private MutablePendingProcessMessageSubscriptionState transientState;
 
   @Before
   public void setUp() {
-    persistentState = stateRule.getZeebeState().getProcessMessageSubscriptionState();
-    transientState = stateRule.getZeebeState().getPendingProcessMessageSubscriptionState();
+    persistentState = stateRule.getProcessingState().getProcessMessageSubscriptionState();
+    transientState = stateRule.getProcessingState().getPendingProcessMessageSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscriptionStateTest.java
@@ -12,7 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.ArrayList;
@@ -24,13 +24,13 @@ import org.junit.Test;
 
 public final class ProcessMessageSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableProcessMessageSubscriptionState state;
 
   @Before
   public void setUp() {
-    state = stateRule.getZeebeState().getProcessMessageSubscriptionState();
+    state = stateRule.getProcessingState().getProcessMessageSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigrationControllerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigrationControllerTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -32,7 +32,8 @@ public class DbMigrationControllerTest {
     mockDbMigrator = mock(DbMigrator.class);
 
     sutMigrationController =
-        new DbMigrationController(mock(MutableZeebeState.class), zeebeState -> mockDbMigrator);
+        new DbMigrationController(
+            mock(MutableProcessingState.class), processingState -> mockDbMigrator);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -24,48 +24,48 @@ public class DbMigratorImplTest {
   @Test
   void shouldRunMigrationThatNeedsToBeRun() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration = mock(MigrationTask.class);
-    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+        new DbMigratorImpl(mockProcessingState, () -> Collections.singletonList(mockMigration));
 
     // when
     sut.runMigrations();
 
     // then
-    verify(mockMigration).runMigration(mockZeebeState);
+    verify(mockMigration).runMigration(mockProcessingState);
   }
 
   @Test
   void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration = mock(MigrationTask.class);
-    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(false);
+    when(mockMigration.needsToRun(mockProcessingState)).thenReturn(false);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+        new DbMigratorImpl(mockProcessingState, () -> Collections.singletonList(mockMigration));
 
     // when
     sut.runMigrations();
 
     // then
-    verify(mockMigration, never()).runMigration(mockZeebeState);
+    verify(mockMigration, never()).runMigration(mockProcessingState);
   }
 
   @Test
   void shouldRunMigrationsInOrder() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration1 = mock(MigrationTask.class);
-    when(mockMigration1.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
     final var mockMigration2 = mock(MigrationTask.class);
-    when(mockMigration2.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> List.of(mockMigration1, mockMigration2));
+        new DbMigratorImpl(mockProcessingState, () -> List.of(mockMigration1, mockMigration2));
 
     // when
     sut.runMigrations();
@@ -73,19 +73,19 @@ public class DbMigratorImplTest {
     // then
     final var inOrder = Mockito.inOrder(mockMigration1, mockMigration2);
 
-    inOrder.verify(mockMigration1).runMigration(mockZeebeState);
-    inOrder.verify(mockMigration2).runMigration(mockZeebeState);
+    inOrder.verify(mockMigration1).runMigration(mockProcessingState);
+    inOrder.verify(mockMigration2).runMigration(mockProcessingState);
   }
 
   @Test
   void shouldNotRunAnyMigrationIfAbortSignalWasReceivedInTheVeryBeginning() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration = mock(MigrationTask.class);
-    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(false);
+    when(mockMigration.needsToRun(mockProcessingState)).thenReturn(false);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+        new DbMigratorImpl(mockProcessingState, () -> Collections.singletonList(mockMigration));
 
     // when
     sut.abort();
@@ -99,14 +99,14 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotRunSubsequentMigrationsAfterAbortSignalWasReceived() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration1 = mock(MigrationTask.class);
-    when(mockMigration1.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
     final var mockMigration2 = mock(MigrationTask.class);
-    when(mockMigration2.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> List.of(mockMigration1, mockMigration2));
+        new DbMigratorImpl(mockProcessingState, () -> List.of(mockMigration1, mockMigration2));
 
     doAnswer(
             (invocationOnMock) -> {
@@ -115,13 +115,13 @@ public class DbMigratorImplTest {
               return null;
             })
         .when(mockMigration1)
-        .runMigration(mockZeebeState);
+        .runMigration(mockProcessingState);
 
     // when
     sut.runMigrations();
 
     // then
-    verify(mockMigration1).runMigration(mockZeebeState);
-    verify(mockMigration2, never()).runMigration(mockZeebeState);
+    verify(mockMigration1).runMigration(mockProcessingState);
+    verify(mockMigration2, never()).runMigration(mockProcessingState);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/DbMigrationStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/DbMigrationStateTest.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.engine.state.message.MessageSubscription;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 public class DbMigrationStateTest {
 
   private static final long TEST_SENT_TIME = 1000L;
 
   private ZeebeDb<ZbColumnFamilies> zeebeDb;
 
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   private TransactionContext transactionContext;
 
@@ -56,9 +56,10 @@ public class DbMigrationStateTest {
     transactionContext.getCurrentTransaction().commit();
 
     // when
-    final var migrationState = zeebeState.getMigrationState();
+    final var migrationState = processingState.getMigrationState();
     migrationState.migrateMessageSubscriptionSentTime(
-        zeebeState.getMessageSubscriptionState(), zeebeState.getPendingMessageSubscriptionState());
+        processingState.getMessageSubscriptionState(),
+        processingState.getPendingMessageSubscriptionState());
 
     // then
 
@@ -68,7 +69,7 @@ public class DbMigrationStateTest {
         .describedAs("Column family MESSAGE_SUBSCRIPTION_BY_SENT_TIME is empty")
         .isTrue();
 
-    final var subscriptionState = zeebeState.getMessageSubscriptionState();
+    final var subscriptionState = processingState.getMessageSubscriptionState();
 
     // the correlating subscription has correlating = true in persistent state
     final var migratedSubscriptionInCorrelation =
@@ -96,7 +97,7 @@ public class DbMigrationStateTest {
   }
 
   private void assertThaRecordIsPresentInTransientState(final MessageSubscriptionRecord record) {
-    final var transientSubscriptionState = zeebeState.getPendingMessageSubscriptionState();
+    final var transientSubscriptionState = processingState.getPendingMessageSubscriptionState();
 
     final var correlatingSubscriptions = new ArrayList<MessageSubscriptionRecord>();
 
@@ -119,7 +120,7 @@ public class DbMigrationStateTest {
     // given database with legacy records
     final var legacySubscriptionState =
         new LegacyDbProcessMessageSubscriptionState(zeebeDb, transactionContext);
-    final var subscriptionState = zeebeState.getProcessMessageSubscriptionState();
+    final var subscriptionState = processingState.getProcessMessageSubscriptionState();
 
     final var openingProcessMessageSubscription =
         TestUtilities.createLegacyProcessMessageSubscription(100, 1);
@@ -146,10 +147,10 @@ public class DbMigrationStateTest {
         closingProcessMessageSubscription.getRecord(), TEST_SENT_TIME);
 
     // when
-    final var migrationState = zeebeState.getMigrationState();
+    final var migrationState = processingState.getMigrationState();
     migrationState.migrateProcessMessageSubscriptionSentTime(
-        zeebeState.getProcessMessageSubscriptionState(),
-        zeebeState.getPendingProcessMessageSubscriptionState());
+        processingState.getProcessMessageSubscriptionState(),
+        processingState.getPendingProcessMessageSubscriptionState());
 
     // then
     // the sent time column family is empty
@@ -195,7 +196,8 @@ public class DbMigrationStateTest {
 
   private void assertThatRecordsArePresentInTransientState(
       final ProcessMessageSubscriptionRecord... subscriptionRecords) {
-    final var transientSubscriptionState = zeebeState.getPendingProcessMessageSubscriptionState();
+    final var transientSubscriptionState =
+        processingState.getPendingProcessMessageSubscriptionState();
 
     final var correlatingSubscriptions = new ArrayList<ProcessMessageSubscriptionRecord>();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/MessageSubscriptionSentTimeMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/MessageSubscriptionSentTimeMigrationTest.java
@@ -16,10 +16,10 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.migration.MessageSubscriptionSentTimeMigration;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -37,11 +37,11 @@ public class MessageSubscriptionSentTimeMigrationTest {
     @Test
     public void noMigrationNeededWhenColumnIsEmpty() {
       // given
-      final var mockZeebeState = mock(ZeebeState.class);
-      when(mockZeebeState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME))
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME))
           .thenReturn(true);
       // when
-      final var actual = sutMigration.needsToRun(mockZeebeState);
+      final var actual = sutMigration.needsToRun(mockProcessingState);
 
       // then
       assertThat(actual).isFalse();
@@ -50,12 +50,12 @@ public class MessageSubscriptionSentTimeMigrationTest {
     @Test
     public void migrationNeededWhenColumnIsNotEmpty() {
       // given
-      final var mockZeebeState = mock(ZeebeState.class);
-      when(mockZeebeState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME))
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME))
           .thenReturn(false);
 
       // when
-      final var actual = sutMigration.needsToRun(mockZeebeState);
+      final var actual = sutMigration.needsToRun(mockProcessingState);
 
       // then
       assertThat(actual).isTrue();
@@ -64,30 +64,30 @@ public class MessageSubscriptionSentTimeMigrationTest {
     @Test
     public void migrationCallsMethodInMigrationState() {
       // given
-      final var mockZeebeState = mock(MutableZeebeState.class, RETURNS_DEEP_STUBS);
+      final var mockProcessingState = mock(MutableProcessingState.class, RETURNS_DEEP_STUBS);
 
       // when
-      sutMigration.runMigration(mockZeebeState);
+      sutMigration.runMigration(mockProcessingState);
 
       // then
-      verify(mockZeebeState.getMigrationState())
+      verify(mockProcessingState.getMigrationState())
           .migrateMessageSubscriptionSentTime(
-              mockZeebeState.getMessageSubscriptionState(),
-              mockZeebeState.getPendingMessageSubscriptionState());
+              mockProcessingState.getMessageSubscriptionState(),
+              mockProcessingState.getPendingMessageSubscriptionState());
 
-      verifyNoMoreInteractions(mockZeebeState.getMigrationState());
+      verifyNoMoreInteractions(mockProcessingState.getMigrationState());
     }
   }
 
   @Nested
-  @ExtendWith(ZeebeStateExtension.class)
+  @ExtendWith(ProcessingStateExtension.class)
   public class BlackboxTest {
 
     private static final long TEST_SENT_TIME = 1000L;
 
     private ZeebeDb<ZbColumnFamilies> zeebeDb;
 
-    private MutableZeebeState zeebeState;
+    private MutableProcessingState processingState;
 
     private TransactionContext transactionContext;
 
@@ -108,7 +108,7 @@ public class MessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
 
       // when
-      final var actual = sutMigration.needsToRun(zeebeState);
+      final var actual = sutMigration.needsToRun(processingState);
 
       // then
       assertThat(actual).describedAs("Migration should run").isTrue();
@@ -119,8 +119,8 @@ public class MessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
 
       // when
-      sutMigration.runMigration(zeebeState);
-      final var actual = sutMigration.needsToRun(zeebeState);
+      sutMigration.runMigration(processingState);
+      final var actual = sutMigration.needsToRun(processingState);
 
       // then
       assertThat(actual).describedAs("Migration should run").isFalse();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/ProcessMessageSubscriptionSentTimeMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/ProcessMessageSubscriptionSentTimeMigrationTest.java
@@ -96,7 +96,6 @@ public class ProcessMessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
       final var legacySubscriptionState =
           new LegacyDbProcessMessageSubscriptionState(zeebeDb, transactionContext);
-      final var subscriptionState = processingState.getProcessMessageSubscriptionState();
 
       final var openingProcessMessageSubscription =
           TestUtilities.createLegacyProcessMessageSubscription(100, 1);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/TemporaryVariableMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/TemporaryVariableMigrationTest.java
@@ -16,13 +16,13 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.DbElementInstanceState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.engine.state.migration.TemporaryVariableMigration;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.variable.DbVariableState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -47,11 +47,11 @@ public class TemporaryVariableMigrationTest {
     @Test
     public void noMigrationNeededWhenColumnIsEmpty() {
       // given
-      final var mockZeebeState = mock(ZeebeState.class);
+      final var mockProcessingState = mock(ProcessingState.class);
 
       // when
-      when(mockZeebeState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE)).thenReturn(true);
-      final var actual = sutMigration.needsToRun(mockZeebeState);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE)).thenReturn(true);
+      final var actual = sutMigration.needsToRun(mockProcessingState);
 
       // then
       assertThat(actual).isFalse();
@@ -60,11 +60,12 @@ public class TemporaryVariableMigrationTest {
     @Test
     public void migrationNeededWhenColumnIsNotEmpty() {
       // given
-      final var mockZeebeState = mock(ZeebeState.class);
+      final var mockProcessingState = mock(ProcessingState.class);
 
       // when
-      when(mockZeebeState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE)).thenReturn(false);
-      final var actual = sutMigration.needsToRun(mockZeebeState);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE))
+          .thenReturn(false);
+      final var actual = sutMigration.needsToRun(mockProcessingState);
 
       // then
       assertThat(actual).isTrue();
@@ -73,27 +74,27 @@ public class TemporaryVariableMigrationTest {
     @Test
     public void migrationCallsMethodInMigrationState() {
       // given
-      final var mockZeebeState = mock(MutableZeebeState.class, RETURNS_DEEP_STUBS);
+      final var mockProcessingState = mock(MutableProcessingState.class, RETURNS_DEEP_STUBS);
 
       // when
-      sutMigration.runMigration(mockZeebeState);
+      sutMigration.runMigration(mockProcessingState);
 
       // then
-      verify(mockZeebeState.getMigrationState())
+      verify(mockProcessingState.getMigrationState())
           .migrateTemporaryVariables(
-              mockZeebeState.getEventScopeInstanceState(),
-              mockZeebeState.getElementInstanceState());
+              mockProcessingState.getEventScopeInstanceState(),
+              mockProcessingState.getElementInstanceState());
 
-      verifyNoMoreInteractions(mockZeebeState.getMigrationState());
+      verifyNoMoreInteractions(mockProcessingState.getMigrationState());
     }
   }
 
   @Nested
-  @ExtendWith(ZeebeStateExtension.class)
+  @ExtendWith(ProcessingStateExtension.class)
   public class BlackboxTest {
 
     private ZeebeDb<ZbColumnFamilies> zeebeDb;
-    private MutableZeebeState zeebeState;
+    private MutableProcessingState processingState;
     private TransactionContext transactionContext;
     private LegacyDbTemporaryVariablesState legacyTemporaryVariablesState;
     private DbVariableState variableState;
@@ -114,7 +115,7 @@ public class TemporaryVariableMigrationTest {
       // given database with legacy records
 
       // when
-      final var actual = sutMigration.needsToRun(zeebeState);
+      final var actual = sutMigration.needsToRun(processingState);
 
       // then
       assertThat(actual).describedAs("Migration should run").isTrue();
@@ -126,14 +127,14 @@ public class TemporaryVariableMigrationTest {
       // given database with legacy records
 
       // when
-      sutMigration.runMigration(zeebeState);
-      final var actual = sutMigration.needsToRun(zeebeState);
+      sutMigration.runMigration(processingState);
+      final var actual = sutMigration.needsToRun(processingState);
 
       // then
       assertThat(actual).describedAs("Migration should run").isFalse();
       assertThat(legacyTemporaryVariablesState.isEmpty()).isTrue();
       final EventTrigger eventTrigger =
-          zeebeState.getEventScopeInstanceState().peekEventTrigger(EVENT_SCOPE_KEY);
+          processingState.getEventScopeInstanceState().peekEventTrigger(EVENT_SCOPE_KEY);
       assertThat(eventTrigger.getVariables()).isEqualTo(VARIABLES);
       assertThat(eventTrigger.getEventKey()).isEqualTo(-1L);
       assertThat(eventTrigger.getElementId())
@@ -151,13 +152,13 @@ public class TemporaryVariableMigrationTest {
           EVENT_SCOPE_KEY, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
       // when
-      sutMigration.runMigration(zeebeState);
+      sutMigration.runMigration(processingState);
 
       // then
       final EventTrigger oldEventTrigger =
-          zeebeState.getEventScopeInstanceState().peekEventTrigger(EVENT_SCOPE_KEY);
+          processingState.getEventScopeInstanceState().peekEventTrigger(EVENT_SCOPE_KEY);
       final EventTrigger newEventTrigger =
-          zeebeState.getEventScopeInstanceState().peekEventTrigger(flowScopeKey);
+          processingState.getEventScopeInstanceState().peekEventTrigger(flowScopeKey);
       assertThat(oldEventTrigger).isNull();
       assertThat(newEventTrigger).isNotNull();
       assertThat(newEventTrigger.getEventKey()).isEqualTo(-1L);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
@@ -13,9 +13,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.QueryService.ClosedServiceException;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.engine.util.Records;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -30,12 +30,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 final class StateQueryServiceTest {
 
   private StateQueryService sut;
   private ZeebeDb<ZbColumnFamilies> db;
-  private MutableZeebeState state;
+  private MutableProcessingState state;
   private TransactionContext transactionContext;
 
   @BeforeEach

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/signal/SignalSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/signal/SignalSubscriptionStateTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.state.mutable.MutableSignalSubscriptionState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
@@ -27,13 +27,13 @@ import org.junit.Test;
 
 public final class SignalSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableSignalSubscriptionState state;
 
   @Before
   public void setUp() {
-    state = stateRule.getZeebeState().getSignalSubscriptionState();
+    state = stateRule.getProcessingState().getSignalSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
@@ -18,9 +18,9 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 public final class VariableStateTest {
 
-  @ClassRule public static final ZeebeStateRule ZEEBE_STATE_RULE = new ZeebeStateRule();
+  @ClassRule public static final ProcessingStateRule ZEEBE_STATE_RULE = new ProcessingStateRule();
   private static final long PROCESS_KEY = 123;
   private static final AtomicLong PARENT_KEY = new AtomicLong(0);
   private static final AtomicLong CHILD_KEY = new AtomicLong(1);
@@ -49,9 +49,9 @@ public final class VariableStateTest {
 
   @BeforeClass
   public static void setUp() {
-    final MutableZeebeState zeebeState = ZEEBE_STATE_RULE.getZeebeState();
-    elementInstanceState = zeebeState.getElementInstanceState();
-    variableState = zeebeState.getVariableState();
+    final MutableProcessingState processingState = ZEEBE_STATE_RULE.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
+    variableState = processingState.getVariableState();
   }
 
   @Before

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
@@ -275,8 +275,8 @@ public final class EngineRule extends ExternalResource {
     return environmentRule.getClock();
   }
 
-  public ZeebeState getZeebeState() {
-    return environmentRule.getZeebeState();
+  public ProcessingState getProcessingState() {
+    return environmentRule.getProcessingState();
   }
 
   public StreamProcessor getStreamProcessor(final int partitionId) {
@@ -369,7 +369,7 @@ public final class EngineRule extends ExternalResource {
                 Function.identity(),
                 columnFamily -> {
                   final var entries = new HashMap<>();
-                  ((ZeebeDbState) getZeebeState())
+                  ((ProcessingDbState) getProcessingState())
                       .forEach(
                           columnFamily,
                           keyInstance,

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -14,8 +14,8 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
@@ -44,7 +44,7 @@ import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
  * <ul>
  *   <li>{@code ZeebeDb} (exact type match)
  *   <li>{@code TransactionContext} (exact type match)
- *   <li>{@code MutableZeebeState} (exact type match or supertypes)
+ *   <li>{@code MutableProcessingState} (exact type match or supertypes)
  * </ul>
  *
  * on fields with the corresponding type.
@@ -52,11 +52,11 @@ import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
  * <p>Usage:
  *
  * <pre>{@code
- * @ExtendWith(ZeebeStateExtension)
+ * @ExtendWith(ProcessingStateExtension)
  * public class Test {
  *   private ZeebeDb db; //will be injected
  *   private TransactionContext txContext; //will be injected
- *   private MutableZeebeState state //will be injected
+ *   private MutableProcessingState state //will be injected
  *
  *   ...
  * }
@@ -69,7 +69,7 @@ import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
  * private ZeebeDb db2; // will be injected, but will be the same instance as db1
  * }</pre>
  */
-public class ZeebeStateExtension implements BeforeEachCallback {
+public class ProcessingStateExtension implements BeforeEachCallback {
 
   private static final String FIELD_STATE = "state";
 
@@ -81,11 +81,11 @@ public class ZeebeStateExtension implements BeforeEachCallback {
         .forEach(instance -> injectFields(context, instance, instance.getClass()));
   }
 
-  public ZeebeStateExtensionState lookupOrCreate(final ExtensionContext extensionContext) {
+  public ProcessingStateExtensionState lookupOrCreate(final ExtensionContext extensionContext) {
     final var store = getStore(extensionContext);
 
-    return (ZeebeStateExtensionState)
-        store.getOrComputeIfAbsent(FIELD_STATE, (key) -> new ZeebeStateExtensionState());
+    return (ProcessingStateExtensionState)
+        store.getOrComputeIfAbsent(FIELD_STATE, (key) -> new ProcessingStateExtensionState());
   }
 
   private void injectFields(
@@ -123,12 +123,13 @@ public class ZeebeStateExtension implements BeforeEachCallback {
             testClass,
             field ->
                 ReflectionUtils.isNotStatic(field)
-                    && field.getType().isAssignableFrom(MutableZeebeState.class),
+                    && field.getType().isAssignableFrom(MutableProcessingState.class),
             HierarchyTraversalMode.TOP_DOWN)
         .forEach(
             field -> {
               try {
-                makeAccessible(field).set(testInstance, lookupOrCreate(context).getZeebeState());
+                makeAccessible(field)
+                    .set(testInstance, lookupOrCreate(context).getProcessingState());
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
               }
@@ -139,13 +140,13 @@ public class ZeebeStateExtension implements BeforeEachCallback {
     return context.getStore(Namespace.create(getClass(), context.getUniqueId()));
   }
 
-  private static final class ZeebeStateExtensionState implements CloseableResource {
+  private static final class ProcessingStateExtensionState implements CloseableResource {
     private Path tempFolder;
     private ZeebeDb<ZbColumnFamilies> zeebeDb;
     private TransactionContext transactionContext;
-    private MutableZeebeState zeebeState;
+    private MutableProcessingState processingState;
 
-    private ZeebeStateExtensionState() {
+    private ProcessingStateExtensionState() {
 
       final var factory = DefaultZeebeDbFactory.defaultFactory();
       try {
@@ -154,8 +155,8 @@ public class ZeebeStateExtension implements BeforeEachCallback {
         transactionContext = zeebeDb.createContext();
         final var keyGenerator =
             new DbKeyGenerator(Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext);
-        zeebeState =
-            new ZeebeDbState(
+        processingState =
+            new ProcessingDbState(
                 Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext, keyGenerator);
       } catch (final Exception e) {
         ExceptionUtils.throwAsUncheckedException(e);
@@ -227,8 +228,8 @@ public class ZeebeStateExtension implements BeforeEachCallback {
       return zeebeDb;
     }
 
-    private MutableZeebeState getZeebeState() {
-      return zeebeState;
+    private MutableProcessingState getProcessingState() {
+      return processingState;
     }
 
     private TransactionContext getTransactionContext() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
@@ -9,26 +9,26 @@ package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 
-public final class ZeebeStateRule extends ExternalResource {
+public final class ProcessingStateRule extends ExternalResource {
 
   private final TemporaryFolder tempFolder = new TemporaryFolder();
   private final int partition;
   private ZeebeDb<ZbColumnFamilies> db;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
-  public ZeebeStateRule() {
+  public ProcessingStateRule() {
     this(Protocol.DEPLOYMENT_PARTITION);
   }
 
-  public ZeebeStateRule(final int partition) {
+  public ProcessingStateRule(final int partition) {
     this.partition = partition;
   }
 
@@ -39,7 +39,7 @@ public final class ZeebeStateRule extends ExternalResource {
 
     final var context = db.createContext();
     final var keyGenerator = new DbKeyGenerator(partition, db, context);
-    zeebeState = new ZeebeDbState(partition, db, context, keyGenerator);
+    processingState = new ProcessingDbState(partition, db, context, keyGenerator);
   }
 
   @Override
@@ -52,8 +52,8 @@ public final class ZeebeStateRule extends ExternalResource {
     tempFolder.delete();
   }
 
-  public MutableZeebeState getZeebeState() {
-    return zeebeState;
+  public MutableProcessingState getProcessingState() {
+    return processingState;
   }
 
   public ZeebeDb<ZbColumnFamilies> createNewDb() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.util.SynchronousLogStream;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -33,7 +33,7 @@ public class StreamProcessingComposite {
   private final TestStreams streams;
   private final int partitionId;
   private final ZeebeDbFactory<?> zeebeDbFactory;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
   private final WriteActor writeActor = new WriteActor();
 
   public StreamProcessingComposite(
@@ -67,11 +67,11 @@ public class StreamProcessingComposite {
   private TypedRecordProcessors createTypedRecordProcessors(
       final StreamProcessorTestFactory factory,
       final TypedRecordProcessorContext typedRecordProcessorContext) {
-    zeebeState = typedRecordProcessorContext.getZeebeState();
+    processingState = typedRecordProcessorContext.getProcessingState();
 
     return factory.build(
         TypedRecordProcessors.processors(
-            zeebeState.getKeyGenerator(), typedRecordProcessorContext.getWriters()),
+            processingState.getKeyGenerator(), typedRecordProcessorContext.getWriters()),
         typedRecordProcessorContext);
   }
 
@@ -90,7 +90,7 @@ public class StreamProcessingComposite {
             getLogName(partitionId),
             zeebeDbFactory,
             (processingContext -> {
-              zeebeState = processingContext.getZeebeState();
+              processingState = processingContext.getProcessingState();
 
               return factory.createProcessors(processingContext);
             }),
@@ -123,8 +123,8 @@ public class StreamProcessingComposite {
     return streams.getStreamProcessor(getLogName(partitionId));
   }
 
-  public MutableZeebeState getZeebeState() {
-    return zeebeState;
+  public MutableProcessingState getProcessingState() {
+    return processingState;
   }
 
   public RecordStream events() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -12,7 +12,7 @@ import static io.camunda.zeebe.engine.util.StreamProcessingComposite.getLogName;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.StreamProcessingComposite.StreamProcessorTestFactory;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.util.ListLogStorage;
@@ -169,8 +169,8 @@ public final class StreamProcessorRule implements TestRule {
     return clock;
   }
 
-  public MutableZeebeState getZeebeState() {
-    return streamProcessingComposite.getZeebeState();
+  public MutableProcessingState getProcessingState() {
+    return streamProcessingComposite.getProcessingState();
   }
 
   public RecordStream events() {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -15,9 +15,10 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
    * the task is executed, it is rescheduled with the same delay again.
    *
-   * <p>The execution of the scheduled task is running asynchron/concurrent to other scheduled
-   * tasks. Other methods will guarantee ordering of scheduled tasks and running always in same
-   * thread, these guarantees don't apply to this method.
+   * <p>The execution of the scheduled task is running asynchronously/concurrently to task scheduled
+   * through non-async methods. While other, non-async methods guarantee the execution order of
+   * scheduled tasks and always execute scheduled tasks on the same thread, this method does not
+   * guarantee this.
    *
    * <p>Note that time-traveling in tests only affects the delay of the currently scheduled next
    * task and not any of the iterations after. This is because the next task is scheduled with the


### PR DESCRIPTION
## Description

Schedule the Message TTL checker as an async tasks to run concurrently to processing.

To safely access the state, a new immutable state is provided for scheduled tasks. These state objects are not shared with processing.

## Related issues

closes #11761 
