### PR TITLE
Add the CommandDistributionRecord

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -49,6 +50,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(
         ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.SIGNAL, SignalRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.COMMAND_DISTRIBUTION, CommandDistributionRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -657,6 +657,7 @@
         #     event: true
         #     rejection: false
         #
+        #     commandDistribution: true
         #     decisionRequirements: true
         #     decision: true
         #     decisionEvaluation: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -587,6 +587,7 @@
         #     event: true
         #     rejection: false
         #
+        #     commandDistribution: true
         #     decisionRequirements: true
         #     decision: true
         #     decisionEvaluation: true

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -120,6 +120,7 @@ More specifically, each option configures the following:
 * `rejection` (`boolean`): if true, rejection records will be exported; if false, ignored.
 
 
+* `commandDistribution` (`boolean`): if true, records related to command distributions will be exported; if false, ignored.
 * `decisionRequirements` (`boolean`): if true, records related to decision requirements will be
   exported; if false, ignored.
 * `decision` (`boolean`): if true, records related to decisions will be exported; if false, ignored.
@@ -195,6 +196,7 @@ exporters:
         event: true
         rejection: false
 
+        commandDistribution: true
         decisionRequirements: true
         decision: true
         decisionEvaluation: true

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -272,6 +272,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.resourceDeletion) {
         createValueIndexTemplate(ValueType.RESOURCE_DELETION);
       }
