### PR TITLE
feat(bpmn-model): add dueDate and followUpDate as user task properties

### DIFF
--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -54,6 +54,30 @@
         },
         {
           "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeDueDate(java.lang.String)",
+          "justification": "Ignore new methods for user task properties builder."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeDueDateExpression(java.lang.String)",
+          "justification": "Ignore new methods for user task properties builder."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeFollowUpDate(java.lang.String)",
+          "justification": "Ignore new methods for user task properties builder."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeFollowUpDateExpression(java.lang.String)",
+          "justification": "Ignore new methods for user task properties builder."
+        },
+        {
+          "ignore": true,
           "code": "java.method.removed",
           "old": "method void io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder<B extends io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder<B, E>, E extends io.camunda.zeebe.model.bpmn.instance.BaseElement>::resizeSubProcess(io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape)",
           "justification": "change the name to reuse for SubProcess and Link Events"

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -228,6 +228,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeScriptImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeSubscriptionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskHeadersImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskScheduleImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskFormImpl;
 import io.camunda.zeebe.model.bpmn.instance.Definitions;
 import io.camunda.zeebe.model.bpmn.instance.Process;
@@ -648,6 +649,7 @@ public class Bpmn {
     ZeebeFormDefinitionImpl.registerType(bpmnModelBuilder);
     ZeebeUserTaskFormImpl.registerType(bpmnModelBuilder);
     ZeebeAssignmentDefinitionImpl.registerType(bpmnModelBuilder);
+    ZeebeTaskScheduleImpl.registerType(bpmnModelBuilder);
     ZeebeCalledDecisionImpl.registerType(bpmnModelBuilder);
     ZeebePropertyImpl.registerType(bpmnModelBuilder);
     ZeebePropertiesImpl.registerType(bpmnModelBuilder);

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 
 /**
@@ -118,6 +119,32 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
   @Override
   public B zeebeCandidateUsersExpression(final String expression) {
     return zeebeCandidateUsers(asZeebeExpression(expression));
+  }
+
+  @Override
+  public B zeebeDueDate(final String dueDate) {
+    final ZeebeTaskSchedule taskSchedule =
+        myself.getCreateSingleExtensionElement(ZeebeTaskSchedule.class);
+    taskSchedule.setDueDate(dueDate);
+    return myself;
+  }
+
+  @Override
+  public B zeebeDueDateExpression(final String expression) {
+    return zeebeDueDate(asZeebeExpression(expression));
+  }
+
+  @Override
+  public B zeebeFollowUpDate(final String followUpDate) {
+    final ZeebeTaskSchedule taskSchedule =
+        myself.getCreateSingleExtensionElement(ZeebeTaskSchedule.class);
+    taskSchedule.setFollowUpDate(followUpDate);
+    return myself;
+  }
+
+  @Override
+  public B zeebeFollowUpDateExpression(final String expression) {
+    return zeebeFollowUpDate(asZeebeExpression(expression));
   }
 
   public B zeebeTaskHeader(final String key, final String value) {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
@@ -102,4 +102,36 @@ public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertie
    * @return the builder object
    */
   B zeebeCandidateUsersExpression(String expression);
+
+  /**
+   * Sets a static dueDate for the user task
+   *
+   * @param dueDate the dueDate of the user task
+   * @return the builder object
+   */
+  B zeebeDueDate(String dueDate);
+
+  /**
+   * Sets a dynamic dueDate for the user task that is retrieved from the given expression
+   *
+   * @param expression the expression for the dueDate of the user task
+   * @return the builder object
+   */
+  B zeebeDueDateExpression(String expression);
+
+  /**
+   * Sets a static followUpDate for the user task
+   *
+   * @param followUpDate the followUpDate of the user task
+   * @return the builder object
+   */
+  B zeebeFollowUpDate(String followUpDate);
+
+  /**
+   * Sets a dynamic followUpDate for the user task that is retrieved from the given expression
+   *
+   * @param expression the expression for the followUpDate of the user task
+   * @return the builder object
+   */
+  B zeebeFollowUpDateExpression(String expression);
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -43,6 +43,9 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_CANDIDATE_GROUPS = "candidateGroups";
   public static final String ATTRIBUTE_CANDIDATE_USERS = "candidateUsers";
 
+  public static final String ATTRIBUTE_DUE_DATE = "dueDate";
+  public static final String ATTRIBUTE_FOLLOW_UP_DATE = "followUpDate";
+
   public static final String ATTRIBUTE_DECISION_ID = "decisionId";
 
   public static final String ATTRIBUTE_ERROR_CODE_VARIABLE = "errorCodeVariable";
@@ -69,6 +72,8 @@ public class ZeebeConstants {
   public static final String ELEMENT_USER_TASK_FORM = "userTaskForm";
 
   public static final String ELEMENT_ASSIGNMENT_DEFINITION = "assignmentDefinition";
+
+  public static final String ELEMENT_SCHEDULE_DEFINITION = "taskSchedule";
 
   public static final String ELEMENT_LOOP_CHARACTERISTICS = "loopCharacteristics";
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeTaskScheduleImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeTaskScheduleImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeTaskScheduleImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeTaskSchedule {
+
+  private static Attribute<String> dueDateAttribute;
+  private static Attribute<String> followUpDateAttribute;
+
+  public ZeebeTaskScheduleImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeTaskSchedule.class, ZeebeConstants.ELEMENT_SCHEDULE_DEFINITION)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeTaskScheduleImpl::new);
+
+    dueDateAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_DUE_DATE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    followUpDateAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_FOLLOW_UP_DATE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    typeBuilder.build();
+  }
+
+  @Override
+  public String getDueDate() {
+    return dueDateAttribute.getValue(this);
+  }
+
+  @Override
+  public void setDueDate(final String dueDate) {
+    dueDateAttribute.setValue(this, dueDate);
+  }
+
+  @Override
+  public String getFollowUpDate() {
+    return followUpDateAttribute.getValue(this);
+  }
+
+  @Override
+  public void setFollowUpDate(final String followUpDate) {
+    followUpDateAttribute.setValue(this, followUpDate);
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskSchedule.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskSchedule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+public interface ZeebeTaskSchedule extends BpmnModelElementInstance {
+
+  String getDueDate();
+
+  void setDueDate(String dueDate);
+
+  String getFollowUpDate();
+
+  void setFollowUpDate(String followUpDate);
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskScheduleTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskScheduleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public class ZeebeTaskScheduleTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "dueDate", false, false),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "followUpDate", false, false));
+  }
+}


### PR DESCRIPTION
## Description

As a user, I can use the Zeebe BPMN Model API to define the following properties on user tasks:

* `dueDate`
* `followUpDate`

The properties accept static values and expressions. 
The properties are encapsulated by the new `ZeebeTaskSchedule` extension element.

## Related issues

closes #11795 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [x] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
