### PR TITLE
Simplify ClusterCommunicationService interface

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
@@ -202,11 +202,10 @@ public interface ClusterCommunicationService {
    * @param executor executor to run this handler on
    * @param <M> incoming message type
    * @param <R> reply message type
-   * @return future to be completed once the subscription has been propagated
    */
-  default <M, R> CompletableFuture<Void> subscribe(
+  default <M, R> void subscribe(
       final String subject, final Function<M, R> handler, final Executor executor) {
-    return subscribe(subject, BASIC::decode, handler, BASIC::encode, executor);
+    subscribe(subject, BASIC::decode, handler, BASIC::encode, executor);
   }
 
   /**
@@ -219,9 +218,8 @@ public interface ClusterCommunicationService {
    * @param executor executor to run this handler on
    * @param <M> incoming message type
    * @param <R> reply message type
-   * @return future to be completed once the subscription has been propagated
    */
-  <M, R> CompletableFuture<Void> subscribe(
+  <M, R> void subscribe(
       String subject,
       Function<byte[], M> decoder,
       Function<M, R> handler,
@@ -235,11 +233,10 @@ public interface ClusterCommunicationService {
    * @param handler handler function that processes the incoming message and produces a reply
    * @param <M> incoming message type
    * @param <R> reply message type
-   * @return future to be completed once the subscription has been propagated
    */
-  default <M, R> CompletableFuture<Void> subscribe(
+  default <M, R> void subscribe(
       final String subject, final Function<M, CompletableFuture<R>> handler) {
-    return subscribe(subject, BASIC::decode, handler, BASIC::encode);
+    subscribe(subject, BASIC::decode, handler, BASIC::encode);
   }
 
   /**
@@ -251,9 +248,8 @@ public interface ClusterCommunicationService {
    * @param encoder encoder for serializing reply
    * @param <M> incoming message type
    * @param <R> reply message type
-   * @return future to be completed once the subscription has been propagated
    */
-  <M, R> CompletableFuture<Void> subscribe(
+  <M, R> void subscribe(
       String subject,
       Function<byte[], M> decoder,
       Function<M, CompletableFuture<R>> handler,
@@ -266,11 +262,10 @@ public interface ClusterCommunicationService {
    * @param handler handler for handling message
    * @param executor executor to run this handler on
    * @param <M> incoming message type
-   * @return future to be completed once the subscription has been propagated
    */
-  default <M> CompletableFuture<Void> subscribe(
+  default <M> void subscribe(
       final String subject, final Consumer<M> handler, final Executor executor) {
-    return subscribe(subject, BASIC::decode, handler, executor);
+    subscribe(subject, BASIC::decode, handler, executor);
   }
 
   /**
@@ -280,11 +275,10 @@ public interface ClusterCommunicationService {
    * @param handler handler for handling message
    * @param executor executor to run this handler on
    * @param <M> incoming message type
-   * @return future to be completed once the subscription has been propagated
    */
-  default <M> CompletableFuture<Void> subscribe(
+  default <M> void subscribe(
       final String subject, final BiConsumer<MemberId, M> handler, final Executor executor) {
-    return subscribe(subject, BASIC::decode, handler, executor);
+    subscribe(subject, BASIC::decode, handler, executor);
   }
 
   /**
@@ -295,9 +289,8 @@ public interface ClusterCommunicationService {
    * @param handler handler for handling message
    * @param executor executor to run this handler on
    * @param <M> incoming message type
-   * @return future to be completed once the subscription has been propagated
    */
-  <M> CompletableFuture<Void> subscribe(
+  <M> void subscribe(
       String subject, Function<byte[], M> decoder, Consumer<M> handler, Executor executor);
 
   /**
@@ -308,9 +301,8 @@ public interface ClusterCommunicationService {
    * @param handler handler for handling message
    * @param executor executor to run this handler on
    * @param <M> incoming message type
-   * @return future to be completed once the subscription has been propagated
    */
-  <M> CompletableFuture<Void> subscribe(
+  <M> void subscribe(
       String subject,
       Function<byte[], M> decoder,
       BiConsumer<MemberId, M> handler,

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterCommunicationService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterCommunicationService.java
@@ -118,7 +118,7 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
   }
 
   @Override
-  public <M, R> CompletableFuture<Void> subscribe(
+  public <M, R> void subscribe(
       final String subject,
       final Function<byte[], M> decoder,
       final Function<M, R> handler,
@@ -141,22 +141,20 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
                   });
               return responseFuture;
             }));
-    return CompletableFuture.completedFuture(null);
   }
 
   @Override
-  public <M, R> CompletableFuture<Void> subscribe(
+  public <M, R> void subscribe(
       final String subject,
       final Function<byte[], M> decoder,
       final Function<M, CompletableFuture<R>> handler,
       final Function<R, byte[]> encoder) {
     messagingService.registerHandler(
         subject, new InternalMessageResponder<>(decoder, encoder, handler));
-    return CompletableFuture.completedFuture(null);
   }
 
   @Override
-  public <M> CompletableFuture<Void> subscribe(
+  public <M> void subscribe(
       final String subject,
       final Function<byte[], M> decoder,
       final Consumer<M> handler,
@@ -167,11 +165,10 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
         new InternalMessageConsumer<>(decoder, handler);
     unicastConsumers.put(subject, unicastConsumer);
     unicastService.addListener(subject, unicastConsumer, executor);
-    return CompletableFuture.completedFuture(null);
   }
 
   @Override
-  public <M> CompletableFuture<Void> subscribe(
+  public <M> void subscribe(
       final String subject,
       final Function<byte[], M> decoder,
       final BiConsumer<MemberId, M> handler,
@@ -182,7 +179,6 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
         new InternalMessageBiConsumer<>(decoder, handler);
     unicastConsumers.put(subject, unicastConsumer);
     unicastService.addListener(subject, unicastConsumer, executor);
-    return CompletableFuture.completedFuture(null);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.scheduler.Actor;
 import java.util.Map;
+import java.util.function.Function;
 import org.slf4j.Logger;
 
 /**
@@ -58,7 +59,8 @@ public final class InterPartitionCommandReceiverActor extends Actor
 
   @Override
   protected void onActorStarting() {
-    communicationService.subscribe(TOPIC_PREFIX + partitionId, this::tryHandleMessage, actor::run);
+    communicationService.subscribe(
+        TOPIC_PREFIX + partitionId, Function.identity(), this::tryHandleMessage, actor::run);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Objects;
+import java.util.function.Function;
 import org.agrona.collections.Int2IntHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
@@ -74,7 +75,11 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
         Encoder.encode(checkpointId, receiverPartitionId, valueType, intent, recordKey, command);
 
     communicationService.unicast(
-        TOPIC_PREFIX + receiverPartitionId, message, MemberId.from("" + partitionLeader));
+        TOPIC_PREFIX + receiverPartitionId,
+        message,
+        Function.identity(),
+        MemberId.from("" + partitionLeader),
+        true);
   }
 
   void setCheckpointId(final long checkpointId) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -187,7 +188,13 @@ final class InterPartitionCommandCheckpointTest {
     sender.sendCommand(1, valueType, intent, new JobRecord());
 
     final var messageCaptor = ArgumentCaptor.forClass(byte[].class);
-    verify(communicationService).unicast(eq(TOPIC_PREFIX + 1), messageCaptor.capture(), any());
+    verify(communicationService)
+        .unicast(
+            eq(TOPIC_PREFIX + 1),
+            messageCaptor.capture(),
+            eq(Function.identity()),
+            any(),
+            eq(true));
     receiver.handleMessage(new MemberId("0"), messageCaptor.getValue());
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import java.util.function.Function;
 import org.agrona.ExpandableArrayBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -242,7 +243,12 @@ final class InterPartitionCommandReceiverTest {
 
     final var messageCaptor = ArgumentCaptor.forClass(byte[].class);
     verify(communicationService)
-        .unicast(eq(TOPIC_PREFIX + receiverPartitionId), messageCaptor.capture(), any());
+        .unicast(
+            eq(TOPIC_PREFIX + receiverPartitionId),
+            messageCaptor.capture(),
+            eq(Function.identity()),
+            any(),
+            eq(true));
 
     return messageCaptor.getValue();
   }


### PR DESCRIPTION
## Description

This PRs removes unused and/or seldom used variants of the methods in the `ClusterCommunicationService` interface. The seldom used ones also remove unnecessary usage of Kryo in some places where all we do is a copy of a byte array to another byte array.

The motivation for this was:

1. Removing Kryo usage where we don't need it
2. Remove having to figure out which variant you want to use in auto-complete and what each mean
3. Remove dead code
4. Reduce API surface so one day we can maybe actually support a test implementation (not yet easily done, since there's still 12 methods to implement...)

It's still too big to my liking (see point 4), but I guess every little bit counts.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
