### PR TITLE
fix(docker): data and logs mount for unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,14 +101,17 @@ ENV PATH "${ZB_HOME}/bin:${PATH}"
 WORKDIR ${ZB_HOME}
 EXPOSE 26500 26501 26502
 VOLUME ${ZB_HOME}/data
+VOLUME ${ZB_HOME}/logs
 
 RUN groupadd -g 1000 zeebe && \
     adduser -u 1000 zeebe --system --ingroup zeebe && \
     chmod g=u /etc/passwd && \
-    chown 1000:0 ${ZB_HOME} && \
-    chmod 0775 ${ZB_HOME} && \
+    # These directories are to be mounted by users, eagerly creating them and setting ownership
+    # helps to avoid potential permission issues due to default volume ownership.
     mkdir ${ZB_HOME}/data && \
-    chmod 0775 ${ZB_HOME}/data
+    mkdir ${ZB_HOME}/logs && \
+    chown -R 1000:0 ${ZB_HOME} && \
+    chmod -R 0775 ${ZB_HOME}
 
 COPY --from=init --chown=1000:0 /zeebe/tini ${ZB_HOME}/bin/
 COPY --from=init --chown=1000:0 /zeebe/startup.sh /usr/local/bin/startup.sh

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RootlessImageTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RootlessImageTest.java
@@ -12,90 +12,86 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.zeebe.containers.ZeebeBrokerContainer;
 import io.zeebe.containers.ZeebeGatewayContainer;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.Network;
-import org.testcontainers.junit.jupiter.Container;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-/**
- * Tests a small deployment of one standalone broker and gateway, running "rootless". While this
- * cannot guarantee OpenShift compatibility, it's the most common compatibility issue.
- *
- * <p>See <a
- * href="https://docs.openshift.com/container-platform/latest/openshift_images/create-images.html">here</a>
- * for more.
- *
- * <p>From their docs: By default, OpenShift Container Platform runs containers using an arbitrarily
- * assigned user ID. This provides additional security against processes escaping the container due
- * to a container engine vulnerability and thereby achieving escalated permissions on the host node.
- * For an image to support running as an arbitrary user, directories and files that are written to
- * by processes in the image must be owned by the root group and be read/writable by that group.
- * Files to be executed must also have "group" execute permissions.
- *
- * <p>You can read more about UIDs/GIDs <a
- * href="https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids">here</a>.
- */
+/** Tests a small deployment of one standalone broker and gateway, running "rootless". */
 @Testcontainers
