### PR TITLE
[Backport stable/8.1] fix(clients/java): make a `ZeebeCallCredentials#applyRequestMetadata`call non-blocking

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java
@@ -41,13 +41,16 @@ public final class ZeebeCallCredentials extends io.grpc.CallCredentials {
           "The request's security level does not guarantee that the credentials will be confidential.");
     }
 
-    try {
-      final Metadata headers = new Metadata();
-      credentialsProvider.applyCredentials(headers);
-      applier.apply(headers);
-    } catch (IOException e) {
-      applier.fail(Status.CANCELLED.withCause(e));
-    }
+    appExecutor.execute(
+        () -> {
+          try {
+            final Metadata headers = new Metadata();
+            credentialsProvider.applyCredentials(headers);
+            applier.apply(headers);
+          } catch (final IOException e) {
+            applier.fail(Status.CANCELLED.withCause(e));
+          }
+        });
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #11817 to `stable/8.1`.

relates to #11816