### PR TITLE
Add CommandDistribution ACKNOWLEDGE processor

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -44,7 +44,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.RESOURCE_DELETION);
+      EnumSet.range(ValueType.JOB, ValueType.COMMAND_DISTRIBUTION);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.CompleteDeployme
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionAcknowledgeProcessor;
 import io.camunda.zeebe.engine.processing.dmn.EvaluateDecisionProcessor;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
@@ -37,6 +38,7 @@ import io.camunda.zeebe.engine.state.migration.DbMigrationController;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
@@ -129,6 +131,7 @@ public final class EngineProcessors {
     addIncidentProcessors(processingState, bpmnStreamProcessor, typedRecordProcessors, writers);
     addResourceDeletionProcessors(typedRecordProcessors, writers, processingState);
     addSignalBroadcastProcessors(typedRecordProcessors, bpmnBehaviors, writers, processingState);
+    addCommandDistributionProcessors(typedRecordProcessors, writers, processingState);
 
     return typedRecordProcessors;
   }
@@ -276,5 +279,18 @@ public final class EngineProcessors {
             processingState.getSignalSubscriptionState());
     typedRecordProcessors.onCommand(
         ValueType.SIGNAL, SignalIntent.BROADCAST, signalBroadcastProcessor);
+  }
+
+  private static void addCommandDistributionProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers,
+      final ProcessingState processingState) {
+    final var commandDistributionAcknowledgeProcessor =
+        new CommandDistributionAcknowledgeProcessor(
+            processingState.getDistributionState(), writers);
+    typedRecordProcessors.onCommand(
+        ValueType.COMMAND_DISTRIBUTION,
+        CommandDistributionIntent.ACKNOWLEDGE,
+        commandDistributionAcknowledgeProcessor);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.distribution;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.DistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class CommandDistributionAcknowledgeProcessor
+    implements TypedRecordProcessor<CommandDistributionRecord> {
+
+  private static final String ERROR_PENDING_DISTRIBUTION_NOT_FOUND =
+      """
+      Expected to find pending distribution with key %d for partition %d, but no pending \
+      distribution was found.""";
+  private static final CommandDistributionRecord EMPTY_DISTRIBUTION_RECORD =
+      new CommandDistributionRecord();
+
+  private final DistributionState distributionState;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+
+  public CommandDistributionAcknowledgeProcessor(
+      final DistributionState distributionState, final Writers writers) {
+    this.distributionState = distributionState;
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<CommandDistributionRecord> record) {
+    final var distributionKey = record.getKey();
+    final var partitionId = record.getValue().getPartitionId();
+
+    if (!distributionState.hasPendingDistribution(distributionKey, partitionId)) {
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.NOT_FOUND,
+          String.format(ERROR_PENDING_DISTRIBUTION_NOT_FOUND, distributionKey, partitionId));
+    }
+
+    stateWriter.appendFollowUpEvent(
+        distributionKey, CommandDistributionIntent.ACKNOWLEDGED, record.getValue());
+
+    if (!distributionState.hasPendingDistribution(distributionKey)) {
+      // We write an empty command here as a distribution could contain a lot of data. Because of
+      // this we could exceed the max message size. As we only need the distributionKey in the
+      // FINISHED event applier an empty record will suffice here.
+      stateWriter.appendFollowUpEvent(
+          distributionKey, CommandDistributionIntent.FINISHED, EMPTY_DISTRIBUTION_RECORD);
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -103,6 +103,13 @@ public class DbDistributionState implements MutableDistributionState {
   }
 
   @Override
+  public boolean hasPendingDistribution(final long distributionKey, final int partition) {
+    this.distributionKey.wrapLong(distributionKey);
+    partitionKey.wrapInt(partition);
+    return pendingDistributionColumnFamily.exists(distributionPartitionKey);
+  }
+
+  @Override
   public CommandDistributionRecord getCommandDistributionRecord(
       final long distributionKey, final int partition) {
     this.distributionKey.wrapLong(distributionKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -20,6 +20,15 @@ public interface DistributionState {
   boolean hasPendingDistribution(long distributionKey);
 
   /**
+   * Returns whether a specific distribution for a specific partition is pending.
+   *
+   * @param distributionKey the key of the distribution that may be pending
+   * @param partition the id of the partition for which the distribution might be pending
+   * @return {@code true} if the specific pending distribution exists, otherwise {@code false}.
+   */
+  boolean hasPendingDistribution(long distributionKey, int partition);
+
+  /**
    * Returns the {@link CommandDistributionRecord} for the given distribution key. This method takes
    * a partition id. This is only used to set the partition property in the {@link
    * CommandDistributionRecord}. Doing so allows us to return a whole record, without the need to

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -43,6 +43,15 @@ public final class DistributionStateTest {
   }
 
   @Test
+  public void shouldReturnFalseOnEmptyStateForHasPendingForPartitionCheck() {
+    // when
+    final var hasPending = distributionState.hasPendingDistribution(10L, 10);
+
+    // then
+    assertThat(hasPending).isFalse();
+  }
+
+  @Test
   public void shouldAddPendingDistribution() {
     // given
     final var distributionKey = 10L;
@@ -54,6 +63,7 @@ public final class DistributionStateTest {
 
     // then
     assertThat(distributionState.hasPendingDistribution(distributionKey)).isTrue();
+    assertThat(distributionState.hasPendingDistribution(distributionKey, partition)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Adds the process for CommandDistribution ACKNOWLEDGE commands. It is responsible for the deletion of pending distributions. When all pending distributions have been acknowledged it will write a FINISHED event for this distribution, indicating that the distribution has been completed.

Note: there are no tests as part of this PR. Since we test engine behaviour this will be thoroughly tested when we migrate the deployment distributions to this new way of distributing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11659

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
