### PR TITLE
feat(db): convenient fallback behavior when no `startAt` is provided

### DIFF
--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -375,6 +375,30 @@ public final class ColumnFamilyTest {
   }
 
   @Test
+  public void shouldUseWhileTrueWithNullStartAt() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    final List<Long> values = new ArrayList<>();
+    columnFamily.whileTrue(
+        null,
+        (key, value) -> {
+          keys.add(key.getValue());
+          values.add(value.getValue());
+
+          return key.getValue() != 4567;
+        });
+
+    // then
+    assertThat(keys).containsExactly(1213L, 4567L);
+    assertThat(values).containsExactly(255L, 123L);
+  }
+
+  @Test
   public void shouldCheckIfEmpty() {
     assertThat(columnFamily.isEmpty()).isTrue();
 


### PR DESCRIPTION
When `startAt` is null, seek to the prefix key which is the same behavior as not specifying a `startAt` key and using `forEachInPrefix` without `startAt`. 
Adding the fallback to `forEachInPrefix` propagates to `whileTrue` (the only usage currently) and all future usages of this method.

This makes using this method a bit easier; no need to switch between two separate methods.


Requested here: https://github.com/camunda/zeebe/pull/11856#discussion_r1123424989
