### PR TITLE
[Backport stable/8.0] fix: don't re-wrap runtime exceptions thrown inside a transaction

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.TransactionOperation;
 import io.camunda.zeebe.db.ZeebeDbException;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
-import io.camunda.zeebe.util.exception.RecoverableException;
-import io.camunda.zeebe.util.exception.UnrecoverableException;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Status;
 
@@ -34,8 +32,8 @@ public final class DefaultTransactionContext implements TransactionContext {
       } else {
         runInNewTransaction(operations);
       }
-    } catch (final RecoverableException | UnrecoverableException reportableException) {
-      throw reportableException;
+    } catch (final RuntimeException e) {
+      throw e;
     } catch (final RocksDBException rdbex) {
       final String errorMessage = "Unexpected error occurred during RocksDB transaction.";
       if (isRocksDbExceptionRecoverable(rdbex)) {

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
@@ -219,9 +219,8 @@ public final class DbStringColumnFamilyTest {
                             columnFamily.whileEqualPrefix(key, (k2, v2) -> {});
                           });
                     }))
-        .hasRootCauseInstanceOf(IllegalStateException.class)
-        .hasMessage("Unexpected error occurred during zeebe db transaction operation.")
-        .hasStackTraceContaining(
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
             "Currently nested prefix iterations are not supported! This will cause unexpected behavior.");
   }
 


### PR DESCRIPTION
Manual backport of #11701 without the last commit which contained a test that is not straight forward to re-implement without the stream-platform abstraction.