### PR TITLE
[Backport 8.1] Disable flaky shouldRunAsyncSchedulingEvenIfProcessingIsBlocked test

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -59,7 +59,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -372,8 +372,8 @@ public final class StreamProcessorTest {
     countDownLatch.countDown();
   }
 
+  @Disabled("Should be enabled when https://github.com/camunda/zeebe/issues/11849 is fixed")
   @Test
-  @Ignore("Should be enabled when https://github.com/camunda/zeebe/issues/11849 is fixed")
   public void shouldRunAsyncSchedulingEvenIfProcessingIsBlocked() throws InterruptedException {
     // given
     final var mockProcessorLifecycleAware = streamPlatform.getMockProcessorLifecycleAware();

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -411,17 +411,26 @@ public final class StreamProcessorTest {
         .process(any(), any());
     streamPlatform.startStreamProcessor();
 
-    // when
-    streamPlatform.writeBatch(
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
-    assertThat(processorLatch.await(10, TimeUnit.SECONDS)).isTrue();
-    actorClock.addTime(Duration.ofMinutes(2));
+    try {
+      // when
+      streamPlatform.writeBatch(
+          RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+      assertThat(processorLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
-    // then
-    assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
-    verify(defaultRecordProcessor, TIMEOUT).process(any(), any());
-    // free schedule service
-    waitLatch.countDown();
+      // then
+      await("ProcessScheduleService should still work")
+          .timeout(Duration.ofSeconds(5))
+          .until(
+              () -> {
+                actorClock.addTime(Duration.ofMillis(100));
+                return asyncServiceLatch.await(100, TimeUnit.MILLISECONDS);
+              });
+      verify(defaultRecordProcessor, TIMEOUT).process(any(), any());
+
+    } finally {
+      // free schedule service
+      waitLatch.countDown();
+    }
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -59,6 +59,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -372,6 +373,7 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  @Ignore("Should be enabled when https://github.com/camunda/zeebe/issues/11849 is fixed")
   public void shouldRunAsyncSchedulingEvenIfProcessingIsBlocked() throws InterruptedException {
     // given
     final var mockProcessorLifecycleAware = streamPlatform.getMockProcessorLifecycleAware();


### PR DESCRIPTION
## Description
Backports #11851 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11851

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
