### PR TITLE
Fix direct message correlation with pending checkers

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
@@ -36,22 +36,19 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
   private boolean sendCommand(final MessageSubscription subscription) {
     final var record = subscription.getRecord();
 
-    final boolean success =
-        commandSender.correlateProcessMessageSubscription(
-            record.getProcessInstanceKey(),
-            record.getElementInstanceKey(),
-            record.getBpmnProcessIdBuffer(),
-            record.getMessageNameBuffer(),
-            record.getMessageKey(),
-            record.getVariablesBuffer(),
-            record.getCorrelationKeyBuffer());
+    commandSender.sendDirectCorrelateProcessMessageSubscription(
+        record.getProcessInstanceKey(),
+        record.getElementInstanceKey(),
+        record.getBpmnProcessIdBuffer(),
+        record.getMessageNameBuffer(),
+        record.getMessageKey(),
+        record.getVariablesBuffer(),
+        record.getCorrelationKeyBuffer());
 
-    if (success) {
-      // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)
-      final var sentTime = ActorClock.currentTimeMillis();
-      transientState.updateCommandSentTime(subscription.getRecord(), sentTime);
-    }
+    // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)
+    final var sentTime = ActorClock.currentTimeMillis();
+    transientState.updateCommandSentTime(subscription.getRecord(), sentTime);
 
-    return success;
+    return true; // to continue visiting
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -100,7 +100,7 @@ public final class PendingProcessMessageSubscriptionChecker
   }
 
   private boolean sendOpenCommand(final ProcessMessageSubscription subscription) {
-    return commandSender.openMessageSubscription(
+    commandSender.sendDirectOpenMessageSubscription(
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
         subscription.getRecord().getElementInstanceKey(),
@@ -108,6 +108,7 @@ public final class PendingProcessMessageSubscriptionChecker
         subscription.getRecord().getMessageNameBuffer(),
         subscription.getRecord().getCorrelationKeyBuffer(),
         subscription.getRecord().isInterrupting());
+    return true;
   }
 
   private boolean sendCloseCommand(final ProcessMessageSubscription subscription) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -82,24 +82,20 @@ public final class PendingProcessMessageSubscriptionChecker
   }
 
   private boolean sendPendingCommand(final ProcessMessageSubscription subscription) {
-    final boolean success;
-
     // can only be opening/closing as an opened subscription is not indexed in the sent time column
     if (subscription.isOpening()) {
-      success = sendOpenCommand(subscription);
+      sendOpenCommand(subscription);
     } else {
-      success = sendCloseCommand(subscription);
+      sendCloseCommand(subscription);
     }
 
-    if (success) {
-      final var sentTime = ActorClock.currentTimeMillis();
-      pendingState.updateSentTime(subscription.getRecord(), sentTime);
-    }
+    final var sentTime = ActorClock.currentTimeMillis();
+    pendingState.updateSentTime(subscription.getRecord(), sentTime);
 
-    return success;
+    return true; // to continue visiting
   }
 
