### PR TITLE
TEST: fix(ci): optionally connect to internal Nexus

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -28,22 +28,34 @@ inputs:
     required: false
   secret_vault_address:
     description: 'secret vault url'
-    required: true
+    required: false
   secret_vault_roleId:
     description: 'secret vault roleId'
-    required: true
+    required: false
   secret_vault_secretId:
     description: 'secret valut secret id'
-    required: true
+    required: false
 
 outputs: {}
 
 runs:
   using: composite
   steps:
+    - name: Secrets check
+      if: |
+        ${{ github.event.pull_request.head.repo.full_name == 'org/repo'
+        && (github.event.inputs.secret_vault_address != ''
+        || github.event.inputs.secret_vault_roleId != ''
+        || github.event.inputs.secret_vault_secretId != '') }}
+      shell: bash
+      run: exit 1
     - name: Import Secrets
       id: secrets
       uses: hashicorp/vault-action@v2.4.3
+      if: |
+        ${{ github.event.inputs.secret_vault_address != ''
+        && github.event.inputs.secret_vault_roleId != ''
+        && github.event.inputs.secret_vault_secretId != '' }}
       with:
         url: ${{ inputs.secret_vault_address }}
         method: approle
@@ -63,6 +75,10 @@ runs:
     # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: 'Create settings.xml'
       uses: s4u/maven-settings-action@v2.8.0
+      if: |
+        ${{ github.event.inputs.secret_vault_address != ''
+        && github.event.inputs.secret_vault_roleId != ''
+        && github.event.inputs.secret_vault_secretId != '' }}
       with:
         githubServer: false
         servers: |


### PR DESCRIPTION
As a cost-saving measure a change was made to always connect to our internal Nexus instead of Artifactory. The internal Nexus is not publicly available and thus requires secrets. Since a forked PR does not have access to the repository secrets (dependabot excluded) the change breaks the CI for external contributors.

This change makes it optional to have these secrets available. If they are not available we will connect to Artifactory, otherwise we will use the internal Nexus. The vast majority of the traffic will still use the internal Nexus, keeping the cost-saving measurements relevant.

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
