### PR TITLE
[stable/8.1]: Support addition async API

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
@@ -15,7 +15,7 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
    * the task is executed, it is rescheduled with the same delay again.
    *
-   * <p>The execution of the scheduled task is running asynchron/concurrent to other scheduled
+   * <p>The execution of the scheduled task is running asynchronously/concurrent to other scheduled
    * tasks. Other methods will guarantee ordering of scheduled tasks and running always in same
    * thread, these guarantees don't apply to this method.
    *
@@ -28,4 +28,16 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * @param task The task to execute at the fixed rate
    */
   void runAtFixedRateAsync(final Duration delay, final Task task);
+
+  /**
+   * Schedule a task to execute with a specific delay. After that delay, the task is executed.
+   *
+   * <p>The execution of the scheduled task is running asynchronously/concurrent to other scheduled
+   * tasks. Other methods will guarantee ordering of scheduled tasks and running always in same
+   * thread, these guarantees don't apply to this method.
+   *
+   * @param delay The delay to wait before executing the task
+   * @param task The task to execute after the delay
+   */
+  void runDelayedAsync(final Duration delay, final Task task);
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ExtendedProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ExtendedProcessingScheduleServiceImpl.java
@@ -38,6 +38,15 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
+  public void runDelayedAsync(final Duration delay, final Task task) {
+    concurrencyControl.run(
+        () -> {
+          // we must run in different actor in order to schedule task
+          asyncActorService.runDelayed(delay, task);
+        });
+  }
+
+  @Override
   public void runDelayed(final Duration delay, final Runnable task) {
     processorActorService.runDelayed(delay, task);
   }


### PR DESCRIPTION
## Description

ZPA needs additional async API in order to schedule task on a separate actor, instead on a fixed rate it is necessary to schedule the task with an delay which might be dynamic. This is the reason why runWithDelay is the better fit.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

Related to open PR https://github.com/camunda/zeebe/pull/11856

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
