### PR TITLE
Add Broadcast Signal RPC

### DIFF
--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -559,6 +559,20 @@ message DeleteResourceResponse {
 
 }
 
+message BroadcastSignalRequest {
+  // The name of the signal
+  string signalName = 1;
+
+  // the signal variables as a JSON document; to be valid, the root of the document must be an
+  // object, e.g. { "a": "foo" }. [ "foo" ] would not be valid.
+  string variables = 2;
+}
+
+message BroadcastSignalResponse {
+  // the unique ID of the signal that was broadcasted.
+  int64 key = 1;
+}
+
 service Gateway {
   /*
     Iterates through all known partitions round-robin and activates up to the requested
@@ -803,6 +817,13 @@ service Gateway {
 
    */
   rpc DeleteResource (DeleteResourceRequest) returns (DeleteResourceResponse) {
+
+  }
+
+  /*
+    Broadcasts a signal.
+   */
+  rpc BroadcastSignal (BroadcastSignalRequest) returns (BroadcastSignalResponse) {
 
   }
 }

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -1031,6 +1031,24 @@
           },
           {
             "name": "DeleteResourceResponse"
+          },
+          {
+            "name": "BroadcastSignalRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "signalName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "variables",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "BroadcastSignalResponse"
           }
         ],
         "services": [
@@ -1128,6 +1146,11 @@
                 "name": "DeleteResource",
                 "in_type": "DeleteResourceRequest",
                 "out_type": "DeleteResourceResponse"
+              },
+              {
+                "name": "BroadcastSignal",
+                "in_type": "BroadcastSignalRequest",
+                "out_type": "BroadcastSignalResponse"
               }
             ]
           }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BrokerInfo;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BrokerInfo.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceRequest;
@@ -348,6 +350,16 @@ public final class EndpointManager {
         request,
         RequestMapper::toDeleteResourceRequest,
         ResponseMapper::toDeleteResourceResponse,
+        responseObserver);
+  }
+
+  public void broadcastSignal(
+      final BroadcastSignalRequest request,
+      final ServerStreamObserver<BroadcastSignalResponse> responseObserver) {
+    sendRequest(
+        request,
+        RequestMapper::toBroadcastSignalRequest,
+        ResponseMapper::toBroadcastSignalResponse,
         responseObserver);
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.gateway.grpc.ErrorMappingStreamObserver;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
@@ -180,6 +182,14 @@ public class GatewayGrpcService extends GatewayImplBase {
       final DeleteResourceRequest request,
       final StreamObserver<DeleteResourceResponse> responseObserver) {
     endpointManager.deleteResource(
+        request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
+  }
+
+  @Override
+  public void broadcastSignal(
+      final BroadcastSignalRequest request,
+      final StreamObserver<BroadcastSignalResponse> responseObserver) {
+    endpointManager.broadcastSignal(
         request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -11,6 +11,7 @@ import static org.agrona.LangUtil.rethrowUnchecked;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerBroadcastSignalRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCompleteJobRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
@@ -26,6 +27,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerThrowErrorRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
@@ -200,6 +202,12 @@ public final class RequestMapper {
   public static BrokerDeleteResourceRequest toDeleteResourceRequest(
       final DeleteResourceRequest grpcRequest) {
     return new BrokerDeleteResourceRequest().setResourceKey(grpcRequest.getResourceKey());
+  }
+
+  public static BrokerBroadcastSignalRequest toBroadcastSignalRequest(
+      final BroadcastSignalRequest grpcRequest) {
+    return new BrokerBroadcastSignalRequest(grpcRequest.getSignalName())
+        .setVariables(ensureJsonSet(grpcRequest.getVariables()));
   }
 
   public static DirectBuffer ensureJsonSet(final String value) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
@@ -46,6 +47,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import java.util.Iterator;
@@ -286,6 +288,11 @@ public final class ResponseMapper {
   public static DeleteResourceResponse toDeleteResourceResponse(
       final long key, final ResourceDeletionRecord brokerResponse) {
     return DeleteResourceResponse.getDefaultInstance();
+  }
+
+  public static BroadcastSignalResponse toBroadcastSignalResponse(
+      final long key, final SignalRecord brokerResponse) {
+    return BroadcastSignalResponse.newBuilder().setKey(key).build();
   }
 
   private static String bufferAsJson(final DirectBuffer customHeaders) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerBroadcastSignalRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerBroadcastSignalRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import org.agrona.DirectBuffer;
+
+public final class BrokerBroadcastSignalRequest extends BrokerExecuteCommand<SignalRecord> {
+
+  private final SignalRecord requestDto = new SignalRecord();
+
+  public BrokerBroadcastSignalRequest(final String signalName) {
+    super(ValueType.SIGNAL, SignalIntent.BROADCAST);
+    requestDto.setSignalName(signalName);
+  }
+
+  public BrokerBroadcastSignalRequest setVariables(final DirectBuffer variables) {
+    requestDto.setVariables(variables);
+    return this;
+  }
+
+  @Override
+  public SignalRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected SignalRecord toResponseDto(final DirectBuffer buffer) {
+    final SignalRecord responseDto = new SignalRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/signal/BroadcastSignalStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/signal/BroadcastSignalStub.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.api.signal;
+
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerBroadcastSignalRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+
+public final class BroadcastSignalStub
+    implements RequestStub<BrokerBroadcastSignalRequest, BrokerResponse<SignalRecord>> {
+
+  @Override
+  public void registerWith(final StubbedBrokerClient gateway) {
+    gateway.registerHandler(BrokerBroadcastSignalRequest.class, this);
+  }
+
+  @Override
+  public BrokerResponse<SignalRecord> handle(final BrokerBroadcastSignalRequest request)
+      throws Exception {
+    return new BrokerResponse<>(null);
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/signal/BroadcastSignalTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/signal/BroadcastSignalTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.api.signal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerBroadcastSignalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.test.util.JsonUtil;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.util.Collections;
+import org.junit.Test;
+
+public class BroadcastSignalTest extends GatewayTest {
+
+  @Test
+  public void shouldMapRequestAndResponse() {
+    // given
+    final BroadcastSignalStub stub = new BroadcastSignalStub();
+    stub.registerWith(brokerClient);
+
+    final String variables = JsonUtil.toJson(Collections.singletonMap("key", "value"));
+
+    final BroadcastSignalRequest request =
+        BroadcastSignalRequest.newBuilder().setSignalName("signal").setVariables(variables).build();
+
+    // when
+    final BroadcastSignalResponse response = client.broadcastSignal(request);
+
+    // then
+    assertThat(response).isNotNull();
+
+    final BrokerBroadcastSignalRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getIntent()).isEqualTo(SignalIntent.BROADCAST);
+    assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.SIGNAL);
+
+    final SignalRecord brokerRequestValue = brokerRequest.getRequestWriter();
+    assertThat(brokerRequestValue.getSignalName()).isEqualTo(request.getSignalName());
+    MsgPackUtil.assertEqualityExcluding(brokerRequestValue.getVariablesBuffer(), variables);
+  }
+}


### PR DESCRIPTION
## Description
This PR introduces new broadcast signal RPC. It includes the extension of the gateway protocol and the mapping of the request and the response.

## Related issues
closes #11878

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
