### PR TITLE
[Backport stable/8.1] fix: don't re-wrap runtime exceptions thrown inside a transaction

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -297,6 +297,10 @@ public final class StreamPlatform {
     processorContext.close();
   }
 
+  public ZeebeDb getZeebeDb() {
+    return processorContext.zeebeDb;
+  }
+
   /** Used to run writes within an actor thread. */
   private static final class WriteActor extends Actor {
     public ActorFuture<Long> submit(final Callable<Long> write) {

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -38,6 +38,8 @@ import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.api.records.RecordBatch.ExceededBatchRecordSizeException;
+import io.camunda.zeebe.engine.api.records.RecordBatchEntry;
 import io.camunda.zeebe.engine.state.processing.DbKeyGenerator;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.engine.util.Records;
@@ -1103,6 +1105,46 @@ public final class StreamProcessorTest {
             () ->
                 assertThat(streamPlatform.getStreamProcessor().getLastWrittenPositionAsync().join())
                     .isEqualTo(-1));
+  }
+
+  @Test
+  public void shouldCallOnErrorWhenProcessingFailsWithExceedingBatchInTransaction() {
+    // given
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+
+    final var processingError =
+        new ExceededBatchRecordSizeException(mock(RecordBatchEntry.class), 10, 1, 1);
+
+    when(defaultRecordProcessor.process(any(), any()))
+        .then(
+            (invocationOnMock -> {
+              streamPlatform
+                  .getZeebeDb()
+                  .createContext()
+                  .runInTransaction(
+                      () -> {
+                        throw processingError;
+                      });
+              return null;
+            }));
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.event()
+            .processInstance(ELEMENT_ACTIVATING, Records.processInstance(1))
+            .causedBy(0));
+
+    // then
+    final var inOrder = inOrder(defaultRecordProcessor);
+    inOrder.verify(defaultRecordProcessor, TIMEOUT).init(any());
+    inOrder.verify(defaultRecordProcessor, TIMEOUT).accepts(ValueType.PROCESS_INSTANCE);
+    inOrder.verify(defaultRecordProcessor, TIMEOUT).process(any(), any());
+    inOrder
+        .verify(defaultRecordProcessor, TIMEOUT)
+        .onProcessingError(eq(processingError), any(), any());
+    inOrder.verifyNoMoreInteractions();
   }
 
   private static final class TestProcessor implements RecordProcessor {

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.TransactionOperation;
 import io.camunda.zeebe.db.ZeebeDbException;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
-import io.camunda.zeebe.util.exception.RecoverableException;
-import io.camunda.zeebe.util.exception.UnrecoverableException;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Status;
 
@@ -34,8 +32,8 @@ public final class DefaultTransactionContext implements TransactionContext {
       } else {
         runInNewTransaction(operations);
       }
-    } catch (final RecoverableException | UnrecoverableException reportableException) {
-      throw reportableException;
+    } catch (final RuntimeException e) {
+      throw e;
     } catch (final RocksDBException rdbex) {
       final String errorMessage = "Unexpected error occurred during RocksDB transaction.";
       if (isRocksDbExceptionRecoverable(rdbex)) {

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
@@ -247,9 +247,8 @@ public final class DbStringColumnFamilyTest {
                             columnFamily.whileEqualPrefix(key, (k2, v2) -> {});
                           });
                     }))
-        .hasRootCauseInstanceOf(IllegalStateException.class)
-        .hasMessage("Unexpected error occurred during zeebe db transaction operation.")
-        .hasStackTraceContaining(
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
             "Currently nested prefix iterations are not supported! This will cause unexpected behavior.");
   }
 


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/11701

I had to resolve some conflicts in import paths and minor merge conflicts in `StreamPlatform`.