### PR TITLE
Generate proto DeleteResource messages

### DIFF
--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -1018,6 +1018,19 @@
           },
           {
             "name": "ModifyProcessInstanceResponse"
+          },
+          {
+            "name": "DeleteResourceRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "resourceKey",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "DeleteResourceResponse"
           }
         ],
         "services": [
@@ -1110,6 +1123,11 @@
                 "name": "ModifyProcessInstance",
                 "in_type": "ModifyProcessInstanceRequest",
                 "out_type": "ModifyProcessInstanceResponse"
+              },
+              {
+                "name": "DeleteResource",
+                "in_type": "DeleteResourceRequest",
+                "out_type": "DeleteResourceResponse"
               }
             ]
           }


### PR DESCRIPTION
## Description

I run into this now multiple times now. Adds the generate proto.lock to main.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_
