### PR TITLE
ci: cache maven dependencies explicitly to improve reliability

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -18,14 +18,6 @@ inputs:
     description: The JDK version to setup
     default: "17"
     required: false
-  maven-cache:
-    description: A modifier key used to toggle the usage of a maven repo cache.
-    default: "false"
-    required: false
-  maven-cache-key-modifier:
-    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
-    default: "default"
-    required: false
   secret_vault_address:
     description: 'secret vault url'
     required: false
@@ -91,14 +83,15 @@ runs:
             "password": "${{ steps.secrets.outputs.ARTIFACTS_PSW }}"
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
-    - if: ${{ inputs.maven-cache == 'true' }}
-      name: Cache local Maven repository
-      uses: actions/cache@v3
+    # Restores what the maven-cache job saved
+    - name: Restore maven cache
+      if: inputs.java == 'true'
+      uses: actions/cache/restore@v3
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-${{ inputs.maven-cache-key-modifier }}-
+          ${{ runner.os }}-maven-
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v3
       with:

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -89,9 +89,9 @@ runs:
       uses: actions/cache/restore@v3
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-mvn-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-mvn-
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,7 +27,12 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Download dependencies
         if: steps.restore.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline
+        run: ./mvnw -B -T1C dependency:go-offline
+      - name: Run package goal
+        if: steps.restore.outputs.cache-hit != 'true'
+        # Run the package goal but skip all tests while still using failsafe and surefire
+        run: |
+          ./mvnw -B -T1C package -DskipTests -DskipChecks
       # Saves what the setup-zeebe action restores
       - name: Save dependencies to cache
         if: steps.restore.outputs.cache-hit != 'true'

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   cache-maven-dependencies:
     runs-on: ${{ matrix.runner }}
+    concurrency: cache-maven
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -14,9 +14,6 @@ jobs:
         runner: [ macos-latest, windows-latest, ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-zeebe
-        with:
-          go: false
       - name: Restore maven cache
         id: restore
         uses: actions/cache/restore@v3
@@ -25,6 +22,10 @@ jobs:
           key: ${{ runner.os }}-mvn-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - uses: ./.github/actions/setup-zeebe
+        if: steps.restore.outputs.cache-hit != 'true'
+        with:
+          go: false
       - name: Download dependencies
         if: steps.restore.outputs.cache-hit != 'true'
         run: ./mvnw -B -T1C dependency:go-offline

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,37 @@
+name: Cache
+
+on:
+  push:
+    branches:
+      - main
+      - stable/*
+jobs:
+  cache-maven-dependencies:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ macos-latest, windows-latest, ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          go: false
+      - name: Restore maven cache
+        id: restore
+        uses: actions/cache/restore@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-mvn-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Download dependencies
+        if: steps.restore.outputs.cache-hit != 'true'
+        run: ./mvnw dependency:go-offline
+      # Saves what the setup-zeebe action restores
+      - name: Save dependencies to cache
+        if: steps.restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -34,4 +34,4 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-mvn-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
         with:
-          maven-cache: 'true'
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -102,7 +101,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
         with:
-          maven-cache: 'true'
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -153,7 +151,6 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: 'true'
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -253,7 +250,6 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: 'true'
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -323,8 +319,6 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: 'true'
-          maven-cache-key-modifier: java-client
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -370,7 +364,6 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: 'true'
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -425,8 +418,6 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: 'true'
-          maven-cache-key-modifier: java-checks
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
Many of our CI jobs would enable maven caching, some with a modifier, some not. In many cases the only reason we haven't enabled caching is because we forgot it. Looking at the history of our CI jobs, caching also appears to be not very effective. One explanation for this is that all jobs would race for the same cache, overwriting or invalidating what other jobs already saved. Another possibility is that we simply exceed the cache limit of 10GB too fast and evict useful caches too frequently.

This change introduces a dedicated maven-cache workflow which runs on main and stable branches only. For each OS, we use the `dependency:go-offline` maven target and save that in a cache keyed by OS and a hash of all POM files. The `setup-zeebe` action only restores from this cache and never saves to the cache again. This makes the caching behavior very easy to understand. All dependencies that are found by `dependency:go-offline` in the main branch are cached, everything else is not.
This also reduces the number of caches. Effectively we only care about 3 cache lines, one for main and two for the stable branches. Regular CI jobs no longer have to update the maven cache which might save a couple of seconds on each job and removes one source of failures.

A negative effect from this is that feature branches that add new dependencies will always download the new dependency because it will not be cached until the dependency exists on main.
Additionally, `dependency:go-offline` is not exact and can miss some dependencies. If this becomes an issue we can extend our `maven-cache` workflow to explicitly download dependencies that are not found by `dependency:go-offline`.