### PR TITLE
Validate user task dates on deployment 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ExpressionTransformer;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +23,8 @@ import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
 public final class ZeebeExpressionValidator<T extends ModelElementInstance>
     implements ModelElementValidator<T> {
+
+  private static final long NO_VARIABLE_SCOPE = -1L;
 
   private static final Pattern PATH_PATTERN =
       Pattern.compile("[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*");
@@ -104,6 +107,11 @@ public final class ZeebeExpressionValidator<T extends ModelElementInstance>
 
   public static boolean isListOfCsv(final Expression staticExp) {
     return ExpressionTransformer.parseListOfCsv(staticExp.getExpression()).isRight();
+  }
+
+  public static boolean isValidDateTime(
+      final Expression staticExp, final ExpressionProcessor expressionProcessor) {
+    return expressionProcessor.evaluateDateTimeExpression(staticExp, NO_VARIABLE_SCOPE).isRight();
   }
 
   public static class Builder<T extends ModelElementInstance> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -126,9 +126,26 @@ public final class ZeebeRuntimeValidators {
             .build(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeTaskSchedule.class)
-            .hasValidExpression(ZeebeTaskSchedule::getDueDate, ExpressionVerification::isOptional)
             .hasValidExpression(
-                ZeebeTaskSchedule::getFollowUpDate, ExpressionVerification::isOptional)
+                ZeebeTaskSchedule::getDueDate,
+                expression ->
+                    expression
+                        .isOptional()
+                        .satisfiesIfStatic(
+                            staticExpression ->
+                                ZeebeExpressionValidator.isValidDateTime(
+                                    staticExpression, expressionProcessor),
+                            "be a valid DateTime String, e.g. '2023-03-02T15:35+02:00'"))
+            .hasValidExpression(
+                ZeebeTaskSchedule::getFollowUpDate,
+                expression ->
+                    expression
+                        .isOptional()
+                        .satisfiesIfStatic(
+                            staticExpression ->
+                                ZeebeExpressionValidator.isValidDateTime(
+                                    staticExpression, expressionProcessor),
+                            "be a valid DateTime String, e.g. '2023-03-02T15:35+02:00'"))
             .build(expressionLanguage),
         // ----------------------------------------
         new TimerCatchEventExpressionValidator(expressionLanguage, expressionProcessor),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -392,12 +392,38 @@ public final class ZeebeRuntimeValidationTest {
         List.of(expect(ZeebeTaskSchedule.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
+        /* invalid dueDate static value */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeDueDate("12345"))
+            .done(),
+        List.of(
+            expect(
+                ZeebeTaskSchedule.class,
+                """
+                Expected static value to be a valid DateTime String, e.g. \
+                '2023-03-02T15:35+02:00', but found '12345'."""))
+      },
+      {
         /* invalid followUpDate expression */
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .userTask("task", b -> b.zeebeFollowUpDateExpression(INVALID_EXPRESSION))
             .done(),
         List.of(expect(ZeebeTaskSchedule.class, INVALID_EXPRESSION_MESSAGE))
+      },
+      {
+        /* invalid followUpDate static value */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeFollowUpDate("12345"))
+            .done(),
+        List.of(
+            expect(
+                ZeebeTaskSchedule.class,
+                """
+                Expected static value to be a valid DateTime String, e.g. \
+                '2023-03-02T15:35+02:00', but found '12345'."""))
       },
       {
         /* reserved header key */


### PR DESCRIPTION
## Description

Check for a valid DateTime string during deployment when static values are provided for the user task `dueDate` and `followUpDate` properties.

:information_source: I decided to expand the `ZeebeExpressionValidator` class instead of creating a new (dedicated) validator class. The reason is that with the `ZeebeExpressionValidator` class, we can re-use this validation for other date-related properties in the future. A dedicated validator class would be limited to the `UserTask` element. We can still create a dedicated validator class in the future if we decide to support additional formats for dates in the `ZeebeTaskSchedule` element.

## Related issues

closes #11809 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criteria of the issue
* [x] New tests are written to ensure backward compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
