### PR TITLE
ci: fix publisher replicas

### DIFF
--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
         --set starter.rate=25
         --set timer.replicas=1
         --set timer.rate=25
-        --set publisher.replica=1
+        --set publisher.replicas=1
         --set publisher.rate=25
   setup-latency-benchmark:
     name: Latency Benchmark


### PR DESCRIPTION
## Description

Fix type for creating mixed benchmark. The setting to enable publisher is `publisher.replicas`. This part explains why publisher are not deployed.
