### PR TITLE
Due and follow-up dates are included in user task activation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import java.time.ZonedDateTime;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -97,7 +98,9 @@ public final class BpmnJobBehavior {
         .flatMap(p -> evalRetriesExp(jobWorkerProps, scopeKey).map(p::retries))
         .flatMap(p -> evalAssigneeExp(jobWorkerProps, scopeKey).map(p::assignee))
         .flatMap(p -> evalCandidateGroupsExp(jobWorkerProps, scopeKey).map(p::candidateGroups))
-        .flatMap(p -> evalCandidateUsersExp(jobWorkerProps, scopeKey).map(p::candidateUsers));
+        .flatMap(p -> evalCandidateUsersExp(jobWorkerProps, scopeKey).map(p::candidateUsers))
+        .flatMap(p -> evalDateExp(jobWorkerProps.getDueDate(), scopeKey).map(p::dueDate))
+        .flatMap(p -> evalDateExp(jobWorkerProps.getFollowUpDate(), scopeKey).map(p::followUpDate));
   }
 
   private Either<Failure, String> evalTypeExp(
@@ -143,6 +146,15 @@ public final class BpmnJobBehavior {
         .map(ExpressionTransformer::asListLiteral);
   }
 
+  private Either<Failure, String> evalDateExp(final Expression date, final long scopeKey) {
+    if (date == null) {
+      return Either.right(null);
+    }
+    return expressionBehavior
+        .evaluateDateTimeExpression(date, scopeKey, true)
+        .map(optionalDate -> optionalDate.map(ZonedDateTime::toString).orElse(null));
+  }
+
   private void writeJobCreatedEvent(
       final BpmnElementContext context,
       final ExecutableJobWorkerElement jobWorkerElement,
@@ -172,6 +184,8 @@ public final class BpmnJobBehavior {
     final String assignee = props.getAssignee();
     final String candidateGroups = props.getCandidateGroups();
     final String candidateUsers = props.getCandidateUsers();
+    final String dueDate = props.getDueDate();
+    final String followUpDate = props.getFollowUpDate();
     if (assignee != null && !assignee.isEmpty()) {
       headers.put(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, assignee);
     }
@@ -180,6 +194,12 @@ public final class BpmnJobBehavior {
     }
     if (candidateUsers != null && !candidateUsers.isEmpty()) {
       headers.put(Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, candidateUsers);
+    }
+    if (dueDate != null && !dueDate.isEmpty()) {
+      headers.put(Protocol.USER_TASK_DUE_DATE_HEADER_NAME, dueDate);
+    }
+    if (followUpDate != null && !followUpDate.isEmpty()) {
+      headers.put(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, followUpDate);
     }
     return headerEncoder.encode(headers);
   }
@@ -215,6 +235,8 @@ public final class BpmnJobBehavior {
     private String assignee;
     private String candidateGroups;
     private String candidateUsers;
+    private String dueDate;
+    private String followUpDate;
 
     public JobProperties type(final String type) {
       this.type = type;
@@ -259,6 +281,24 @@ public final class BpmnJobBehavior {
 
     public String getCandidateUsers() {
       return candidateUsers;
+    }
+
+    public JobProperties dueDate(final String dueDate) {
+      this.dueDate = dueDate;
+      return this;
+    }
+
+    public String getDueDate() {
+      return dueDate;
+    }
+
+    public JobProperties followUpDate(final String followUpDate) {
+      this.followUpDate = followUpDate;
+      return this;
+    }
+
+    public String getFollowUpDate() {
+      return followUpDate;
     }
   }
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -84,6 +84,14 @@ public final class Protocol {
   public static final String USER_TASK_CANDIDATE_USERS_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "candidateUsers";
 
+  /** Task header key used for due date */
+  public static final String USER_TASK_DUE_DATE_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "dueDate";
+
+  /** Task header key used for follow-up date */
+  public static final String USER_TASK_FOLLOW_UP_DATE_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "followUpDate";
+
   public static long encodePartitionId(final int partitionId, final long key) {
     return ((long) partitionId << KEY_BITS) + key;
   }


### PR DESCRIPTION
## Description

On user task activation, the `dueDate` and `followUpDate` properties in the `JobWorkerProperties` class are evaluated and included in the `JobIntent.CREATED` event.

## Related issues

closes #11797

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [x] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
