### PR TITLE
[Backport 8.1] fix: never drop responses during batch processing

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
@@ -95,7 +95,7 @@ public final class CommandResponseWriterImpl implements CommandResponseWriter, B
   }
 
   @Override
-  public boolean tryWriteResponse(final int remoteStreamId, final long requestId) {
+  public void tryWriteResponse(final int remoteStreamId, final long requestId) {
     Objects.requireNonNull(valueWriter);
 
     try {
@@ -105,7 +105,6 @@ public final class CommandResponseWriterImpl implements CommandResponseWriter, B
     } finally {
       reset();
     }
-    return true;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/CommandResponseWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/CommandResponseWriter.java
@@ -32,5 +32,5 @@ public interface CommandResponseWriter {
 
   CommandResponseWriter valueWriter(BufferWriter value);
 
-  boolean tryWriteResponse(int requestStreamId, long requestId);
+  void tryWriteResponse(int requestStreamId, long requestId);
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -527,23 +527,17 @@ public final class ProcessingStateMachine {
 
                 final var responseValue = processingResponse.responseValue();
                 final var recordMetadata = responseValue.recordMetadata();
-                final boolean responseSent =
-                    responseWriter
-                        .intent(recordMetadata.getIntent())
-                        .key(responseValue.key())
-                        .recordType(recordMetadata.getRecordType())
-                        .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
-                        .rejectionType(recordMetadata.getRejectionType())
-                        .partitionId(context.getPartitionId())
-                        .valueType(recordMetadata.getValueType())
-                        .valueWriter(responseValue.recordValue())
-                        .tryWriteResponse(
-                            processingResponse.requestStreamId(), processingResponse.requestId());
-                if (!responseSent) {
-                  return false;
-                } else {
-                  return executePostCommitTasks();
-                }
+                responseWriter
+                    .intent(recordMetadata.getIntent())
+                    .key(responseValue.key())
+                    .recordType(recordMetadata.getRecordType())
+                    .rejectionReason(BufferUtil.wrapString(recordMetadata.getRejectionReason()))
+                    .rejectionType(recordMetadata.getRejectionType())
+                    .partitionId(context.getPartitionId())
+                    .valueType(recordMetadata.getValueType())
+                    .valueWriter(responseValue.recordValue())
+                    .tryWriteResponse(
+                        processingResponse.requestStreamId(), processingResponse.requestId());
               }
               return executePostCommitTasks();
             },

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.streamprocessor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.engine.api.EmptyProcessingResult;
+import io.camunda.zeebe.engine.api.ProcessingResponse;
 import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
 import io.camunda.zeebe.engine.api.RecordProcessor;
@@ -38,6 +39,7 @@ import io.prometheus.client.Histogram;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
@@ -139,6 +141,7 @@ public final class ProcessingStateMachine {
   private final StreamProcessorContext context;
   private final List<RecordProcessor> recordProcessors;
   private ProcessingResult currentProcessingResult;
+  private Collection<ProcessingResponse> pendingResponses;
 
   private RecordProcessor currentProcessor;
   private final LogStreamBatchWriter logStreamBatchWriter;
@@ -317,6 +320,7 @@ public final class ProcessingStateMachine {
     final var currentProcessingBatchLimit =
         processedCommandsCount > 0 ? processedCommandsCount : maxCommandsInBatch;
     processedCommandsCount = 0;
+    pendingResponses = new ArrayList<>();
     final var pendingCommands = new ArrayDeque<TypedRecord<?>>();
     pendingCommands.addLast(initialCommand);
 
@@ -341,6 +345,7 @@ public final class ProcessingStateMachine {
                 currentProcessingBatchLimit);
 
         pendingCommands.addAll(nextToProcessCommands);
+        currentProcessingResult.getProcessingResponse().ifPresent(pendingResponses::add);
       }
 
       lastProcessingResultSize = currentProcessingResult.getRecordBatch().entries().size();
@@ -446,6 +451,7 @@ public final class ProcessingStateMachine {
                       .sourceIndex(entry.sourceIndex())
                       .valueWriter(entry.recordValue())
                       .done());
+          pendingResponses = currentProcessingResult.getProcessingResponse().stream().toList();
         });
   }
 
