### PR TITLE
Introduce DistributionState for generalised command distribution

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.deployment.DbDecisionState;
 import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
 import io.camunda.zeebe.engine.state.deployment.DbProcessState;
+import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
 import io.camunda.zeebe.engine.state.instance.DbElementInstanceState;
 import io.camunda.zeebe.engine.state.instance.DbEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.instance.DbIncidentState;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.engine.state.migration.DbMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableBlackListState;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
@@ -74,6 +76,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableMigrationState mutableMigrationState;
   private final MutableDecisionState decisionState;
   private final MutableSignalSubscriptionState signalSubscriptionState;
+  private final MutableDistributionState distributionState;
 
   private final int partitionId;
 
@@ -104,6 +107,7 @@ public class ProcessingDbState implements MutableProcessingState {
     blackListState = new DbBlackListState(zeebeDb, transactionContext, partitionId);
     decisionState = new DbDecisionState(zeebeDb, transactionContext);
     signalSubscriptionState = new DbSignalSubscriptionState(zeebeDb, transactionContext);
+    distributionState = new DbDistributionState(zeebeDb, transactionContext);
 
     mutableMigrationState = new DbMigrationState(zeebeDb, transactionContext);
   }
@@ -185,6 +189,16 @@ public class ProcessingDbState implements MutableProcessingState {
   }
 
   @Override
+  public MutableSignalSubscriptionState getSignalSubscriptionState() {
+    return signalSubscriptionState;
+  }
+
+  @Override
+  public MutableDistributionState getDistributionState() {
+    return distributionState;
+  }
+
+  @Override
   public MutableMigrationState getMigrationState() {
     return mutableMigrationState;
   }
