### PR TITLE
fix: don't duplicate responses during batch processing

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -45,6 +45,8 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
@@ -327,7 +329,7 @@ public final class ProcessingStateMachine {
         processedCommandsCount > 0 ? processedCommandsCount : maxCommandsInBatch;
     processedCommandsCount = 0;
     pendingWrites = new ArrayList<>();
-    pendingResponses = new ArrayList<>();
+    pendingResponses = Collections.newSetFromMap(new IdentityHashMap<>(2));
     final var pendingCommands = new ArrayDeque<TypedRecord<?>>();
     pendingCommands.addLast(initialCommand);
 


### PR DESCRIPTION
The result builder is reused during batch processing, once a response is added to the result, every following result will contain the same response again.
This uses a set instead of a list to collect the responses, effectively ignoring repeated response results.

The set uses the response object identity because each response is a new object. We also expect at most 2 responses (job completion or message publish response + process instance completion) so we can set an expected upper bound to limit memory usage.

fixes #11891 