-final class RootlessImageTest {
-  private final Network network = Network.newNetwork();
+public class RootlessImageTest {
 
-  @Container
-  private final ZeebeBrokerContainer broker =
-      new ZeebeBrokerContainer(ZeebeTestContainerDefaults.defaultTestImage())
-          .withNetwork(network)
-          .withCreateContainerCmdModifier(cmd -> cmd.withUser("1000620000:0"));
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        /* Tests running with the default unprivileged user. */
+        "zeebe",
+        /*
+         * Runs with a random uid and guid of 0 as common for Openshift.
+         * While this cannot guarantee OpenShift compatibility, it's a common compatibility issue.
+         *
+         * <p>See <a
+         * href="https://docs.openshift.com/container-platform/latest/openshift_images/create-images.html">here</a>
+         * for more.
+         *
+         * <p>From their docs: By default, OpenShift Container Platform runs containers using an
+         * arbitrarily assigned user ID. This provides additional security against processes escaping the
+         * container due to a container engine vulnerability and thereby achieving escalated permissions
+         * on the host node. For an image to support running as an arbitrary user, directories and files
+         * that are written to by processes in the image must be owned by the root group and be
+         * read/writable by that group. Files to be executed must also have "group" execute permissions.
+         *
+         * <p>You can read more about UIDs/GIDs <a
+         * href="https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids">here</a>.
+         */
+        "1000620000:0"
+      })
+  void runWithUnprivilegedUser(final String user) {
+    try (final ZeebeBrokerContainer broker =
+            new ZeebeBrokerContainer(ZeebeTestContainerDefaults.defaultTestImage())
+                .withCreateContainerCmdModifier(cmd -> cmd.withUser(user));
+        final ZeebeGatewayContainer gateway =
+            new ZeebeGatewayContainer(ZeebeTestContainerDefaults.defaultTestImage())
+                .withNetwork(broker.getNetwork())
+                .withCreateContainerCmdModifier(cmd -> cmd.withUser(user))
+                .dependsOn(broker)
+                .withEnv(
+                    "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS",
+                    broker.getInternalClusterAddress())) {
+      // given
+      broker.start();
+      gateway.start();
+      final var process = Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+      final ProcessInstanceResult result;
+      try (final ZeebeClient client =
+          ZeebeClient.newClientBuilder()
+              .usePlaintext()
+              .gatewayAddress(gateway.getExternalGatewayAddress())
+              .build()) {
+        // when
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .send()
+            .join(10, TimeUnit.SECONDS);
+        result =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId("process")
+                .latestVersion()
+                .withResult()
+                .send()
+                .join(10, TimeUnit.SECONDS);
+      }
 
-  @Container
-  private final ZeebeGatewayContainer gateway =
-      new ZeebeGatewayContainer(ZeebeTestContainerDefaults.defaultTestImage())
-          .withNetwork(network)
-          .withCreateContainerCmdModifier(cmd -> cmd.withUser("1000620000:0"))
-          .dependsOn(broker)
-          .withEnv(
-              "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", broker.getInternalClusterAddress());
-
-  @SuppressWarnings("unused")
-  @RegisterExtension
-  final ContainerLogsDumper logsWatcher =
-      new ContainerLogsDumper(() -> Map.of("broker", broker, "gateway", gateway));
-
-  @Test
-  void smokeTest() {
-    // given
-    final var process = Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
-    final ProcessInstanceResult result;
-    try (final ZeebeClient client =
-        ZeebeClient.newClientBuilder()
-            .usePlaintext()
-            .gatewayAddress(gateway.getExternalGatewayAddress())
-            .build()) {
-      // when
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .send()
-          .join(10, TimeUnit.SECONDS);
-      result =
-          client
-              .newCreateInstanceCommand()
-              .bpmnProcessId("process")
-              .latestVersion()
-              .withResult()
-              .send()
-              .join(10, TimeUnit.SECONDS);
+      // then
+      assertThat(result)
+          .isNotNull()
+          .extracting(ProcessInstanceResult::getBpmnProcessId)
+          .isEqualTo("process");
     }
-
-    // then
-    assertThat(result)
-        .isNotNull()
-        .extracting(ProcessInstanceResult::getBpmnProcessId)
-        .isEqualTo("process");
   }
 }


### PR DESCRIPTION
## Description

This change fixes permission issues if zeebe would be run with the `zeebe` user, a test to verify this works is also added.

Additionally the log directory is marked as a mount point in the Dockerfile now, this will instruct docker to always create volumes for it and thus allow us to verify mounting this dir works fine, without potential permission issues when using the `zeebe` user.

Note this does not make the `zeebe` user the default user which would be a breaking change for existing setups where volume data might be owned by root. I will handle this separately.

Ownership before this change:
```
root@9f6bb138376a:/usr/local/zeebe# ls -al
...
drwxrwxr-x 3 root  root  4096 Feb 23 17:26 data
drwxr-xr-x 2 zeebe root 12288 Feb 23 07:59 lib
drwxr-xr-x 2 root  root  4096 Feb 23 17:26 logs
```
after
```
root@753497ed6a06:/usr/local/zeebe# ls -al
...
drwxrwxr-x 3 zeebe root  4096 Feb 23 17:27 data
drwxr-xr-x 2 zeebe root 12288 Feb 23 07:59 lib
drwxrwxr-x 2 zeebe root  4096 Feb 23 17:27 logs
...
```

## Related issues

relates to #11784
closes #11866

