### PR TITLE
[Backport stable/8.1] fix: don't duplicate responses during batch processing

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -40,6 +40,8 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
@@ -320,7 +322,7 @@ public final class ProcessingStateMachine {
     final var currentProcessingBatchLimit =
         processedCommandsCount > 0 ? processedCommandsCount : maxCommandsInBatch;
     processedCommandsCount = 0;
-    pendingResponses = new ArrayList<>();
+    pendingResponses = Collections.newSetFromMap(new IdentityHashMap<>(2));
     final var pendingCommands = new ArrayDeque<TypedRecord<?>>();
     pendingCommands.addLast(initialCommand);
 

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -753,6 +753,69 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  public void shouldWriteResponseOnlyOnce() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any()))
+        .thenAnswer(
+            invocation ->
+                ((ProcessingResultBuilder) invocation.getArgument(1))
+                    .withResponse(
+                        RecordType.EVENT,
+                        3,
+                        ELEMENT_ACTIVATING,
+                        Records.processInstance(1),
+                        ValueType.PROCESS_INSTANCE,
+                        RejectionType.NULL_VAL,
+                        "",
+                        1,
+                        12)
+                    .appendRecord(
+                        4,
+                        RecordType.COMMAND,
+                        ELEMENT_ACTIVATING,
+                        RejectionType.NULL_VAL,
+                        "",
+                        Records.processInstance(1))
+                    .build())
+        .thenAnswer(
+            invocation ->
+                ((ProcessingResultBuilder) invocation.getArgument(1))
+                    .appendRecord(
+                        5,
+                        RecordType.COMMAND,
+                        ELEMENT_ACTIVATING,
+                        RejectionType.NULL_VAL,
+                        "",
+                        Records.processInstance(2))
+                    .build())
+        .thenAnswer(
+            invocation ->
+                ((ProcessingResultBuilder) invocation.getArgument(1))
+                    .appendRecord(
+                        6,
+                        RecordType.EVENT,
+                        ELEMENT_ACTIVATING,
+                        RejectionType.NULL_VAL,
+                        "",
+                        Records.processInstance(2))
+                    .build());
+
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(3)).process(any(), any());
+
+    final var commandResponseWriter = streamPlatform.getMockCommandResponseWriter();
+
+    verify(commandResponseWriter, TIMEOUT.times(1)).tryWriteResponse(eq(12), eq(1L));
+  }
+
+  @Test
   public void shouldWriteResponseOnFailedEventProcessing() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();


### PR DESCRIPTION
Manual backport of #11892

No significant merge conflicts.