### PR TITLE
fix(gateway): return down when liveness status is unknown

### DIFF
--- a/util/src/main/java/io/camunda/zeebe/util/health/DelayedHealthIndicator.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/DelayedHealthIndicator.java
@@ -46,9 +46,9 @@ public class DelayedHealthIndicator implements HealthIndicator {
   protected DelayedHealthIndicator(
       final HealthIndicator originalHealthIndicator,
       final Duration maxDowntime,
-      Supplier<Long> clock) {
+      final Supplier<Long> clock) {
     if (requireNonNull(maxDowntime).toMillis() < 0) {
-      throw new IllegalArgumentException("maxDonwtime must be >= 0");
+      throw new IllegalArgumentException("maxDowntime must be >= 0");
     }
     this.originalHealthIndicator = requireNonNull(originalHealthIndicator);
     this.maxDowntime = maxDowntime;
@@ -60,7 +60,7 @@ public class DelayedHealthIndicator implements HealthIndicator {
 
   public DelayedHealthIndicator(
       final HealthIndicator originalHealthIndicator, final Duration maxDowntime) {
-    this(originalHealthIndicator, maxDowntime, () -> System.currentTimeMillis());
+    this(originalHealthIndicator, maxDowntime, System::currentTimeMillis);
   }
 
   @Scheduled(fixedDelay = 5000)
@@ -92,7 +92,7 @@ public class DelayedHealthIndicator implements HealthIndicator {
     return responseBuilder.withDetails(createDetails(now)).build();
   }
 
-  private Map<String, Object> createDetails(long referenceTime) {
+  private Map<String, Object> createDetails(final long referenceTime) {
     final var result = new HashMap<>(staticDetails);
 
     if (lastHealthStatus != null) {

--- a/util/src/main/java/io/camunda/zeebe/util/health/DelayedHealthIndicator.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/DelayedHealthIndicator.java
@@ -78,7 +78,7 @@ public class DelayedHealthIndicator implements HealthIndicator {
     final long now = clock.get();
 
     if (lastHealthStatus == null) { // was never checked
-      responseBuilder = Health.unknown();
+      responseBuilder = Health.down();
     } else {
       if (lastTimeUp == null) { // was never up
         responseBuilder = Health.status(lastHealthStatus.getStatus());

--- a/util/src/test/java/io/camunda/zeebe/util/health/DelayedHealthIndicatorTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/health/DelayedHealthIndicatorTest.java
@@ -47,7 +47,7 @@ public class DelayedHealthIndicatorTest {
   }
 
   @Test
-  public void shouldReportUnknownHealthStatusIfAskedBeforeDelegateHealthIndicatorWasCalled() {
+  public void shouldReportDownHealthStatusIfAskedBeforeDelegateHealthIndicatorWasCalled() {
     // given
     final var sutDelayedHealthIndicator =
         new DelayedHealthIndicator(mockHealthIndicator, TEST_MAX_DOWNTIME);
@@ -57,7 +57,7 @@ public class DelayedHealthIndicatorTest {
 
     // then
     Assertions.assertThat(actualHealth).isNotNull();
-    Assertions.assertThat(actualHealth.getStatus()).isEqualTo(Status.UNKNOWN);
+    Assertions.assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
   }
 
   @Test


### PR DESCRIPTION
## Description

Test failed  because it is expecting liveness status=down with HTTP status 503, but it receives 200 indicating it is live.

There were two problems:
- Actuator returns HTTP 200 when liveness status is UNKNOWN or UP ([ref](https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingle/#actuator.endpoints.health.writing-custom-health-indicators)). This is not expected in our case, because we want to treat unknown as not live. 
- When aggregating statuses, for some reason UNKNOWN and UP will be aggregated to UP instead of UNKNOWN ([ref](https://github.com/spring-projects/spring-boot/blob/v2.7.9/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/SimpleStatusAggregator.java), [comment](https://github.com/camunda/zeebe/issues/11812#issuecomment-1451950154)).

As a fix, we do not return UNKNOWN when the status is unknown, instead return DOWN.

## Related issues

closes #11812 

