### PR TITLE
Add generalised command distribution event appliers

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionAcknowledgedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionAcknowledgedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+
+public final class CommandDistributionAcknowledgedApplier
+    implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
+
+  private final MutableDistributionState distributionState;
+
+  public CommandDistributionAcknowledgedApplier(final MutableDistributionState distributionState) {
+    this.distributionState = distributionState;
+  }
+
+  @Override
+  public void applyState(final long key, final CommandDistributionRecord value) {
+    distributionState.removePendingDistribution(key, value.getPartitionId());
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionDistributingApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionDistributingApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+
+public final class CommandDistributionDistributingApplier
+    implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
+
+  private final MutableDistributionState distributionState;
+
+  public CommandDistributionDistributingApplier(final MutableDistributionState distributionState) {
+    this.distributionState = distributionState;
+  }
+
+  @Override
+  public void applyState(final long key, final CommandDistributionRecord value) {
+    distributionState.addPendingDistribution(key, value.getPartitionId());
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionFinishedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionFinishedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+
+public final class CommandDistributionFinishedApplier
+    implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
+
+  private final MutableDistributionState distributionState;
+
+  public CommandDistributionFinishedApplier(final MutableDistributionState distributionState) {
+    this.distributionState = distributionState;
+  }
+
+  @Override
+  public void applyState(final long key, final CommandDistributionRecord value) {
+    distributionState.removeCommandDistribution(key);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionStartedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionStartedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+
+public final class CommandDistributionStartedApplier
+    implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
+
+  private final MutableDistributionState distributionState;
+
+  public CommandDistributionStartedApplier(final MutableDistributionState distributionState) {
+    this.distributionState = distributionState;
+  }
+
+  @Override
+  public void applyState(final long key, final CommandDistributionRecord value) {
+    distributionState.addCommandDistribution(key, value);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -284,6 +284,9 @@ public final class EventAppliers implements EventApplier {
         CommandDistributionIntent.DISTRIBUTING,
         new CommandDistributionDistributingApplier(distributionState));
     register(
+        CommandDistributionIntent.ACKNOWLEDGED,
+        new CommandDistributionAcknowledgedApplier(distributionState));
+    register(
         CommandDistributionIntent.FINISHED,
         new CommandDistributionFinishedApplier(distributionState));
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
@@ -74,6 +75,8 @@ public final class EventAppliers implements EventApplier {
     registerDecisionRequirementsAppliers(state);
 
     registerSignalSubscriptionAppliers(state);
+
+    registerCommandDistributionAppliers(state);
   }
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {
@@ -270,6 +273,13 @@ public final class EventAppliers implements EventApplier {
     register(
         DecisionRequirementsIntent.DELETED,
         new DecisionRequirementsDeletedApplier(state.getDecisionState()));
+  }
+
+  private void registerCommandDistributionAppliers(final MutableProcessingState state) {
+    final var distributionState = state.getDistributionState();
+    register(
+        CommandDistributionIntent.STARTED,
+        new CommandDistributionStartedApplier(distributionState));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -280,6 +280,9 @@ public final class EventAppliers implements EventApplier {
     register(
         CommandDistributionIntent.STARTED,
         new CommandDistributionStartedApplier(distributionState));
+    register(
+        CommandDistributionIntent.FINISHED,
+        new CommandDistributionFinishedApplier(distributionState));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -281,6 +281,9 @@ public final class EventAppliers implements EventApplier {
         CommandDistributionIntent.STARTED,
         new CommandDistributionStartedApplier(distributionState));
     register(
+        CommandDistributionIntent.DISTRIBUTING,
+        new CommandDistributionDistributingApplier(distributionState));
+    register(
         CommandDistributionIntent.FINISHED,
         new CommandDistributionFinishedApplier(distributionState));
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Adds 4 new event appliers to the engine. There is no way to test these appliers yet. Testing is done by checking engine behaviour. These appliers are not yet used. They will be tested properly once we change the deployment distribution to this new generalised way.

**CommandDistributionStartedApplier**
Adds an EventApplier for the CommandDistribution STARTED event. This applier will be responsible to store the command that's being distributed into the state, so that it can later be used for redistribution attempts.

**CommandDistributionFinishedApplier**
Adds an EventApplier for the CommandDistribution FINISHED event. This applier will be responsible to remove the command that's been distributed from the state.

**CommandDistributionDistributingApplier**
Adds an EventApplier for the CommandDistribution DISTRIBUTING event. This applier will be responsible to add a pending distribution to the state. This will be used to know which partitions have been distributed to, and which have acknowledged the distribution.

**CommandDistributionAcknowledgedApplier**
Adds an EventApplier for the CommandDistribution ACKNOWLEDGED event. This applier will be responsible to remove a pending distribution from the state. This will be used to mark the distribution to a specific partition as completed.

## Related issues

<!-- Which issues are closed by this PR or are related -->

based upon #11869. This needs to be merged before this one can be reviewed.
closes #11658 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
