### PR TITLE
[stable/8.1] Limit expire message commands in result

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -38,10 +38,10 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
     // it is safe to reuse the write because we running in the same actor/thread
-    final MessageTimeToLiveChecker timeToLiveChecker = new MessageTimeToLiveChecker(messageState);
-    scheduleService.runAtFixedRateAsync(MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, timeToLiveChecker);
+    final var timeToLiveChecker = new MessageTimeToLiveChecker(scheduleService, messageState);
+    scheduleService.runDelayedAsync(MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, timeToLiveChecker);
 
-    final PendingMessageSubscriptionChecker pendingSubscriptionChecker =
+    final var pendingSubscriptionChecker =
         new PendingMessageSubscriptionChecker(
             subscriptionCommandSender, pendingState, SUBSCRIPTION_TIMEOUT.toMillis());
     scheduleService.runAtFixedRate(SUBSCRIPTION_CHECK_INTERVAL, pendingSubscriptionChecker);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -62,7 +62,15 @@ public final class MessageTimeToLiveChecker implements Task {
             ActorClock.currentTimeMillis(),
             lastIndex,
             (deadline, expiredMessageKey) -> {
-              lastIndex = new Index(expiredMessageKey, deadline);
+              final var newIndex = new Index(expiredMessageKey, deadline);
+              final boolean wasIndexAlreadyVisitedLastTime = newIndex.equals(lastIndex);
+              lastIndex = newIndex;
+
+              if (wasIndexAlreadyVisitedLastTime) {
+                // skip this entry
+                return true;
+              }
+
               final boolean stillFitsInResult =
                   taskResultBuilder.appendCommandRecord(
                       expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -7,33 +7,75 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.Task;
 import io.camunda.zeebe.engine.api.TaskResult;
 import io.camunda.zeebe.engine.api.TaskResultBuilder;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.MessageState.Index;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.Duration;
+import org.agrona.collections.MutableInteger;
 
+/**
+ * The Message TTL Checker looks for expired message deadlines, and for each of those it writes an
+ * EXPIRE Message command.
+ *
+ * <p>To prevent that it clogs the log stream with too many EXPIRE Message commands, it only writes
+ * a limited number of these commands in a single run of {@link #execute(TaskResultBuilder)}.
+ *
+ * <p>It determines whether to reschedule itself immediately, or after the configured {@link
+ * MessageObserver#MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL interval}. If it reschedules itself
+ * immediately, then it will continue where it left off the last time. Otherwise, it starts with the
+ * first expired message deadline it can find.
+ */
 public final class MessageTimeToLiveChecker implements Task {
 
   private static final MessageRecord EMPTY_DELETE_MESSAGE_COMMAND =
       new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
 
-  private final MessageState messageState;
+  private static final int EXPIRE_COMMANDS_LIMIT_DEFAULT = 10;
 
-  public MessageTimeToLiveChecker(final MessageState messageState) {
+  /** This determines the maximum number of EXPIRE commands it will attempt to fit in the result. */
+  private static final int LIMIT = EXPIRE_COMMANDS_LIMIT_DEFAULT;
+
+  private final ProcessingScheduleService scheduleService;
+  private final MessageState messageState;
+  /** Keeps track of where to continue between iterations. */
+  private MessageState.Index lastIndex;
+
+  public MessageTimeToLiveChecker(
+      final ProcessingScheduleService scheduleService, final MessageState messageState) {
+    this.scheduleService = scheduleService;
     this.messageState = messageState;
+    lastIndex = null;
   }
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    messageState.visitMessagesWithDeadlineBeforeTimestamp(
-        ActorClock.currentTimeMillis(),
-        null,
-        ((deadline, expiredMessageKey) -> taskResultBuilder.appendCommandRecord(
-            expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND));
+    final var counter = new MutableInteger(0);
+
+    final boolean shouldContinueWhereLeftOff =
+        messageState.visitMessagesWithDeadlineBeforeTimestamp(
+            ActorClock.currentTimeMillis(),
+            lastIndex,
+            (deadline, expiredMessageKey) -> {
+              lastIndex = new Index(expiredMessageKey, deadline);
+              final boolean stillFitsInResult =
+                  taskResultBuilder.appendCommandRecord(
+                      expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND);
+              return stillFitsInResult && counter.incrementAndGet() <= LIMIT;
+            });
+
+    if (shouldContinueWhereLeftOff) {
+      scheduleService.runDelayedAsync(Duration.ZERO, this);
+    } else {
+      lastIndex = null;
+      scheduleService.runDelayedAsync(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, this);
+    }
+
     return taskResultBuilder.build();
   }
-
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -80,7 +80,7 @@ public final class MessageTimeToLiveChecker implements Task {
               final boolean stillFitsInResult =
                   taskResultBuilder.appendCommandRecord(
                       expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND);
-              return stillFitsInResult && counter.incrementAndGet() <= LIMIT;
+              return stillFitsInResult && counter.incrementAndGet() < LIMIT;
             });
 
     if (shouldContinueWhereLeftOff) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -31,13 +31,9 @@ public final class MessageTimeToLiveChecker implements Task {
     messageState.visitMessagesWithDeadlineBeforeTimestamp(
         ActorClock.currentTimeMillis(),
         null,
-        ((deadline, expiredMessageKey) -> writeDeleteMessageCommand(expiredMessageKey, taskResultBuilder));
+        ((deadline, expiredMessageKey) -> taskResultBuilder.appendCommandRecord(
+            expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND));
     return taskResultBuilder.build();
   }
 
-  private boolean writeDeleteMessageCommand(
-      final long expiredMessageKey, final TaskResultBuilder taskResultBuilder) {
-    return taskResultBuilder.appendCommandRecord(
-        expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND);
-  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -28,9 +28,10 @@ public final class MessageTimeToLiveChecker implements Task {
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    messageState.visitMessagesWithDeadlineBefore(
+    messageState.visitMessagesWithDeadlineBeforeTimestamp(
         ActorClock.currentTimeMillis(),
-        expiredMessageKey -> writeDeleteMessageCommand(expiredMessageKey, taskResultBuilder));
+        null,
+        ((deadline, expiredMessageKey) -> writeDeleteMessageCommand(expiredMessageKey, taskResultBuilder));
     return taskResultBuilder.build();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
@@ -22,9 +22,32 @@ public interface MessageState {
 
   StoredMessage getMessage(long messageKey);
 
-  void visitMessagesWithDeadlineBefore(long timestamp, ExpiredMessageVisitor visitor);
+  /**
+   * Visits the messages with expired deadline, using the provided visitor. The visitor stops when
+   * all messages with expired deadline have been visited, but can also be controlled through the
+   * visitor function.
+   *
+   * @param timestamp Timestamp used to determine whether the deadline has expired
+   * @param startAt Index used to start the iteration at; visiting starts at the beginning when
+   *     startAt is {@code null}
+   * @param visitor This method is called for each message with expired deadline. It must return a
+   *     boolean that when {@code true} allows the visiting to continue, or when {@code false} stops
+   *     the visiting.
+   * @return {@code true} when the visiting is stopped due to the returned value of the last call to
+   *     visitor, otherwise {@code false}
+   */
+  boolean visitMessagesWithDeadlineBeforeTimestamp(
+      long timestamp, final Index startAt, ExpiredMessageVisitor visitor);
 
   boolean exist(DirectBuffer name, DirectBuffer correlationKey, DirectBuffer messageId);
+
+  /**
+   * Index to point to a specific position in the messages with deadline column family.
+   *
+   * @param key The message key
+   * @param deadline The deadline of the message
+   */
+  record Index(long key, long deadline) {}
 
   @FunctionalInterface
   interface MessageVisitor {
@@ -33,6 +56,6 @@ public interface MessageState {
 
   @FunctionalInterface
   interface ExpiredMessageVisitor {
-    boolean visit(long messageKey);
+    boolean visit(final long deadline, long messageKey);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.MutableBoolean;
 
 public final class DbMessageState implements MutableMessageState {
 
@@ -336,17 +337,28 @@ public final class DbMessageState implements MutableMessageState {
   }
 
   @Override
-  public void visitMessagesWithDeadlineBefore(
-      final long timestamp, final ExpiredMessageVisitor visitor) {
-    deadlineColumnFamily.whileTrue(
-        ((compositeKey, zbNil) -> {
-          final long deadline = compositeKey.first().getValue();
-          if (deadline <= timestamp) {
-            final long messageKey = compositeKey.second().inner().getValue();
-            return visitor.visit(messageKey);
-          }
-          return false;
-        }));
+  public boolean visitMessagesWithDeadlineBeforeTimestamp(
+      final long timestamp, final Index startAt, final ExpiredMessageVisitor visitor) {
+    final var stoppedByVisitor = new MutableBoolean(false);
+    if (startAt == null) {
+      deadlineColumnFamily.whileTrue(
+          (key, value) -> {
+            final var shouldContinue = visit(timestamp, visitor, key);
+            stoppedByVisitor.set(!shouldContinue);
+            return shouldContinue;
+          });
+    } else {
+      deadline.wrapLong(startAt.deadline());
+      messageKey.wrapLong(startAt.key());
+      deadlineColumnFamily.whileTrue(
+          deadlineMessageKey,
+          (key, value) -> {
+            final var shouldContinue = visit(timestamp, visitor, key);
+            stoppedByVisitor.set(!shouldContinue);
+            return shouldContinue;
+          });
+    }
+    return stoppedByVisitor.get();
   }
 
   @Override
@@ -357,5 +369,17 @@ public final class DbMessageState implements MutableMessageState {
     this.messageId.wrapBuffer(messageId);
 
     return messageIdColumnFamily.exists(nameCorrelationMessageIdKey);
+  }
+
+  private static boolean visit(
+      final long timestamp,
+      final ExpiredMessageVisitor visitor,
+      final DbCompositeKey<DbLong, DbForeignKey<DbLong>> compositeDeadlineKey) {
+    final long deadline = compositeDeadlineKey.first().getValue();
+    if (deadline <= timestamp) {
+      final long messageKey = compositeDeadlineKey.second().inner().getValue();
+      return visitor.visit(deadline, messageKey);
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This adds a virtual limit to the number of EXPIRE Message commands the MessageTimeToLiveChecker adds to a result when executed to prevent that it clogs the log stream with too many of these commands.

I suggest to review this pull request per commit.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11762 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