-  private boolean sendOpenCommand(final ProcessMessageSubscription subscription) {
+  private void sendOpenCommand(final ProcessMessageSubscription subscription) {
     commandSender.sendDirectOpenMessageSubscription(
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
@@ -108,15 +104,13 @@ public final class PendingProcessMessageSubscriptionChecker
         subscription.getRecord().getMessageNameBuffer(),
         subscription.getRecord().getCorrelationKeyBuffer(),
         subscription.getRecord().isInterrupting());
-    return true;
   }
 
-  private boolean sendCloseCommand(final ProcessMessageSubscription subscription) {
+  private void sendCloseCommand(final ProcessMessageSubscription subscription) {
     commandSender.sendDirectCloseMessageSubscription(
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getMessageNameBuffer());
-    return true;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -111,10 +111,11 @@ public final class PendingProcessMessageSubscriptionChecker
   }
 
   private boolean sendCloseCommand(final ProcessMessageSubscription subscription) {
-    return commandSender.closeMessageSubscription(
+    commandSender.sendDirectCloseMessageSubscription(
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getMessageNameBuffer());
+    return true;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -149,6 +149,42 @@ public class SubscriptionCommandSender {
             .setCorrelationKey(correlationKey));
   }
 
+  /**
+   * Sends the correlate process message subscription command directly to the subscribed partition.
+   * This differs to ${link correlateProcessMessageSubscription}, as the sending/writing is not
+   * delayed. Usually useful or used in scheduled tasks, which want to directly send commands.
+   *
+   * @param processInstanceKey the related process instance key
+   * @param elementInstanceKey the related element instance key
+   * @param bpmnProcessId the related process id
+   * @param messageName the name of the message for which the subscription should be correlated
+   * @param messageKey the key of the message for which the subscription should be correlated
+   * @param variables the variables of the message
+   * @param correlationKey the correlation key for which the message should be correlated
+   */
+  public void sendDirectCorrelateProcessMessageSubscription(
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final DirectBuffer bpmnProcessId,
+      final DirectBuffer messageName,
+      final long messageKey,
+      final DirectBuffer variables,
+      final DirectBuffer correlationKey) {
+    interPartitionCommandSender.sendCommand(
+        Protocol.decodePartitionId(processInstanceKey),
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+        ProcessMessageSubscriptionIntent.CORRELATE,
+        new ProcessMessageSubscriptionRecord()
+            .setSubscriptionPartitionId(senderPartition)
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageKey(messageKey)
+            .setMessageName(messageName)
+            .setVariables(variables)
+            .setCorrelationKey(correlationKey));
+  }
+
   public boolean correlateMessageSubscription(
       final int subscriptionPartitionId,
       final long processInstanceKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -148,6 +148,32 @@ public class SubscriptionCommandSender {
             .setMessageName(messageName));
   }
 
+  /**
+   * Sends the close message subscription command directly to the subscription partition. This
+   * differs to ${link closeMessageSubscription}, as the sending/writing is not delayed. Usually
+   * useful or used in scheduled tasks, which want to directly send commands.
+   *
+   * @param subscriptionPartitionId the partition Id which should receive the command
+   * @param processInstanceKey the related process instance key
+   * @param elementInstanceKey the related element instance key
+   * @param messageName the name of the message for which the subscription should be closed
+   */
+  public void sendDirectCloseMessageSubscription(
+      final int subscriptionPartitionId,
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final DirectBuffer messageName) {
+    interPartitionCommandSender.sendCommand(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.DELETE,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setMessageKey(-1L)
+            .setMessageName(messageName));
+  }
+
   public boolean closeProcessMessageSubscription(
       final long processInstanceKey,
       final long elementInstanceKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -73,6 +73,41 @@ public class SubscriptionCommandSender {
             .setInterrupting(closeOnCorrelate));
   }
 
+  /**
+   * Sends the open message subscription command directly to the subscription partition. This
+   * differs to ${link openMessageSubscription}, as the sending/writing is not delayed. Usually
+   * useful or used in scheduled tasks, which want to directly send commands.
+   *
+   * @param subscriptionPartitionId the partition Id which should receive the command
+   * @param processInstanceKey the related process instance key
+   * @param elementInstanceKey the related element instance key
+   * @param bpmnProcessId the related process id
+   * @param messageName the name of the message for which the subscription should be correlated
+   * @param correlationKey the correlation key for which the message should be correlated
+   * @param closeOnCorrelate indicates whether the subscription should be closed after correlation
+   */
+  public void sendDirectOpenMessageSubscription(
+      final int subscriptionPartitionId,
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final DirectBuffer bpmnProcessId,
+      final DirectBuffer messageName,
+      final DirectBuffer correlationKey,
+      final boolean closeOnCorrelate) {
+    interPartitionCommandSender.sendCommand(
+        subscriptionPartitionId,
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.CREATE,
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setMessageKey(-1)
+            .setMessageName(messageName)
+            .setCorrelationKey(correlationKey)
+            .setInterrupting(closeOnCorrelate));
+  }
+
   public boolean openProcessMessageSubscription(
       final long processInstanceKey,
       final long elementInstanceKey,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -153,6 +153,29 @@ public class SubscriptionCommandSenderTest {
   }
 
   @Test
+  public void shouldSendDirectCloseMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.sendDirectCloseMessageSubscription(
+        DIFFERENT_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_MESSAGE_NAME);
+
+    // then
+    verify(mockInterPartitionCommandSender)
+        .sendCommand(
+            eq(DIFFERENT_PARTITION),
+            eq(ValueType.MESSAGE_SUBSCRIPTION),
+            eq(MessageSubscriptionIntent.DELETE),
+            any());
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
   public void shouldSentFollowUpCommandForOpenMessageSubscription() {
     // given
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -215,6 +215,32 @@ public class SubscriptionCommandSenderTest {
   }
 
   @Test
+  public void shouldSendDirectOpenMessageSubscription() {
+    // given
+
+    // when
+    subscriptionCommandSender.sendDirectOpenMessageSubscription(
+        DIFFERENT_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_PROCESS_ID,
+        DEFAULT_MESSAGE_NAME,
+        DEFAULT_CORRELATION_KEY,
+        true);
+
+    // then
+    verify(mockInterPartitionCommandSender)
+        .sendCommand(
+            eq(DIFFERENT_PARTITION),
+            eq(ValueType.MESSAGE_SUBSCRIPTION),
+            eq(MessageSubscriptionIntent.CREATE),
+            any());
+    verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
+    verify(mockProcessingResultBuilder, never())
+        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
   public void shouldSentFollowUpCommandForOpenProcessMessageSubscription() {
     // given
 


### PR DESCRIPTION
## Description

I discovered recently that with https://github.com/camunda/zeebe/pull/11549 I have broken several pending checkers.

The problem is that the pending checkers are running inside the ProcessingScheduleService, and shouldn't use side effects nor any other writers to write into the processing result. **The commans will be just lost.** Previously the SubscriptionCommandSender has sent the request directly. As we want to send the requests only (on processing) if the receiver partition is not the same we moved the follow-up writing into the SubscriptionCommandSender. For the pending checker, it makes sense to use the interpartition command sender only, there is no use-case in directly writing (since it was written already in the processor directly as a follow-up command).

Right now we had in the Code the challenge that the SubscriptionCommandSender is used by Processors and Checkers, which are running inside scheduled Tasks. Ideally, I think it makes sense to split this class completely to not use the same class for Processors and Tasks, as this might lead to others issues in the future, especially if we migrate to a different actor. But I leave that up to your team to refactor this further.

The current naive solution, which has been done in this PR, was to split the usage up and create separate methods in the SubscriptionCommandSender which can be used by the Tasks. 

Affected methods:

 * [closeMessageSubscription](https://github.com/camunda/zeebe/commit/36a6c714d93ed8a75d6ac0ea6cf58a8857d3750e)
 * [openMessageSubscription](https://github.com/camunda/zeebe/commit/cde2a4df167dec82fa3b79554a22de56e171d870)
* [correlateProcessMessageSubscription](https://github.com/camunda/zeebe/commit/9e301509e5941ad5cae12c645f674bcf78486b71)


> **Note:** I have added new tests to the SubscriptionSender (which I created earlier)

But I was wondering why no tests actually failed before, looks like we have an lack of integration test, but I would also leave that to you to verify that this works as expected. Or at least wait on your input for that.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/11787

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
