### PR TITLE
Support user task deployments with due and follow-up date attributes

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
@@ -21,6 +21,8 @@ public class JobWorkerProperties {
   private Expression assignee;
   private Expression candidateGroups;
   private Expression candidateUsers;
+  private Expression dueDate;
+  private Expression followUpDate;
   private Map<String, String> taskHeaders = Map.of();
 
   public Expression getType() {
@@ -61,6 +63,22 @@ public class JobWorkerProperties {
 
   public void setCandidateUsers(final Expression candidateUsers) {
     this.candidateUsers = candidateUsers;
+  }
+
+  public Expression getDueDate() {
+    return dueDate;
+  }
+
+  public void setDueDate(final Expression dueDate) {
+    this.dueDate = dueDate;
+  }
+
+  public Expression getFollowUpDate() {
+    return followUpDate;
+  }
+
+  public void setFollowUpDate(final Expression followUpDate) {
+    this.followUpDate = followUpDate;
   }
 
   public Map<String, String> getTaskHeaders() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.protocol.Protocol;
 import java.util.HashMap;
 import java.util.List;
@@ -54,6 +55,7 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
 
     transformTaskDefinition(jobWorkerProperties);
     transformAssignmentDefinition(element, jobWorkerProperties);
+    transformTaskSchedule(element, jobWorkerProperties);
     transformTaskHeaders(element, jobWorkerProperties);
   }
 
@@ -102,6 +104,25 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
       } else {
         jobWorkerProperties.setCandidateUsers(candidateUsersExpression);
       }
+    }
+  }
+
+  private void transformTaskSchedule(
+      final UserTask element, final JobWorkerProperties jobWorkerProperties) {
+
+    final var taskSchedule = element.getSingleExtensionElement(ZeebeTaskSchedule.class);
+    if (taskSchedule == null) {
+      return;
+    }
+
+    final var dueDate = taskSchedule.getDueDate();
+    if (dueDate != null && !dueDate.isBlank()) {
+      jobWorkerProperties.setDueDate(expressionLanguage.parseExpression(dueDate));
+    }
+
+    final var followUpDate = taskSchedule.getFollowUpDate();
+    if (followUpDate != null && !followUpDate.isBlank()) {
+      jobWorkerProperties.setFollowUpDate(expressionLanguage.parseExpression(followUpDate));
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeOutput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import java.util.Collection;
 import java.util.List;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
@@ -122,6 +123,12 @@ public final class ZeebeRuntimeValidators {
                         .satisfiesIfStatic(
                             ZeebeExpressionValidator::isListOfCsv,
                             "be a list of comma-separated values, e.g. 'a,b,c'"))
+            .build(expressionLanguage),
+        // ----------------------------------------
+        ZeebeExpressionValidator.verifyThat(ZeebeTaskSchedule.class)
+            .hasValidExpression(ZeebeTaskSchedule::getDueDate, ExpressionVerification::isOptional)
+            .hasValidExpression(
+                ZeebeTaskSchedule::getFollowUpDate, ExpressionVerification::isOptional)
             .build(expressionLanguage),
         // ----------------------------------------
         new TimerCatchEventExpressionValidator(expressionLanguage, expressionProcessor),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -136,4 +136,73 @@ class UserTaskTransformerTest {
       }
     }
   }
+
+  @Nested
+  class TaskScheduleTests {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class DueDateTests {
+
+      Stream<Arguments> dueDates() {
+        return Stream.of(
+            Arguments.of(null, null),
+            Arguments.of("", null),
+            Arguments.of(" ", null),
+            Arguments.of("2023-02-27T14:35:00Z", "2023-02-27T14:35:00Z"),
+            Arguments.of("2023-02-27T14:35:00+02:00", "2023-02-27T14:35:00+02:00"),
+            Arguments.of(
+                "2023-02-27T14:35:00+02:00[Europe/Berlin]",
+                "2023-02-27T14:35:00+02:00[Europe/Berlin]"),
+            Arguments.of("=dueDateSchedule", "dueDateSchedule"),
+            Arguments.of("=schedule.dueDate", "schedule.dueDate"));
+      }
+
+      @DisplayName("Should transform user task with dueDate")
+      @ParameterizedTest
+      @MethodSource("dueDates")
+      void shouldTransform(final String dueDate, final String parsedExpression) {
+        final var userTask = transformUserTask(processWithUserTask(b -> b.zeebeDueDate(dueDate)));
+        if (parsedExpression == null) {
+          assertThat(userTask.getJobWorkerProperties().getDueDate()).isNull();
+        } else {
+          assertThat(userTask.getJobWorkerProperties().getDueDate().getExpression())
+              .isEqualTo(parsedExpression);
+        }
+      }
+    }
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class FollowUpDateTests {
+
+    Stream<Arguments> followUpDates() {
+      return Stream.of(
+          Arguments.of(null, null),
+          Arguments.of("", null),
+          Arguments.of(" ", null),
+          Arguments.of("2023-02-27T14:35:00Z", "2023-02-27T14:35:00Z"),
+          Arguments.of("2023-02-27T14:35:00+02:00", "2023-02-27T14:35:00+02:00"),
+          Arguments.of(
+              "2023-02-27T14:35:00+02:00[Europe/Berlin]",
+              "2023-02-27T14:35:00+02:00[Europe/Berlin]"),
+          Arguments.of("=followUpDateSchedule", "followUpDateSchedule"),
+          Arguments.of("=schedule.followUpDate", "schedule.followUpDate"));
+    }
+
+    @DisplayName("Should transform user task with followUpDate")
+    @ParameterizedTest
+    @MethodSource("followUpDates")
+    void shouldTransform(final String followUpDate, final String parsedExpression) {
+      final var userTask =
+          transformUserTask(processWithUserTask(b -> b.zeebeFollowUpDate(followUpDate)));
+      if (parsedExpression == null) {
+        assertThat(userTask.getJobWorkerProperties().getFollowUpDate()).isNull();
+      } else {
+        assertThat(userTask.getJobWorkerProperties().getFollowUpDate().getExpression())
+            .isEqualTo(parsedExpression);
+      }
+    }
+  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeOutput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import io.camunda.zeebe.model.bpmn.validation.ValidationVisitor;
 import io.camunda.zeebe.protocol.Protocol;
@@ -381,6 +382,22 @@ public final class ZeebeRuntimeValidationTest {
             expect(
                 ZeebeAssignmentDefinition.class,
                 "Expected static value to be a list of comma-separated values, e.g. 'a,b,c', but found '1,,'"))
+      },
+      {
+        /* invalid dueDate expression */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeDueDateExpression(INVALID_EXPRESSION))
+            .done(),
+        List.of(expect(ZeebeTaskSchedule.class, INVALID_EXPRESSION_MESSAGE))
+      },
+      {
+        /* invalid followUpDate expression */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeFollowUpDateExpression(INVALID_EXPRESSION))
+            .done(),
+        List.of(expect(ZeebeTaskSchedule.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         /* reserved header key */


### PR DESCRIPTION
## Description

Support user task deployments with due and follow-up date attributes.

## Related issues

closes #11796 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [x] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
