### PR TITLE
[Backport stable/8.1] feat: run message TTL checker concurrently to processing

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFa
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.processing.DbBlackListState;
 import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
@@ -47,7 +47,7 @@ public class Engine implements RecordProcessor {
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;
-  private ZeebeDbState zeebeState;
+  private ProcessingDbState processingState;
 
   private final ErrorRecord errorRecord = new ErrorRecord();
 
@@ -65,13 +65,13 @@ public class Engine implements RecordProcessor {
 
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
-    zeebeState =
-        new ZeebeDbState(
+    processingState =
+        new ProcessingDbState(
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getZeebeDb(),
             recordProcessorContext.getTransactionContext(),
             recordProcessorContext.getKeyGenerator());
-    eventApplier = recordProcessorContext.getEventApplierFactory().apply(zeebeState);
+    eventApplier = recordProcessorContext.getEventApplierFactory().apply(processingState);
 
     writers = new Writers(resultBuilderMutex, eventApplier);
 
@@ -79,7 +79,7 @@ public class Engine implements RecordProcessor {
         new TypedRecordProcessorContextImpl(
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getScheduleService(),
-            zeebeState,
+            processingState,
             writers,
             recordProcessorContext.getPartitionCommandSender());
 
@@ -122,7 +122,8 @@ public class Engine implements RecordProcessor {
         return processingResultBuilder.build();
       }
 
-      final boolean isNotOnBlacklist = !zeebeState.getBlackListState().isOnBlacklist(typedCommand);
+      final boolean isNotOnBlacklist =
+          !processingState.getBlackListState().isOnBlacklist(typedCommand);
       if (isNotOnBlacklist) {
         currentProcessor.processRecord(record);
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
@@ -15,9 +15,10 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
    * the task is executed, it is rescheduled with the same delay again.
    *
-   * <p>The execution of the scheduled task is running asynchronously/concurrent to other scheduled
-   * tasks. Other methods will guarantee ordering of scheduled tasks and running always in same
-   * thread, these guarantees don't apply to this method.
+   * <p>The execution of the scheduled task is running asynchronously/concurrently to task scheduled
+   * through non-async methods. While other, non-async methods guarantee the execution order of
+   * scheduled tasks and always execute scheduled tasks on the same thread, this method does not
+   * guarantee this.
    *
    * <p>Note that time-traveling in tests only affects the delay of the currently scheduled next
    * task and not any of the iterations after. This is because the next task is scheduled with the

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.List;
 import java.util.function.Function;
 
@@ -25,7 +25,7 @@ public interface RecordProcessorContext {
 
   TransactionContext getTransactionContext();
 
-  Function<MutableZeebeState, EventApplier> getEventApplierFactory();
+  Function<MutableProcessingState, EventApplier> getEventApplierFactory();
 
   List<StreamProcessorLifecycleAware> getLifecycleListeners();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.state.KeyGenerator;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationController;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -87,7 +88,12 @@ public final class EngineProcessors {
         deploymentDistributionCommandSender,
         processingState.getKeyGenerator());
     addMessageProcessors(
-        bpmnBehaviors, subscriptionCommandSender, processingState, typedRecordProcessors, writers);
+        bpmnBehaviors,
+        subscriptionCommandSender,
+        processingState,
+        typedRecordProcessorContext.getScheduledTaskDbState(),
+        typedRecordProcessors,
+        writers);
 
     final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor =
         addProcessProcessors(
@@ -205,9 +211,15 @@ public final class EngineProcessors {
       final BpmnBehaviorsImpl bpmnBehaviors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableProcessingState processingState,
+      final ScheduledTaskDbState scheduledTaskDbState,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers) {
     MessageEventProcessors.addMessageProcessors(
-        bpmnBehaviors, typedRecordProcessors, processingState, subscriptionCommandSender, writers);
+        bpmnBehaviors,
+        typedRecordProcessors,
+        processingState,
+        scheduledTaskDbState,
+        subscriptionCommandSender,
+        writers);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -28,10 +28,10 @@ import io.camunda.zeebe.engine.processing.timer.TriggerTimerProcessor;
 import io.camunda.zeebe.engine.processing.variable.UpdateVariableDocumentProcessor;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
@@ -45,23 +45,23 @@ import java.util.Arrays;
 public final class ProcessEventProcessors {
 
   public static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final DueDateTimerChecker timerChecker,
       final Writers writers) {
     final MutableProcessMessageSubscriptionState subscriptionState =
-        zeebeState.getProcessMessageSubscriptionState();
-    final var keyGenerator = zeebeState.getKeyGenerator();
+        processingState.getProcessMessageSubscriptionState();
+    final var keyGenerator = processingState.getKeyGenerator();
 
-    final var processEngineMetrics = new ProcessEngineMetrics(zeebeState.getPartitionId());
+    final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());
 
     addProcessInstanceCommandProcessor(
-        writers, typedRecordProcessors, zeebeState.getElementInstanceState());
+        writers, typedRecordProcessors, processingState.getElementInstanceState());
 
     final var bpmnStreamProcessor =
-        new BpmnStreamProcessor(bpmnBehaviors, zeebeState, writers, processEngineMetrics);
+        new BpmnStreamProcessor(bpmnBehaviors, processingState, writers, processEngineMetrics);
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(
@@ -69,20 +69,20 @@ public final class ProcessEventProcessors {
         subscriptionState,
         subscriptionCommandSender,
         bpmnBehaviors,
-        zeebeState,
+        processingState,
         writers);
     addTimerStreamProcessors(
-        typedRecordProcessors, timerChecker, zeebeState, bpmnBehaviors, writers);
+        typedRecordProcessors, timerChecker, processingState, bpmnBehaviors, writers);
     addVariableDocumentStreamProcessors(
         typedRecordProcessors,
         bpmnBehaviors,
-        zeebeState.getElementInstanceState(),
+        processingState.getElementInstanceState(),
         keyGenerator,
         writers);
     addProcessInstanceCreationStreamProcessors(
-        typedRecordProcessors, zeebeState, writers, bpmnBehaviors, processEngineMetrics);
+        typedRecordProcessors, processingState, writers, bpmnBehaviors, processEngineMetrics);
     addProcessInstanceModificationStreamProcessors(
-        typedRecordProcessors, zeebeState, writers, bpmnBehaviors);
+        typedRecordProcessors, processingState, writers, bpmnBehaviors);
 
     return bpmnStreamProcessor;
   }
@@ -120,44 +120,49 @@ public final class ProcessEventProcessors {
       final MutableProcessMessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final BpmnBehaviors bpmnBehaviors,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final Writers writers) {
     typedRecordProcessors
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.CREATE,
             new ProcessMessageSubscriptionCreateProcessor(
-                zeebeState.getProcessMessageSubscriptionState(), writers))
+                processingState.getProcessMessageSubscriptionState(), writers))
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.CORRELATE,
             new ProcessMessageSubscriptionCorrelateProcessor(
-                subscriptionState, subscriptionCommandSender, zeebeState, bpmnBehaviors, writers))
+                subscriptionState,
+                subscriptionCommandSender,
+                processingState,
+                bpmnBehaviors,
+                writers))
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.DELETE,
             new ProcessMessageSubscriptionDeleteProcessor(subscriptionState, writers))
         .withListener(
             new PendingProcessMessageSubscriptionChecker(
-                subscriptionCommandSender, zeebeState.getPendingProcessMessageSubscriptionState()));
+                subscriptionCommandSender,
+                processingState.getPendingProcessMessageSubscriptionState()));
   }
 
   private static void addTimerStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final DueDateTimerChecker timerChecker,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {
     typedRecordProcessors
         .onCommand(
             ValueType.TIMER,
             TimerIntent.TRIGGER,
-            new TriggerTimerProcessor(zeebeState, bpmnBehaviors, writers))
+            new TriggerTimerProcessor(processingState, bpmnBehaviors, writers))
         .onCommand(
             ValueType.TIMER,
             TimerIntent.CANCEL,
             new CancelTimerProcessor(
-                zeebeState.getTimerState(), writers.state(), writers.rejection()))
+                processingState.getTimerState(), writers.state(), writers.rejection()))
         .withListener(timerChecker);
   }
 
@@ -176,16 +181,17 @@ public final class ProcessEventProcessors {
 
   private static void addProcessInstanceCreationStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final Writers writers,
       final BpmnBehaviors bpmnBehaviors,
       final ProcessEngineMetrics metrics) {
-    final MutableElementInstanceState elementInstanceState = zeebeState.getElementInstanceState();
-    final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
+    final MutableElementInstanceState elementInstanceState =
+        processingState.getElementInstanceState();
+    final KeyGenerator keyGenerator = processingState.getKeyGenerator();
 
     final CreateProcessInstanceProcessor createProcessor =
         new CreateProcessInstanceProcessor(
-            zeebeState.getProcessState(), keyGenerator, writers, bpmnBehaviors, metrics);
+            processingState.getProcessState(), keyGenerator, writers, bpmnBehaviors, metrics);
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATE, createProcessor);
 