@@ -202,11 +216,6 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public KeyGenerator getKeyGenerator() {
     return keyGenerator;
-  }
-
-  @Override
-  public MutableSignalSubscriptionState getSignalSubscriptionState() {
-    return signalSubscriptionState;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/CommandValueAndValueTypeWrapper.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/CommandValueAndValueTypeWrapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.distribution;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * The CommandValueAndValueTypeWrapper is used to store a command value with it's corresponding
+ * ValueType in the state.
+ */
+public class CommandValueAndValueTypeWrapper extends UnpackedObject implements DbValue {
+
+  private final EnumProperty<ValueType> valueTypeProperty =
+      new EnumProperty<>("valueType", ValueType.class);
+  private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
+      new ObjectProperty<>("commandValue", new UnifiedRecordValue());
+
+  public CommandValueAndValueTypeWrapper() {
+    declareProperty(valueTypeProperty).declareProperty(commandValueProperty);
+  }
+
+  public CommandValueAndValueTypeWrapper wrap(
+      final CommandDistributionRecord commandDistributionRecord) {
+    valueTypeProperty.setValue(commandDistributionRecord.getValueType());
+
+    final var commandValue = (UnifiedRecordValue) commandDistributionRecord.getCommandValue();
+    final var valueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = commandValue.getLength();
+    valueBuffer.wrap(new byte[encodedLength]);
+    commandValue.write(valueBuffer, 0);
+    commandValueProperty.getValue().wrap(valueBuffer, 0, encodedLength);
+
+    return this;
+  }
+
+  public ValueType getValueType() {
+    return valueTypeProperty.getValue();
+  }
+
+  public UnifiedRecordValue getCommandValue() {
+    return commandValueProperty.getValue();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -26,7 +26,7 @@ public class DbDistributionState implements MutableDistributionState {
   private final DbForeignKey<DbLong> fkDistribution;
   private final DbInt partitionKey;
   private final DbCompositeKey<DbForeignKey<DbLong>, DbInt> distributionPartitionKey;
-  /** [distribution key | partition id] => [pending distributions] */
+  /** [distribution key | partition id] => [DbNil] */
   private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbInt>, DbNil>
       pendingDistributionColumnFamily;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbInt;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
@@ -22,10 +23,12 @@ import org.agrona.collections.MutableBoolean;
 public class DbDistributionState implements MutableDistributionState {
 
   private final DbLong distributionKey;
+  private final DbForeignKey<DbLong> fkDistribution;
   private final DbInt partitionKey;
-  private final DbCompositeKey<DbLong, DbInt> distributionPartitionKey;
+  private final DbCompositeKey<DbForeignKey<DbLong>, DbInt> distributionPartitionKey;
   /** [distribution key | partition id] => [pending distributions] */
-  private final ColumnFamily<DbCompositeKey<DbLong, DbInt>, DbNil> pendingDistributionColumnFamily;
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbInt>, DbNil>
+      pendingDistributionColumnFamily;
 
   private final CommandValueAndValueTypeWrapper commandValueAndValueTypeWrapper;
   /** [distribution key] => [ValueType and RecordValue of distributed command] */
@@ -35,15 +38,8 @@ public class DbDistributionState implements MutableDistributionState {
   public DbDistributionState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     distributionKey = new DbLong();
-    partitionKey = new DbInt();
-    distributionPartitionKey = new DbCompositeKey<>(distributionKey, partitionKey);
-    pendingDistributionColumnFamily =
-        zeebeDb.createColumnFamily(
-            ZbColumnFamilies.PENDING_DISTRIBUTION,
-            transactionContext,
-            distributionPartitionKey,
-            DbNil.INSTANCE);
-
+    fkDistribution =
+        new DbForeignKey<>(distributionKey, ZbColumnFamilies.COMMAND_DISTRIBUTION_RECORD);
     commandValueAndValueTypeWrapper = new CommandValueAndValueTypeWrapper();
     commandDistributionRecordColumnFamily =
         zeebeDb.createColumnFamily(
@@ -51,6 +47,15 @@ public class DbDistributionState implements MutableDistributionState {
             transactionContext,
             distributionKey,
             commandValueAndValueTypeWrapper);
+
+    partitionKey = new DbInt();
+    distributionPartitionKey = new DbCompositeKey<>(fkDistribution, partitionKey);
+    pendingDistributionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PENDING_DISTRIBUTION,
+            transactionContext,
+            distributionPartitionKey,
+            DbNil.INSTANCE);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -106,7 +106,6 @@ public class DbDistributionState implements MutableDistributionState {
   public CommandDistributionRecord getCommandDistributionRecord(
       final long distributionKey, final int partition) {
     this.distributionKey.wrapLong(distributionKey);
-    partitionKey.wrapInt(partition);
 
     final var storedDistribution = commandDistributionRecordColumnFamily.get(this.distributionKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -24,9 +24,11 @@ public class DbDistributionState implements MutableDistributionState {
   private final DbLong distributionKey;
   private final DbInt partitionKey;
   private final DbCompositeKey<DbLong, DbInt> distributionPartitionKey;
+  /** [distribution key | partition id] => [pending distributions] */
   private final ColumnFamily<DbCompositeKey<DbLong, DbInt>, DbNil> pendingDistributionColumnFamily;
 
   private final CommandValueAndValueTypeWrapper commandValueAndValueTypeWrapper;
+  /** [distribution key] => [ValueType and RecordValue of distributed command] */
   private final ColumnFamily<DbLong, CommandValueAndValueTypeWrapper>
       commandDistributionRecordColumnFamily;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.distribution;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbInt;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+
+public class DbDistributionState implements MutableDistributionState {
+
+  private final DbLong distributionKey;
+  private final DbInt partitionKey;
+  private final DbCompositeKey<DbLong, DbInt> distributionPartitionKey;
+  private final ColumnFamily<DbCompositeKey<DbLong, DbInt>, DbNil> pendingDistributionColumnFamily;
+
+  private final CommandValueAndValueTypeWrapper commandValueAndValueTypeWrapper;
+  private final ColumnFamily<DbLong, CommandValueAndValueTypeWrapper>
+      commandDistributionRecordColumnFamily;
+
+  public DbDistributionState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    distributionKey = new DbLong();
+    partitionKey = new DbInt();
+    distributionPartitionKey = new DbCompositeKey<>(distributionKey, partitionKey);
+    pendingDistributionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PENDING_DISTRIBUTION,
+            transactionContext,
+            distributionPartitionKey,
+            DbNil.INSTANCE);
+
+    commandValueAndValueTypeWrapper = new CommandValueAndValueTypeWrapper();
+    commandDistributionRecordColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.COMMAND_DISTRIBUTION_RECORD,
+            transactionContext,
+            distributionKey,
+            commandValueAndValueTypeWrapper);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+public interface DistributionState {}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -20,7 +20,10 @@ public interface DistributionState {
   boolean hasPendingDistribution(long distributionKey);
 
   /**
-   * Returns the {@link CommandDistributionRecord} for the given distribution key
+   * Returns the {@link CommandDistributionRecord} for the given distribution key. This method takes
+   * a partition id. This is only used to set the partition property in the {@link
+   * CommandDistributionRecord}. Doing so allows us to return a whole record, without the need to
+   * remember setting the partition everytime this method is called.
    *
    * @param distributionKey the key of the distribution
    * @param partition the partition to distribute to

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -7,4 +7,24 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
-public interface DistributionState {}
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+
+public interface DistributionState {
+
+  /**
+   * Returns whether there are any distributions pending for a given key.
+   *
+   * @param distributionKey the key of the distribution
+   * @return true if there are pending distributions for the given key, otherwise false
+   */
+  boolean hasPendingDistribution(long distributionKey);
+
+  /**
+   * Returns the {@link CommandDistributionRecord} for the given distribution key
+   *
+   * @param distributionKey the key of the distribution
+   * @param partition the partition to distribute to
+   * @return an new instance of the {@link CommandDistributionRecord}
+   */
+  CommandDistributionRecord getCommandDistributionRecord(long distributionKey, int partition);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -42,6 +42,8 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
 
   SignalSubscriptionState getSignalSubscriptionState();
 
+  DistributionState getDistributionState();
+
   int getPartitionId();
 
   boolean isEmpty(final ZbColumnFamilies column);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.DistributionState;
+
+public interface MutableDistributionState extends DistributionState {}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
@@ -8,5 +8,39 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 
-public interface MutableDistributionState extends DistributionState {}
+public interface MutableDistributionState extends DistributionState {
+
+  /**
+   * Adds a distribution to the state
+   *
+   * @param distributionKey the key of the distribution
+   * @param commandDistributionRecord the distribution record that needs to be stored
+   */
+  void addCommandDistribution(
+      final long distributionKey, final CommandDistributionRecord commandDistributionRecord);
+
+  /**
+   * Removed a distribution from the state
+   *
+   * @param distributionKey the key of the distribution that will be removed
+   */
+  void removeCommandDistribution(final long distributionKey);
+
+  /**
+   * Adds a pending distribution to the state
+   *
+   * @param distributionKey the key of the distribution
+   * @param partition the partition for which the distribution is pending
+   */
+  void addPendingDistribution(final long distributionKey, final int partition);
+
+  /**
+   * Removes a pending distribution fromm the state
+   *
+   * @param distributionKey the key of the pending distribution that will be removed
+   * @param partition the partition of the pending distribution that will be removed
+   */
+  void removePendingDistribution(final long distributionKey, final int partition);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -57,6 +57,9 @@ public interface MutableProcessingState extends ProcessingState {
   @Override
   MutableSignalSubscriptionState getSignalSubscriptionState();
 
+  @Override
+  MutableDistributionState getDistributionState();
+
   MutableMigrationState getMigrationState();
 
   MutablePendingMessageSubscriptionState getPendingMessageSubscriptionState();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.distribution;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public final class DistributionStateTest {
+  private MutableProcessingState processingState;
+  private MutableDistributionState distributionState;
+
+  @BeforeEach
+  public void setUp() {
+    distributionState = processingState.getDistributionState();
+  }
+
+  @Test
+  public void shouldReturnFalseOnEmptyStateForHasPendingCheck() {
+    // when
+    final var hasPending = distributionState.hasPendingDistribution(10L);
+
+    // then
+    assertThat(hasPending).isFalse();
+  }
+
+  @Test
+  public void shouldAddPendingDistribution() {
+    // given
+    final var distributionKey = 10L;
+    final var partition = 1;
+
+    // when
+    distributionState.addPendingDistribution(distributionKey, partition);
+
+    // then
+    assertThat(distributionState.hasPendingDistribution(distributionKey)).isTrue();
+  }
+
+  @Test
+  public void shouldRemovePendingDistribution() {
+    // given
+    final var deploymentKey = 10L;
+    final var partition = 1;
+    distributionState.addPendingDistribution(deploymentKey, partition);
+
+    // when
+    distributionState.removePendingDistribution(deploymentKey, partition);
+
+    // then
+    assertThat(distributionState.hasPendingDistribution(deploymentKey)).isFalse();
+  }
+
+  @Test
+  public void shouldReturnNullOnRequestingStoredDistributionWhenNothingStored() {
+    // when
+    final var distributionRecord = distributionState.getCommandDistributionRecord(1, 1);
+
+    // then
+    assertThat(distributionRecord).isNull();
+  }
+
+  @Test
+  public void shouldStoreDistributionInState() {
+    // given
+    final var distributionRecord = createCommandDistributionRecord();
+
+    // when
+    distributionState.addCommandDistribution(1, distributionRecord);
+
+    // then
+    final var storedDistribution =
+        distributionState.getCommandDistributionRecord(1, distributionRecord.getPartitionId());
+
+    assertThat(storedDistribution).isNotNull().isEqualTo(distributionRecord);
+  }
+
+  @Test
+  public void shouldRemoveDistribution() {
+    // given
+    final var distributionRecord = createCommandDistributionRecord();
+    distributionState.addCommandDistribution(1, distributionRecord);
+
+    // when
+    distributionState.removeCommandDistribution(1);
+
+    // then
+    final var storedDistribution =
+        distributionState.getCommandDistributionRecord(1, distributionRecord.getPartitionId());
+    assertThat(storedDistribution).isNull();
+  }
+
+  @Test
+  public void shouldRemoveDifferentDistributions() {
+    // given
+    final var distributionRecord = createCommandDistributionRecord();
+    distributionState.addCommandDistribution(1, distributionRecord);
+    distributionState.addCommandDistribution(2, distributionRecord);
+
+    // when
+    distributionState.removeCommandDistribution(1);
+
+    // then
+    var storedDistribution =
+        distributionState.getCommandDistributionRecord(1, distributionRecord.getPartitionId());
+    assertThat(storedDistribution).isNull();
+    storedDistribution =
+        distributionState.getCommandDistributionRecord(2, distributionRecord.getPartitionId());
+    assertThat(storedDistribution).isNotNull().isEqualTo(distributionRecord);
+  }
+
+  @Test
+  public void shouldRemoveDistributionIdempotent() {
+    // when
+    distributionState.removeCommandDistribution(1);
+
+    // then
+    final var storedDistributionRecord = distributionState.getCommandDistributionRecord(1, 1);
+    assertThat(storedDistributionRecord).isNull();
+  }
+
+  private CommandDistributionRecord createCommandDistributionRecord() {
+    return new CommandDistributionRecord()
+        .setPartitionId(1)
+        .setValueType(ValueType.DEPLOYMENT)
+        .setRecordValue(createDeploymentRecord());
+  }
+
+  private DeploymentRecord createDeploymentRecord() {
+    final var modelInstance =
+        Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+    final var deploymentRecord = new DeploymentRecord();
+
+    deploymentRecord
+        .resources()
+        .add()
+        .setResourceName(wrapString("resource"))
+        .setResource(wrapString(Bpmn.convertToString(modelInstance)));
+
+    deploymentRecord
+        .processesMetadata()
+        .add()
+        .setChecksum(wrapString("checksum"))
+        .setBpmnProcessId("process")
+        .setKey(1)
+        .setVersion(1)
+        .setResourceName(wrapString("resource"));
+
+    return deploymentRecord;
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -111,20 +111,21 @@ public final class DistributionStateTest {
   @Test
   public void shouldRemoveDifferentDistributions() {
     // given
-    final var distributionRecord = createCommandDistributionRecord();
-    distributionState.addCommandDistribution(1, distributionRecord);
-    distributionState.addCommandDistribution(2, distributionRecord);
+    final var distributionRecord1 = createCommandDistributionRecord();
+    final var distributionRecord2 = createCommandDistributionRecord();
+    distributionState.addCommandDistribution(1, distributionRecord1);
+    distributionState.addCommandDistribution(2, distributionRecord2);
 
     // when
     distributionState.removeCommandDistribution(1);
 
     // then
     var storedDistribution =
-        distributionState.getCommandDistributionRecord(1, distributionRecord.getPartitionId());
+        distributionState.getCommandDistributionRecord(1, distributionRecord1.getPartitionId());
     assertThat(storedDistribution).isNull();
     storedDistribution =
-        distributionState.getCommandDistributionRecord(2, distributionRecord.getPartitionId());
-    assertThat(storedDistribution).isNotNull().isEqualTo(distributionRecord);
+        distributionState.getCommandDistributionRecord(2, distributionRecord2.getPartitionId());
+    assertThat(storedDistribution).isNotNull().isEqualTo(distributionRecord2);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -45,6 +45,7 @@ public final class DistributionStateTest {
     // given
     final var distributionKey = 10L;
     final var partition = 1;
+    distributionState.addCommandDistribution(distributionKey, createCommandDistributionRecord());
 
     // when
     distributionState.addPendingDistribution(distributionKey, partition);
@@ -56,15 +57,16 @@ public final class DistributionStateTest {
   @Test
   public void shouldRemovePendingDistribution() {
     // given
-    final var deploymentKey = 10L;
+    final var distributionKey = 10L;
     final var partition = 1;
-    distributionState.addPendingDistribution(deploymentKey, partition);
+    distributionState.addCommandDistribution(distributionKey, createCommandDistributionRecord());
+    distributionState.addPendingDistribution(distributionKey, partition);
 
     // when
-    distributionState.removePendingDistribution(deploymentKey, partition);
+    distributionState.removePendingDistribution(distributionKey, partition);
 
     // then
-    assertThat(distributionState.hasPendingDistribution(deploymentKey)).isFalse();
+    assertThat(distributionState.hasPendingDistribution(distributionKey)).isFalse();
   }
 
   @Test

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -110,4 +110,8 @@ public enum ZbColumnFamilies {
   // signal subscription
   SIGNAL_SUBSCRIPTION_BY_NAME_AND_KEY,
   SIGNAL_SUBSCRIPTION_BY_KEY_AND_NAME,
+
+  // distribution
+  PENDING_DISTRIBUTION,
+  COMMAND_DISTRIBUTION_RECORD,
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds the new `DistributionState`. This will be used by the event appliers for generalised command distribution.
It adds some basic functionality to add, retrieve and remove pending distributions and the distributed command.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11868 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
