### PR TITLE
feat(backup/gcs): store can be configured

### DIFF
--- a/backup-stores/gcs/README.md
+++ b/backup-stores/gcs/README.md
@@ -1,2 +1,12 @@
 # Backup Store for Google Cloud Storage
 
+Work in progress implementation of a Google Cloud Storage (GCS) backup store.
+
+## Configuration
+
+**Required**
+- _bucketName_: Name of the bucket that will be used for storing backups. The bucket must already
+exist.
+
+**Optional**
+- _basePath_: Prefix to use for all backup blobs. Useful for using one bucket across multiple Zeebe clusters.

--- a/backup-stores/gcs/README.md
+++ b/backup-stores/gcs/README.md
@@ -1,0 +1,2 @@
+# Backup Store for Google Cloud Storage
+

--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Zeebe Community License 1.1. You may not use this file
+  ~ except in compliance with the Zeebe Community License 1.1.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.2.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>zeebe-backup-store-gcs</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Zeebe Backup Store for GCS</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -26,6 +26,18 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+public record GcsBackupConfig(String bucketName, String basePath) {
+  public GcsBackupConfig {
+    if (bucketName == null || bucketName.isEmpty()) {
+      throw new IllegalArgumentException("bucketName must be provided");
+    }
+  }
+
+  public static final class Builder {
+    private String bucketName;
+    private String basePath;
+
+    public Builder withBucketName(final String bucketName) {
+      this.bucketName = bucketName;
+      return this;
+    }
+
+    public Builder withBasePath(final String basePath) {
+      this.basePath = basePath;
+      return this;
+    }
+
+    public GcsBackupConfig build() {
+      return new GcsBackupConfig(bucketName, basePath);
+    }
+  }
+}

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -8,10 +8,38 @@
 package io.camunda.zeebe.backup.gcs;
 
 public record GcsBackupConfig(String bucketName, String basePath) {
-  public GcsBackupConfig {
-    if (bucketName == null || bucketName.isEmpty()) {
+  public GcsBackupConfig(String bucketName, String basePath) {
+    this.bucketName = requireBucketName(bucketName);
+    this.basePath = sanitizeBasePath(basePath);
+  }
+
+  private String requireBucketName(final String bucketName) {
+    if (bucketName == null || bucketName.isBlank()) {
       throw new IllegalArgumentException("bucketName must be provided");
     }
+    return bucketName;
+  }
+
+  private String sanitizeBasePath(final String basePath) {
+    if (basePath == null || basePath.isBlank()) {
+      return null;
+    }
+
+    // Remove one leading and one trailing slash if present.
+    String sanitized = basePath;
+    if (basePath.startsWith("/")) {
+      sanitized = basePath.substring(1);
+    }
+    if (basePath.endsWith("/")) {
+      sanitized = sanitized.substring(0, sanitized.length() - 1);
+    }
+
+    if (sanitized.isBlank()) {
+      throw new IllegalArgumentException(
+          "After removing leading and trailing '/' characters from basePath '%s', the remainder is empty and not a valid base path"
+              .formatted(basePath));
+    }
+    return sanitized;
   }
 
   public static final class Builder {

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+public final class GcsBackupStore implements BackupStore {
+
+  @Override
+  public CompletableFuture<Void> save(final Backup backup) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CompletableFuture<Collection<BackupStatus>> list(final BackupIdentifierWildcard wildcard) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CompletableFuture<Void> delete(final BackupIdentifier id) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CompletableFuture<BackupStatusCode> markFailed(
+      final BackupIdentifier id, final String failureReason) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CompletableFuture<Void> closeAsync() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -18,6 +18,11 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 public final class GcsBackupStore implements BackupStore {
+  private final GcsBackupConfig config;
+
+  public GcsBackupStore(final GcsBackupConfig config) {
+    this.config = config;
+  }
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class ConfigTest {
+
+  @Test
+  void shouldRejectMissingBucketName() {
+    // given
+    final String bucketName = null;
+    // when
+    final var config = new GcsBackupConfig.Builder().withBucketName(bucketName);
+
+    // then
+    Assertions.assertThatThrownBy(config::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bucketName");
+  }
+
+  @Test
+  void shouldRejectEmptyBucketName() {
+    // given
+    final var bucketName = "";
+    // when
+    final var config = new GcsBackupConfig.Builder().withBucketName(bucketName);
+
+    // then
+    Assertions.assertThatThrownBy(config::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bucketName");
+  }
+
+  @Test
+  void shouldRemoveLeadingSlashesFromBasePath() {
+    // given
+    final var bucketName = "test";
+    final var basePath = "/tenant";
+    // when
+    final var config =
+        new GcsBackupConfig.Builder().withBucketName(bucketName).withBasePath(basePath).build();
+
+    // then
+    Assertions.assertThat(config.basePath()).isEqualTo("tenant");
+  }
+
+  @Test
+  void shouldRemoveTrailingSlashesFromBasePath() {
+    // given
+    final var bucketName = "test";
+    final var basePath = "/tenants/abc/";
+    // when
+    final var config =
+        new GcsBackupConfig.Builder().withBucketName(bucketName).withBasePath(basePath).build();
+
+    // then
+    Assertions.assertThat(config.basePath()).isEqualTo("tenants/abc");
+  }
+
+  @Test
+  void shouldRejectBasePathConsistingOfOnlySlashes() {
+    // given
+    final var bucketName = "test";
+    final var basePath = "//";
+    // when
+    final var config =
+        new GcsBackupConfig.Builder().withBucketName(bucketName).withBasePath(basePath);
+
+    // then
+    Assertions.assertThatThrownBy(config::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("basePath");
+  }
+}

--- a/backup-stores/gcs/src/test/resources/junit-platform.properties
+++ b/backup-stores/gcs/src/test/resources/junit-platform.properties
@@ -1,0 +1,10 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Zeebe Community License 1.1. You may not use this file
+# except in compliance with the Zeebe Community License 1.1.
+#
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=same_thread

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -128,6 +128,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-gcs</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-journal</artifactId>
     </dependency>
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
@@ -14,6 +14,7 @@ public class BackupStoreCfg implements ConfigurationEntry {
   private BackupStoreType store = BackupStoreType.NONE;
 
   private S3BackupStoreConfig s3 = new S3BackupStoreConfig();
+  private GCSBackupStoreConfig gcs = new GCSBackupStoreConfig();
 
   public S3BackupStoreConfig getS3() {
     return s3;
@@ -21,6 +22,14 @@ public class BackupStoreCfg implements ConfigurationEntry {
 
   public void setS3(final S3BackupStoreConfig s3) {
     this.s3 = s3;
+  }
+
+  public GCSBackupStoreConfig getGcs() {
+    return gcs;
+  }
+
+  public void setGcs(final GCSBackupStoreConfig gcs) {
+    this.gcs = gcs;
   }
 
   public BackupStoreType getStore() {
@@ -33,7 +42,11 @@ public class BackupStoreCfg implements ConfigurationEntry {
 
   @Override
   public String toString() {
-    return "BackupStoreCfg{" + "store=" + store + ", s3=" + s3 + '}';
+    return switch (store) {
+      case NONE -> "BackupStoreCfg{" + "store=" + store + '}';
+      case S3 -> "BackupStoreCfg{" + "store=" + store + ", s3=" + s3 + '}';
+      case GCS -> "BackupStoreCfg{" + "store=" + store + ", gcs=" + gcs + '}';
+    };
   }
 
   public enum BackupStoreType {
@@ -42,6 +55,12 @@ public class BackupStoreCfg implements ConfigurationEntry {
      * store
      */
     S3,
+
+    /**
+     * When type = GCS, {@link io.camunda.zeebe.backup.gcs.GcsBackupStore} will be used as the
+     * backup store
+     */
+    GCS,
 
     /** Set type = NONE when no backup store is available. No backup will be taken. */
     NONE

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GCSBackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GCSBackupStoreConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.backup;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import java.util.Objects;
+
+public class GCSBackupStoreConfig implements ConfigurationEntry {
+  private String bucketName;
+  private String basePath;
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  public void setBucketName(final String bucketName) {
+    this.bucketName = bucketName;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
+  public void setBasePath(final String basePath) {
+    this.basePath = basePath;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GCSBackupStoreConfig that = (GCSBackupStoreConfig) o;
+    return Objects.equals(bucketName, that.bucketName) && Objects.equals(basePath, that.basePath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bucketName, basePath);
+  }
+
+  @Override
+  public String toString() {
+    return "GCSBackupStoreConfig{"
+        + "bucketName='"
+        + bucketName
+        + '\''
+        + ", basePath='"
+        + basePath
+        + '\''
+        + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -9,9 +9,9 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
-import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
@@ -80,7 +80,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
     try {
       final var s3Config = backupCfg.getS3();
       final S3BackupConfig storeConfig =
-          new Builder()
+          new S3BackupConfig.Builder()
               .withBucketName(s3Config.getBucketName())
               .withEndpoint(s3Config.getEndpoint())
               .withRegion(s3Config.getRegion())
@@ -104,7 +104,12 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final ActorFuture<Void> installed) {
     try {
       final var gcsConfig = backupCfg.getGcs();
-      final var gcsStore = new GcsBackupStore();
+      final GcsBackupConfig storeConfig =
+          new GcsBackupConfig.Builder()
+              .withBucketName(gcsConfig.getBucketName())
+              .withBasePath(gcsConfig.getBasePath())
+              .build();
+      final var gcsStore = new GcsBackupStore(storeConfig);
       context.setBackupStore(gcsStore);
       installed.complete(null);
     } catch (final Exception error) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -9,11 +9,11 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -49,16 +49,16 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
 
     if (shouldInstallOnTransition(context.getCurrentRole(), targetRole)
         || (context.getBackupStore() == null && targetRole != Role.INACTIVE)) {
-
       final var backupCfg = context.getBrokerCfg().getData().getBackup();
-      if (backupCfg.getStore() == BackupStoreType.NONE) {
-        // No backup store is installed. BackupManager can handle this case
-        context.setBackupStore(null);
-        installed.complete(null);
-      } else if (backupCfg.getStore() == BackupStoreType.S3) {
-        installS3Store(context, backupCfg, installed);
-      } else {
-        installed.completeExceptionally(
+      switch (backupCfg.getStore()) {
+        case NONE -> {
+          // No backup store is installed. BackupManager can handle this case
+          context.setBackupStore(null);
+          installed.complete(null);
+        }
+        case S3 -> installS3Store(context, backupCfg, installed);
+        case GCS -> installGcsStore(context, backupCfg, installed);
+        default -> installed.completeExceptionally(
             new IllegalArgumentException(
                 "Unknown backup store type %s".formatted(backupCfg.getStore())));
       }
@@ -92,6 +92,20 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
               .build();
       final S3BackupStore backupStore = new S3BackupStore(storeConfig);
       context.setBackupStore(backupStore);
+      installed.complete(null);
+    } catch (final Exception error) {
+      installed.completeExceptionally("Failed to create backup store", error);
+    }
+  }
+
+  private static void installGcsStore(
+      final PartitionTransitionContext context,
+      final BackupStoreCfg backupCfg,
+      final ActorFuture<Void> installed) {
+    try {
+      final var gcsConfig = backupCfg.getGcs();
+      final var gcsStore = new GcsBackupStore();
+      context.setBackupStore(gcsStore);
       installed.complete(null);
     } catch (final Exception error) {
       installed.completeExceptionally("Failed to create backup store", error);

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -72,6 +72,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-gcs</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -275,9 +275,10 @@
       # backup:
         # Configure backup store. NOTE:- Use the same configuration on all brokers of this cluster.
 
-        # Set the backup store type. Supported values are [NONE, S3]. Default value is NONE
+        # Set the backup store type. Supported values are [NONE, S3, GCS]. Default value is NONE
         # When NONE, no backup store is configured and no backup will be taken.
         # Use S3 to use any S3 compatible storage (https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html).
+        # Use GCS to use Google Cloud Storage (https://cloud.google.com/storage/)
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_STORE
         # store: NONE
 
@@ -330,6 +331,19 @@
           # When set, all objects in the bucket will use this prefix. Must be non-empty and not start or end with '/'.
           # Useful for using the same bucket for multiple Zeebe clusters. In this case, basePath must be unique.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BASEPATH
+          # basePath:
+
+        # Configure the following if store is set to GCS
+        # gcs:
+          # Name of the bucket where the backup will be stored.
+          # The bucket must already exist.
+          # The bucket must not be shared with other Zeebe clusters unless basePath is also set.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BUCKETNAME
+          # bucketName:
+
+          # When set, all blobs in the bucket will use this prefix. Must be non-empty and not start or end with '/'.
+          # Useful for using the same bucket for multiple Zeebe clusters. In this case, basePath must be unique.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 
     # cluster:

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -341,8 +341,9 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BUCKETNAME
           # bucketName:
 
-          # When set, all blobs in the bucket will use this prefix. Must be non-empty and not start or end with '/'.
+          # When set, all blobs in the bucket will use this prefix.
           # Useful for using the same bucket for multiple Zeebe clusters. In this case, basePath must be unique.
+          # Should not start or end with '/' character. Must be non-empty and not consist of only '/' characters.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -207,9 +207,10 @@
       # backup:
         # Configure backup store. NOTE:- Use the same configuration on all brokers of this cluster.
 
-        # Set the backup store type. Supported values are [NONE, S3]. Default value is NONE
+        # Set the backup store type. Supported values are [NONE, S3, GCS]. Default value is NONE
         # When NONE, no backup store is configured and no backup will be taken.
         # Use S3 to use any S3 compatible storage (https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html).
+        # Use GCS to use Google Cloud Storage (https://cloud.google.com/storage/)
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_STORE
         # store: NONE
 
@@ -260,8 +261,21 @@
           # compression: none
 
           # When set, all objects in the bucket will use this prefix. Must be non-empty and not start or end with '/'.
-          # Useful for using the same bucket for multiple Zeebe clusters.
+          # Useful for using the same bucket for multiple Zeebe clusters. In this case, basePath must be unique.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BASEPATH
+          # basePath:
+
+        # Configure the following if store is set to GCS
+        # gcs:
+          # Name of the bucket where the backup will be stored.
+          # The bucket must already exist.
+          # The bucket must not be shared with other Zeebe clusters unless basePath is also set.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BUCKETNAME
+          # bucketName:
+
+          # When set, all blobs in the bucket will use this prefix. Must be non-empty and not start or end with '/'.
+          # Useful for using the same bucket for multiple Zeebe clusters. In this case, basePath must be unique.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 
     # cluster:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -273,8 +273,9 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BUCKETNAME
           # bucketName:
 
-          # When set, all blobs in the bucket will use this prefix. Must be non-empty and not start or end with '/'.
+          # When set, all blobs in the bucket will use this prefix.
           # Useful for using the same bucket for multiple Zeebe clusters. In this case, basePath must be unique.
+          # Should not start or end with '/' character. Must be non-empty and not consist of only '/' characters.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -8,12 +8,12 @@
 package io.camunda.zeebe.restore;
 
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -35,28 +35,31 @@ final class BackupStoreComponent {
 
   private BackupStore buildBackupStore(final BackupStoreCfg backupCfg) {
     final var store = backupCfg.getStore();
-    if (store == BackupStoreType.NONE) {
-      throw new IllegalArgumentException("No backup store configured, cannot restore from backup.");
-    }
+    return switch (store) {
+      case S3 -> buildS3BackupStore(backupCfg);
+      case GCS -> new GcsBackupStore();
+      case NONE -> throw new IllegalArgumentException(
+          "No backup store configured, cannot restore from backup.");
+    };
+  }
 
-    if (store == BackupStoreType.S3) {
-      final var s3Config = backupCfg.getS3();
-      final S3BackupConfig storeConfig =
-          new Builder()
-              .withBucketName(s3Config.getBucketName())
-              .withEndpoint(s3Config.getEndpoint())
-              .withRegion(s3Config.getRegion())
-              .withCredentials(s3Config.getAccessKey(), s3Config.getSecretKey())
-              .withApiCallTimeout(s3Config.getApiCallTimeout())
-              .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
-              .withCompressionAlgorithm(s3Config.getCompression())
-              .withBasePath(s3Config.getBasePath())
-              .build();
-      return new S3BackupStore(storeConfig);
-    } else {
-      throw new IllegalArgumentException(
-          "The configured backup store type (%s) is unsupported. Cannot restore from backup"
-              .formatted(store));
-    }
+  private static S3BackupStore buildS3BackupStore(final BackupStoreCfg backupStoreCfg) {
+    final var s3Config = backupStoreCfg.getS3();
+    final S3BackupConfig storeConfig =
+        new Builder()
+            .withBucketName(s3Config.getBucketName())
+            .withEndpoint(s3Config.getEndpoint())
+            .withRegion(s3Config.getRegion())
+            .withCredentials(s3Config.getAccessKey(), s3Config.getSecretKey())
+            .withApiCallTimeout(s3Config.getApiCallTimeout())
+            .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
+            .withCompressionAlgorithm(s3Config.getCompression())
+            .withBasePath(s3Config.getBasePath())
+            .build();
+    return new S3BackupStore(storeConfig);
+  }
+
+  private static GcsBackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
+    return new GcsBackupStore();
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -8,9 +8,9 @@
 package io.camunda.zeebe.restore;
 
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
-import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
@@ -37,7 +37,7 @@ final class BackupStoreComponent {
     final var store = backupCfg.getStore();
     return switch (store) {
       case S3 -> buildS3BackupStore(backupCfg);
-      case GCS -> new GcsBackupStore();
+      case GCS -> buildGcsBackupStore(backupCfg);
       case NONE -> throw new IllegalArgumentException(
           "No backup store configured, cannot restore from backup.");
     };
@@ -46,7 +46,7 @@ final class BackupStoreComponent {
   private static S3BackupStore buildS3BackupStore(final BackupStoreCfg backupStoreCfg) {
     final var s3Config = backupStoreCfg.getS3();
     final S3BackupConfig storeConfig =
-        new Builder()
+        new S3BackupConfig.Builder()
             .withBucketName(s3Config.getBucketName())
             .withEndpoint(s3Config.getEndpoint())
             .withRegion(s3Config.getRegion())
@@ -60,6 +60,12 @@ final class BackupStoreComponent {
   }
 
   private static GcsBackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
-    return new GcsBackupStore();
+    final var gcsConfig = backupStoreCfg.getGcs();
+    final GcsBackupConfig storeConfig =
+        new GcsBackupConfig.Builder()
+            .withBucketName(gcsConfig.getBucketName())
+            .withBasePath(gcsConfig.getBasePath())
+            .build();
+    return new GcsBackupStore(storeConfig);
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -372,6 +372,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>zeebe-backup-store-gcs</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>zeebe-backup-testkit</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <module>backup</module>
     <module>backup-stores/testkit</module>
     <module>backup-stores/s3</module>
+    <module>backup-stores/gcs</module>
     <module>restore</module>
   </modules>
 


### PR DESCRIPTION
Adds initial configuration for the GCS backup store:

```yaml
zeebe.broker.data.backup:
  store: gcs
  gcs:
    bucketName:
    basePath:
```

Broker and Restore app use the GCS store when `zeebe.broker.data.backup.store: gcs`.
Initial implementation of GCS store is empty, all methods throw `UnsupportedOperationException`.

closes #11924 

