### PR TITLE
fix: never drop responses during batch processing

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
@@ -95,7 +95,7 @@ public final class CommandResponseWriterImpl implements CommandResponseWriter, B
   }
 
   @Override
-  public boolean tryWriteResponse(final int remoteStreamId, final long requestId) {
+  public void tryWriteResponse(final int remoteStreamId, final long requestId) {
     Objects.requireNonNull(valueWriter);
 
     try {
@@ -105,7 +105,6 @@ public final class CommandResponseWriterImpl implements CommandResponseWriter, B
     } finally {
       reset();
     }
-    return true;
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
@@ -11,14 +11,11 @@ import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -331,8 +328,6 @@ public final class EngineErrorHandlingTest {
   @Test
   public void shouldBlacklistInstanceOnReplay() throws Exception {
     // given
-    when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
-
     final long failedPos =
         streams
             .newRecord(STREAM_NAME)
@@ -385,7 +380,6 @@ public final class EngineErrorHandlingTest {
   @Test
   public void shouldNotBlacklistInstanceOnJobCommand() {
     // given
-    when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     final List<Long> processedInstances = new ArrayList<>();
     final AtomicReference<TypedRecordProcessor<JobRecord>> dumpProcessorRef =
         new AtomicReference<>();
@@ -471,7 +465,6 @@ public final class EngineErrorHandlingTest {
   @Test
   public void shouldNotBlacklistInstanceAndIgnoreTimerStartEvents() {
     // given
-    when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     final List<Long> processedInstances = new ArrayList<>();
 
     final BpmnModelInstance process =

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -106,7 +106,6 @@ public final class TestStreams {
     when(mockCommandResponseWriter.valueType(any())).thenReturn(mockCommandResponseWriter);
     when(mockCommandResponseWriter.valueWriter(any())).thenReturn(mockCommandResponseWriter);
 
-    when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     mockStreamProcessorListener = mock(StreamProcessorListener.class);
   }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/CommandResponseWriter.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/CommandResponseWriter.java
@@ -32,5 +32,5 @@ public interface CommandResponseWriter {
 
   CommandResponseWriter valueWriter(BufferWriter value);
 
-  boolean tryWriteResponse(int requestStreamId, long requestId);
+  void tryWriteResponse(int requestStreamId, long requestId);
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -519,23 +519,17 @@ public final class ProcessingStateMachine {
 
                 final var responseValue = processingResponse.responseValue();
                 final var recordMetadata = responseValue.recordMetadata();
-                final boolean responseSent =
-                    responseWriter
-                        .intent(recordMetadata.getIntent())
-                        .key(responseValue.key())
-                        .recordType(recordMetadata.getRecordType())
-                        .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
-                        .rejectionType(recordMetadata.getRejectionType())
-                        .partitionId(context.getPartitionId())
-                        .valueType(recordMetadata.getValueType())
-                        .valueWriter(responseValue.recordValue())
-                        .tryWriteResponse(
-                            processingResponse.requestStreamId(), processingResponse.requestId());
-                if (!responseSent) {
-                  return false;
-                } else {
-                  return executePostCommitTasks();
-                }
+                responseWriter
+                    .intent(recordMetadata.getIntent())
+                    .key(responseValue.key())
+                    .recordType(recordMetadata.getRecordType())
+                    .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
+                    .rejectionType(recordMetadata.getRejectionType())
+                    .partitionId(context.getPartitionId())
+                    .valueType(recordMetadata.getValueType())
+                    .valueWriter(responseValue.recordValue())
+                    .tryWriteResponse(
+                        processingResponse.requestStreamId(), processingResponse.requestId());
               }
               return executePostCommitTasks();
             },

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import io.camunda.zeebe.stream.api.EmptyProcessingResult;
 import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.api.MetadataFilter;
+import io.camunda.zeebe.stream.api.ProcessingResponse;
 import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.RecordProcessor;
@@ -43,6 +44,7 @@ import io.prometheus.client.Histogram;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
@@ -145,6 +147,7 @@ public final class ProcessingStateMachine {
   private final List<RecordProcessor> recordProcessors;
   private ProcessingResult currentProcessingResult;
   private List<LogAppendEntry> pendingWrites;
+  private Collection<ProcessingResponse> pendingResponses;
 
   private RecordProcessor currentProcessor;
   private final LogStreamWriter logStreamWriter;
@@ -324,6 +327,7 @@ public final class ProcessingStateMachine {
         processedCommandsCount > 0 ? processedCommandsCount : maxCommandsInBatch;
     processedCommandsCount = 0;
     pendingWrites = new ArrayList<>();
+    pendingResponses = new ArrayList<>();
     final var pendingCommands = new ArrayDeque<TypedRecord<?>>();
     pendingCommands.addLast(initialCommand);
 
@@ -349,6 +353,7 @@ public final class ProcessingStateMachine {
 
         pendingCommands.addAll(batchProcessingStepResult.toProcess());
         pendingWrites.addAll(batchProcessingStepResult.toWrite());
+        currentProcessingResult.getProcessingResponse().ifPresent(pendingResponses::add);
       }
 
       lastProcessingResultSize = currentProcessingResult.getRecordBatch().entries().size();
@@ -437,6 +442,7 @@ public final class ProcessingStateMachine {
               currentProcessor.onProcessingError(
                   processingException, typedCommand, processingResultBuilder);
           pendingWrites = currentProcessingResult.getRecordBatch().entries();
+          pendingResponses = currentProcessingResult.getProcessingResponse().stream().toList();
         });
   }
 
@@ -509,12 +515,7 @@ public final class ProcessingStateMachine {
             () -> {
               // TODO refactor this into two parallel tasks, which are then combined, and on the
               // completion of which the process continues
-
-              final var processingResponseOptional =
-                  currentProcessingResult.getProcessingResponse();
-
-              if (processingResponseOptional.isPresent()) {
-                final var processingResponse = processingResponseOptional.get();
+              for (final var processingResponse : pendingResponses) {
                 final var responseWriter = context.getCommandResponseWriter();
 
                 final var responseValue = processingResponse.responseValue();

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -91,8 +91,6 @@ public final class StreamPlatform {
     when(mockCommandResponseWriter.valueType(any())).thenReturn(mockCommandResponseWriter);
     when(mockCommandResponseWriter.valueWriter(any())).thenReturn(mockCommandResponseWriter);
 
-    when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
-
     defaultMockedRecordProcessor = mock(RecordProcessor.class);
     when(defaultMockedRecordProcessor.process(any(), any()))
         .thenReturn(EmptyProcessingResult.INSTANCE);

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -796,6 +796,61 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  public void shouldWriteMultipleResponses() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder
+        .withResponse(
+            RecordType.EVENT,
+            3,
+            ELEMENT_ACTIVATING,
+            Records.processInstance(1),
+            ValueType.PROCESS_INSTANCE,
+            RejectionType.NULL_VAL,
+            "",
+            1,
+            12)
+        .appendRecord(
+            4,
+            RecordType.COMMAND,
+            ELEMENT_ACTIVATING,
+            RejectionType.NULL_VAL,
+            "",
+            Records.processInstance(1));
+    final var secondResultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    secondResultBuilder.withResponse(
+        RecordType.EVENT,
+        4,
+        ELEMENT_ACTIVATING,
+        Records.processInstance(1),
+        ValueType.PROCESS_INSTANCE,
+        RejectionType.NULL_VAL,
+        "",
+        2,
+        12);
+
+    when(defaultMockedRecordProcessor.process(any(), any()))
+        .thenReturn(resultBuilder.build())
+        .thenReturn(secondResultBuilder.build());
+
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
+
+    final var commandResponseWriter = streamPlatform.getMockCommandResponseWriter();
+
+    verify(commandResponseWriter, TIMEOUT.times(1)).key(3);
+    verify(commandResponseWriter, TIMEOUT.times(1)).key(4);
+  }
+
+  @Test
   public void shouldWriteResponseOnFailedEventProcessing() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();


### PR DESCRIPTION
## Description

During batch processing the stream processor now accumulates multiple responses and sends them out together.
Keeping only one response was not correct in some situations, for example when using `CreateProcessInstanceWithResponse` when the process ends with a service task or message event.

## Related issues

closes #11848