@@ -197,14 +203,14 @@ public final class ProcessEventProcessors {
 
   private static void addProcessInstanceModificationStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final Writers writers,
       final BpmnBehaviors bpmnBehaviors) {
     final ProcessInstanceModificationProcessor modificationProcessor =
         new ProcessInstanceModificationProcessor(
             writers,
-            zeebeState.getElementInstanceState(),
-            zeebeState.getProcessState(),
+            processingState.getElementInstanceState(),
+            processingState.getProcessState(),
             bpmnBehaviors);
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MODIFICATION,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -40,17 +40,17 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
 
   public BpmnStreamProcessor(
       final BpmnBehaviors bpmnBehaviors,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final Writers writers,
       final ProcessEngineMetrics processEngineMetrics) {
-    processState = zeebeState.getProcessState();
+    processState = processingState.getProcessState();
 
     rejectionWriter = writers.rejection();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     stateTransitionGuard = bpmnBehaviors.stateTransitionGuard();
     stateTransitionBehavior =
         new BpmnStateTransitionBehavior(
-            zeebeState.getKeyGenerator(),
+            processingState.getKeyGenerator(),
             bpmnBehaviors.stateBehavior(),
             processEngineMetrics,
             this::getContainerProcessor,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.util.Optional;
@@ -31,19 +31,19 @@ public final class BpmnBufferedMessageStartEventBehavior {
   private final EventHandle eventHandle;
 
   public BpmnBufferedMessageStartEventBehavior(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final KeyGenerator keyGenerator,
       final EventTriggerBehavior eventTriggerBehavior,
       final BpmnStateBehavior stateBehavior,
       final Writers writers) {
-    messageState = zeebeState.getMessageState();
-    processState = zeebeState.getProcessState();
-    messageStartEventSubscriptionState = zeebeState.getMessageStartEventSubscriptionState();
+    messageState = processingState.getMessageState();
+    processState = processingState.getProcessState();
+    messageStartEventSubscriptionState = processingState.getMessageStartEventSubscriptionState();
 
     eventHandle =
         new EventHandle(
             keyGenerator,
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getEventScopeInstanceState(),
             writers,
             processState,
             eventTriggerBehavior,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -28,8 +28,8 @@ import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -60,15 +60,15 @@ public final class BpmnDecisionBehavior {
 
   public BpmnDecisionBehavior(
       final DecisionEngine decisionEngine,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final EventTriggerBehavior eventTriggerBehavior,
       final StateWriter stateWriter,
       final KeyGenerator keyGenerator,
       final ExpressionProcessor expressionBehavior,
       final ProcessEngineMetrics metrics) {
     this.decisionEngine = decisionEngine;
-    decisionState = zeebeState.getDecisionState();
-    variableState = zeebeState.getVariableState();
+    decisionState = processingState.getDecisionState();
+    variableState = processingState.getVariableState();
     this.eventTriggerBehavior = eventTriggerBehavior;
     this.stateWriter = stateWriter;
     this.keyGenerator = keyGenerator;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTuple;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
@@ -30,21 +30,22 @@ public final class BpmnEventPublicationBehavior {
   private final CatchEventAnalyzer catchEventAnalyzer;
 
   public BpmnEventPublicationBehavior(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final KeyGenerator keyGenerator,
       final EventTriggerBehavior eventTriggerBehavior,
       final BpmnStateBehavior stateBehavior,
       final Writers writers) {
-    elementInstanceState = zeebeState.getElementInstanceState();
+    elementInstanceState = processingState.getElementInstanceState();
     eventHandle =
         new EventHandle(
             keyGenerator,
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getEventScopeInstanceState(),
             writers,
-            zeebeState.getProcessState(),
+            processingState.getProcessState(),
             eventTriggerBehavior,
             stateBehavior);
-    catchEventAnalyzer = new CatchEventAnalyzer(zeebeState.getProcessState(), elementInstanceState);
+    catchEventAnalyzer =
+        new CatchEventAnalyzer(processingState.getProcessState(), elementInstanceState);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -32,12 +32,12 @@ public final class BpmnEventSubscriptionBehavior {
   public BpmnEventSubscriptionBehavior(
       final CatchEventBehavior catchEventBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
-      final ZeebeState zeebeState) {
+      final ProcessingState processingState) {
     this.catchEventBehavior = catchEventBehavior;
     this.eventTriggerBehavior = eventTriggerBehavior;
 
-    processState = zeebeState.getProcessState();
-    eventScopeInstanceState = zeebeState.getEventScopeInstanceState();
+    processState = processingState.getProcessState();
+    eventScopeInstanceState = processingState.getEventScopeInstanceState();
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.util.collection.Tuple;
@@ -26,8 +26,10 @@ public final class BpmnIncidentBehavior {
   private final KeyGenerator keyGenerator;
 
   public BpmnIncidentBehavior(
-      final ZeebeState zeebeState, final KeyGenerator keyGenerator, final StateWriter stateWriter) {
-    incidentState = zeebeState.getIncidentState();
+      final ProcessingState processingState,
+      final KeyGenerator keyGenerator,
+      final StateWriter stateWriter) {
+    incidentState = processingState.getIncidentState();
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.AwaitProcessInstanceResultMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -33,9 +33,9 @@ public final class BpmnProcessResultSenderBehavior {
   private final TypedResponseWriter responseWriter;
 
   public BpmnProcessResultSenderBehavior(
-      final ZeebeState zeebeState, final TypedResponseWriter responseWriter) {
-    elementInstanceState = zeebeState.getElementInstanceState();
-    variableState = zeebeState.getVariableState();
+      final ProcessingState processingState, final TypedResponseWriter responseWriter) {
+    elementInstanceState = processingState.getElementInstanceState();
+    variableState = processingState.getVariableState();
     this.responseWriter = responseWriter;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
@@ -32,13 +32,14 @@ public final class BpmnStateBehavior {
   private final ProcessState processState;
   private final VariableBehavior variableBehavior;
 
-  public BpmnStateBehavior(final ZeebeState zeebeState, final VariableBehavior variableBehavior) {
+  public BpmnStateBehavior(
+      final ProcessingState processingState, final VariableBehavior variableBehavior) {
     this.variableBehavior = variableBehavior;
 
-    processState = zeebeState.getProcessState();
-    elementInstanceState = zeebeState.getElementInstanceState();
-    variablesState = zeebeState.getVariableState();
-    jobState = zeebeState.getJobState();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
+    variablesState = processingState.getVariableState();
+    jobState = processingState.getJobState();
   }
 
   public ElementInstance getElementInstance(final BpmnElementContext context) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -34,13 +34,13 @@ public final class BpmnVariableMappingBehavior {
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final VariableBehavior variableBehavior) {
     this.expressionProcessor = expressionProcessor;
-    elementInstanceState = zeebeState.getElementInstanceState();
-    variablesState = zeebeState.getVariableState();
+    elementInstanceState = processingState.getElementInstanceState();
+    variablesState = processingState.getVariableState();
     this.variableBehavior = variableBehavior;
-    eventScopeInstanceState = zeebeState.getEventScopeInstanceState();
+    eventScopeInstanceState = processingState.getEventScopeInstanceState();
   }
 
   /**
@@ -141,9 +141,16 @@ public final class BpmnVariableMappingBehavior {
   }
 
   private boolean isConnectedToEventBasedGateway(final ExecutableFlowNode element) {
-    if (element instanceof ExecutableCatchEventElement) {
-      final var catchEvent = (ExecutableCatchEventElement) element;
+    if (element instanceof final ExecutableCatchEventElement catchEvent) {
       return catchEvent.isConnectedToEventBasedGateway();
+    } else {
+      return false;
+    }
+  }
+
+  private boolean isErrorEvent(final ExecutableFlowNode element) {
+    if (element instanceof final ExecutableCatchEventElement catchEvent) {
+      return catchEvent.isError();
     } else {
       return false;
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -147,12 +147,4 @@ public final class BpmnVariableMappingBehavior {
       return false;
     }
   }
-
-  private boolean isErrorEvent(final ExecutableFlowNode element) {
-    if (element instanceof final ExecutableCatchEventElement catchEvent) {
-      return catchEvent.isError();
-    } else {
-      return false;
-    }
-  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -22,8 +22,8 @@ import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
@@ -60,7 +60,7 @@ public final class CatchEventBehavior {
   private final int currentPartitionId;
 
   public CatchEventBehavior(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final KeyGenerator keyGenerator,
       final ExpressionProcessor expressionProcessor,
       final SubscriptionCommandSender subscriptionCommandSender,
@@ -74,14 +74,14 @@ public final class CatchEventBehavior {
     this.sideEffectWriter = sideEffectWriter;
     this.partitionsCount = partitionsCount;
 
-    timerInstanceState = zeebeState.getTimerState();
-    processMessageSubscriptionState = zeebeState.getProcessMessageSubscriptionState();
-    processState = zeebeState.getProcessState();
+    timerInstanceState = processingState.getTimerState();
+    processMessageSubscriptionState = processingState.getProcessMessageSubscriptionState();
+    processState = processingState.getProcessState();
 
     this.keyGenerator = keyGenerator;
     this.timerChecker = timerChecker;
 
-    currentPartitionId = zeebeState.getPartitionId();
+    currentPartitionId = processingState.getPartitionId();
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
@@ -45,17 +45,17 @@ public class EventTriggerBehavior {
       final KeyGenerator keyGenerator,
       final CatchEventBehavior catchEventBehavior,
       final Writers writers,
-      final ZeebeState zeebeState) {
+      final ProcessingState processingState) {
     this.keyGenerator = keyGenerator;
     this.catchEventBehavior = catchEventBehavior;
     commandWriter = writers.command();
     stateWriter = writers.state();
 
-    elementInstanceState = zeebeState.getElementInstanceState();
-    eventScopeInstanceState = zeebeState.getEventScopeInstanceState();
+    elementInstanceState = processingState.getElementInstanceState();
+    eventScopeInstanceState = processingState.getEventScopeInstanceState();
 
     variableBehavior =
-        new VariableBehavior(zeebeState.getVariableState(), writers.state(), keyGenerator);
+        new VariableBehavior(processingState.getVariableState(), writers.state(), keyGenerator);
   }
 
   public void triggerEventSubProcess(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -27,8 +27,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -57,14 +57,14 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   private final TypedResponseWriter responseWriter;
 
   public DeploymentCreateProcessor(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final int partitionsCount,
       final Writers writers,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
       final KeyGenerator keyGenerator) {
-    processState = zeebeState.getProcessState();
-    timerInstanceState = zeebeState.getTimerState();
+    processState = processingState.getProcessState();
+    timerInstanceState = processingState.getTimerState();
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -72,10 +72,10 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     expressionProcessor = bpmnBehaviors.expressionBehavior();
     deploymentTransformer =
-        new DeploymentTransformer(stateWriter, zeebeState, expressionProcessor, keyGenerator);
+        new DeploymentTransformer(stateWriter, processingState, expressionProcessor, keyGenerator);
     messageStartEventSubscriptionManager =
         new MessageStartEventSubscriptionManager(
-            processState, zeebeState.getMessageStartEventSubscriptionState(), keyGenerator);
+            processState, processingState.getMessageStartEventSubscriptionState(), keyGenerator);
     deploymentDistributionBehavior =
         new DeploymentDistributionBehavior(
             writers, partitionsCount, deploymentDistributionCommandSender);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -44,7 +44,7 @@ public final class DeploymentTransformer {
 
   public DeploymentTransformer(
       final StateWriter stateWriter,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final ExpressionProcessor expressionProcessor,
       final KeyGenerator keyGenerator) {
 
@@ -64,11 +64,11 @@ public final class DeploymentTransformer {
             keyGenerator,
             stateWriter,
             this::getChecksum,
-            zeebeState.getProcessState(),
+            processingState.getProcessState(),
             expressionProcessor);
     final var dmnResourceTransformer =
         new DmnResourceTransformer(
-            keyGenerator, stateWriter, this::getChecksum, zeebeState.getDecisionState());
+            keyGenerator, stateWriter, this::getChecksum, processingState.getDecisionState());
 
     resourceTransformers =
         Map.ofEntries(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.incident;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -19,12 +19,12 @@ public final class IncidentEventProcessors {
 
   public static void addProcessors(
       final TypedRecordProcessors typedRecordProcessors,
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
       final Writers writers) {
     typedRecordProcessors.onCommand(
         ValueType.INCIDENT,
         IncidentIntent.RESOLVE,
-        new ResolveIncidentProcessor(zeebeState, bpmnStreamProcessor, writers));
+        new ResolveIncidentProcessor(processingState, bpmnStreamProcessor, writers));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -42,15 +42,15 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
   private final TypedResponseWriter responseWriter;
 
   public ResolveIncidentProcessor(
-      final ZeebeState zeebeState,
+      final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
       final Writers writers) {
     this.bpmnStreamProcessor = bpmnStreamProcessor;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
-    incidentState = zeebeState.getIncidentState();
-    elementInstanceState = zeebeState.getElementInstanceState();
+    incidentState = processingState.getIncidentState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -41,7 +41,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
   public JobBatchActivateProcessor(
       final Writers writers,
-      final ZeebeState state,
+      final ProcessingState state,
       final KeyGenerator keyGenerator,
       final JobMetrics jobMetrics) {
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -23,7 +23,7 @@ public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
   private final JobState jobState;
   private final JobMetrics jobMetrics;
 
-  public JobCancelProcessor(final ZeebeState state, final JobMetrics jobMetrics) {
+  public JobCancelProcessor(final ProcessingState state, final JobMetrics jobMetrics) {
     jobState = state.getJobState();
     this.jobMetrics = jobMetrics;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -31,7 +31,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
   private final EventHandle eventHandle;
 
   public JobCompleteProcessor(
-      final ZeebeState state, final JobMetrics jobMetrics, final EventHandle eventHandle) {
+      final ProcessingState state, final JobMetrics jobMetrics, final EventHandle eventHandle) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
     defaultProcessor =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -24,21 +24,21 @@ public final class JobEventProcessors {
 
   public static void addJobProcessors(
       final TypedRecordProcessors typedRecordProcessors,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final Consumer<String> onJobsAvailableCallback,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
       final JobMetrics jobMetrics) {
 
-    final var jobState = zeebeState.getJobState();
-    final var keyGenerator = zeebeState.getKeyGenerator();
+    final var jobState = processingState.getJobState();
+    final var keyGenerator = processingState.getKeyGenerator();
 
     final EventHandle eventHandle =
         new EventHandle(
             keyGenerator,
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getEventScopeInstanceState(),
             writers,
-            zeebeState.getProcessState(),
+            processingState.getProcessState(),
             bpmnBehaviors.eventTriggerBehavior(),
             bpmnBehaviors.stateBehavior());
 
@@ -47,28 +47,37 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.COMPLETE,
-            new JobCompleteProcessor(zeebeState, jobMetrics, eventHandle))
+            new JobCompleteProcessor(processingState, jobMetrics, eventHandle))
         .onCommand(
             ValueType.JOB,
             JobIntent.FAIL,
             new JobFailProcessor(
-                zeebeState, writers, zeebeState.getKeyGenerator(), jobMetrics, jobBackoffChecker))
+                processingState,
+                writers,
+                processingState.getKeyGenerator(),
+                jobMetrics,
+                jobBackoffChecker))
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,
             new JobThrowErrorProcessor(
-                zeebeState, bpmnBehaviors.eventPublicationBehavior(), keyGenerator, jobMetrics))
+                processingState,
+                bpmnBehaviors.eventPublicationBehavior(),
+                keyGenerator,
+                jobMetrics))
         .onCommand(
-            ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState, jobMetrics))
+            ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(processingState, jobMetrics))
         .onCommand(
-            ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(zeebeState))
-        .onCommand(ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(zeebeState, jobMetrics))
-        .onCommand(ValueType.JOB, JobIntent.RECUR_AFTER_BACKOFF, new JobRecurProcessor(zeebeState))
+            ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(processingState))
+        .onCommand(
+            ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(processingState, jobMetrics))
+        .onCommand(
+            ValueType.JOB, JobIntent.RECUR_AFTER_BACKOFF, new JobRecurProcessor(processingState))
         .onCommand(
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
-                writers, zeebeState, zeebeState.getKeyGenerator(), jobMetrics))
+                writers, processingState, processingState.getKeyGenerator(), jobMetrics))
         .withListener(new JobTimeoutTrigger(jobState))
         .withListener(jobBackoffChecker)
         .withListener(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWr
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -40,7 +40,7 @@ public final class JobFailProcessor implements CommandProcessor<JobRecord> {
   private final SideEffectWriter sideEffectWriter;
 
   public JobFailProcessor(
-      final ZeebeState state,
+      final ProcessingState state,
       final Writers writers,
       final KeyGenerator keyGenerator,
       final JobMetrics jobMetrics,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -22,8 +22,8 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
       "Expected to back off failed job with key '%d', but %s";
   private final JobState jobState;
 
-  public JobRecurProcessor(final ZeebeState zeebeState) {
-    jobState = zeebeState.getJobState();
+  public JobRecurProcessor(final ProcessingState processingState) {
+    jobState = processingState.getJobState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTupl
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -54,7 +54,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
   private final JobMetrics jobMetrics;
 
   public JobThrowErrorProcessor(
-      final ZeebeState state,
+      final ProcessingState state,
       final BpmnEventPublicationBehavior eventPublicationBehavior,
       final KeyGenerator keyGenerator,
       final JobMetrics jobMetrics) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -23,7 +23,7 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
   private final JobState jobState;
   private final JobMetrics jobMetrics;
 
-  public JobTimeOutProcessor(final ZeebeState state, final JobMetrics jobMetrics) {
+  public JobTimeOutProcessor(final ProcessingState state, final JobMetrics jobMetrics) {
     jobState = state.getJobState();
     this.jobMetrics = jobMetrics;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -25,7 +25,7 @@ public final class JobUpdateRetriesProcessor implements CommandProcessor<JobReco
 
   private final JobState jobState;
 
-  public JobUpdateRetriesProcessor(final ZeebeState state) {
+  public JobUpdateRetriesProcessor(final ProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -26,26 +26,26 @@ public final class MessageEventProcessors {
   public static void addMessageProcessors(
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers) {
 
-    final MutableMessageState messageState = zeebeState.getMessageState();
+    final MutableMessageState messageState = processingState.getMessageState();
     final MutableMessageSubscriptionState subscriptionState =
-        zeebeState.getMessageSubscriptionState();
+        processingState.getMessageSubscriptionState();
     final MutableMessageStartEventSubscriptionState startEventSubscriptionState =
-        zeebeState.getMessageStartEventSubscriptionState();
+        processingState.getMessageStartEventSubscriptionState();
     final MutableEventScopeInstanceState eventScopeInstanceState =
-        zeebeState.getEventScopeInstanceState();
-    final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
-    final var processState = zeebeState.getProcessState();
+        processingState.getEventScopeInstanceState();
+    final KeyGenerator keyGenerator = processingState.getKeyGenerator();
+    final var processState = processingState.getProcessState();
 
     typedRecordProcessors
         .onCommand(
             ValueType.MESSAGE,
             MessageIntent.PUBLISH,
             new MessagePublishProcessor(
-                zeebeState.getPartitionId(),
+                processingState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 startEventSubscriptionState,
@@ -62,7 +62,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CREATE,
             new MessageSubscriptionCreateProcessor(
-                zeebeState.getPartitionId(),
+                processingState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 subscriptionCommandSender,
@@ -72,7 +72,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
             new MessageSubscriptionCorrelateProcessor(
-                zeebeState.getPartitionId(),
+                processingState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 subscriptionCommandSender,
@@ -90,7 +90,7 @@ public final class MessageEventProcessors {
         .withListener(
             new MessageObserver(
                 messageState,
-                zeebeState.getPendingMessageSubscriptionState(),
+                processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSen
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
@@ -27,6 +28,7 @@ public final class MessageEventProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
+      final ScheduledTaskDbState scheduledTaskDbState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers) {
 
@@ -89,7 +91,7 @@ public final class MessageEventProcessors {
                 messageState, subscriptionState, subscriptionCommandSender, writers))
         .withListener(
             new MessageObserver(
-                messageState,
+                scheduledTaskDbState.getMessageState(),
                 processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender));
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -39,7 +39,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
     final var scheduleService = context.getScheduleService();
     // it is safe to reuse the write because we running in the same actor/thread
     final MessageTimeToLiveChecker timeToLiveChecker = new MessageTimeToLiveChecker(messageState);
-    scheduleService.runAtFixedRate(MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, timeToLiveChecker);
+    scheduleService.runAtFixedRateAsync(MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, timeToLiveChecker);
 
     final PendingMessageSubscriptionChecker pendingSubscriptionChecker =
         new PendingMessageSubscriptionChecker(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -54,19 +54,19 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   public ProcessMessageSubscriptionCorrelateProcessor(
       final ProcessMessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender subscriptionCommandSender,
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {
     this.subscriptionState = subscriptionState;
     this.subscriptionCommandSender = subscriptionCommandSender;
-    processState = zeebeState.getProcessState();
-    elementInstanceState = zeebeState.getElementInstanceState();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     eventHandle =
         new EventHandle(
-            zeebeState.getKeyGenerator(),
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getKeyGenerator(),
+            processingState.getEventScopeInstanceState(),
             writers,
             processState,
             bpmnBehaviors.eventTriggerBehavior(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 public interface TypedRecordProcessorContext {
 
@@ -18,7 +18,7 @@ public interface TypedRecordProcessorContext {
 
   ProcessingScheduleService getScheduleService();
 
-  MutableZeebeState getZeebeState();
+  MutableProcessingState getProcessingState();
 
   Writers getWriters();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 public interface TypedRecordProcessorContext {
@@ -23,4 +24,6 @@ public interface TypedRecordProcessorContext {
   Writers getWriters();
 
   InterPartitionCommandSender getPartitionCommandSender();
+
+  ScheduledTaskDbState getScheduledTaskDbState();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 public class TypedRecordProcessorContextImpl implements TypedRecordProcessorContext {
@@ -18,6 +19,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
   private final ProcessingDbState processingState;
+  private final ScheduledTaskDbState scheduledTaskDbState;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
 
@@ -25,11 +27,13 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
       final int partitionId,
       final ProcessingScheduleService scheduleService,
       final ProcessingDbState processingState,
+      final ScheduledTaskDbState scheduledTaskDbState,
       final Writers writers,
       final InterPartitionCommandSender partitionCommandSender) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.processingState = processingState;
+    this.scheduledTaskDbState = scheduledTaskDbState;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
   }
@@ -57,5 +61,10 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   @Override
   public InterPartitionCommandSender getPartitionCommandSender() {
     return partitionCommandSender;
+  }
+
+  @Override
+  public ScheduledTaskDbState getScheduledTaskDbState() {
+    return scheduledTaskDbState;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -10,26 +10,26 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 public class TypedRecordProcessorContextImpl implements TypedRecordProcessorContext {
 
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
-  private final ZeebeDbState zeebeState;
+  private final ProcessingDbState processingState;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
 
   public TypedRecordProcessorContextImpl(
       final int partitionId,
       final ProcessingScheduleService scheduleService,
-      final ZeebeDbState zeebeState,
+      final ProcessingDbState processingState,
       final Writers writers,
       final InterPartitionCommandSender partitionCommandSender) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
-    this.zeebeState = zeebeState;
+    this.processingState = processingState;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
   }
@@ -45,8 +45,8 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   }
 
   @Override
-  public MutableZeebeState getZeebeState() {
-    return zeebeState;
+  public MutableProcessingState getProcessingState() {
+    return processingState;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -21,8 +21,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.model.bpmn.util.time.Interval;
 import io.camunda.zeebe.model.bpmn.util.time.RepeatingInterval;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
@@ -55,7 +55,7 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
   private final EventHandle eventHandle;
 
   public TriggerTimerProcessor(
-      final MutableZeebeState zeebeState,
+      final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
@@ -63,14 +63,14 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
 
-    processState = zeebeState.getProcessState();
-    elementInstanceState = zeebeState.getElementInstanceState();
-    timerInstanceState = zeebeState.getTimerState();
-    keyGenerator = zeebeState.getKeyGenerator();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
+    timerInstanceState = processingState.getTimerState();
+    keyGenerator = processingState.getKeyGenerator();
     eventHandle =
         new EventHandle(
             keyGenerator,
-            zeebeState.getEventScopeInstanceState(),
+            processingState.getEventScopeInstanceState(),
             writers,
             processState,
             bpmnBehaviors.eventTriggerBehavior(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -40,14 +40,14 @@ import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionSt
 import io.camunda.zeebe.engine.state.mutable.MutablePendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.engine.state.processing.DbBlackListState;
 import io.camunda.zeebe.engine.state.variable.DbVariableState;
 import java.util.function.BiConsumer;
 
-public class ZeebeDbState implements MutableZeebeState {
+public class ProcessingDbState implements MutableProcessingState {
 
   private final ZeebeDb<ZbColumnFamilies> zeebeDb;
   private final KeyGenerator keyGenerator;
@@ -71,7 +71,7 @@ public class ZeebeDbState implements MutableZeebeState {
 
   private final int partitionId;
 
-  public ZeebeDbState(
+  public ProcessingDbState(
       final int partitionId,
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.message.DbMessageState;
+
+/** Contains read-only state that can be accessed safely by scheduled tasks. */
+public final class ScheduledTaskDbState {
+  private final MessageState messageState;
+
+  public ScheduledTaskDbState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    messageState = new DbMessageState(zeebeDb, transactionContext);
+  }
+
+  public MessageState getMessageState() {
+    return messageState;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/TypedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/TypedEventApplier.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.engine.state;
 
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 
-/** Applies state changes for a specific event to the {@link MutableZeebeState}. */
+/** Applies state changes for a specific event to the {@link MutableProcessingState}. */
 public interface TypedEventApplier<I extends Intent, V extends RecordValue> {
 
   void applyState(final long key, final V value);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributionApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributionApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 
@@ -18,8 +18,8 @@ public class DeploymentDistributionApplier
 
   private final MutableDeploymentState deploymentState;
 
-  public DeploymentDistributionApplier(final MutableZeebeState zeebeState) {
-    deploymentState = zeebeState.getDeploymentState();
+  public DeploymentDistributionApplier(final MutableProcessingState processingState) {
+    deploymentState = processingState.getDeploymentState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Applies state changes from events to the {@link MutableZeebeState}.
+ * Applies state changes from events to the {@link MutableProcessingState}.
  *
  * <p>Finds the correct {@link TypedEventApplier} and delegates.
  */
@@ -48,7 +48,7 @@ public final class EventAppliers implements EventApplier {
 
   private final Map<Intent, TypedEventApplier> mapping = new HashMap<>();
 
-  public EventAppliers(final MutableZeebeState state) {
+  public EventAppliers(final MutableProcessingState state) {
     registerProcessInstanceEventAppliers(state);
     registerProcessInstanceCreationAppliers(state);
     registerProcessInstanceModificationAppliers(state);
@@ -75,13 +75,13 @@ public final class EventAppliers implements EventApplier {
         new DecisionRequirementsCreatedApplier(state.getDecisionState()));
   }
 
-  private void registerTimeEventAppliers(final MutableZeebeState state) {
+  private void registerTimeEventAppliers(final MutableProcessingState state) {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
   }
 
-  private void registerDeploymentAppliers(final MutableZeebeState state) {
+  private void registerDeploymentAppliers(final MutableProcessingState state) {
     register(DeploymentDistributionIntent.DISTRIBUTING, new DeploymentDistributionApplier(state));
     register(
         DeploymentDistributionIntent.COMPLETED,
@@ -96,13 +96,13 @@ public final class EventAppliers implements EventApplier {
         new DeploymentFullyDistributedApplier(state.getDeploymentState()));
   }
 
-  private void registerVariableEventAppliers(final MutableZeebeState state) {
+  private void registerVariableEventAppliers(final MutableProcessingState state) {
     final VariableApplier variableApplier = new VariableApplier(state.getVariableState());
     register(VariableIntent.CREATED, variableApplier);
     register(VariableIntent.UPDATED, variableApplier);
   }
 
-  private void registerProcessInstanceEventAppliers(final MutableZeebeState state) {
+  private void registerProcessInstanceEventAppliers(final MutableProcessingState state) {
     final var elementInstanceState = state.getElementInstanceState();
     final var eventScopeInstanceState = state.getEventScopeInstanceState();
     final var processState = state.getProcessState();
@@ -140,7 +140,7 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState, processState));
   }
 
-  private void registerProcessInstanceCreationAppliers(final MutableZeebeState state) {
+  private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {
     final var processState = state.getProcessState();
     final var elementInstanceState = state.getElementInstanceState();
 
@@ -149,14 +149,14 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceCreationCreatedApplier(processState, elementInstanceState));
   }
 
-  private void registerProcessInstanceModificationAppliers(final MutableZeebeState state) {
+  private void registerProcessInstanceModificationAppliers(final MutableProcessingState state) {
     register(
         ProcessInstanceModificationIntent.MODIFIED,
         new ProcessInstanceModifiedEventApplier(
             state.getElementInstanceState(), state.getProcessState()));
   }
 
-  private void registerJobIntentEventAppliers(final MutableZeebeState state) {
+  private void registerJobIntentEventAppliers(final MutableProcessingState state) {
     register(JobIntent.CANCELED, new JobCanceledApplier(state));
     register(JobIntent.COMPLETED, new JobCompletedApplier(state));
     register(JobIntent.CREATED, new JobCreatedApplier(state));
@@ -167,12 +167,12 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.RECURRED_AFTER_BACKOFF, new JobRecurredApplier(state));
   }
 
-  private void registerMessageAppliers(final MutableZeebeState state) {
+  private void registerMessageAppliers(final MutableProcessingState state) {
     register(MessageIntent.PUBLISHED, new MessagePublishedApplier(state.getMessageState()));
     register(MessageIntent.EXPIRED, new MessageExpiredApplier(state.getMessageState()));
   }
 
-  private void registerMessageSubscriptionAppliers(final MutableZeebeState state) {
+  private void registerMessageSubscriptionAppliers(final MutableProcessingState state) {
     register(
         MessageSubscriptionIntent.CREATED,
         new MessageSubscriptionCreatedApplier(state.getMessageSubscriptionState()));
@@ -191,7 +191,7 @@ public final class EventAppliers implements EventApplier {
         new MessageSubscriptionDeletedApplier(state.getMessageSubscriptionState()));
   }
 
-  private void registerMessageStartEventSubscriptionAppliers(final MutableZeebeState state) {
+  private void registerMessageStartEventSubscriptionAppliers(final MutableProcessingState state) {
     register(
         MessageStartEventSubscriptionIntent.CREATED,
         new MessageStartEventSubscriptionCreatedApplier(
@@ -205,7 +205,7 @@ public final class EventAppliers implements EventApplier {
             state.getMessageStartEventSubscriptionState()));
   }
 
-  private void registerIncidentEventAppliers(final MutableZeebeState state) {
+  private void registerIncidentEventAppliers(final MutableProcessingState state) {
     register(
         IncidentIntent.CREATED,
         new IncidentCreatedApplier(state.getIncidentState(), state.getJobState()));
@@ -215,7 +215,7 @@ public final class EventAppliers implements EventApplier {
             state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
   }
 
-  private void registerProcessMessageSubscriptionEventAppliers(final MutableZeebeState state) {
+  private void registerProcessMessageSubscriptionEventAppliers(final MutableProcessingState state) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         state.getProcessMessageSubscriptionState();
 
@@ -236,7 +236,7 @@ public final class EventAppliers implements EventApplier {
         new ProcessMessageSubscriptionDeletedApplier(subscriptionState));
   }
 
-  private void registerProcessEventAppliers(final MutableZeebeState state) {
+  private void registerProcessEventAppliers(final MutableProcessingState state) {
     register(
         ProcessEventIntent.TRIGGERING,
         new ProcessEventTriggeringApplier(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchActivatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobBatchActivatedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -20,7 +20,7 @@ public class JobBatchActivatedApplier implements TypedEventApplier<JobBatchInten
 
   private final MutableJobState jobState;
 
-  public JobBatchActivatedApplier(final MutableZeebeState state) {
+  public JobBatchActivatedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,7 +17,7 @@ public class JobCanceledApplier implements TypedEventApplier<JobIntent, JobRecor
 
   private final MutableJobState jobState;
 
-  JobCanceledApplier(final MutableZeebeState state) {
+  JobCanceledApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplier.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -20,7 +20,7 @@ class JobCompletedApplier implements TypedEventApplier<JobIntent, JobRecord> {
   private final MutableJobState jobState;
   private final MutableElementInstanceState elementInstanceState;
 
-  JobCompletedApplier(final MutableZeebeState state) {
+  JobCompletedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -20,7 +20,7 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
   private final MutableElementInstanceState elementInstanceState;
   private final MutableJobState jobState;
 
-  JobCreatedApplier(final MutableZeebeState state) {
+  JobCreatedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobErrorThrownApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobErrorThrownApplier.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -21,7 +21,7 @@ public class JobErrorThrownApplier implements TypedEventApplier<JobIntent, JobRe
   private final MutableJobState jobState;
   private final MutableElementInstanceState elementInstanceState;
 
-  JobErrorThrownApplier(final MutableZeebeState state) {
+  JobErrorThrownApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobFailedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobFailedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,7 +17,7 @@ final class JobFailedApplier implements TypedEventApplier<JobIntent, JobRecord> 
 
   private final MutableJobState jobState;
 
-  JobFailedApplier(final MutableZeebeState state) {
+  JobFailedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobRecurredApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobRecurredApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,8 +17,8 @@ public class JobRecurredApplier implements TypedEventApplier<JobIntent, JobRecor
 
   private final MutableJobState jobState;
 
-  JobRecurredApplier(final MutableZeebeState zeebeState) {
-    jobState = zeebeState.getJobState();
+  JobRecurredApplier(final MutableProcessingState processingState) {
+    jobState = processingState.getJobState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobRetriesUpdatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobRetriesUpdatedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,7 +17,7 @@ public class JobRetriesUpdatedApplier implements TypedEventApplier<JobIntent, Jo
 
   private final MutableJobState jobState;
 
-  JobRetriesUpdatedApplier(final MutableZeebeState state) {
+  JobRetriesUpdatedApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobTimedOutApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobTimedOutApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
@@ -17,7 +17,7 @@ public class JobTimedOutApplier implements TypedEventApplier<JobIntent, JobRecor
 
   private final MutableJobState jobState;
 
-  JobTimedOutApplier(final MutableZeebeState state) {
+  JobTimedOutApplier(final MutableProcessingState state) {
     jobState = state.getJobState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 
@@ -17,7 +17,7 @@ public class ProcessCreatedApplier implements TypedEventApplier<ProcessIntent, P
 
   private final MutableProcessState processState;
 
-  public ProcessCreatedApplier(final MutableZeebeState state) {
+  public ProcessCreatedApplier(final MutableProcessingState state) {
     processState = state.getProcessState();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 
-public interface ZeebeState extends StreamProcessorLifecycleAware {
+public interface ProcessingState extends StreamProcessorLifecycleAware {
 
   DeploymentState getDeploymentState();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationController.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationController.java
@@ -9,29 +9,29 @@ package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.function.Function;
 
 public final class DbMigrationController implements StreamProcessorLifecycleAware {
 
   private DbMigrator dbMigrator;
-  private final Function<MutableZeebeState, DbMigrator> migratorFactory;
-  private final MutableZeebeState mutableZeebeState;
+  private final Function<MutableProcessingState, DbMigrator> migratorFactory;
+  private final MutableProcessingState mutableProcessingState;
 
-  public DbMigrationController(final MutableZeebeState mutableZeebeState) {
-    this(mutableZeebeState, DbMigratorImpl::new);
+  public DbMigrationController(final MutableProcessingState mutableProcessingState) {
+    this(mutableProcessingState, DbMigratorImpl::new);
   }
 
   DbMigrationController(
-      final MutableZeebeState mutableZeebeState,
-      final Function<MutableZeebeState, DbMigrator> migratorFactory) {
-    this.mutableZeebeState = mutableZeebeState;
+      final MutableProcessingState mutableProcessingState,
+      final Function<MutableProcessingState, DbMigrator> migratorFactory) {
+    this.mutableProcessingState = mutableProcessingState;
     this.migratorFactory = migratorFactory;
   }
 
   @Override
-  public final void onRecovered(final ReadonlyStreamProcessorContext context) {
-    final var migrator = migratorFactory.apply(mutableZeebeState);
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    final var migrator = migratorFactory.apply(mutableProcessingState);
 
     synchronized (this) {
       dbMigrator = migrator;
@@ -46,12 +46,12 @@ public final class DbMigrationController implements StreamProcessorLifecycleAwar
   }
 
   @Override
-  public final void onClose() {
+  public void onClose() {
     abortMigrationIfRunning();
   }
 
   @Override
-  public final void onFailed() {
+  public void onFailed() {
     abortMigrationIfRunning();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MessageSubscriptionSentTimeMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MessageSubscriptionSentTimeMigration.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 /**
  * Reads out the sent time for message subscriptions and sets the {@code correlating} field in
@@ -23,16 +23,16 @@ public class MessageSubscriptionSentTimeMigration implements MigrationTask {
   }
 
   @Override
-  public boolean needsToRun(final ZeebeState zeebeState) {
-    return !zeebeState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME);
+  public boolean needsToRun(final ProcessingState processingState) {
+    return !processingState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME);
   }
 
   @Override
-  public void runMigration(final MutableZeebeState zeebeState) {
-    zeebeState
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState
         .getMigrationState()
         .migrateMessageSubscriptionSentTime(
-            zeebeState.getMessageSubscriptionState(),
-            zeebeState.getPendingMessageSubscriptionState());
+            processingState.getMessageSubscriptionState(),
+            processingState.getPendingMessageSubscriptionState());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 /**
  * Interface for migration tasks.
@@ -54,15 +54,15 @@ public interface MigrationTask {
   /**
    * Returns whether the migration needs to run
    *
-   * @param zeebeState the immutable Zeebe state
+   * @param processingState the immutable Zeebe state
    * @return whether the migration needs to run
    */
-  boolean needsToRun(final ZeebeState zeebeState);
+  boolean needsToRun(final ProcessingState processingState);
 
   /**
    * Implementations of this method perform the actual migration
    *
-   * @param zeebeState the mutable Zeebe state
+   * @param processingState the mutable Zeebe state
    */
-  void runMigration(final MutableZeebeState zeebeState);
+  void runMigration(final MutableProcessingState processingState);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/ProcessMessageSubscriptionSentTimeMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/ProcessMessageSubscriptionSentTimeMigration.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 /**
  * Migrates pending process message subscriptions by adding them to {@code
@@ -24,16 +24,16 @@ public class ProcessMessageSubscriptionSentTimeMigration implements MigrationTas
   }
 
   @Override
-  public boolean needsToRun(final ZeebeState zeebeState) {
-    return !zeebeState.isEmpty(ZbColumnFamilies.PROCESS_SUBSCRIPTION_BY_SENT_TIME);
+  public boolean needsToRun(final ProcessingState processingState) {
+    return !processingState.isEmpty(ZbColumnFamilies.PROCESS_SUBSCRIPTION_BY_SENT_TIME);
   }
 
   @Override
-  public void runMigration(final MutableZeebeState zeebeState) {
-    zeebeState
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState
         .getMigrationState()
         .migrateProcessMessageSubscriptionSentTime(
-            zeebeState.getProcessMessageSubscriptionState(),
-            zeebeState.getPendingProcessMessageSubscriptionState());
+            processingState.getProcessMessageSubscriptionState(),
+            processingState.getPendingProcessMessageSubscriptionState());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariableMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariableMigration.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 
 /** Reads out the temporary variable column and creates an EventTrigger for reach of them. */
 public class TemporaryVariableMigration implements MigrationTask {
@@ -20,15 +20,16 @@ public class TemporaryVariableMigration implements MigrationTask {
   }
 
   @Override
-  public boolean needsToRun(final ZeebeState zeebeState) {
-    return !zeebeState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE);
+  public boolean needsToRun(final ProcessingState processingState) {
+    return !processingState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE);
   }
 
   @Override
-  public void runMigration(final MutableZeebeState zeebeState) {
-    zeebeState
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState
         .getMigrationState()
         .migrateTemporaryVariables(
-            zeebeState.getEventScopeInstanceState(), zeebeState.getElementInstanceState());
+            processingState.getEventScopeInstanceState(),
+            processingState.getElementInstanceState());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -8,9 +8,9 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 
-public interface MutableZeebeState extends ZeebeState {
+public interface MutableProcessingState extends ProcessingState {
 
   @Override
   MutableDeploymentState getDeploymentState();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -8,11 +8,11 @@
 package io.camunda.zeebe.engine.state.query;
 
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -22,7 +22,7 @@ import org.agrona.DirectBuffer;
 
 public final class StateQueryService implements QueryService {
   private volatile boolean isClosed;
-  private ZeebeState state;
+  private ProcessingState state;
   private final ZeebeDb<ZbColumnFamilies> zeebeDb;
 
   public StateQueryService(final ZeebeDb<ZbColumnFamilies> zeebeDb) {
@@ -67,7 +67,8 @@ public final class StateQueryService implements QueryService {
       // service is used for the first time, create state now
       // we don't need a key generator here, so we set it to null
       state =
-          new ZeebeDbState(Protocol.DEPLOYMENT_PARTITION, zeebeDb, zeebeDb.createContext(), null);
+          new ProcessingDbState(
+              Protocol.DEPLOYMENT_PARTITION, zeebeDb, zeebeDb.createContext(), null);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.KeyGeneratorControls;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -27,7 +27,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final ProcessingScheduleService scheduleService;
   private final ZeebeDb zeebeDb;
   private final TransactionContext transactionContext;
-  private final Function<MutableZeebeState, EventApplier> eventApplierFactory;
+  private final Function<MutableProcessingState, EventApplier> eventApplierFactory;
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private final InterPartitionCommandSender partitionCommandSender;
   private final KeyGenerator keyGenerator;
@@ -37,7 +37,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
       final ProcessingScheduleService scheduleService,
       final ZeebeDb zeebeDb,
       final TransactionContext transactionContext,
-      final Function<MutableZeebeState, EventApplier> eventApplierFactory,
+      final Function<MutableProcessingState, EventApplier> eventApplierFactory,
       final InterPartitionCommandSender partitionCommandSender,
       final KeyGeneratorControls keyGeneratorControls) {
     this.partitionId = partitionId;
@@ -70,7 +70,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   }
 
   @Override
-  public Function<MutableZeebeState, EventApplier> getEventApplierFactory() {
+  public Function<MutableProcessingState, EventApplier> getEventApplierFactory() {
     return eventApplierFactory;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.metrics.StreamProcessorMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordValues;
 import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.processing.DbKeyGenerator;
 import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.logstreams.log.LogRecordAwaiter;
@@ -88,7 +88,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private final ActorSchedulingService actorSchedulingService;
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
   private final List<StreamProcessorLifecycleAware> lifecycleAwareListeners;
-  private final Function<MutableZeebeState, EventApplier> eventApplierFactory;
+  private final Function<MutableProcessingState, EventApplier> eventApplierFactory;
   private final Set<FailureListener> failureListeners = new HashSet<>();
   private final StreamProcessorMetrics metrics;
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import java.util.ArrayList;
@@ -27,7 +27,7 @@ public final class StreamProcessorBuilder {
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private ActorSchedulingService actorSchedulingService;
   private ZeebeDb zeebeDb;
-  private Function<MutableZeebeState, EventApplier> eventApplierFactory;
+  private Function<MutableProcessingState, EventApplier> eventApplierFactory;
   private int nodeId;
 
   private List<RecordProcessor> recordProcessors;
@@ -74,7 +74,7 @@ public final class StreamProcessorBuilder {
   }
 
   public StreamProcessorBuilder eventApplierFactory(
-      final Function<MutableZeebeState, EventApplier> eventApplierFactory) {
+      final Function<MutableProcessingState, EventApplier> eventApplierFactory) {
     this.eventApplierFactory = eventApplierFactory;
     return this;
   }
@@ -114,7 +114,7 @@ public final class StreamProcessorBuilder {
     return recordProcessors;
   }
 
-  public Function<MutableZeebeState, EventApplier> getEventApplierFactory() {
+  public Function<MutableProcessingState, EventApplier> getEventApplierFactory() {
     return eventApplierFactory;
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -11,9 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -41,14 +41,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 final class JobBatchCollectorTest {
   private static final String JOB_TYPE = "job";
 
   private final RecordLengthEvaluator lengthEvaluator = new RecordLengthEvaluator();
 
   @SuppressWarnings("unused") // injected by the extension
-  private MutableZeebeState state;
+  private MutableProcessingState state;
 
   private JobBatchCollector collector;
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -59,11 +59,11 @@ public final class MessageStreamProcessorTest {
 
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
-          final var zeebeState = processingContext.getZeebeState();
+          final var processingState = processingContext.getProcessingState();
           MessageEventProcessors.addMessageProcessors(
               mock(BpmnBehaviors.class),
               typedRecordProcessors,
-              zeebeState,
+              processingState,
               spySubscriptionCommandSender,
               processingContext.getWriters());
           return typedRecordProcessors;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -60,10 +60,12 @@ public final class MessageStreamProcessorTest {
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
           final var processingState = processingContext.getProcessingState();
+          final var scheduledTaskDbState = processingContext.getScheduledTaskDbState();
           MessageEventProcessors.addMessageProcessors(
               mock(BpmnBehaviors.class),
               typedRecordProcessors,
               processingState,
+              scheduledTaskDbState,
               spySubscriptionCommandSender,
               processingContext.getWriters());
           return typedRecordProcessors;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayTest.java
@@ -167,7 +167,7 @@ public final class StreamProcessorReplayTest {
     startStreamProcessor(typedRecordProcessor, eventApplier);
 
     // then
-    final var keyGenerator = streamProcessorRule.getZeebeState().getKeyGenerator();
+    final var keyGenerator = streamProcessorRule.getProcessingState().getKeyGenerator();
     assertThat(keyGenerator.nextKey()).isEqualTo(lastGeneratedKey + 1);
   }
 
@@ -187,7 +187,7 @@ public final class StreamProcessorReplayTest {
     startStreamProcessor(typedRecordProcessor, eventApplier);
 
     // then
-    final var keyGenerator = streamProcessorRule.getZeebeState().getKeyGenerator();
+    final var keyGenerator = streamProcessorRule.getProcessingState().getKeyGenerator();
     assertThat(keyGenerator.nextKey()).isEqualTo(keyOfThisPartition + 1);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -11,11 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.engine.util.RecordingTypedEventWriter;
 import io.camunda.zeebe.engine.util.RecordingTypedEventWriter.RecordedEvent;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValueAssert;
@@ -29,13 +29,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 final class VariableBehaviorTest {
 
   private final RecordingTypedEventWriter eventWriter = new RecordingTypedEventWriter();
 
   @SuppressWarnings("unused") // injected by the extension
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   private MutableVariableState state;
   private VariableBehavior behavior;
@@ -43,10 +43,10 @@ final class VariableBehaviorTest {
   @BeforeEach
   void beforeEach() {
     final var stateWriter =
-        new EventApplyingStateWriter(eventWriter, new EventAppliers(zeebeState));
+        new EventApplyingStateWriter(eventWriter, new EventAppliers(processingState));
 
-    state = zeebeState.getVariableState();
-    behavior = new VariableBehavior(state, stateWriter, zeebeState.getKeyGenerator());
+    state = processingState.getVariableState();
+    behavior = new VariableBehavior(state, stateWriter, processingState.getKeyGenerator());
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/BlacklistInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/BlacklistInstanceTest.java
@@ -12,8 +12,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -46,7 +46,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public final class BlacklistInstanceTest {
 
-  @ClassRule public static final ZeebeStateRule ZEEBE_STATE_RULE = new ZeebeStateRule();
+  @ClassRule public static final ProcessingStateRule ZEEBE_STATE_RULE = new ProcessingStateRule();
   private static final AtomicLong KEY_GENERATOR = new AtomicLong(0);
 
   @Parameter(0)
@@ -207,14 +207,14 @@ public final class BlacklistInstanceTest {
     typedEvent.wrap(loggedEvent, metadata, new Value());
 
     // when
-    final MutableZeebeState zeebeState = ZEEBE_STATE_RULE.getZeebeState();
-    zeebeState.getBlackListState().tryToBlacklist(typedEvent, (processInstanceKey) -> {});
+    final MutableProcessingState processingState = ZEEBE_STATE_RULE.getProcessingState();
+    processingState.getBlackListState().tryToBlacklist(typedEvent, (processInstanceKey) -> {});
 
     // then
     metadata.intent(ProcessInstanceIntent.ELEMENT_ACTIVATING);
     metadata.valueType(ValueType.PROCESS_INSTANCE);
     typedEvent.wrap(null, metadata, new Value());
-    assertThat(zeebeState.getBlackListState().isOnBlacklist(typedEvent))
+    assertThat(processingState.getBlackListState().isOnBlacklist(typedEvent))
         .isEqualTo(expectedToBlacklist);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.processing.DbKeyGenerator;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.Protocol;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,13 +19,13 @@ import org.junit.Test;
 
 public final class KeyGeneratorTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private KeyGenerator keyGenerator;
 
   @Before
   public void setUp() throws Exception {
-    keyGenerator = stateRule.getZeebeState().getKeyGenerator();
+    keyGenerator = stateRule.getProcessingState().getKeyGenerator();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -11,7 +11,7 @@ import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.processing.message.MessageObserver;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -46,11 +46,11 @@ public final class ProcessExecutionCleanStateTest {
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 
-  private ZeebeState zeebeState;
+  private ProcessingState processingState;
 
   @Before
   public void init() {
-    zeebeState = engineRule.getZeebeState();
+    processingState = engineRule.getProcessingState();
 
     assertThatStateIsEmpty();
   }
@@ -788,7 +788,7 @@ public final class ProcessExecutionCleanStateTest {
               final var nonEmptyColumns =
                   Arrays.stream(ZbColumnFamilies.values())
                       .filter(not(IGNORE_NON_EMPTY_COLUMNS::contains))
-                      .filter(not(zeebeState::isEmpty))
+                      .filter(not(processingState::isEmpty))
                       .collect(Collectors.toList());
 
               assertThat(nonEmptyColumns).describedAs("Expected all columns to be empty").isEmpty();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -13,8 +13,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,15 +22,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 public final class DecisionStateTest {
 
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
   private MutableDecisionState decisionState;
 
   @BeforeEach
   public void setup() {
-    decisionState = zeebeState.getDecisionState();
+    decisionState = processingState.getDecisionState();
   }
 
   @DisplayName("should return empty if no decision is deployed")

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -26,14 +26,14 @@ import org.junit.Test;
 
 public class DeploymentStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableDeploymentState deploymentState;
 
   @Before
   public void setUp() {
-    final var zeebeState = stateRule.getZeebeState();
-    deploymentState = zeebeState.getDeploymentState();
+    final var processingState = stateRule.getProcessingState();
+    deploymentState = processingState.getDeploymentState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
@@ -16,8 +16,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.state.mutable.MutableBlackListState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -30,15 +30,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 public final class BlackListStateTest {
 
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
   private MutableBlackListState blackListState;
 
   @BeforeEach
   public void setup() {
-    blackListState = zeebeState.getBlackListState();
+    blackListState = processingState.getBlackListState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -13,8 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -33,15 +33,15 @@ public final class ElementInstanceStateTest {
 
   private static final long PROCESS_KEY = 123;
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableElementInstanceState elementInstanceState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    elementInstanceState = zeebeState.getElementInstanceState();
+    processingState = stateRule.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Test
@@ -291,7 +291,7 @@ public final class ElementInstanceStateTest {
     final ElementInstance parentInstance =
         elementInstanceState.newInstance(
             parent, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
-    zeebeState
+    processingState
         .getVariableState()
         .setVariableLocal(
             1, parent, PROCESS_KEY, BufferUtil.wrapString("a"), MsgPackUtil.asMsgPack("1"));
@@ -299,7 +299,7 @@ public final class ElementInstanceStateTest {
     processInstanceRecord.setElementId("subProcess");
     elementInstanceState.newInstance(
         parentInstance, child, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
-    zeebeState
+    processingState
         .getVariableState()
         .setVariableLocal(
             2, child, PROCESS_KEY, BufferUtil.wrapString("b"), MsgPackUtil.asMsgPack("2"));
@@ -312,7 +312,7 @@ public final class ElementInstanceStateTest {
     final var nonEmptyColumns =
         Arrays.stream(ZbColumnFamilies.values())
             .filter(not(ZbColumnFamilies.KEY::equals))
-            .filter(not(zeebeState::isEmpty))
+            .filter(not(processingState::isEmpty))
             .collect(Collectors.toList());
 
     assertThat(nonEmptyColumns).describedAs("Expected all columns to be empty").isEmpty();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
@@ -13,8 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 public final class EventScopeInstanceStateTest {
 
   private static final int SCOPE_KEY = 123;
@@ -32,13 +32,13 @@ public final class EventScopeInstanceStateTest {
       Collections.emptySet();
   private static final Collection<DirectBuffer> NO_BOUNDARY_ELEMENT_IDS = Collections.emptySet();
 
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   private MutableEventScopeInstanceState state;
 
   @BeforeEach
   void setUp() {
-    state = zeebeState.getEventScopeInstanceState();
+    state = processingState.getEventScopeInstanceState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/IncidentStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/IncidentStateTest.java
@@ -14,8 +14,8 @@ import io.camunda.zeebe.engine.state.immutable.IncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -27,19 +27,19 @@ import org.junit.Test;
 
 public final class IncidentStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableIncidentState incidentState;
   private MutableElementInstanceState elementInstanceState;
   private MutableJobState jobState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    elementInstanceState = zeebeState.getElementInstanceState();
-    jobState = zeebeState.getJobState();
-    incidentState = zeebeState.getIncidentState();
+    processingState = stateRule.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
+    jobState = processingState.getJobState();
+    incidentState = processingState.getIncidentState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -14,8 +14,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.test.util.BufferAssert;
@@ -35,15 +35,15 @@ import org.junit.Test;
 
 public final class JobStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableJobState jobState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    jobState = zeebeState.getJobState();
+    processingState = stateRule.getProcessingState();
+    jobState = processingState.getJobState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/NumberOfTakenSequenceFlowsStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/NumberOfTakenSequenceFlowsStateTest.java
@@ -12,8 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import org.agrona.DirectBuffer;
@@ -30,15 +30,15 @@ public final class NumberOfTakenSequenceFlowsStateTest {
   private static final DirectBuffer SEQUENCE_FLOW_ELEMENT_ID = wrapString("flow-1");
   private static final DirectBuffer OTHER_SEQUENCE_FLOW_ELEMENT_ID = wrapString("flow-2");
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableElementInstanceState elementInstanceState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    elementInstanceState = zeebeState.getElementInstanceState();
+    processingState = stateRule.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Test
@@ -162,7 +162,7 @@ public final class NumberOfTakenSequenceFlowsStateTest {
         elementInstanceState.getNumberOfTakenSequenceFlows(FLOW_SCOPE_KEY, GATEWAY_ELEMENT_ID);
     assertThat(number).isZero();
 
-    assertThat(zeebeState.isEmpty(ZbColumnFamilies.NUMBER_OF_TAKEN_SEQUENCE_FLOWS))
+    assertThat(processingState.isEmpty(ZbColumnFamilies.NUMBER_OF_TAKEN_SEQUENCE_FLOWS))
         .describedAs("Expected the entries to be removed")
         .isTrue();
   }
@@ -185,7 +185,7 @@ public final class NumberOfTakenSequenceFlowsStateTest {
         elementInstanceState.getNumberOfTakenSequenceFlows(FLOW_SCOPE_KEY, GATEWAY_ELEMENT_ID);
     assertThat(number).isZero();
 
-    assertThat(zeebeState.isEmpty(ZbColumnFamilies.NUMBER_OF_TAKEN_SEQUENCE_FLOWS))
+    assertThat(processingState.isEmpty(ZbColumnFamilies.NUMBER_OF_TAKEN_SEQUENCE_FLOWS))
         .describedAs("Expected the entries to be removed")
         .isTrue();
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -9,9 +9,9 @@ package io.camunda.zeebe.engine.state.instance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import java.util.ArrayList;
@@ -23,14 +23,14 @@ import org.junit.Test;
 
 public final class TimerInstanceStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableTimerInstanceState state;
 
   @Before
   public void setUp() {
-    final MutableZeebeState zeebeState = stateRule.getZeebeState();
-    state = zeebeState.getTimerState();
+    final MutableProcessingState processingState = stateRule.getProcessingState();
+    state = processingState.getTimerState();
   }
 
   @Test
@@ -214,7 +214,7 @@ public final class TimerInstanceStateTest {
 
   private void createElementInstance(final long key) {
     stateRule
-        .getZeebeState()
+        .getProcessingState()
         .getElementInstanceState()
         .createInstance(
             new ElementInstance(

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscriptionStateTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
@@ -27,13 +27,13 @@ import org.junit.Test;
 
 public final class MessageStartEventSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageStartEventSubscriptionState state;
 
   @Before
   public void setUp() {
-    state = stateRule.getZeebeState().getMessageStartEventSubscriptionState();
+    state = stateRule.getProcessingState().getMessageStartEventSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -11,8 +11,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
@@ -24,15 +24,15 @@ import org.junit.Test;
 
 public final class MessageStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageState messageState;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
   @Before
   public void setUp() {
-    zeebeState = stateRule.getZeebeState();
-    messageState = zeebeState.getMessageState();
+    processingState = stateRule.getProcessingState();
+    messageState = processingState.getMessageState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageSubscriptionStateTest.java
@@ -11,8 +11,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,15 +22,15 @@ import org.junit.Test;
 
 public final class MessageSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageSubscriptionState state;
 
   @Before
   public void setUp() {
 
-    final MutableZeebeState zeebeState = stateRule.getZeebeState();
-    state = zeebeState.getMessageSubscriptionState();
+    final MutableProcessingState processingState = stateRule.getProcessingState();
+    state = processingState.getMessageSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingMessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingMessageSubscriptionStateTest.java
@@ -12,8 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.ArrayList;
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 public final class PendingMessageSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageSubscriptionState persistentState;
   private MutablePendingMessageSubscriptionState transientState;
@@ -33,9 +33,9 @@ public final class PendingMessageSubscriptionStateTest {
   @Before
   public void setUp() {
 
-    final MutableZeebeState zeebeState = stateRule.getZeebeState();
-    persistentState = zeebeState.getMessageSubscriptionState();
-    transientState = zeebeState.getPendingMessageSubscriptionState();
+    final MutableProcessingState processingState = stateRule.getProcessingState();
+    persistentState = processingState.getMessageSubscriptionState();
+    transientState = processingState.getPendingMessageSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingProcessMessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingProcessMessageSubscriptionStateTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutablePendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,15 +23,15 @@ import org.junit.Test;
 
 public final class PendingProcessMessageSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableProcessMessageSubscriptionState persistentState;
   private MutablePendingProcessMessageSubscriptionState transientState;
 
   @Before
   public void setUp() {
-    persistentState = stateRule.getZeebeState().getProcessMessageSubscriptionState();
-    transientState = stateRule.getZeebeState().getPendingProcessMessageSubscriptionState();
+    persistentState = stateRule.getProcessingState().getProcessMessageSubscriptionState();
+    transientState = stateRule.getProcessingState().getPendingProcessMessageSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscriptionStateTest.java
@@ -12,7 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.ArrayList;
@@ -24,13 +24,13 @@ import org.junit.Test;
 
 public final class ProcessMessageSubscriptionStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableProcessMessageSubscriptionState state;
 
   @Before
   public void setUp() {
-    state = stateRule.getZeebeState().getProcessMessageSubscriptionState();
+    state = stateRule.getProcessingState().getProcessMessageSubscriptionState();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigrationControllerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigrationControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +32,8 @@ public class DbMigrationControllerTest {
     mockDbMigrator = mock(DbMigrator.class);
 
     sutMigrationController =
-        new DbMigrationController(mock(MutableZeebeState.class), zeebeState -> mockDbMigrator);
+        new DbMigrationController(
+            mock(MutableProcessingState.class), processingState -> mockDbMigrator);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -24,48 +24,48 @@ public class DbMigratorImplTest {
   @Test
   void shouldRunMigrationThatNeedsToBeRun() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration = mock(MigrationTask.class);
-    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+        new DbMigratorImpl(mockProcessingState, () -> Collections.singletonList(mockMigration));
 
     // when
     sut.runMigrations();
 
     // then
-    verify(mockMigration).runMigration(mockZeebeState);
+    verify(mockMigration).runMigration(mockProcessingState);
   }
 
   @Test
   void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration = mock(MigrationTask.class);
-    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(false);
+    when(mockMigration.needsToRun(mockProcessingState)).thenReturn(false);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+        new DbMigratorImpl(mockProcessingState, () -> Collections.singletonList(mockMigration));
 
     // when
     sut.runMigrations();
 
     // then
-    verify(mockMigration, never()).runMigration(mockZeebeState);
+    verify(mockMigration, never()).runMigration(mockProcessingState);
   }
 
   @Test
   void shouldRunMigrationsInOrder() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration1 = mock(MigrationTask.class);
-    when(mockMigration1.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
     final var mockMigration2 = mock(MigrationTask.class);
-    when(mockMigration2.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> List.of(mockMigration1, mockMigration2));
+        new DbMigratorImpl(mockProcessingState, () -> List.of(mockMigration1, mockMigration2));
 
     // when
     sut.runMigrations();
@@ -73,19 +73,19 @@ public class DbMigratorImplTest {
     // then
     final var inOrder = Mockito.inOrder(mockMigration1, mockMigration2);
 
-    inOrder.verify(mockMigration1).runMigration(mockZeebeState);
-    inOrder.verify(mockMigration2).runMigration(mockZeebeState);
+    inOrder.verify(mockMigration1).runMigration(mockProcessingState);
+    inOrder.verify(mockMigration2).runMigration(mockProcessingState);
   }
 
   @Test
   void shouldNotRunAnyMigrationIfAbortSignalWasReceivedInTheVeryBeginning() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration = mock(MigrationTask.class);
-    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(false);
+    when(mockMigration.needsToRun(mockProcessingState)).thenReturn(false);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+        new DbMigratorImpl(mockProcessingState, () -> Collections.singletonList(mockMigration));
 
     // when
     sut.abort();
@@ -99,14 +99,14 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotRunSubsequentMigrationsAfterAbortSignalWasReceived() {
     // given
-    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigration1 = mock(MigrationTask.class);
-    when(mockMigration1.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
     final var mockMigration2 = mock(MigrationTask.class);
-    when(mockMigration2.needsToRun(mockZeebeState)).thenReturn(true);
+    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var sut =
-        new DbMigratorImpl(mockZeebeState, () -> List.of(mockMigration1, mockMigration2));
+        new DbMigratorImpl(mockProcessingState, () -> List.of(mockMigration1, mockMigration2));
 
     doAnswer(
             (invocationOnMock) -> {
@@ -115,13 +115,13 @@ public class DbMigratorImplTest {
               return null;
             })
         .when(mockMigration1)
-        .runMigration(mockZeebeState);
+        .runMigration(mockProcessingState);
 
     // when
     sut.runMigrations();
 
     // then
-    verify(mockMigration1).runMigration(mockZeebeState);
-    verify(mockMigration2, never()).runMigration(mockZeebeState);
+    verify(mockMigration1).runMigration(mockProcessingState);
+    verify(mockMigration2, never()).runMigration(mockProcessingState);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/MessageSubscriptionSentTimeMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/MessageSubscriptionSentTimeMigrationTest.java
@@ -17,10 +17,10 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.migration.MessageSubscriptionSentTimeMigration;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,11 +37,11 @@ public class MessageSubscriptionSentTimeMigrationTest {
     @Test
     public void noMigrationNeededWhenColumnIsEmpty() {
       // given
-      final var mockZeebeState = mock(ZeebeState.class);
-      when(mockZeebeState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME))
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME))
           .thenReturn(true);
       // when
-      final var actual = sutMigration.needsToRun(mockZeebeState);
+      final var actual = sutMigration.needsToRun(mockProcessingState);
 
       // then
       assertThat(actual).isFalse();
@@ -50,12 +50,12 @@ public class MessageSubscriptionSentTimeMigrationTest {
     @Test
     public void migrationNeededWhenColumnIsNotEmpty() {
       // given
-      final var mockZeebeState = mock(ZeebeState.class);
-      when(mockZeebeState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME))
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME))
           .thenReturn(false);
 
       // when
-      final var actual = sutMigration.needsToRun(mockZeebeState);
+      final var actual = sutMigration.needsToRun(mockProcessingState);
 
       // then
       assertThat(actual).isTrue();
@@ -64,30 +64,30 @@ public class MessageSubscriptionSentTimeMigrationTest {
     @Test
     public void migrationCallsMethodInMigrationState() {
       // given
-      final var mockZeebeState = mock(MutableZeebeState.class, RETURNS_DEEP_STUBS);
+      final var mockProcessingState = mock(MutableProcessingState.class, RETURNS_DEEP_STUBS);
 
       // when
-      sutMigration.runMigration(mockZeebeState);
+      sutMigration.runMigration(mockProcessingState);
 
       // then
-      verify(mockZeebeState.getMigrationState())
+      verify(mockProcessingState.getMigrationState())
           .migrateMessageSubscriptionSentTime(
-              mockZeebeState.getMessageSubscriptionState(),
-              mockZeebeState.getPendingMessageSubscriptionState());
+              mockProcessingState.getMessageSubscriptionState(),
+              mockProcessingState.getPendingMessageSubscriptionState());
 
-      verifyNoMoreInteractions(mockZeebeState.getMigrationState());
+      verifyNoMoreInteractions(mockProcessingState.getMigrationState());
     }
   }
 
   @Nested
-  @ExtendWith(ZeebeStateExtension.class)
+  @ExtendWith(ProcessingStateExtension.class)
   public class BlackboxTest {
 
     private static final long TEST_SENT_TIME = 1000L;
 
     private ZeebeDb<ZbColumnFamilies> zeebeDb;
 
-    private MutableZeebeState zeebeState;
+    private MutableProcessingState processingState;
 
     private TransactionContext transactionContext;
 
@@ -108,7 +108,7 @@ public class MessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
 
       // when
-      final var actual = sutMigration.needsToRun(zeebeState);
+      final var actual = sutMigration.needsToRun(processingState);
 
       // then
       assertThat(actual).describedAs("Migration should run").isTrue();
@@ -119,8 +119,8 @@ public class MessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
 
       // when
-      sutMigration.runMigration(zeebeState);
-      final var actual = sutMigration.needsToRun(zeebeState);
+      sutMigration.runMigration(processingState);
+      final var actual = sutMigration.needsToRun(processingState);
 
       // then
       assertThat(actual).describedAs("Migration should run").isFalse();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/ProcessMessageSubscriptionSentTimeMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/ProcessMessageSubscriptionSentTimeMigrationTest.java
@@ -17,10 +17,10 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.migration.ProcessMessageSubscriptionSentTimeMigration;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,11 +37,11 @@ public class ProcessMessageSubscriptionSentTimeMigrationTest {
     @Test
     public void noMigrationNeededWhenColumnIsEmpty() {
       // given
-      final var mockZeebeState = mock(ZeebeState.class);
-      when(mockZeebeState.isEmpty(ZbColumnFamilies.PROCESS_SUBSCRIPTION_BY_SENT_TIME))
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.PROCESS_SUBSCRIPTION_BY_SENT_TIME))
           .thenReturn(true);
       // when
-      final var actual = sutMigration.needsToRun(mockZeebeState);
+      final var actual = sutMigration.needsToRun(mockProcessingState);
 
       // then
       assertThat(actual).isFalse();
@@ -50,12 +50,12 @@ public class ProcessMessageSubscriptionSentTimeMigrationTest {
     @Test
     public void migrationNeededWhenColumnIsNotEmpty() {
       // given
-      final var mockZeebeState = mock(ZeebeState.class);
-      when(mockZeebeState.isEmpty(ZbColumnFamilies.PROCESS_SUBSCRIPTION_BY_SENT_TIME))
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.PROCESS_SUBSCRIPTION_BY_SENT_TIME))
           .thenReturn(false);
 
       // when
-      final var actual = sutMigration.needsToRun(mockZeebeState);
+      final var actual = sutMigration.needsToRun(mockProcessingState);
 
       // then
       assertThat(actual).isTrue();
@@ -64,30 +64,30 @@ public class ProcessMessageSubscriptionSentTimeMigrationTest {
     @Test
     public void migrationCallsMethodInMigrationState() {
       // given
-      final var mockZeebeState = mock(MutableZeebeState.class, RETURNS_DEEP_STUBS);
+      final var mockProcessingState = mock(MutableProcessingState.class, RETURNS_DEEP_STUBS);
 
       // when
-      sutMigration.runMigration(mockZeebeState);
+      sutMigration.runMigration(mockProcessingState);
 
       // then
-      verify(mockZeebeState.getMigrationState())
+      verify(mockProcessingState.getMigrationState())
           .migrateProcessMessageSubscriptionSentTime(
-              mockZeebeState.getProcessMessageSubscriptionState(),
-              mockZeebeState.getPendingProcessMessageSubscriptionState());
+              mockProcessingState.getProcessMessageSubscriptionState(),
+              mockProcessingState.getPendingProcessMessageSubscriptionState());
 
-      verifyNoMoreInteractions(mockZeebeState.getMigrationState());
+      verifyNoMoreInteractions(mockProcessingState.getMigrationState());
     }
   }
 
   @Nested
-  @ExtendWith(ZeebeStateExtension.class)
+  @ExtendWith(ProcessingStateExtension.class)
   public class BlackboxTest {
 
     private static final long TEST_SENT_TIME = 1000L;
 
     private ZeebeDb<ZbColumnFamilies> zeebeDb;
 
-    private MutableZeebeState zeebeState;
+    private MutableProcessingState processingState;
 
     private TransactionContext transactionContext;
 
@@ -96,7 +96,7 @@ public class ProcessMessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
       final var legacySubscriptionState =
           new LegacyDbProcessMessageSubscriptionState(zeebeDb, transactionContext);
-      final var subscriptionState = zeebeState.getProcessMessageSubscriptionState();
+      final var subscriptionState = processingState.getProcessMessageSubscriptionState();
 
       final var openingProcessMessageSubscription =
           TestUtilities.createLegacyProcessMessageSubscription(100, 1);
@@ -111,7 +111,7 @@ public class ProcessMessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
 
       // when
-      final var actual = sutMigration.needsToRun(zeebeState);
+      final var actual = sutMigration.needsToRun(processingState);
 
       // then
       assertThat(actual).describedAs("Migration should run").isTrue();
@@ -122,8 +122,8 @@ public class ProcessMessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
 
       // when
-      sutMigration.runMigration(zeebeState);
-      final var actual = sutMigration.needsToRun(zeebeState);
+      sutMigration.runMigration(processingState);
+      final var actual = sutMigration.needsToRun(processingState);
 
       // then
       assertThat(actual).describedAs("Migration should run").isFalse();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/ProcessMessageSubscriptionSentTimeMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/ProcessMessageSubscriptionSentTimeMigrationTest.java
@@ -96,7 +96,6 @@ public class ProcessMessageSubscriptionSentTimeMigrationTest {
       // given database with legacy records
       final var legacySubscriptionState =
           new LegacyDbProcessMessageSubscriptionState(zeebeDb, transactionContext);
-      final var subscriptionState = processingState.getProcessMessageSubscriptionState();
 
       final var openingProcessMessageSubscription =
           TestUtilities.createLegacyProcessMessageSubscription(100, 1);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
@@ -14,9 +14,9 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.QueryService.ClosedServiceException;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.engine.util.Records;
-import io.camunda.zeebe.engine.util.ZeebeStateExtension;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -30,12 +30,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@ExtendWith(ZeebeStateExtension.class)
+@ExtendWith(ProcessingStateExtension.class)
 final class StateQueryServiceTest {
 
   private StateQueryService sut;
   private ZeebeDb<ZbColumnFamilies> db;
-  private MutableZeebeState state;
+  private MutableProcessingState state;
   private TransactionContext transactionContext;
 
   @BeforeEach

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
@@ -19,9 +19,9 @@ import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import java.util.Arrays;
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 public final class VariableStateTest {
 
-  @ClassRule public static final ZeebeStateRule ZEEBE_STATE_RULE = new ZeebeStateRule();
+  @ClassRule public static final ProcessingStateRule ZEEBE_STATE_RULE = new ProcessingStateRule();
   private static final long PROCESS_KEY = 123;
   private static final AtomicLong PARENT_KEY = new AtomicLong(0);
   private static final AtomicLong CHILD_KEY = new AtomicLong(1);
@@ -49,9 +49,9 @@ public final class VariableStateTest {
 
   @BeforeClass
   public static void setUp() {
-    final MutableZeebeState zeebeState = ZEEBE_STATE_RULE.getZeebeState();
-    elementInstanceState = zeebeState.getElementInstanceState();
-    variableState = zeebeState.getVariableState();
+    final MutableProcessingState processingState = ZEEBE_STATE_RULE.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
+    variableState = processingState.getVariableState();
   }
 
   @Before

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -22,9 +22,9 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistri
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordValues;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
 import io.camunda.zeebe.engine.util.client.JobActivationClient;
@@ -281,8 +281,8 @@ public final class EngineRule extends ExternalResource {
     return environmentRule.getClock();
   }
 
-  public ZeebeState getZeebeState() {
-    return environmentRule.getZeebeState();
+  public ProcessingState getProcessingState() {
+    return environmentRule.getProcessingState();
   }
 
   public StreamProcessor getStreamProcessor(final int partitionId) {
@@ -371,7 +371,7 @@ public final class EngineRule extends ExternalResource {
                 Function.identity(),
                 columnFamily -> {
                   final var entries = new HashMap<>();
-                  ((ZeebeDbState) getZeebeState())
+                  ((ProcessingDbState) getProcessingState())
                       .forEach(
                           columnFamily,
                           keyInstance,

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
@@ -9,26 +9,26 @@ package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.processing.DbKeyGenerator;
 import io.camunda.zeebe.protocol.Protocol;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 
-public final class ZeebeStateRule extends ExternalResource {
+public final class ProcessingStateRule extends ExternalResource {
 
   private final TemporaryFolder tempFolder = new TemporaryFolder();
   private final int partition;
   private ZeebeDb<ZbColumnFamilies> db;
-  private MutableZeebeState zeebeState;
+  private MutableProcessingState processingState;
 
-  public ZeebeStateRule() {
+  public ProcessingStateRule() {
     this(Protocol.DEPLOYMENT_PARTITION);
   }
 
-  public ZeebeStateRule(final int partition) {
+  public ProcessingStateRule(final int partition) {
     this.partition = partition;
   }
 
@@ -39,7 +39,7 @@ public final class ZeebeStateRule extends ExternalResource {
 
     final var context = db.createContext();
     final var keyGenerator = new DbKeyGenerator(partition, db, context);
-    zeebeState = new ZeebeDbState(partition, db, context, keyGenerator);
+    processingState = new ProcessingDbState(partition, db, context, keyGenerator);
   }
 
   @Override
@@ -52,8 +52,8 @@ public final class ZeebeStateRule extends ExternalResource {
     tempFolder.delete();
   }
 
-  public MutableZeebeState getZeebeState() {
-    return zeebeState;
+  public MutableProcessingState getProcessingState() {
+    return processingState;
   }
 
   public ZeebeDb<ZbColumnFamilies> createNewDb() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.api.CommandResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.StreamProcessingComposite.StreamProcessorTestFactory;
 import io.camunda.zeebe.engine.util.TestStreams.FluentLogWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
@@ -126,7 +126,7 @@ public final class StreamProcessorRule implements TestRule {
   }
 
   public StreamProcessorRule withEventApplierFactory(
-      final Function<MutableZeebeState, EventApplier> eventApplierFactory) {
+      final Function<MutableProcessingState, EventApplier> eventApplierFactory) {
     streams.withEventApplierFactory(eventApplierFactory);
     return this;
   }
@@ -210,8 +210,8 @@ public final class StreamProcessorRule implements TestRule {
     return clock;
   }
 
-  public MutableZeebeState getZeebeState() {
-    return streamProcessingComposite.getZeebeState();
+  public MutableProcessingState getProcessingState() {
+    return streamProcessingComposite.getProcessingState();
   }
 
   public long getLastSuccessfulProcessedRecordPosition() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
@@ -89,7 +89,7 @@ public final class TestStreams {
   private final Map<String, ProcessorContext> streamContextMap = new HashMap<>();
   private boolean snapshotWasTaken = false;
 
-  private Function<MutableZeebeState, EventApplier> eventApplierFactory = EventAppliers::new;
+  private Function<MutableProcessingState, EventApplier> eventApplierFactory = EventAppliers::new;
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
   private int maxCommandsInBatch = StreamProcessorContext.DEFAULT_MAX_COMMANDS_IN_BATCH;
 
@@ -115,7 +115,7 @@ public final class TestStreams {
   }
 
   public void withEventApplierFactory(
-      final Function<MutableZeebeState, EventApplier> eventApplierFactory) {
+      final Function<MutableProcessingState, EventApplier> eventApplierFactory) {
     this.eventApplierFactory = eventApplierFactory;
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Backports #11792 to `stable/8.1`.

Conflicts had to be resolved in many files, particularly in 834e5d415429740899c2347b02aa52023bc039ef. Please consider reviewing this with extra care.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to https://github.com/camunda/zeebe/issues/11761

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
