### PR TITLE
ci: keep test output in artifacts

### DIFF
--- a/.github/actions/collect-test-artifacts/action.yml
+++ b/.github/actions/collect-test-artifacts/action.yml
@@ -11,23 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-
-    # MacOS sed is not compatible with the remove script, we need gnu sed instead
-  - name: Install GNU sed
-    if: runner.os == 'macOS'
-    shell: bash
-    run: |
-      brew install gnu-sed
-      echo "SED_BIN=gsed" >> $GITHUB_ENV
-
-    # Mitigate to large test output files by deleting the system-out element using sed
-    # Note: we cannot use XML tools like xmlstarlet as they all suffer the same libxml2 limitation
-    # Related to https://github.com/camunda/zeebe/issues/9959
-  - name: Remove system-out from test xml files
-    shell: bash
-    run: |
-      find . -iname TEST-*.xml -print0 | xargs -0 -r ${SED_BIN:-sed} '/<system-out>/,/<\/system-out>/d' -i
-
   - name: Archive Test Results
     uses: actions/upload-artifact@v3
     with:


### PR DESCRIPTION
Now that the `publish-test-results` action trims the test output, the `collect-test-artifacts` action does not need to remove it. Keeping them is useful because for tests that run concurrently, the system-out in the test report xml file is the only source for logs.

The usual `*-output.txt` files contain logs from the concurrent execution of all tests within one class which makes them unusable for debugging.

Part two of https://github.com/camunda/zeebe/pull/11779, follow up of https://github.com/camunda/zeebe/pull/11801