### PR TITLE
Add command distribution behavior

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -47,7 +47,6 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionTran
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
-import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -226,15 +225,12 @@ final class PartitionFactory {
       final SubscriptionCommandSender subscriptionCommandSender =
           new SubscriptionCommandSender(
               recordProcessorContext.getPartitionId(), partitionCommandSender);
-      final DeploymentDistributionCommandSender deploymentDistributionCommandSender =
-          new DeploymentDistributionCommandSender(
-              recordProcessorContext.getPartitionId(), partitionCommandSender);
 
       return EngineProcessors.createEngineProcessors(
           recordProcessorContext,
           localBroker.getPartitionsCount(),
           subscriptionCommandSender,
-          deploymentDistributionCommandSender,
+          partitionCommandSender,
           featureFlags);
     };
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.FeatureFlags;
 
@@ -53,7 +54,7 @@ public final class EngineProcessors {
       final TypedRecordProcessorContext typedRecordProcessorContext,
       final int partitionsCount,
       final SubscriptionCommandSender subscriptionCommandSender,
-      final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
+      final InterPartitionCommandSender interPartitionCommandSender,
       final FeatureFlags featureFlags) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
@@ -88,6 +89,10 @@ public final class EngineProcessors {
             timerChecker,
             jobMetrics,
             decisionBehavior);
