### PR TITLE
Add StreamRegistry on broker side to keep track of open streams

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/ImmutableStreamRegistry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/ImmutableStreamRegistry.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.atomix.cluster.MemberId;
+import java.util.Set;
+import java.util.UUID;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public interface ImmutableStreamRegistry<M> {
+
+  /**
+   * Returns a set of streams for the given type.
+   *
+   * <p>Implementations of this must be thread-safe.
+   *
+   * @param streamType type of the stream
+   * @return set of streams for the given type
+   */
+  Set<StreamConsumer<M>> get(final UnsafeBuffer streamType);
+
+  /**
+   * A stream consumer uniquely identified by the id, with its properties and streamType.
+   *
+   * @param id unique id
+   * @param properties properties of the stream
+   * @param streamType type of the stream
+   * @param <M> type of the properties
+   */
+  record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
+
+  /**
+   * Uniquely identifies a stream
+   *
+   * @param streamId
+   * @param receiver
+   */
+  record StreamId(UUID streamId, MemberId receiver) {}
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
@@ -26,7 +26,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  *
  * @param <M> the type of the properties of the stream.
  */
-public class StreamRegistry<M> {
+public class StreamRegistry<M> implements ImmutableStreamRegistry<M> {
   // Needs to be thread-safe for readers
   private final Map<UnsafeBuffer, Set<StreamConsumer<M>>> typeToConsumers =
       new ConcurrentHashMap<>();
@@ -93,12 +93,7 @@ public class StreamRegistry<M> {
     streamOfReceiver.forEach(stream -> remove(stream.streamId(), stream.receiver()));
   }
 
-  /**
-   * Thread-safe with concurrent add/remove
-   *
-   * @param streamType type of the stream
-   * @return set of streams for the given type
-   */
+  @Override
   public Set<StreamConsumer<M>> get(final UnsafeBuffer streamType) {
     // TODO: we may have to return an immutable collection here.
     return typeToConsumers.get(streamType);
@@ -108,22 +103,4 @@ public class StreamRegistry<M> {
     typeToConsumers.clear();
     idToConsumer.clear();
   }
-
-  /**
-   * A stream consumer uniquely identified by the id, with its properties and streamType.
-   *
-   * @param id unique id
-   * @param properties properties of the stream
-   * @param streamType type of the stream
-   * @param <M> type of the properties
-   */
-  public record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
-
-  /**
-   * Uniquely identifies a stream
-   *
-   * @param streamId
-   * @param receiver
-   */
-  public record StreamId(UUID streamId, MemberId receiver) {}
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -28,7 +29,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  */
 public class StreamRegistry<M> implements ImmutableStreamRegistry<M> {
   // Needs to be thread-safe for readers
-  private final Map<UnsafeBuffer, Set<StreamConsumer<M>>> typeToConsumers =
+  private final ConcurrentMap<UnsafeBuffer, Set<StreamConsumer<M>>> typeToConsumers =
       new ConcurrentHashMap<>();
   private final Map<StreamId, StreamConsumer<M>> idToConsumer = new HashMap<>();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
@@ -28,8 +28,8 @@ import org.agrona.concurrent.UnsafeBuffer;
  */
 public class StreamRegistry<M> {
   // Needs to be thread-safe for readers
-  Map<UnsafeBuffer, Set<StreamConsumer<M>>> typeToConsumers = new ConcurrentHashMap<>();
-  Map<StreamId, StreamConsumer<M>> idToConsumer = new HashMap<>();
+  private final Map<UnsafeBuffer, Set<StreamConsumer<M>>> typeToConsumers = new ConcurrentHashMap<>();
+  private final Map<StreamId, StreamConsumer<M>> idToConsumer = new HashMap<>();
 
   /**
    * Adds a stream receiver that can receive data from the stream with the given streamType.

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
@@ -28,7 +28,8 @@ import org.agrona.concurrent.UnsafeBuffer;
  */
 public class StreamRegistry<M> {
   // Needs to be thread-safe for readers
-  private final Map<UnsafeBuffer, Set<StreamConsumer<M>>> typeToConsumers = new ConcurrentHashMap<>();
+  private final Map<UnsafeBuffer, Set<StreamConsumer<M>>> typeToConsumers =
+      new ConcurrentHashMap<>();
   private final Map<StreamId, StreamConsumer<M>> idToConsumer = new HashMap<>();
 
   /**
@@ -109,14 +110,6 @@ public class StreamRegistry<M> {
   }
 
   /**
-   * Uniquely identifies a stream
-   *
-   * @param streamId
-   * @param receiver
-   */
-  record StreamId(UUID streamId, MemberId receiver) {}
-
-  /**
    * A stream consumer uniquely identified by the id, with its properties and streamType.
    *
    * @param id unique id
@@ -124,5 +117,13 @@ public class StreamRegistry<M> {
    * @param streamType type of the stream
    * @param <M> type of the properties
    */
-  record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
+  public record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
+
+  /**
+   * Uniquely identifies a stream
+   *
+   * @param streamId
+   * @param receiver
+   */
+  public record StreamId(UUID streamId, MemberId receiver) {}
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.atomix.cluster.MemberId;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * A registry for remote streams. The streams are typically between broker and the gateway, where
+ * the broker pushes data to the stream and the gateway consumes them.
+ *
+ * <p>A stream is uniquely identified by the streamId and the receiver. A stream has also an
+ * associated type and properties. Two streams with the same type and properties can consume the
+ * same data.
+ *
+ * @param <M> the type of the properties of the stream.
+ */
+public class StreamRegistry<M> {
+
+  /**
+   * Adds a stream receiver that can receive data from the stream with the given streamType.
+   *
+   * @param streamType type of the stream
+   * @param streamId id of the stream. The pair (receiver, streamId) must uniquely identify the
+   *     stream.
+   * @param receiver The id of the node that receives data from the stream
+   * @param properties properties used by the producer to generate data to be pushed to the stream
+   */
+  public void add(
+      final UnsafeBuffer streamType,
+      final long streamId,
+      final MemberId receiver,
+      final M properties) {}
+
+  /**
+   * Removes the stream.
+   *
+   * @param streamId id of the stream
+   * @param receiver The id of the node that receives data from the stream
+   */
+  public void remove(final long streamId, final MemberId receiver) {}
+
+  /**
+   * Removes all stream from the given receiver
+   *
+   * @param receiver id of the node
+   */
+  public void removeAll(final MemberId receiver) {}
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamRegistryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamRegistryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.jobstream.StreamRegistry.StreamConsumer;
+import io.camunda.zeebe.broker.jobstream.StreamRegistry.StreamId;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.UUID;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+class StreamRegistryTest {
+
+  final StreamRegistry<Integer> streamRegistry = new StreamRegistry<>();
+  final MemberId gateway = MemberId.from("gateway");
+  final MemberId otherGateway = MemberId.from("gateway-other");
+  final UnsafeBuffer typeBar = new UnsafeBuffer(BufferUtil.wrapString("bar"));
+  private final UnsafeBuffer typeFoo = new UnsafeBuffer(BufferUtil.wrapString("foo"));
+
+  @Test
+  void shouldAddMultipleStreams() {
+    // given
+    final UUID id1 = UUID.randomUUID();
+    final UUID id2 = UUID.randomUUID();
+
+    // when
+    streamRegistry.add(typeFoo, id1, gateway, 1);
+    streamRegistry.add(typeFoo, id2, gateway, 2);
+
+    // then
+    assertThat(streamRegistry.get(typeFoo))
+        .containsExactlyInAnyOrder(
+            new StreamConsumer<>(new StreamId(id1, gateway), 1, typeFoo),
+            new StreamConsumer<>(new StreamId(id2, gateway), 2, typeFoo));
+  }
+
+  @Test
+  void shouldRemoveStream() {
+    // given
+    final UUID id = UUID.randomUUID();
+    streamRegistry.add(typeFoo, id, gateway, 1);
+    streamRegistry.add(typeFoo, id, otherGateway, 1);
+
+    // when
+    streamRegistry.remove(id, gateway);
+
+    // then
+    assertThat(streamRegistry.get(typeFoo))
+        .containsExactly(new StreamConsumer<>(new StreamId(id, otherGateway), 1, typeFoo));
+  }
+
+  @Test
+  void shouldAddStreamAfterRemoved() {
+    // given
+    final UUID id = UUID.randomUUID();
+    streamRegistry.add(typeFoo, id, gateway, 1);
+    streamRegistry.remove(id, gateway);
+
+    // when
+    streamRegistry.add(typeFoo, id, gateway, 1);
+
+    // then
+    assertThat(streamRegistry.get(typeFoo))
+        .contains(new StreamConsumer<>(new StreamId(id, gateway), 1, typeFoo));
+  }
+
+  @Test
+  void shouldRemoveAllStreamsFromAReceiver() {
+    // given
+    streamRegistry.add(typeFoo, UUID.randomUUID(), gateway, 1);
+    streamRegistry.add(typeBar, UUID.randomUUID(), gateway, 2);
+    final UUID idOther = UUID.randomUUID();
+    streamRegistry.add(typeBar, idOther, otherGateway, 3);
+
+    // when
+    streamRegistry.removeAll(gateway);
+
+    // then
+    assertThat(streamRegistry.get(typeFoo)).isNull();
+    assertThat(streamRegistry.get(typeBar))
+        .contains(new StreamConsumer<>(new StreamId(idOther, otherGateway), 3, typeBar));
+  }
+
+  @Test
+  void shouldClearAll() {
+    // given
+    streamRegistry.add(typeFoo, UUID.randomUUID(), gateway, 1);
+    streamRegistry.add(typeBar, UUID.randomUUID(), gateway, 2);
+    streamRegistry.add(typeBar, UUID.randomUUID(), otherGateway, 3);
+
+    // when
+    streamRegistry.clear();
+
+    // then
+    assertThat(streamRegistry.get(typeFoo)).isNull();
+    assertThat(streamRegistry.get(typeBar)).isNull();
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamRegistryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamRegistryTest.java
@@ -17,12 +17,12 @@ import java.util.UUID;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
-class StreamRegistryTest {
+final class StreamRegistryTest {
 
-  final StreamRegistry<Integer> streamRegistry = new StreamRegistry<>();
-  final MemberId gateway = MemberId.from("gateway");
-  final MemberId otherGateway = MemberId.from("gateway-other");
-  final UnsafeBuffer typeBar = new UnsafeBuffer(BufferUtil.wrapString("bar"));
+  private final StreamRegistry<Integer> streamRegistry = new StreamRegistry<>();
+  private final MemberId gateway = MemberId.from("gateway");
+  private final MemberId otherGateway = MemberId.from("gateway-other");
+  private final UnsafeBuffer typeBar = new UnsafeBuffer(BufferUtil.wrapString("bar"));
   private final UnsafeBuffer typeFoo = new UnsafeBuffer(BufferUtil.wrapString("foo"));
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamRegistryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamRegistryTest.java
@@ -10,8 +10,8 @@ package io.camunda.zeebe.broker.jobstream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.broker.jobstream.StreamRegistry.StreamConsumer;
-import io.camunda.zeebe.broker.jobstream.StreamRegistry.StreamId;
+import io.camunda.zeebe.broker.jobstream.ImmutableStreamRegistry.StreamConsumer;
+import io.camunda.zeebe.broker.jobstream.ImmutableStreamRegistry.StreamId;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.UUID;
 import org.agrona.concurrent.UnsafeBuffer;


### PR DESCRIPTION
## Description

Adds a StreamRegistry to keep track of open streams between gateway and broker.  This is in preparation for #11707.

## Related issues

Related #11707 
