### PR TITLE
Introduce GatewayStream API

### DIFF
--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.impl.RecordProcessorContextImpl;
@@ -69,7 +70,13 @@ final class CheckpointRecordsProcessorTest {
       final ProcessingScheduleService executor, final ZeebeDb zeebeDb) {
     final var context = zeebeDb.createContext();
     return new RecordProcessorContextImpl(
-        1, executor, zeebeDb, context, null, new DbKeyGenerator(1, zeebeDb, context));
+        1,
+        executor,
+        zeebeDb,
+        context,
+        null,
+        new DbKeyGenerator(1, zeebeDb, context),
+        GatewayStreamer.noop());
   }
 
   @AfterEach

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/LongPollingJobNotification.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/LongPollingJobNotification.java
@@ -8,8 +8,15 @@
 package io.camunda.zeebe.broker.engine.impl;
 
 import io.atomix.cluster.messaging.ClusterEventService;
+import io.camunda.zeebe.stream.api.ActivatedJob;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
 
-public final class LongPollingJobNotification {
+public final class LongPollingJobNotification
+    implements GatewayStreamer<JobActivationProperties, ActivatedJob> {
   private static final String TOPIC = "jobsAvailable";
   private final ClusterEventService eventService;
 
@@ -17,7 +24,15 @@ public final class LongPollingJobNotification {
     this.eventService = eventService;
   }
 
-  public void onJobsAvailable(final String jobType) {
+  @Override
+  public Optional<GatewayStream<JobActivationProperties, ActivatedJob>> streamFor(
+      final DirectBuffer streamId) {
+    onJobsAvailable(BufferUtil.bufferAsString(streamId));
+
+    return Optional.empty();
+  }
+
+  private void onJobsAvailable(final String jobType) {
     eventService.broadcast(TOPIC, jobType);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.broker.partitioning;
 
 import io.atomix.cluster.MemberId;
-import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionGroup;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -138,7 +137,7 @@ final class PartitionFactory {
             .map(RaftPartition.class::cast)
             .toList();
 
-    final var typedRecordProcessorsFactory = createFactory(localBroker, eventService, featureFlags);
+    final var typedRecordProcessorsFactory = createFactory(localBroker, featureFlags);
     final var jobStreamer = new LongPollingJobNotification(eventService);
 
     for (final RaftPartition owningPartition : owningPartitions) {
@@ -220,9 +219,7 @@ final class PartitionFactory {
   }
 
   private TypedRecordProcessorsFactory createFactory(
-      final BrokerInfo localBroker,
-      final ClusterEventService eventService,
-      final FeatureFlags featureFlags) {
+      final BrokerInfo localBroker, final FeatureFlags featureFlags) {
     return recordProcessorContext -> {
       final InterPartitionCommandSender partitionCommandSender =
           recordProcessorContext.getPartitionCommandSender();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -343,7 +343,7 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer() {
+  public GatewayStreamer<JobActivationProperties, ActivatedJob> getJobStreamer() {
     return jobStreamer;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -37,7 +37,10 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
+import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -98,6 +101,7 @@ public class PartitionStartupAndTransitionContextImpl
   private BackupManager backupManager;
   private CheckpointRecordsProcessor checkpointRecordsProcessor;
   private final TopologyManager topologyManager;
+  private final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer;
 
   private BackupStore backupStore;
 
@@ -118,7 +122,8 @@ public class PartitionStartupAndTransitionContextImpl
       final PartitionProcessingState partitionProcessingState,
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final AtomixServerTransport gatewayBrokerTransport,
-      final TopologyManager topologyManager) {
+      final TopologyManager topologyManager,
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
     this.nodeId = nodeId;
     this.clusterCommunicationService = clusterCommunicationService;
     this.raftPartition = raftPartition;
@@ -138,6 +143,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.topologyManager = topologyManager;
+    this.jobStreamer = jobStreamer;
   }
 
   public PartitionAdminControl getPartitionAdminControl() {
@@ -334,6 +340,11 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public void setBackupStore(final BackupStore backupStore) {
     this.backupStore = backupStore;
+  }
+
+  @Override
+  public GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer() {
+    return jobStreamer;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -132,5 +132,5 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   void setBackupStore(BackupStore backupStore);
 
-  GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer();
+  GatewayStreamer<JobActivationProperties, ActivatedJob> getJobStreamer();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -29,7 +29,10 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
+import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -128,4 +131,6 @@ public interface PartitionTransitionContext extends PartitionContext {
   BackupStore getBackupStore();
 
   void setBackupStore(BackupStore backupStore);
+
+  GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -141,6 +141,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .nodeId(context.getNodeId())
         .commandResponseWriter(context.getCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
+        .jobStreamer(context.jobStreamer())
         .listener(
             new StreamProcessorListener() {
               @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -141,7 +141,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .nodeId(context.getNodeId())
         .commandResponseWriter(context.getCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
-        .jobStreamer(context.jobStreamer())
+        .jobStreamer(context.getJobStreamer())
         .listener(
             new StreamProcessorListener() {
               @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -34,7 +34,10 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
+import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -70,6 +73,8 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private BackupManager backupManager;
   private CheckpointRecordsProcessor checkpointRecordsProcessor;
   private BackupStore backupStore;
+  private final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer =
+      GatewayStreamer.noop();
 
   @Override
   public int getPartitionId() {
@@ -253,6 +258,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public void setBackupStore(final BackupStore backupStore) {
     this.backupStore = backupStore;
+  }
+
+  @Override
+  public GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer() {
+    return jobStreamer;
   }
 
   public void setGatewayBrokerTransport(final AtomixServerTransport gatewayBrokerTransport) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -261,7 +261,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
-  public GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer() {
+  public GatewayStreamer<JobActivationProperties, ActivatedJob> getJobStreamer() {
     return jobStreamer;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -72,7 +72,8 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getPartitionId(),
             zeebeDb,
             recordProcessorContext.getTransactionContext(),
-            recordProcessorContext.getKeyGenerator());
+            recordProcessorContext.getKeyGenerator(),
+            recordProcessorContext.jobStreamer());
     final var scheduledTaskDbState = new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
 
     eventApplier = new EventAppliers(processingState);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -44,7 +44,6 @@ import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.FeatureFlags;
-import java.util.function.Consumer;
 
 public final class EngineProcessors {
 
@@ -55,7 +54,6 @@ public final class EngineProcessors {
       final int partitionsCount,
       final SubscriptionCommandSender subscriptionCommandSender,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
-      final Consumer<String> onJobsAvailableCallback,
       final FeatureFlags featureFlags) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
@@ -119,12 +117,7 @@ public final class EngineProcessors {
     addDecisionProcessors(typedRecordProcessors, decisionBehavior, writers, processingState);
 
     JobEventProcessors.addJobProcessors(
-        typedRecordProcessors,
-        processingState,
-        onJobsAvailableCallback,
-        bpmnBehaviors,
-        writers,
-        jobMetrics);
+        typedRecordProcessors, processingState, bpmnBehaviors, writers, jobMetrics);
 
     addIncidentProcessors(processingState, bpmnStreamProcessor, typedRecordProcessors, writers);
     addResourceDeletionProcessors(typedRecordProcessors, writers, processingState);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -16,16 +16,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
-import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
-import java.util.function.Consumer;
 
 public final class JobEventProcessors {
 
   public static void addJobProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
-      final Consumer<String> onJobsAvailableCallback,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
       final JobMetrics jobMetrics) {
@@ -80,13 +76,6 @@ public final class JobEventProcessors {
             new JobBatchActivateProcessor(
                 writers, processingState, processingState.getKeyGenerator(), jobMetrics))
         .withListener(new JobTimeoutTrigger(jobState))
-        .withListener(jobBackoffChecker)
-        .withListener(
-            new StreamProcessorLifecycleAware() {
-              @Override
-              public void onRecovered(final ReadonlyStreamProcessorContext context) {
-                jobState.setJobsAvailableCallback(onJobsAvailableCallback);
-              }
-            });
+        .withListener(jobBackoffChecker);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -49,6 +49,9 @@ import io.camunda.zeebe.engine.state.processing.DbBlackListState;
 import io.camunda.zeebe.engine.state.signal.DbSignalSubscriptionState;
 import io.camunda.zeebe.engine.state.variable.DbVariableState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.stream.api.ActivatedJob;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Objects;
@@ -84,7 +87,8 @@ public class ProcessingDbState implements MutableProcessingState {
       final int partitionId,
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
     this.partitionId = partitionId;
     this.zeebeDb = zeebeDb;
     this.keyGenerator = Objects.requireNonNull(keyGenerator);
@@ -96,7 +100,7 @@ public class ProcessingDbState implements MutableProcessingState {
     eventScopeInstanceState = new DbEventScopeInstanceState(zeebeDb, transactionContext);
 
     deploymentState = new DbDeploymentState(zeebeDb, transactionContext);
-    jobState = new DbJobState(zeebeDb, transactionContext, partitionId);
+    jobState = new DbJobState(zeebeDb, transactionContext, partitionId, jobStreamer);
     messageState = new DbMessageState(zeebeDb, transactionContext);
     messageSubscriptionState = new DbMessageSubscriptionState(zeebeDb, transactionContext);
     messageStartEventSubscriptionState =

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
-import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 
 public interface JobState {
@@ -26,8 +25,6 @@ public interface JobState {
   void forEachActivatableJobs(DirectBuffer type, BiFunction<Long, JobRecord, Boolean> callback);
 
   JobRecord getJob(long key);
-
-  void setJobsAvailableCallback(Consumer<String> callback);
 
   long findBackedOffJobs(final long timestamp, final BiPredicate<Long, JobRecord> callback);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -21,6 +21,9 @@ import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.stream.api.ActivatedJob;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.util.EnsureUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.function.BiFunction;
@@ -67,12 +70,15 @@ public final class DbJobState implements JobState, MutableJobState {
 
   private final JobMetrics metrics;
 
-  private Consumer<String> onJobsAvailableCallback;
+  private final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer;
 
   public DbJobState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final int partitionId) {
+      final int partitionId,
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
+    this.jobStreamer = jobStreamer;
+
     jobKey = new DbLong();
     fkJob = new DbForeignKey<>(jobKey, ZbColumnFamilies.JOBS);
     jobsColumnFamily =
@@ -308,9 +314,7 @@ public final class DbJobState implements JobState, MutableJobState {
   }
 
   @Override
-  public void setJobsAvailableCallback(final Consumer<String> onJobsAvailableCallback) {
-    this.onJobsAvailableCallback = onJobsAvailableCallback;
-  }
+  public void setJobsAvailableCallback(final Consumer<String> onJobsAvailableCallback) {}
 
   @Override
   public long findBackedOffJobs(final long timestamp, final BiPredicate<Long, JobRecord> callback) {
@@ -345,8 +349,11 @@ public final class DbJobState implements JobState, MutableJobState {
   }
 
   private void notifyJobAvailable(final DirectBuffer jobType) {
-    if (onJobsAvailableCallback != null) {
-      onJobsAvailableCallback.accept(BufferUtil.bufferAsString(jobType));
+    if (jobStreamer != null) {
+      // ignore the result for now
+      // TODO: remove the cloneBuffer eventually, but it's required now due to the
+      //  ActivatableJobsNotificationTests
+      jobStreamer.streamFor(BufferUtil.cloneBuffer(jobType));
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.util.EnsureUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
-import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 
@@ -312,9 +311,6 @@ public final class DbJobState implements JobState, MutableJobState {
     final JobRecordValue jobState = jobsColumnFamily.get(jobKey);
     return jobState == null ? null : jobState.getRecord();
   }
-
-  @Override
-  public void setJobsAvailableCallback(final Consumer<String> onJobsAvailableCallback) {}
 
   @Override
   public long findBackedOffJobs(final long timestamp, final BiPredicate<Long, JobRecord> callback) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
@@ -73,7 +74,8 @@ public final class StateQueryService implements QueryService {
               zeebeDb.createContext(),
               () -> {
                 throw new UnsupportedOperationException("Not allowed to generate a new key");
-              });
+              },
+              GatewayStreamer.noop());
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -157,7 +158,11 @@ public class ProcessingStateExtension implements BeforeEachCallback {
             new DbKeyGenerator(Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext);
         processingState =
             new ProcessingDbState(
-                Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext, keyGenerator);
+                Protocol.DEPLOYMENT_PARTITION,
+                zeebeDb,
+                transactionContext,
+                keyGenerator,
+                GatewayStreamer.noop());
       } catch (final Exception e) {
         ExceptionUtils.throwAsUncheckedException(e);
       }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
@@ -39,7 +40,8 @@ public final class ProcessingStateRule extends ExternalResource {
 
     final var context = db.createContext();
     final var keyGenerator = new DbKeyGenerator(partition, db, context);
-    processingState = new ProcessingDbState(partition, db, context, keyGenerator);
+    processingState =
+        new ProcessingDbState(partition, db, context, keyGenerator, GatewayStreamer.noop());
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -20,6 +20,9 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.stream.api.ActivatedJob;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import java.util.Arrays;
@@ -97,6 +100,11 @@ public class StreamProcessingComposite {
             streamProcessorListenerOpt);
 
     return result;
+  }
+
+  public void setJobStreamer(
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
+    streams.setJobStreamer(jobStreamer);
   }
 
   public void pauseProcessing(final int partitionId) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -21,7 +21,10 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
+import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessorContext;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
@@ -139,6 +142,11 @@ public final class StreamProcessorRule implements TestRule {
       final Optional<StreamProcessorListener> streamProcessorListenerOpt) {
     return streamProcessingComposite.startTypedStreamProcessor(
         partitionId, factory, streamProcessorListenerOpt);
+  }
+
+  public void setJobStreamer(
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
+    streamProcessingComposite.setJobStreamer(jobStreamer);
   }
 
   public void pauseProcessing(final int partitionId) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -34,8 +34,11 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
@@ -87,6 +90,7 @@ public final class TestStreams {
   private boolean snapshotWasTaken = false;
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
   private int maxCommandsInBatch = StreamProcessorContext.DEFAULT_MAX_COMMANDS_IN_BATCH;
+  private GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer;
 
   public TestStreams(
       final TemporaryFolder dataDirectory,
@@ -260,6 +264,7 @@ public final class TestStreams {
             .recordProcessors(List.of(new Engine(wrappedFactory)))
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)
+            .jobStreamer(id -> Optional.ofNullable(jobStreamer).flatMap(s -> s.streamFor(id)))
             .partitionCommandSender(mock(InterPartitionCommandSender.class));
 
     final StreamProcessor streamProcessor = builder.build();
@@ -280,6 +285,11 @@ public final class TestStreams {
     closeables.manage(processorContext);
 
     return streamProcessor;
+  }
+
+  public void setJobStreamer(
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
+    this.jobStreamer = jobStreamer;
   }
 
   public void pauseProcessing(final String streamName) {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ActivatedJob.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ActivatedJob.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.api;
+
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+
+/**
+ * Represents an activated {@link io.camunda.zeebe.protocol.record.value.JobRecordValue}. It's
+ * expected that the {@link JobRecord#getVariables()} map has been filled out during activation.
+ */
+public interface ActivatedJob extends BufferWriter {
+
+  /** Returns the unique key of this job */
+  long jobKey();
+
+  /** Returns the actual job, with the variables collected during activation. */
+  JobRecord record();
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/GatewayStreamer.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/GatewayStreamer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.api;
+
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
+
+/**
+ * A {@link GatewayStreamer} allows the engine to push data back to a single gateway (any). It keeps
+ * track of multiple {@link GatewayStream} instances, each with their own ID. The semantics of the
+ * ID, associated with the metadata and payload, are owned by the consumer of the API.
+ *
+ * <p>NOTE: {@link GatewayStream#push(BufferWriter, ErrorHandler)} is a side effect, and should be
+ * treated as a post-commit task for consistency. TODO: see if the platform cannot already enforce
+ * with its own implementation.
+ *
+ * <p>NOTE: implementations of the {@link GatewayStream#push(BufferWriter, ErrorHandler)} method are
+ * likely asynchronous. As such, errors handled via the {@link ErrorHandler} may be executed after
+ * the initial call. Callers should be careful with the state they close on in the implementations
+ * of their {@link ErrorHandler}.
+ *
+ * @param <Metadata> associated metadata with a single stream
+ * @param <Payload> the payload type that can be pushed to the stream
+ */
+public interface GatewayStreamer<Metadata extends BufferReader, Payload extends BufferWriter> {
+
+  /** Returns a valid stream for the given ID, or {@link Optional#empty()} if there is none. */
+  Optional<GatewayStream<Metadata, Payload>> streamFor(final DirectBuffer streamId);
+
+  /**
+   * A {@link GatewayStream} allows consumers to push out {@link Payload} types to a stream with the
+   * given {@link #metadata()} associated.
+   *
+   * <p>NOTE: it's up to consumers of this API to interpret the metadata and its relation to the
+   * payload.
+   *
+   * @param <Metadata> associated metadata with the stream
+   * @param <Payload> the payload type that can be pushed to the stream
+   */
+  interface GatewayStream<Metadata extends BufferReader, Payload extends BufferWriter> {
+
+    /** Returns the stream's metadata */
+    Metadata metadata();
+
+    /**
+     * Pushes the given payload to the stream. Implementations of this are likely asynchronous; it's
+     * recommended that callers ensure that the given payload is immutable, and that the error
+     * handler does not close over any shared state.
+     *
+     * @param payload the data to push to the remote gateway
+     * @param errorHandler logic to execute if the data could not be pushed to the underlying stream
+     */
+    void push(final Payload payload, ErrorHandler<Payload> errorHandler);
+  }
+
+  /**
+   * Allows consumers of this API to specify error handling logic when a payload cannot be pushed
+   * out.
+   *
+   * @param <Payload> the payload type
+   */
+  interface ErrorHandler<Payload> {
+    void handleError(final Throwable error, Payload data);
+  }
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/GatewayStreamer.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/GatewayStreamer.java
@@ -29,7 +29,11 @@ import org.agrona.DirectBuffer;
  * @param <Metadata> associated metadata with a single stream
  * @param <Payload> the payload type that can be pushed to the stream
  */
+@FunctionalInterface
 public interface GatewayStreamer<Metadata extends BufferReader, Payload extends BufferWriter> {
+  static <M extends BufferReader, P extends BufferWriter> GatewayStreamer<M, P> noop() {
+    return streamId -> Optional.empty();
+  }
 
   /** Returns a valid stream for the given ID, or {@link Optional#empty()} if there is none. */
   Optional<GatewayStream<Metadata, Payload>> streamFor(final DirectBuffer streamId);

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/JobActivationProperties.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/JobActivationProperties.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.api;
+
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import java.util.Collection;
+import org.agrona.DirectBuffer;
+
+/**
+ * {@link JobActivationProperties} represents the minimum set of properties required to activate a
+ * {@link io.camunda.zeebe.protocol.record.value.JobRecordValue} in the engine.
+ */
+public interface JobActivationProperties extends BufferReader {
+
+  /**
+   * Returns the name of the worker. This is mostly used for debugging purposes.
+   *
+   * @see JobRecordValue#getWorker()
+   */
+  DirectBuffer worker();
+
+  /**
+   * Returns the variables requested by the worker, or an empty collection if all variables are
+   * requested.
+   *
+   * @see JobRecordValue#getVariables()
+   */
+  Collection<String> fetchVariables();
+
+  /**
+   * Returns the activation timeout of the job, i.e. how long before the job is made activate-able
+   * again after activation
+   *
+   * @see JobRecordValue#getDeadline()
+   */
+  long timeout();
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.List;
+import java.util.Optional;
 
 public interface RecordProcessorContext {
 
@@ -30,4 +31,6 @@ public interface RecordProcessorContext {
   InterPartitionCommandSender getPartitionCommandSender();
 
   KeyGenerator getKeyGenerator();
+
+  Optional<GatewayStreamer<JobActivationProperties, ActivatedJob>> jobStreamer();
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.List;
-import java.util.Optional;
 
 public interface RecordProcessorContext {
 
@@ -32,5 +31,5 @@ public interface RecordProcessorContext {
 
   KeyGenerator getKeyGenerator();
 
-  Optional<GatewayStreamer<JobActivationProperties, ActivatedJob>> jobStreamer();
+  GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer();
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
@@ -9,7 +9,10 @@ package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.stream.api.ActivatedJob;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
@@ -17,6 +20,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public final class RecordProcessorContextImpl implements RecordProcessorContext {
 
@@ -81,5 +85,10 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   @Override
   public KeyGenerator getKeyGenerator() {
     return keyGenerator;
+  }
+
+  @Override
+  public Optional<GatewayStreamer<JobActivationProperties, ActivatedJob>> jobStreamer() {
+    return Optional.empty();
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public final class RecordProcessorContextImpl implements RecordProcessorContext {
 
@@ -31,6 +30,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private final InterPartitionCommandSender partitionCommandSender;
   private final KeyGenerator keyGenerator;
+  private final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer;
 
   public RecordProcessorContextImpl(
       final int partitionId,
@@ -38,13 +38,15 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
       final ZeebeDb zeebeDb,
       final TransactionContext transactionContext,
       final InterPartitionCommandSender partitionCommandSender,
-      final KeyGeneratorControls keyGeneratorControls) {
+      final KeyGeneratorControls keyGeneratorControls,
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.zeebeDb = zeebeDb;
     this.transactionContext = transactionContext;
     this.partitionCommandSender = partitionCommandSender;
     keyGenerator = keyGeneratorControls;
+    this.jobStreamer = jobStreamer;
   }
 
   @Override
@@ -88,7 +90,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   }
 
   @Override
-  public Optional<GatewayStreamer<JobActivationProperties, ActivatedJob>> jobStreamer() {
-    return Optional.empty();
+  public GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer() {
+    return jobStreamer;
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -359,7 +359,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             zeebeDb,
             streamProcessorContext.getTransactionContext(),
             streamProcessorContext.getPartitionCommandSender(),
-            streamProcessorContext.getKeyGeneratorControls());
+            streamProcessorContext.getKeyGeneratorControls(),
+            streamProcessorContext.jobStreamer());
 
     recordProcessors.forEach(processor -> processor.init(processorContext));
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -360,7 +360,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             streamProcessorContext.getTransactionContext(),
             streamProcessorContext.getPartitionCommandSender(),
             streamProcessorContext.getKeyGeneratorControls(),
-            streamProcessorContext.jobStreamer());
+            streamProcessorContext.getJobStreamer());
 
     recordProcessors.forEach(processor -> processor.init(processorContext));
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -10,8 +10,11 @@ package io.camunda.zeebe.stream.impl;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.util.ArrayList;
@@ -133,6 +136,12 @@ public final class StreamProcessorBuilder {
 
   public StreamProcessorBuilder maxCommandsInBatch(final int maxCommandsInBatch) {
     streamProcessorContext.maxCommandsInBatch(maxCommandsInBatch);
+    return this;
+  }
+
+  public StreamProcessorBuilder jobStreamer(
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
+    streamProcessorContext.jobStreamer(jobStreamer);
     return this;
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -13,8 +13,11 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
@@ -56,6 +59,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
   private KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
+  private GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -205,5 +209,15 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public int getMaxCommandsInBatch() {
     return maxCommandsInBatch;
+  }
+
+  public StreamProcessorContext jobStreamer(
+      final GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer) {
+    this.jobStreamer = jobStreamer;
+    return this;
+  }
+
+  public GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer() {
+    return jobStreamer;
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -217,7 +217,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     return this;
   }
 
-  public GatewayStreamer<JobActivationProperties, ActivatedJob> jobStreamer() {
+  public GatewayStreamer<JobActivationProperties, ActivatedJob> getJobStreamer() {
     return jobStreamer;
   }
 }


### PR DESCRIPTION
## Description

Introduces a new platform API to allow record processors to stream data out to Zeebe Gateway instances.

Additionally adds concrete type implementations for the upcoming job streaming feature, and an optional accessor in the `RecordProcessorContext`.

Introducing this API as a first step will allow both the ZPA and ZDP team to work mostly independently with minimal friction, even if it is likely to change in the future.

## Related issues

closes #11706 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
