### PR TITLE
fix(clients/java): make a `OAuthCredentialsProvider` class thread-safe

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -84,6 +84,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>

--- a/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.grpc.Metadata;
 import java.io.IOException;
 
+/** Implementations of this interface must be thread-safe. */
 public interface CredentialsProvider {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/FunctionWithIO.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/FunctionWithIO.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.util;
+
+import java.io.IOException;
+
+public interface FunctionWithIO<T, R> {
+
+  R apply(final T value) throws IOException;
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/SupplierWithIO.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/SupplierWithIO.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.util;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface SupplierWithIO<T> {
+  T get() throws IOException;
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -25,6 +25,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -216,5 +223,44 @@ public final class OAuthCredentialsCacheTest {
     assertThat(copy.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
     assertThat(copy.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
     assertThat(copy.size()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldBeThreadSafe() throws InterruptedException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);
+
+    final int threads = 5;
+    final List<Callable<Object>> cacheOperations = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      cacheOperations.add(() -> cache.readCache().get(WOMBAT_ENDPOINT));
+      cacheOperations.add(
+          () -> {
+            final OAuthCredentialsCache credentialsCache = cache.put(WOMBAT_ENDPOINT, WOMBAT);
+            credentialsCache.writeCache();
+            return credentialsCache;
+          });
+    }
+
+    final ExecutorService pool = Executors.newFixedThreadPool(threads);
+    try {
+      // when
+      pool.invokeAll(cacheOperations)
+          .forEach(
+              future -> {
+                try {
+                  future.get();
+                } catch (final InterruptedException | ExecutionException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+    } finally {
+      pool.shutdownNow();
+      pool.awaitTermination(60, TimeUnit.SECONDS);
+    }
+
+    // then
+    assertThat(cache.get(WOMBAT_ENDPOINT)).isNotEmpty().contains(WOMBAT);
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -234,13 +234,22 @@ public final class OAuthCredentialsCacheTest {
     final List<Callable<Object>> cacheOperations = new ArrayList<>();
 
     for (int i = 0; i < 5; i++) {
-      cacheOperations.add(() -> cache.readCache().get(WOMBAT_ENDPOINT));
       cacheOperations.add(
-          () -> {
-            final OAuthCredentialsCache credentialsCache = cache.put(WOMBAT_ENDPOINT, WOMBAT);
-            credentialsCache.writeCache();
-            return credentialsCache;
-          });
+          () ->
+              cache.computeIfMissingOrInvalid(
+                  WOMBAT_ENDPOINT,
+                  () -> {
+                    cache.put(WOMBAT_ENDPOINT, WOMBAT).writeCache();
+                    return WOMBAT;
+                  }));
+      cacheOperations.add(
+          () ->
+              cache.withCache(
+                  WOMBAT_ENDPOINT,
+                  value -> {
+                    cache.put(WOMBAT_ENDPOINT, WOMBAT).writeCache();
+                    return WOMBAT;
+                  }));
     }
 
     final ExecutorService pool = Executors.newFixedThreadPool(threads);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I introduced some locking mechanisms in the OAuth2 integration in Zeebe Client Java to make it thread-safe.
I don't like the current solution but I don't have nice ideas on how to fix it in another way.

In the future, we could allow users to move [this call](https://github.com/camunda/zeebe/blob/main/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java#L49) inside their `CredentialsProvider`, because in the `io.grpc.CallCredentials` class [JavaDoc says](https://github.com/grpc/grpc-java/blob/5be17e8b22d1d3eb99ea92140af2297734100e63/api/src/main/java/io/grpc/CallCredentials.java#L39-L54): 
> If metadata is not immediately available, e.g., needs to be fetched from the network, the implementation may give the applier to an asynchronous task which will eventually call the applier. The RPC proceeds only after the applier is called.

And we could build a nice asynchronous pipeline without locking (in my mind it could be based on a queue or something like this: we just push some actions in the queue and a single consumer of this queue does all logic (thus these consumers calls could be lock-free and not thread-safe, but the whole construction will be thread safe)).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11885 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
