### PR TITLE
ci: fix performance measurement for medic benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ on:
         required: false
 jobs:
   build-zeebe-image:
-    name: Build zeebe image
+    name: Build Zeebe
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -98,7 +98,7 @@ jobs:
           build-args: DIST=build
           target: app
   build-benchmark-images:
-    name: Build starter and worker images
+    name: Build Starter and Worker
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -137,7 +137,7 @@ jobs:
       - name: Build Worker Image
         run: ./mvnw -pl benchmarks/project jib:build -P worker -D image="gcr.io/zeebe-io/worker:${{ steps.image-tag.outputs.image-tag }}"
   deploy-benchmark-measurement:
-    name: Measure network latency
+    name: Measure
     needs:
       - build-zeebe-image
       - build-benchmark-images
@@ -155,7 +155,7 @@ jobs:
         --set camunda-platform.zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
         ${{ inputs.benchmark-load }}
   deploy-benchmark-cluster:
-    name: Deploy benchmark cluster
+    name: Deploy
     needs:
       - build-zeebe-image
       - build-benchmark-images

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,6 +25,11 @@ on:
         default: ""
         type: string
         required: false
+      measure:
+        description: 'If enabled, impact of network latency is measured.'
+        type: string
+        required: false
+        default: 'true'
 
   workflow_call:
     inputs:
@@ -51,6 +56,11 @@ on:
         description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitary helm arguments, like --set starter.rate=100'
         type: string
         required: false
+      measure:
+        description: 'If enabled, impact of network latency is measured.'
+        type: string
+        required: false
+        default: 'true'
       publish:
         description: 'Where to publish the results, can be "slack" or "comment"'
         default: ""
@@ -143,6 +153,7 @@ jobs:
       - build-benchmark-images
     uses: zeebe-io/zeebe-performance-test/.github/workflows/measure.yaml@main
     secrets: inherit
+    if: inputs.measure == 'true'
     with:
       name: measurement-${{ github.run_id }}
       chaos: network-latency-5

--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -45,7 +45,7 @@ jobs:
           echo "benchmark=medic-y-$(date +%Y)-cw-$(date +%V)-$(git rev-parse --short HEAD)-benchmark" >> $GITHUB_OUTPUT
 
   setup-normal-benchmark:
-    name: Setup normal benchmark
+    name: Normal Benchmark
     needs:
       - benchmark-data
       - delete-old-benchmarks
@@ -58,7 +58,7 @@ jobs:
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
       publish: "slack"
   setup-mixed-benchmark:
-    name: Setup mixed benchmark
+    name: Mixed Benchmark
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
     needs:
@@ -76,7 +76,7 @@ jobs:
         --set publisher.replica=1
         --set publisher.rate=25
   setup-latency-benchmark:
-    name: Setup latency benchmark
+    name: Latency Benchmark
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
     needs:

--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -69,6 +69,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
+      measure: false
       benchmark-load: >
         --set starter.rate=25
         --set timer.replicas=1
@@ -87,6 +88,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
+      measure: false
       benchmark-load: >
         --set starter.rate=1
         --set worker.replicas=1

--- a/.github/workflows/pr-benchmark.yaml
+++ b/.github/workflows/pr-benchmark.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create-benchmark:
-    name: Create PR benchmark
+    name: Benchmark
     if: github.event.action == 'labeled' && github.event.label.name == 'benchmark'
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
@@ -20,7 +20,7 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
       publish: "comment"
   update-benchmark:
-    name: Update PR benchmark
+    name: Update
     if: github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark')
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
@@ -31,7 +31,7 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
       publish: "comment"
   delete-benchmark:
-    name: Delete PR benchmark
+    name: Benchmark Cleanup
     if: >
       (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark')
       || (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'benchmark'))

--- a/.github/workflows/pr-benchmark.yaml
+++ b/.github/workflows/pr-benchmark.yaml
@@ -10,18 +10,9 @@ on:
 jobs:
   create-benchmark:
     name: Benchmark
-    if: github.event.action == 'labeled' && github.event.label.name == 'benchmark'
-    uses: ./.github/workflows/benchmark.yml
-    secrets: inherit
-    with:
-      name: ${{github.event.pull_request.head.ref}}-benchmark
-      cluster: zeebe-cluster
-      cluster-region: europe-west1-b
-      ref: ${{ github.event.pull_request.head.ref }}
-      publish: "comment"
-  update-benchmark:
-    name: Update
-    if: github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark')
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'benchmark')
+      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit
     with:


### PR DESCRIPTION
This contains two smaller commits to improve the readability of the workflow diagrams a little bit and, more importantly, a fix for our weekly medic benchmarks.

This week's [run failed](https://github.com/camunda/zeebe/actions/runs/4277993003) because all three benchmark types (normal, mixed and latency) tried to use the same namespace for measuring the impact of network latency. This doesn't work so as a fix I simply disabled the measurement for latency and mixed benchmarks for now. We were not publishing results anyway so not running them at all feels appropriate.