@@ -517,12 +523,7 @@ public final class ProcessingStateMachine {
             () -> {
               // TODO refactor this into two parallel tasks, which are then combined, and on the
               // completion of which the process continues
-
-              final var processingResponseOptional =
-                  currentProcessingResult.getProcessingResponse();
-
-              if (processingResponseOptional.isPresent()) {
-                final var processingResponse = processingResponseOptional.get();
+              for (final var processingResponse : pendingResponses) {
                 final var responseWriter = context.getCommandResponseWriter();
 
                 final var responseValue = processingResponse.responseValue();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
@@ -10,13 +10,10 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.api.CommandResponseWriter;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
@@ -257,8 +254,6 @@ public final class SkipFailingEventsTest {
   @Test
   public void shouldBlacklistInstanceOnReplay() throws Exception {
     // given
-    when(commandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
-
     final long failedPos =
         streams
             .newRecord(STREAM_NAME)
@@ -311,7 +306,6 @@ public final class SkipFailingEventsTest {
   @Test
   public void shouldNotBlacklistInstanceOnJobCommand() {
     // given
-    when(commandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     final List<Long> processedInstances = new ArrayList<>();
     final AtomicReference<TypedRecordProcessor<JobRecord>> dumpProcessorRef =
         new AtomicReference<>();
@@ -397,7 +391,6 @@ public final class SkipFailingEventsTest {
   @Test
   public void shouldNotBlacklistInstanceAndIgnoreTimerStartEvents() {
     // given
-    when(commandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     final List<Long> processedInstances = new ArrayList<>();
 
     final BpmnModelInstance process =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
@@ -11,8 +11,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.api.CommandResponseWriter;
 import io.camunda.zeebe.engine.api.TypedRecord;
@@ -122,8 +122,7 @@ public final class TypedStreamProcessorTest {
     final AtomicLong requestId = new AtomicLong(0);
     final AtomicInteger requestStreamId = new AtomicInteger(0);
 
-    when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong()))
-        .then(
+    doAnswer(
             (invocationOnMock -> {
               final int streamIdArg = invocationOnMock.getArgument(0);
               final long requestIdArg = invocationOnMock.getArgument(1);
@@ -131,8 +130,10 @@ public final class TypedStreamProcessorTest {
               requestId.set(requestIdArg);
               requestStreamId.set(streamIdArg);
 
-              return true;
-            }));
+              return null;
+            }))
+        .when(mockCommandResponseWriter)
+        .tryWriteResponse(anyInt(), anyLong());
 
     final long failingKey = keyGenerator.nextKey();
     streams

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -99,7 +99,6 @@ public final class StreamPlatform {
     when(mockCommandResponseWriter.valueType(any())).thenReturn(mockCommandResponseWriter);
     when(mockCommandResponseWriter.valueWriter(any())).thenReturn(mockCommandResponseWriter);
 
-    when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     actorScheduler.submitActor(writeActor);
 
     defaultMockedRecordProcessor = mock(RecordProcessor.class);

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -111,7 +111,6 @@ public final class TestStreams {
     when(mockCommandResponseWriter.valueType(any())).thenReturn(mockCommandResponseWriter);
     when(mockCommandResponseWriter.valueWriter(any())).thenReturn(mockCommandResponseWriter);
 
-    when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     mockStreamProcessorListener = mock(StreamProcessorListener.class);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -698,6 +698,61 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  public void shouldWriteMultipleResponses() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder
+        .withResponse(
+            RecordType.EVENT,
+            3,
+            ELEMENT_ACTIVATING,
+            Records.processInstance(1),
+            ValueType.PROCESS_INSTANCE,
+            RejectionType.NULL_VAL,
+            "",
+            1,
+            12)
+        .appendRecord(
+            4,
+            RecordType.COMMAND,
+            ELEMENT_ACTIVATING,
+            RejectionType.NULL_VAL,
+            "",
+            Records.processInstance(1));
+    final var secondResultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    secondResultBuilder.withResponse(
+        RecordType.EVENT,
+        4,
+        ELEMENT_ACTIVATING,
+        Records.processInstance(1),
+        ValueType.PROCESS_INSTANCE,
+        RejectionType.NULL_VAL,
+        "",
+        2,
+        12);
+
+    when(defaultMockedRecordProcessor.process(any(), any()))
+        .thenReturn(resultBuilder.build())
+        .thenReturn(secondResultBuilder.build());
+
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
+
+    final var commandResponseWriter = streamPlatform.getMockCommandResponseWriter();
+
+    verify(commandResponseWriter, TIMEOUT.times(1)).key(3);
+    verify(commandResponseWriter, TIMEOUT.times(1)).key(4);
+  }
+
+  @Test
   public void shouldWriteResponseOnFailedEventProcessing() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();


### PR DESCRIPTION
## Description

Backported https://github.com/camunda/zeebe/pull/11865, had to fix several merge conflict related to structural changes which have been done on main, but not on 8.1

Had to fix another test, because this was removed on main, but still exists on 8.1 [test: adjust test case](https://github.com/camunda/zeebe/commit/aae1a80d3c0927438458c47966275d48041f09db)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/11848

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
