### PR TITLE
fix: prevent access of closed rocksdb instances from async scheduled tasks

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -242,11 +242,9 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   @Override
   public ActorFuture<Void> closeAsync() {
-    if (!isOpened.get()) {
-      return closeFuture;
+    if (isOpened.getAndSet(false)) {
+      actor.run(() -> asyncActor.closeAsync().onComplete((v, t) -> actor.close()));
     }
-
-    actor.run(() -> asyncActor.closeAsync().onComplete((v, t) -> actor.close()));
 
     return closeFuture;
   }


### PR DESCRIPTION
The `asyncActor` used for executing scheduled tasks must be closed synchronously when stopping the stream processor to prevent scheduled tasks from accessing resources, especially the `ZeebeDb`, that will be closed after the stream processor is stopped.

fixes #11908 
related to #11788