+      if (index.commandDistribution) {
+        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -105,6 +105,8 @@ public class ElasticsearchExporterConfiguration {
         return index.signalSubscription;
       case RESOURCE_DELETION:
         return index.resourceDeletion;
+      case COMMAND_DISTRIBUTION:
+        return index.commandDistribution;
       default:
         return false;
     }
@@ -163,6 +165,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean signal = true;
     public boolean signalSubscription = true;
     public boolean resourceDeletion = true;
+    public boolean commandDistribution = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -248,6 +251,8 @@ public class ElasticsearchExporterConfiguration {
           + signalSubscription
           + ", resourceDeletion="
           + resourceDeletion
+          + ", recordDistribution="
+          + commandDistribution
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -1,0 +1,36 @@
+{
+  "index_patterns": [
+    "zeebe-record_command-distribution_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-command-distribution": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "partitionId": {
+              "type": "integer"
+            },
+            "valueType": {
+              "type": "keyword"
+            },
+            "commandValue": {
+              "enabled": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -75,6 +75,7 @@ final class TestSupport {
       case SIGNAL -> config.signal = value;
       case SIGNAL_SUBSCRIPTION -> config.signalSubscription = value;
       case RESOURCE_DELETION -> config.resourceDeletion = value;
+      case COMMAND_DISTRIBUTION -> config.commandDistribution = value;
       default -> throw new IllegalArgumentException(
           "No known indexing configuration option for value type " + valueType);
     }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.distribution;
+
+import io.camunda.zeebe.msgpack.MsgpackException;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class CommandDistributionRecord extends UnifiedRecordValue
+    implements CommandDistributionRecordValue {
+
+  private static final Map<ValueType, Supplier<UnifiedRecordValue>> RECORDS_BY_TYPE =
+      new EnumMap<>(ValueType.class);
+
+  // You'll need to register any of the records value's that you want to distribute
+  static {
+    RECORDS_BY_TYPE.put(ValueType.DEPLOYMENT, DeploymentRecord::new);
+  }
+
+  private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId");
+  private final EnumProperty<ValueType> valueTypeProperty =
+      new EnumProperty<>("valueType", ValueType.class);
+  private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
+      new ObjectProperty<>("commandValue", new UnifiedRecordValue());
+  private final MsgPackWriter recordValueWriter = new MsgPackWriter();
+  private final MsgPackReader recordValueReader = new MsgPackReader();
+
+  public CommandDistributionRecord() {
+    declareProperty(partitionIdProperty)
+        .declareProperty(valueTypeProperty)
+        .declareProperty(commandValueProperty);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionIdProperty.getValue();
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return valueTypeProperty.getValue();
+  }
+
+  @Override
+  public RecordValue getCommandValue() {
+    // fetch a concrete instance of the record value by type
+    if (!valueTypeProperty.hasValue()) {
+      throw new MsgpackException("Expected to read the value type property, but it's not yet set");
+    }
+    final var valueType = getValueType();
+    final var concrecteRecordValueSupplier = RECORDS_BY_TYPE.get(valueType);
+    if (concrecteRecordValueSupplier == null) {
+      throw new IllegalStateException(
+          "Expected to read the record value, but it's type `"
+              + valueType.name()
+              + "` is unknown. Please add it to RecordDistributionRecord.RECORDS_BY_TYPE");
+    }
+    final var concreteRecordValue = concrecteRecordValueSupplier.get();
+
+    // write the record value property's content into a buffer
+    final var storedRecordValue = commandValueProperty.getValue();
+    final var recordValueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = storedRecordValue.getEncodedLength();
+    recordValueBuffer.wrap(new byte[encodedLength]);
+    storedRecordValue.write(recordValueWriter.wrap(recordValueBuffer, 0));
+
+    // read the value back from the buffer into the concrete record value
+    concreteRecordValue.wrap(recordValueBuffer);
+    return concreteRecordValue;
+  }
+
+  public CommandDistributionRecord setValueType(final ValueType valueType) {
+    valueTypeProperty.setValue(valueType);
+    return this;
+  }
+
+  public CommandDistributionRecord setPartitionId(final int partitionId) {
+    partitionIdProperty.setValue(partitionId);
+    return this;
+  }
+
+  public CommandDistributionRecord setRecordValue(final UnifiedRecordValue recordValue) {
+    // inspired by IndexedRecord.setValue
+    final var valueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = recordValue.getLength();
+    valueBuffer.wrap(new byte[encodedLength]);
+
+    recordValue.write(valueBuffer, 0);
+    commandValueProperty.getValue().read(recordValueReader.wrap(valueBuffer, 0, encodedLength));
+    return this;
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -34,6 +34,12 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(ValueType.DEPLOYMENT, DeploymentRecord::new);
   }
 
+  /*
+   NOTE! When adding a new property here it must also be added to the ProtocolFactory! This class
+   contains a randomizer implementation which is used to generate a random
+   CommandDistributionRecord. The new property must be added there. Without it we won't generate a
+   complete record.
+  */
   private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId");
   private final EnumProperty<ValueType> valueTypeProperty =
       new EnumProperty<>("valueType", ValueType.class);

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequiremen
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
@@ -1188,7 +1189,85 @@ final class JsonSerializableToJsonTest {
             "resourceKey":1
           }
           """
-      }
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// CommandDistributionRecord //////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "CommandDistributionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var deploymentRecord = new DeploymentRecord();
+              deploymentRecord
+                  .resources()
+                  .add()
+                  .setResourceName("my_first_bpmn.bpmn")
+                  .setResource(wrapString("This is the contents of the BPMN"));
+              deploymentRecord
+                  .processesMetadata()
+                  .add()
+                  .setKey(123)
+                  .setVersion(1)
+                  .setBpmnProcessId("my_first_process")
+                  .setResourceName("my_first_bpmn.bpmn")
+                  .setChecksum(wrapString("sha1"));
+
+              return new CommandDistributionRecord()
+                  .setPartitionId(1)
+                  .setValueType(ValueType.DEPLOYMENT)
+                  .setRecordValue(deploymentRecord);
+            },
+        """
+          {
+            "partitionId": 1,
+            "valueType": "DEPLOYMENT",
+            "commandValue": {
+              "resources": [{
+                "resource": "VGhpcyBpcyB0aGUgY29udGVudHMgb2YgdGhlIEJQTU4=",
+                "resourceName": "my_first_bpmn.bpmn"
+              }],
+              "processesMetadata": [{
+                "processDefinitionKey": 123,
+                "version": 1,
+                "bpmnProcessId": "my_first_process",
+                "resourceName": "my_first_bpmn.bpmn",
+                "checksum": "c2hhMQ==",
+                "duplicate": false
+              }],
+              "decisionsMetadata": [],
+              "decisionRequirementsMetadata": []
+            }
+          }
+          """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty CommandDistributionRecord ////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty CommandDistributionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var deploymentRecord = new DeploymentRecord();
+              return new CommandDistributionRecord()
+                  .setPartitionId(1)
+                  .setValueType(ValueType.DEPLOYMENT)
+                  .setRecordValue(deploymentRecord);
+            },
+        """
+          {
+              "partitionId": 1,
+              "valueType": "DEPLOYMENT",
+              "commandValue": {
+                "resources": [],
+                "processesMetadata": [],
+                "decisionsMetadata": [],
+                "decisionRequirementsMetadata": []
+              }
+          }
+          """
+      },
     };
   }
 

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/RecordMixin.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/RecordMixin.java
@@ -34,4 +34,8 @@ abstract class RecordMixin<T extends RecordValue> {
   @JsonTypeInfo(use = Id.CUSTOM, include = As.EXTERNAL_PROPERTY, property = "valueType")
   @JsonTypeIdResolver(RecordValueTypeIdResolver.class)
   private T value;
+
+  @JsonTypeInfo(use = Id.CUSTOM, include = As.EXTERNAL_PROPERTY, property = "valueType")
+  @JsonTypeIdResolver(RecordValueTypeIdResolver.class)
+  private T commandValue;
 }

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/ZeebeProtocolModule.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/ZeebeProtocolModule.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue;
 
 /**
  * A Jackson module which enables your {@link ObjectMapper} to serialize and deserialize Zeebe
@@ -34,6 +35,7 @@ import io.camunda.zeebe.protocol.record.Record;
 public final class ZeebeProtocolModule extends SimpleModule {
   public ZeebeProtocolModule() {
     setMixInAnnotation(ImmutableRecord.Builder.class, RecordMixin.class);
+    setMixInAnnotation(ImmutableCommandDistributionRecordValue.Builder.class, RecordMixin.class);
   }
 
   @Override

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.ValueTypeMapping;
+import io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ClassInfoList;
@@ -231,6 +232,18 @@ public final class ProtocolFactory {
     final var recordTypes = EnumSet.complementOf(excludedRecordTypes);
     randomizerRegistry.registerRandomizer(
         RecordType.class, new EnumRandomizer<>(getSeed(), recordTypes.toArray(RecordType[]::new)));
+
+    randomizerRegistry.registerRandomizer(
+        ImmutableCommandDistributionRecordValue.class,
+        () -> {
+          final var valueType = random.nextObject(ValueType.class);
+          final var typeInfo = ValueTypeMapping.get(valueType);
+          return ImmutableCommandDistributionRecordValue.builder()
+              .withPartitionId(random.nextInt())
+              .withValueType(valueType)
+              .withCommandValue(generateObject(typeInfo.getValueClass()))
+              .build();
+        });
   }
 
   private void registerProtocolType(final ClassInfo abstractType) {

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -80,7 +80,7 @@ public final class ProtocolFactory {
    */
   public ProtocolFactory(final long seed) {
     randomizerRegistry = new CustomRandomizerRegistry();
-    parameters = getDefaultParameters().seed(seed);
+    parameters = getDefaultParameters().seed(seed).scanClasspathForConcreteTypes(true);
     random = new EasyRandom(parameters);
     registerRandomizers();
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
@@ -43,6 +44,7 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
@@ -189,6 +191,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.RESOURCE_DELETION,
         new Mapping<>(ResourceDeletionRecordValue.class, ResourceDeletionIntent.class));
+    mapping.put(
+        ValueType.COMMAND_DISTRIBUTION,
+        new Mapping<>(CommandDistributionRecordValue.class, CommandDistributionIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum CommandDistributionIntent implements Intent {
+  STARTED(0),
+  DISTRIBUTING(1),
+  ACKNOWLEDGE(2),
+  ACKNOWLEDGED(3),
+  FINISHED(4);
+
+  private final short value;
+
+  CommandDistributionIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return STARTED;
+      case 1:
+        return DISTRIBUTING;
+      case 2:
+        return ACKNOWLEDGE;
+      case 3:
+        return ACKNOWLEDGED;
+      case 4:
+        return FINISHED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -49,7 +49,8 @@ public interface Intent {
           ProcessInstanceModificationIntent.class,
           SignalIntent.class,
           SignalSubscriptionIntent.class,
-          ResourceDeletionIntent.class);
+          ResourceDeletionIntent.class,
+          CommandDistributionIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -125,6 +126,8 @@ public interface Intent {
         return SignalSubscriptionIntent.from(intent);
       case RESOURCE_DELETION:
         return ResourceDeletionIntent.from(intent);
+      case COMMAND_DISTRIBUTION:
+        return CommandDistributionIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CommandDistributionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CommandDistributionRecordValue.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableCommandDistributionRecordValue.Builder.class)
+public interface CommandDistributionRecordValue extends RecordValue {
+
+  /**
+   * @return the partition where the record should be distributed to
+   */
+  int getPartitionId();
+
+  /**
+   * @return the wrapped record value type
+   */
+  ValueType getValueType();
+
+  /**
+   * @return the wrapped record value
+   */
+  RecordValue getCommandValue();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -47,6 +47,7 @@
       <validValue name="SIGNAL_SUBSCRIPTION">30</validValue>
       <validValue name="SIGNAL">31</validValue>
       <validValue name="RESOURCE_DELETION">32</validValue>
+      <validValue name="COMMAND_DISTRIBUTION">33</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds the `CommandDistributionRecord`. This differs from the naming in the issue. @korthout and I decided that `CommandDistributionRecord` is accurate and reads easier than `RecordDistributionRecord`.
This PR also includes the exporting of the record by the ES exporter. Because the record is different from a regular record in the sense that it embeds another record value some changes had to be made to the protocol in order to successfully generate a random implementation of this record.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11657 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
