### PR TITLE
ci: always remove system-out before publishing test results

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -27,7 +27,14 @@ jobs:
             gh api $url > "$name.zip"
             unzip -d "$name" "$name.zip"
           done
-
+        # Mitigate to large test output files by deleting the system-out element using sed
+        # Note: we cannot use XML tools like xmlstarlet as they all suffer the same libxml2 limitation
+        # Related to https://github.com/camunda/zeebe/issues/9959
+      - name: Remove system-out from test xml files
+        shell: bash
+        run: |
+          cd artifacts
+          find . -iname TEST-*.xml -print0 | xargs -0 -r sed '/<system-out>/,/<\/system-out>/d' -i
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:


### PR DESCRIPTION
Part one of https://github.com/camunda/zeebe/pull/11779#issue-1594777214

This duplicates the existing logic from the `collect-test-artifacts` action.

The goal is to move the logic from `collect-test-artifacts` to `publish-test-results`. Because the `publish-test-results` action is run from the `main` branch, removal needs to be a two-step process of first adding it to `publish-test-results` and then removing it from `collect-test-artifacts` in a separate PR.

https://github.com/camunda/zeebe/pull/11779#issuecomment-1439776727