### PR TITLE
Support broadcast signal in the Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client;
 
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
+import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteResourceCommandStep1;
@@ -227,6 +228,21 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   PublishMessageCommandStep1 newPublishMessageCommand();
+
+  /**
+   * Command to broadcast a signal.
+   *
+   * <pre>
+   * zeebeClient
+   *  .newBroadcastSignalCommand()
+   *  .signalName("signal")
+   *  .variables(json)
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the command
+   */
+  BroadcastSignalCommandStep1 newBroadcastSignalCommand();
 
   /**
    * Command to resolve an existing incident.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
+import java.io.InputStream;
+import java.util.Map;
+
+public interface BroadcastSignalCommandStep1 {
+
+  /**
+   * Set the name of the signal.
+   *
+   * @param signalName the name of the signal
+   * @return the builder for this command
+   */
+  BroadcastSignalCommandStep2 signalName(String signalName);
+
+  interface BroadcastSignalCommandStep2 extends FinalCommandStep<BroadcastSignalResponse> {
+    /**
+     * Set the variables of the signal.
+     *
+     * @param variables the variables (JSON) as stream
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    BroadcastSignalCommandStep2 variables(InputStream variables);
+
+    /**
+     * Set the variables of the message.
+     *
+     * @param variables the variables (JSON) as String
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    BroadcastSignalCommandStep2 variables(String variables);
+
+    /**
+     * Set the variables of the message.
+     *
+     * @param variables the variables as map
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    BroadcastSignalCommandStep2 variables(Map<String, Object> variables);
+
+    /**
+     * Set the variables of the message.
+     *
+     * @param variables the variables as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    BroadcastSignalCommandStep2 variables(Object variables);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BroadcastSignalResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BroadcastSignalResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface BroadcastSignalResponse {
+  /**
+   * Returns the unique key of the signal that was broadcasted.
+   *
+   * @return the unique key of the signal.
+   */
+  long getKey();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
+import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
@@ -41,6 +42,7 @@ import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.client.impl.command.ActivateJobsCommandImpl;
+import io.camunda.zeebe.client.impl.command.BroadcastSignalCommandImpl;
 import io.camunda.zeebe.client.impl.command.CancelProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.CreateProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeleteResourceCommandImpl;
@@ -304,6 +306,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public PublishMessageCommandStep1 newPublishMessageCommand() {
     return new PublishMessageCommandImpl(
+        asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
+  }
+
+  @Override
+  public BroadcastSignalCommandStep1 newBroadcastSignalCommand() {
+    return new BroadcastSignalCommandImpl(
         asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
+import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1.BroadcastSignalCommandStep2;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
+import io.camunda.zeebe.client.impl.RetriableClientFutureImpl;
+import io.camunda.zeebe.client.impl.response.BroadcastSignalResponseImpl;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
+import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+public final class BroadcastSignalCommandImpl
+    extends CommandWithVariables<BroadcastSignalCommandImpl>
+    implements BroadcastSignalCommandStep1, BroadcastSignalCommandStep2 {
+
+  private final GatewayStub asyncStub;
+  private final Predicate<Throwable> retryPredicate;
+  private final BroadcastSignalRequest.Builder builder;
+  private Duration requestTimeout;
+
+  public BroadcastSignalCommandImpl(
+      final GatewayStub asyncStub,
+      final ZeebeClientConfiguration configuration,
+      final JsonMapper jsonMapper,
+      final Predicate<Throwable> retryPredicate) {
+    super(jsonMapper);
+    this.asyncStub = asyncStub;
+    this.retryPredicate = retryPredicate;
+    builder = BroadcastSignalRequest.newBuilder();
+    requestTimeout = configuration.getDefaultRequestTimeout();
+  }
+
+  @Override
+  protected BroadcastSignalCommandImpl setVariablesInternal(final String variables) {
+    builder.setVariables(variables);
+    return this;
+  }
+
+  @Override
+  public BroadcastSignalCommandStep2 signalName(final String signalName) {
+    builder.setSignalName(signalName);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<BroadcastSignalResponse> requestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<BroadcastSignalResponse> send() {
+    final BroadcastSignalRequest request = builder.build();
+    final RetriableClientFutureImpl<
+            BroadcastSignalResponse, GatewayOuterClass.BroadcastSignalResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                BroadcastSignalResponseImpl::new,
+                retryPredicate,
+                streamObserver -> send(request, streamObserver));
+
+    send(request, future);
+    return future;
+  }
+
+  private void send(
+      final BroadcastSignalRequest request,
+      final StreamObserver<GatewayOuterClass.BroadcastSignalResponse> streamObserver) {
+    asyncStub
+        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .broadcastSignal(request, streamObserver);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/BroadcastSignalResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/BroadcastSignalResponseImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+
+public final class BroadcastSignalResponseImpl implements BroadcastSignalResponse {
+
+  private final long key;
+
+  public BroadcastSignalResponseImpl(final GatewayOuterClass.BroadcastSignalResponse response) {
+    key = response.getKey();
+  }
+
+  @Override
+  public long getKey() {
+    return key;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.process;
+
+import static io.camunda.zeebe.client.util.JsonUtil.fromJsonAsMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
+import io.camunda.zeebe.client.util.ClientTest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public final class BroadcastSignalTest extends ClientTest {
+
+  @Test
+  public void shouldBroadcastSignal() {
+    // given
+    final long key = 123;
+    gatewayService.onBroadcastSignalRequest(key);
+
+    // when
+    final BroadcastSignalResponse response =
+        client.newBroadcastSignalCommand().signalName("name").send().join();
+
+    // then
+    final BroadcastSignalRequest request = gatewayService.getLastRequest();
+    assertThat(request.getSignalName()).isEqualTo("name");
+    assertThat(response.getKey()).isEqualTo(key);
+
+    rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldBroadcastSignalWithStringVariables() {
+    // when
+    client
+        .newBroadcastSignalCommand()
+        .signalName("name")
+        .variables("{\"foo\":\"bar\"}")
+        .send()
+        .join();
+
+    // then
+    final BroadcastSignalRequest request = gatewayService.getLastRequest();
+    assertThat(fromJsonAsMap(request.getVariables())).contains(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldBroadcastSignalWithInputStreamVariables() {
+    // given
+    final String variables = "{\"foo\":\"bar\"}";
+    final ByteArrayInputStream byteArrayInputStream =
+        new ByteArrayInputStream(variables.getBytes());
+
+    // when
+    client
+        .newBroadcastSignalCommand()
+        .signalName("name")
+        .variables(byteArrayInputStream)
+        .send()
+        .join();
+
+    // then
+    final BroadcastSignalRequest request = gatewayService.getLastRequest();
+    assertThat(fromJsonAsMap(request.getVariables())).contains(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldBroadcastSignalWithMapVariables() {
+    // given
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("foo", "bar");
+
+    // when
+    client.newBroadcastSignalCommand().signalName("name").variables(variables).send().join();
+
+    // then
+    final BroadcastSignalRequest request = gatewayService.getLastRequest();
+    assertThat(fromJsonAsMap(request.getVariables())).contains(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldBroadcastSignalWithObjectVariables() {
+    // when
+    client.newBroadcastSignalCommand().signalName("name").variables(new Variables()).send().join();
+
+    // then
+    final BroadcastSignalRequest request = gatewayService.getLastRequest();
+    assertThat(fromJsonAsMap(request.getVariables())).contains(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        BroadcastSignalRequest.class, () -> new ClientException("Invalid request"));
+
+    // when
+    assertThatThrownBy(() -> client.newBroadcastSignalCommand().signalName("name").send().join())
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("Invalid request");
+  }
+
+  @Test
+  public void shouldSetRequestTimeout() {
+    // given
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client
+        .newBroadcastSignalCommand()
+        .signalName("name")
+        .requestTimeout(requestTimeout)
+        .send()
+        .join();
+
+    // then
+    rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  public static class Variables {
+
+    private final String foo = "bar";
+
+    Variables() {}
+
+    public String getFoo() {
+      return foo;
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BrokerInfo;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceResponse;
@@ -113,6 +115,8 @@ public final class RecordingGatewayService extends GatewayImplBase {
         EvaluateDecisionRequest.class, r -> EvaluateDecisionResponse.getDefaultInstance());
     addRequestHandler(
         DeleteResourceRequest.class, r -> DeleteResourceResponse.getDefaultInstance());
+    addRequestHandler(
+        BroadcastSignalRequest.class, r -> BroadcastSignalResponse.getDefaultInstance());
   }
 
   public static Partition partition(
@@ -324,6 +328,13 @@ public final class RecordingGatewayService extends GatewayImplBase {
     handle(request, responseObserver);
   }
 
+  @Override
+  public void broadcastSignal(
+      final BroadcastSignalRequest request,
+      final StreamObserver<BroadcastSignalResponse> responseObserver) {
+    handle(request, responseObserver);
+  }
+
   public void onTopologyRequest(
       final int clusterSize,
       final int partitionsCount,
@@ -387,6 +398,12 @@ public final class RecordingGatewayService extends GatewayImplBase {
     addRequestHandler(
         PublishMessageRequest.class,
         request -> PublishMessageResponse.newBuilder().setKey(key).build());
+  }
+
+  public void onBroadcastSignalRequest(final long key) {
+    addRequestHandler(
+        BroadcastSignalRequest.class,
+        request -> BroadcastSignalResponse.newBuilder().setKey(key).build());
   }
 
   public void onCreateProcessInstanceWithResultRequest(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/BroadcastSignalTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/BroadcastSignalTest.java
@@ -98,6 +98,6 @@ public class BroadcastSignalTest {
         signalRecords(SignalIntent.BROADCASTED).withSignalName(signalName).getFirst();
     Assertions.assertThat(record.getValue()).hasSignalName(signalName);
 
-    assertThat(record.getValue().getVariables()).containsExactlyEntriesOf(variables);
+    assertThat(record.getValue().getVariables()).containsExactlyInAnyOrderEntriesOf(variables);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/BroadcastSignalTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/BroadcastSignalTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.it.client.command;
+
+import static io.camunda.zeebe.test.util.record.RecordingExporter.signalRecords;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class BroadcastSignalTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  private String signalName;
+
+  @Before
+  public void init() {
+    signalName = helper.getSignalName();
+
+    final var process =
+        Bpmn.createExecutableProcess().startEvent("start").signal(signalName).endEvent().done();
+    CLIENT_RULE.deployProcess(process);
+  }
+
+  @Test
+  public void shouldCreateProcessInstance() {
+    // when
+    CLIENT_RULE.getClient().newBroadcastSignalCommand().signalName(signalName).send().join();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementType(BpmnElementType.START_EVENT)
+                .withEventType(BpmnEventType.SIGNAL)
+                .limit(1)
+                .getFirst()
+                .getValue())
+        .hasElementId("start");
+  }
+
+  @Test
+  public void shouldBroadcastSignalWithoutVariables() {
+    // when
+    CLIENT_RULE.getClient().newBroadcastSignalCommand().signalName(signalName).send().join();
+
+    // then
+    final Record<SignalRecordValue> record =
+        signalRecords(SignalIntent.BROADCASTED).withSignalName(signalName).getFirst();
+    Assertions.assertThat(record.getValue()).hasSignalName(signalName);
+
+    assertThat(record.getValue().getVariables()).isEmpty();
+  }
+
+  @Test
+  public void shouldBroadcastSignalWithVariables() {
+    // when
+    final var variables = Map.of("x", 1, "y", 2);
+    CLIENT_RULE
+        .getClient()
+        .newBroadcastSignalCommand()
+        .signalName(signalName)
+        .variables(variables)
+        .send()
+        .join();
+
+    // then
+    final Record<SignalRecordValue> record =
+        signalRecords(SignalIntent.BROADCASTED).withSignalName(signalName).getFirst();
+    Assertions.assertThat(record.getValue()).hasSignalName(signalName);
+
+    assertThat(record.getValue().getVariables()).containsExactlyEntriesOf(variables);
+  }
+}


### PR DESCRIPTION
## Description
This PR adds support for sending a `BroadcastSignalCommand` in the java client.

## Related issues
closes #11912

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