+
+    final DeploymentDistributionCommandSender deploymentDistributionCommandSender =
+        new DeploymentDistributionCommandSender(
+            typedRecordProcessorContext.getPartitionId(), interPartitionCommandSender);
 
     addDeploymentRelatedProcessorAndServices(
         bpmnBehaviors,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
+import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.CompleteDeploymentDistributionProcessor;
@@ -93,6 +94,15 @@ public final class EngineProcessors {
     final DeploymentDistributionCommandSender deploymentDistributionCommandSender =
         new DeploymentDistributionCommandSender(
             typedRecordProcessorContext.getPartitionId(), interPartitionCommandSender);
+    // TODO unused for now, will be used with the implementation of
+    // https://github.com/camunda/zeebe/issues/11661
+    final var commandDistributionBehavior =
+        new CommandDistributionBehavior(
+            writers,
+            typedRecordProcessorContext.getPartitionId(),
+            partitionsCount,
+            interPartitionCommandSender,
+            processingState.getKeyGenerator());
 
     addDeploymentRelatedProcessorAndServices(
         bpmnBehaviors,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CommandDistributionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CommandDistributionBehavior.java
@@ -64,10 +64,14 @@ public final class CommandDistributionBehavior {
       final int partition,
       final CommandDistributionRecord distributionRecord,
       final long key) {
+    // We don't need the actual record in the DISTRIBUTING event applier. In order to prevent
+    // reaching the max message size we don't set the record value here.
     stateWriter.appendFollowUpEvent(
         command.getKey(),
         CommandDistributionIntent.DISTRIBUTING,
-        distributionRecord.copy().setPartitionId(partition));
+        new CommandDistributionRecord()
+            .setPartitionId(partition)
+            .setValueType(distributionRecord.getValueType()));
 
     sideEffectWriter.appendSideEffect(
         () -> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CommandDistributionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CommandDistributionBehavior.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+public final class CommandDistributionBehavior {
+
+  private final StateWriter stateWriter;
+  private final SideEffectWriter sideEffectWriter;
+  private final List<Integer> otherPartitions;
+  private final InterPartitionCommandSender interPartitionCommandSender;
+  private final KeyGenerator keyGenerator;
+
+  public CommandDistributionBehavior(
+      final Writers writers,
+      final int currentPartition,
+      final int partitionsCount,
+      final InterPartitionCommandSender partitionCommandSender,
+      final KeyGenerator keyGenerator) {
+    stateWriter = writers.state();
+    sideEffectWriter = writers.sideEffect();
+    interPartitionCommandSender = partitionCommandSender;
+    this.keyGenerator = keyGenerator;
+    otherPartitions =
+        IntStream.range(Protocol.START_PARTITION_ID, Protocol.START_PARTITION_ID + partitionsCount)
+            .filter(partition -> partition != currentPartition)
+            .boxed()
+            .toList();
+  }
+
+  public <T extends UnifiedRecordValue> void distributeCommand(final TypedRecord<T> command) {
+    final var distributionRecord =
+        new CommandDistributionRecord()
+            .setValueType(command.getValueType())
+            .setRecordValue(command.getValue());
+
+    stateWriter.appendFollowUpEvent(
+        command.getKey(), CommandDistributionIntent.STARTED, distributionRecord);
+
+    final long key = keyGenerator.nextKey();
+    otherPartitions.forEach(
+        (partition) -> distributeToPartition(command, partition, distributionRecord, key));
+  }
+
+  private <T extends UnifiedRecordValue> void distributeToPartition(
+      final TypedRecord<T> command,
+      final int partition,
+      final CommandDistributionRecord distributionRecord,
+      final long key) {
+    stateWriter.appendFollowUpEvent(
+        command.getKey(),
+        CommandDistributionIntent.DISTRIBUTING,
+        distributionRecord.copy().setPartitionId(partition));
+
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          interPartitionCommandSender.sendCommand(
+              partition, command.getValueType(), command.getIntent(), key, command.getValue());
+          return true;
+        });
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
-import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
@@ -200,8 +199,7 @@ public final class EngineRule extends ExternalResource {
                           recordProcessorContext,
                           partitionCount,
                           new SubscriptionCommandSender(partitionId, interPartitionCommandSender),
-                          new DeploymentDistributionCommandSender(
-                              partitionId, interPartitionCommandSender),
+                          interPartitionCommandSender,
                           featureFlags)
                       .withListener(
                           new ProcessingExporterTransistor(

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -112,4 +112,11 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     commandValueProperty.getValue().read(recordValueReader.wrap(valueBuffer, 0, encodedLength));
     return this;
   }
+
+  public CommandDistributionRecord copy() {
+    return new CommandDistributionRecord()
+        .setPartitionId(getPartitionId())
+        .setValueType(getValueType())
+        .setRecordValue((UnifiedRecordValue) getCommandValue());
+  }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -112,11 +112,4 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     commandValueProperty.getValue().read(recordValueReader.wrap(valueBuffer, 0, encodedLength));
     return this;
   }
-
-  public CommandDistributionRecord copy() {
-    return new CommandDistributionRecord()
-        .setPartitionId(getPartitionId())
-        .setValueType(getValueType())
-        .setRecordValue((UnifiedRecordValue) getCommandValue());
-  }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
@@ -24,7 +24,10 @@ public interface InterPartitionCommandSender {
 
   /**
    * Uses the given record key when writing the command. Otherwise, behaves like {@link
-   * InterPartitionCommandSender#sendCommand}
+   * InterPartitionCommandSender#sendCommand}. This may be used in cases where the key has been
+   * provided to the users, and the entity must be available on the receiving partition with that
+   * specific key. This also helps inform the receiving partition that this command was sent from
+   * another partition (and from which partition as the key encodes the partition id).
    *
    * @param recordKey Record key to use when writing the command. Ignored if null.
    */

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
@@ -26,10 +26,8 @@ public interface InterPartitionCommandSender {
    * Uses the given record key when writing the command. Otherwise, behaves like {@link
    * InterPartitionCommandSender#sendCommand}
    *
-   * @deprecated This is only available for compatability with deployment distribution.
    * @param recordKey Record key to use when writing the command. Ignored if null.
    */
-  @Deprecated(forRemoval = true)
   void sendCommand(
       final int receiverPartitionId,
       final ValueType valueType,


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR introduces the `CommandDistributionBehavior` this behavior is responsible for distributing commands in a generic way.

Note, this code is untested as of now. Since we test engine behavior and not specific behavior implementations it will be tested when we've switched the `DeploymentCreateProcessor` to this new way of distributing.

@korthout Sorry for assigning you this review but I think some more in-depth knowledge about the topic is useful for this one.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11660 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
