### PR TITLE
feat: add a configuration option for maximum message size in zeebe client java

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -86,6 +86,11 @@ public final class ClientProperties {
   public static final String OVERRIDE_AUTHORITY = "zeebe.client.overrideauthority";
 
   /**
+   * @see ZeebeClientBuilder#maxMessageSize(int) (String)
+   */
+  public static final String MAX_MESSAGE_SIZE = "zeebe.client.maxMessageSize";
+
+  /**
    * @see ZeebeClientCloudBuilderStep1#withClusterId(java.lang.String)
    */
   public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -119,6 +119,13 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder overrideAuthority(String authority);
 
   /**
+   * A custom maxMessageSize allows the client to receive larger or smaller responses from Zeebe.
+   * Technically, it specifies the maxInboundMessageSize of the gRPC channel. The default is 4194304
+   * = 4MB.
+   */
+  ZeebeClientBuilder maxMessageSize(int maxSize);
+
+  /**
    * @return a new {@link ZeebeClient} with the provided configuration options.
    */
   ZeebeClient build();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -92,4 +92,9 @@ public interface ZeebeClientConfiguration {
    * @see ZeebeClientBuilder#overrideAuthority(String)
    */
   String getOverrideAuthority();
+
+  /**
+   * @see ZeebeClientBuilder#maxMessageSize(int)
+   */
+  int getMaxMessageSize();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -192,6 +192,12 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder maxMessageSize(final int maxMessageSize) {
+    innerBuilder.maxMessageSize(maxMessageSize);
+    return this;
+  }
+
+  @Override
   public ZeebeClient build() {
     innerBuilder.gatewayAddress(determineGatewayAddress());
     innerBuilder.credentialsProvider(determineCredentialsProvider());

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -137,7 +137,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
     configureConnectionSecurity(config, channelBuilder);
     channelBuilder.keepAliveTime(config.getKeepAlive().toMillis(), TimeUnit.MILLISECONDS);
     channelBuilder.userAgent("zeebe-client-java/" + VersionUtil.getVersion());
-
+    channelBuilder.maxInboundMessageSize(config.getMaxMessageSize());
     return channelBuilder.build();
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/DataSizeUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/DataSizeUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DataSizeUtil {
+
+  public static final int ONE_KB = 1024;
+  public static final int ONE_MB = 1024 * ONE_KB;
+  private static final Pattern PATTERN = Pattern.compile("^(\\d+)(kb|KB|mb|MB)?$");
+
+  private DataSizeUtil() {}
+
+  public static int parse(String text) {
+    if (text == null) {
+      throw new IllegalArgumentException("Text must not be null");
+    }
+    final Matcher matcher = PATTERN.matcher(text.replace(" ", ""));
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected %s to be a data size, but does not match pattern %s",
+              text, PATTERN.pattern()));
+    }
+
+    final String data = matcher.group(1);
+    final String unit = matcher.group(2);
+    if (null == unit) {
+      return Integer.parseInt(data);
+    }
+    switch (matcher.group(2).toLowerCase()) {
+      case "kb":
+        return Integer.parseInt(matcher.group(1)) * ONE_KB;
+      case "mb":
+        return Integer.parseInt(matcher.group(1)) * ONE_MB;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unexpected data size unit %s, should be one of [kb, mb]", unit));
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithLargeResultTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithLargeResultTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.util.ByteValue;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.springframework.util.unit.DataSize;
+
+public final class CreateProcessInstanceWithLargeResultTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE =
+      new EmbeddedBrokerRule(
+          cfg -> {
+            cfg.getNetwork().setMaxMessageSize(DataSize.ofMegabytes(21));
+            cfg.getGateway().getNetwork().setMaxMessageSize(DataSize.ofMegabytes(21));
+          });
+  private static final GrpcClientRule CLIENT_RULE =
+      new GrpcClientRule(
+          BROKER_RULE, zeebeClientBuilder -> zeebeClientBuilder.maxMessageSize(21 * ONE_MB));
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldCreateInstanceWithLargeResult() {
+    // given
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess("PROCESS").startEvent().endEvent().done());
+
+    // when
+    final ProcessInstanceResult processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId("PROCESS")
+            .latestVersion()
+            .variables(Map.of("variable", "x".repeat((int) (ByteValue.ofMegabytes(10)))))
+            .withResult()
+            .send()
+            .join();
+
+    // then
+    assertThat(processInstance.getVariables().getBytes(StandardCharsets.UTF_8))
+        .hasSizeGreaterThan((int) ByteValue.ofMegabytes(10));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Allows configuring the Java client's inbound max message size, which specifies the maximum size of incoming responses the client can receive. Specifically, it sets the `maxInboundMessageSize` of the gRPC channel. 

The default is 4194304 = 4MB.

It can be configured:
- as an environment variables `zeebe.client.maxMessageSize` (as data size string)
- using a configuration property: `zeebe.client.maxMessageSize` (as data size string)
- or using the Java API: `ZeebeClientBuilder.maxMessageSize(int maxMessageSize)`

A data size string is a number optionally followed by a data size unit `kb|KB|mb|MB`. For example: `4MB`, `4194304`, `4000 kb`, etc.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12122 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
