### PR TITLE
[Backport stable/8.1] chore(release): use new 8 core runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   release:
     name: Maven & Go Release
-    runs-on: n1-standard-16-netssd-preempt-quick
+    runs-on: n1-standard-8-netssd-preempt-quick
     timeout-minutes: 30
     outputs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}


### PR DESCRIPTION
# Description
Backport of #11791 to `stable/8.1`.

relates to 