### PR TITLE
[stable/8.1] Enable message time-to-live checker configuration

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.zeebe.broker.exporter.debug.DebugLogExporter;
 import io.camunda.zeebe.broker.exporter.metrics.MetricsExporter;
 import io.camunda.zeebe.broker.system.configuration.backpressure.BackpressureCfg;
-import io.camunda.zeebe.broker.system.configuration.engine.EngineCfg;
 import io.camunda.zeebe.util.Environment;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
 import java.util.HashMap;
@@ -31,7 +30,6 @@ public final class BrokerCfg {
   private EmbeddedGatewayCfg gateway = new EmbeddedGatewayCfg();
   private BackpressureCfg backpressure = new BackpressureCfg();
   private ProcessingCfg processingCfg = new ProcessingCfg();
-  private EngineCfg engine = new EngineCfg();
 
   private ExperimentalCfg experimental = new ExperimentalCfg();
 
@@ -56,7 +54,6 @@ public final class BrokerCfg {
     gateway.init(this, brokerBase);
     backpressure.init(this, brokerBase);
     processingCfg.init(this, brokerBase);
-    engine.init(this, brokerBase);
     experimental.init(this, brokerBase);
   }
 
@@ -140,14 +137,6 @@ public final class BrokerCfg {
     processingCfg = cfg;
   }
 
-  public EngineCfg getEngine() {
-    return engine;
-  }
-
-  public void setEngine(final EngineCfg engine) {
-    this.engine = engine;
-  }
-
   public ExperimentalCfg getExperimental() {
     return experimental;
   }
@@ -175,8 +164,6 @@ public final class BrokerCfg {
         + backpressure
         + ", processingCfg="
         + processingCfg
-        + ", engineCfg="
-        + engine
         + ", experimental="
         + experimental
         + ", executionMetricsExporterEnabled="

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.zeebe.broker.exporter.debug.DebugLogExporter;
 import io.camunda.zeebe.broker.exporter.metrics.MetricsExporter;
 import io.camunda.zeebe.broker.system.configuration.backpressure.BackpressureCfg;
+import io.camunda.zeebe.broker.system.configuration.engine.EngineCfg;
 import io.camunda.zeebe.util.Environment;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ public final class BrokerCfg {
   private EmbeddedGatewayCfg gateway = new EmbeddedGatewayCfg();
   private BackpressureCfg backpressure = new BackpressureCfg();
   private ProcessingCfg processingCfg = new ProcessingCfg();
+  private EngineCfg engine = new EngineCfg();
 
   private ExperimentalCfg experimental = new ExperimentalCfg();
 
@@ -54,6 +56,7 @@ public final class BrokerCfg {
     gateway.init(this, brokerBase);
     backpressure.init(this, brokerBase);
     processingCfg.init(this, brokerBase);
+    engine.init(this, brokerBase);
     experimental.init(this, brokerBase);
   }
 
@@ -134,7 +137,15 @@ public final class BrokerCfg {
   }
 
   public void setProcessingCfg(final ProcessingCfg cfg) {
-    this.processingCfg = cfg;
+    processingCfg = cfg;
+  }
+
+  public EngineCfg getEngine() {
+    return engine;
+  }
+
+  public void setEngine(final EngineCfg engine) {
+    this.engine = engine;
   }
 
   public ExperimentalCfg getExperimental() {
@@ -164,6 +175,8 @@ public final class BrokerCfg {
         + backpressure
         + ", processingCfg="
         + processingCfg
+        + ", engineCfg="
+        + engine
         + ", experimental="
         + experimental
         + ", executionMetricsExporterEnabled="

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
+import io.camunda.zeebe.broker.system.configuration.engine.EngineCfg;
 import java.util.Optional;
 import org.springframework.util.unit.DataSize;
 
@@ -29,6 +30,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private PartitioningCfg partitioning = new PartitioningCfg();
   private QueryApiCfg queryApi = new QueryApiCfg();
   private ConsistencyCheckCfg consistencyChecks = new ConsistencyCheckCfg();
+  private EngineCfg engine = new EngineCfg();
 
   private FeatureFlagsCfg features = new FeatureFlagsCfg();
 
@@ -36,6 +38,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     rocksdb.init(globalConfig, brokerBase);
     raft.init(globalConfig, brokerBase);
+    engine.init(globalConfig, brokerBase);
   }
 
   public int getMaxAppendsPerFollower() {
@@ -106,6 +109,14 @@ public class ExperimentalCfg implements ConfigurationEntry {
     this.consistencyChecks = consistencyChecks;
   }
 
+  public EngineCfg getEngine() {
+    return engine;
+  }
+
+  public void setEngine(final EngineCfg engine) {
+    this.engine = engine;
+  }
+
   public FeatureFlagsCfg getFeatures() {
     return features;
   }
@@ -131,6 +142,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
         + queryApi
         + ", consistencyChecks="
         + consistencyChecks
+        + ", engineCfg="
+        + engine
         + ", features="
         + features
         + '}';

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -33,6 +33,7 @@ public final class FeatureFlagsCfg {
   private boolean enableYieldingDueDateChecker = DEFAULT_SETTINGS.yieldingDueDateChecker();
   private boolean enableActorMetrics = DEFAULT_SETTINGS.enableActorMetrics();
   private boolean enableBackup = DEFAULT_SETTINGS.enableBackup();
+  private boolean enableMessageTtlCheckerAsync = DEFAULT_SETTINGS.enableMessageTTLCheckerAsync();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -58,9 +59,18 @@ public final class FeatureFlagsCfg {
     this.enableBackup = enableBackup;
   }
 
+  public boolean isEnableMessageTtlCheckerAsync() {
+    return enableMessageTtlCheckerAsync;
+  }
+
+  public void setEnableMessageTtlCheckerAsync(final boolean enableMessageTtlCheckerAsync) {
+    this.enableMessageTtlCheckerAsync = enableMessageTtlCheckerAsync;
+  }
+
   public FeatureFlags toFeatureFlags() {
     return new FeatureFlags(
-        enableYieldingDueDateChecker, enableActorMetrics, enableBackup /*, enableFoo*/);
+        enableYieldingDueDateChecker, enableActorMetrics, enableBackup, enableMessageTtlCheckerAsync
+        /*, enableFoo*/ );
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+
+public final class EngineCfg implements ConfigurationEntry {
+
+  @Override
+  public String toString() {
+    return "EngineCfg{}";
+  }
+
+  public EngineConfiguration createEngineConfiguration() {
+    return new EngineConfiguration();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -7,17 +7,35 @@
  */
 package io.camunda.zeebe.broker.system.configuration.engine;
 
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import io.camunda.zeebe.engine.EngineConfiguration;
 
 public final class EngineCfg implements ConfigurationEntry {
 
+  private MessagesCfg messages = new MessagesCfg();
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    messages.init(globalConfig, brokerBase);
+  }
+
+  public MessagesCfg getMessages() {
+    return messages;
+  }
+
+  public void setMessages(final MessagesCfg messages) {
+    this.messages = messages;
+  }
+
   @Override
   public String toString() {
-    return "EngineCfg{}";
+    return "EngineCfg{" + "messages=" + messages + '}';
   }
 
   public EngineConfiguration createEngineConfiguration() {
-    return new EngineConfiguration();
+    return new EngineConfiguration()
+        .setMessagesTtlCheckerBatchLimit(messages.getTtlCheckerBatchLimit())
+        .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval());
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/MessagesCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/MessagesCfg.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import java.time.Duration;
+
+public final class MessagesCfg implements ConfigurationEntry {
+
+  private int ttlCheckerBatchLimit = EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
+  private Duration ttlCheckerInterval = EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
+
+  public int getTtlCheckerBatchLimit() {
+    return ttlCheckerBatchLimit;
+  }
+
+  public void setTtlCheckerBatchLimit(final int ttlCheckerBatchLimit) {
+    this.ttlCheckerBatchLimit = ttlCheckerBatchLimit;
+  }
+
+  public Duration getTtlCheckerInterval() {
+    return ttlCheckerInterval;
+  }
+
+  public void setTtlCheckerInterval(final Duration ttlCheckerInterval) {
+    this.ttlCheckerInterval = ttlCheckerInterval;
+  }
+
+  @Override
+  public String toString() {
+    return "MessagesCfg{"
+        + "ttlCheckerBatchLimit="
+        + ttlCheckerBatchLimit
+        + ", ttlCheckerInterval="
+        + ttlCheckerInterval
+        + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -132,8 +132,9 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
 
     final var isBackupFeatureEnabled =
         context.getBrokerCfg().getExperimental().getFeatures().isEnableBackup();
+    final var engineCfg = context.getBrokerCfg().getEngine().createEngineConfiguration();
 
-    final Engine engine = new Engine(context.getTypedRecordProcessorFactory());
+    final var engine = new Engine(context.getTypedRecordProcessorFactory(), engineCfg);
     final List<RecordProcessor> recordProcessors =
         isBackupFeatureEnabled
             ? List.of(engine, context.getCheckpointProcessor())

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -130,9 +130,9 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
     final StreamProcessorMode streamProcessorMode =
         targetRole == Role.LEADER ? StreamProcessorMode.PROCESSING : StreamProcessorMode.REPLAY;
 
-    final var isBackupFeatureEnabled =
-        context.getBrokerCfg().getExperimental().getFeatures().isEnableBackup();
-    final var engineCfg = context.getBrokerCfg().getEngine().createEngineConfiguration();
+    final var experimentalCfg = context.getBrokerCfg().getExperimental();
+    final var isBackupFeatureEnabled = experimentalCfg.getFeatures().isEnableBackup();
+    final var engineCfg = experimentalCfg.getEngine().createEngineConfiguration();
 
     final var engine = new Engine(context.getTypedRecordProcessorFactory(), engineCfg);
     final List<RecordProcessor> recordProcessors =

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class EngineCfgTest {
+
+  public final Map<String, String> environment = new HashMap<>();
+
+  @Test
+  void shouldCreateEngineConfigurationFromDefaults() {
+    // given
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+
+    // when
+    final var configuration = cfg.getEngine().createEngineConfiguration();
+
+    // then
+    assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(10);
+    assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofMinutes(1));
+  }
+
+  @Test
+  void shouldCreateEngineConfigurationFromConfig() {
+    // given
+    final BrokerCfg cfg = TestConfigReader.readConfig("engine", environment);
+
+    // when
+    final var configuration = cfg.getEngine().createEngineConfiguration();
+
+    // then
+    assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(1000);
+    assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofSeconds(15));
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -27,7 +27,7 @@ final class EngineCfgTest {
     final var configuration = cfg.getExperimental().getEngine().createEngineConfiguration();
 
     // then
-    assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(10);
+    assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofMinutes(1));
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -24,7 +24,7 @@ final class EngineCfgTest {
     final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
 
     // when
-    final var configuration = cfg.getEngine().createEngineConfiguration();
+    final var configuration = cfg.getExperimental().getEngine().createEngineConfiguration();
 
     // then
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(10);
@@ -37,7 +37,7 @@ final class EngineCfgTest {
     final BrokerCfg cfg = TestConfigReader.readConfig("engine", environment);
 
     // when
-    final var configuration = cfg.getEngine().createEngineConfiguration();
+    final var configuration = cfg.getExperimental().getEngine().createEngineConfiguration();
 
     // then
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(1000);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -72,4 +72,37 @@ final class FeatureFlagsCfgTest {
     // then
     assertThat(featureFlagsCfg.isEnableActorMetrics()).isFalse();
   }
+
+  @Test
+  void shouldDisableMessageTTLCheckerAsyncByDefault() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableMessageTtlCheckerAsync()).isFalse();
+  }
+
+  @Test
+  void shouldSetEnableMessageTtlCheckerAsyncFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableMessageTtlCheckerAsync()).isTrue();
+  }
+
+  @Test
+  void shouldSetEnableMessageTtlCheckerAsyncFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.features.enableMessageTTLCheckerAsync", "true");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableMessageTtlCheckerAsync()).isTrue();
+  }
 }

--- a/broker/src/test/resources/system/engine.yaml
+++ b/broker/src/test/resources/system/engine.yaml
@@ -1,6 +1,7 @@
 zeebe:
   broker:
-    engine:
-      messages:
-        ttlCheckerBatchLimit: 1000
-        ttlCheckerInterval: 15s
+    experimental:
+      engine:
+        messages:
+          ttlCheckerBatchLimit: 1000
+          ttlCheckerInterval: 15s

--- a/broker/src/test/resources/system/engine.yaml
+++ b/broker/src/test/resources/system/engine.yaml
@@ -1,0 +1,6 @@
+zeebe:
+  broker:
+    engine:
+      messages:
+        ttlCheckerBatchLimit: 1000
+        ttlCheckerInterval: 15s

--- a/broker/src/test/resources/system/feature-flags-cfg.yaml
+++ b/broker/src/test/resources/system/feature-flags-cfg.yaml
@@ -4,3 +4,4 @@ zeebe:
       features:
         enableYieldingDueDateChecker: true
         enableActorMetrics: true
+        enableMessageTTLCheckerAsync: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -809,9 +809,9 @@
           # blocking other stream processing activities like process execution and job activation/completion.
           # A smaller batch limit will thus enable greater concurrency with the other stream processing activities.
           # A larger batch limit can allow faster message expiration, but at the cost of blocking the other
-          # stream processing activities for extended periods.
+          # stream processing activities for extended periods. Defaults to MAX_INTEGER (2^31-1).
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERBATCHLIMIT
-          # ttlCheckerBatchLimit: 10
+          # ttlCheckerBatchLimit: 0x7fffffff
 
           # Allows to configure the Message TTL Checker's interval. This is the period during which the
           # checker is idle in between two of its executions. Note that it can expire multiple batches

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -799,6 +799,26 @@
         # This setting can also be set using the environmentvariable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
         # enabled: false
 
+      # engine:
+        # messages:
+          # Allows to configure the Message TTL Checker's batch limit. This is the number of buffered
+          # messages that it can expire in a single batch. When it reaches this limit, it expires
+          # another batch of buffered messages. When there are no messages in the buffer past their
+          # Time-To-Live, then it goes idle, and reschedules itself after an interval defined with
+          # `ttlCheckerInterval`. The batch of message expirations is processed on the stream processor
+          # blocking other stream processing activities like process execution and job activation/completion.
+          # A smaller batch limit will thus enable greater concurrency with the other stream processing activities.
+          # A larger batch limit can allow faster message expiration, but at the cost of blocking the other
+          # stream processing activities for extended periods.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERBATCHLIMIT
+          # ttlCheckerBatchLimit: 10
+
+          # Allows to configure the Message TTL Checker's interval. This is the period during which the
+          # checker is idle in between two of its executions. Note that it can expire multiple batches
+          # of messages in a single execution. See `ttlCheckerBatchLimit` to configure the size of these batches.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERINTERVAL
+          # ttlCheckerInterval: 1m
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -841,3 +841,12 @@
         # To allow backups, enable this flag and configure zeebe.broker.data.backup.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEBACKUP
         # enableBackup: false
+
+        # While disabled, checking the Time-To-Live of buffered messages blocks all other executions
+        # that occur on the stream processor, including process execution and job activation/completion.
+        # When enabled, the Message TTL Checker will run asynchronous to the Engine's stream processor.
+        # This helps improve throughput and process latency in use cases that publish many messages
+        # with a non-zero TTL. We recommend testing this feature in a non-production environment before
+        # enabling it in production.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEMESSAGETTLCHECKERASYNC
+        # enableMessageTTLCheckerAsync: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -747,9 +747,9 @@
           # blocking other stream processing activities like process execution and job activation/completion.
           # A smaller batch limit will thus enable greater concurrency with the other stream processing activities.
           # A larger batch limit can allow faster message expiration, but at the cost of blocking the other
-          # stream processing activities for extended periods.
+          # stream processing activities for extended periods. Defaults to MAX_INTEGER (2^31-1).
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERBATCHLIMIT
-          # ttlCheckerBatchLimit: 10
+          # ttlCheckerBatchLimit: 0x7fffffff
 
           # Allows to configure the Message TTL Checker's interval. This is the period during which the
           # checker is idle in between two of its executions. Note that it can expire multiple batches

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -779,3 +779,12 @@
         # To allow backups, enable this flag and configure zeebe.broker.data.backup.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEBACKUP
         # enableBackup: false
+
+        # While disabled, checking the Time-To-Live of buffered messages blocks all other executions
+        # that occur on the stream processor, including process execution and job activation/completion.
+        # When enabled, the Message TTL Checker will run asynchronous to the Engine's stream processor.
+        # This helps improve throughput and process latency in use cases that publish many messages
+        # with a non-zero TTL. We recommend testing this feature in a non-production environment before
+        # enabling it in production.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEMESSAGETTLCHECKERASYNC
+        # enableMessageTTLCheckerAsync: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -737,6 +737,26 @@
         # This setting can also be set using the environmentvariable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
         # enabled: false
 
+      # engine:
+        # messages:
+          # Allows to configure the Message TTL Checker's batch limit. This is the number of buffered
+          # messages that it can expire in a single batch. When it reaches this limit, it expires
+          # another batch of buffered messages. When there are no messages in the buffer past their
+          # Time-To-Live, then it goes idle, and reschedules itself after an interval defined with
+          # `ttlCheckerInterval`. The batch of message expirations is processed on the stream processor
+          # blocking other stream processing activities like process execution and job activation/completion.
+          # A smaller batch limit will thus enable greater concurrency with the other stream processing activities.
+          # A larger batch limit can allow faster message expiration, but at the cost of blocking the other
+          # stream processing activities for extended periods.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERBATCHLIMIT
+          # ttlCheckerBatchLimit: 10
+
+          # Allows to configure the Message TTL Checker's interval. This is the period during which the
+          # checker is idle in between two of its executions. Note that it can expire multiple batches
+          # of messages in a single execution. See `ttlCheckerBatchLimit` to configure the size of these batches.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERINTERVAL
+          # ttlCheckerInterval: 1m
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -56,9 +56,7 @@ public class Engine implements RecordProcessor {
       new ProcessingResultBuilderMutex();
 
   private Writers writers;
-  private TypedRecordProcessorFactory typedRecordProcessorFactory;
-
-  public Engine() {}
+  private final TypedRecordProcessorFactory typedRecordProcessorFactory;
 
   public Engine(final TypedRecordProcessorFactory typedRecordProcessorFactory) {
     this.typedRecordProcessorFactory = typedRecordProcessorFactory;

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -88,7 +88,8 @@ public class Engine implements RecordProcessor {
             processingState,
             scheduledTaskDbState,
             writers,
-            recordProcessorContext.getPartitionCommandSender());
+            recordProcessorContext.getPartitionCommandSender(),
+            config);
 
     final TypedRecordProcessors typedRecordProcessors =
         typedRecordProcessorFactory.createProcessors(typedProcessorContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -57,9 +57,13 @@ public class Engine implements RecordProcessor {
 
   private Writers writers;
   private final TypedRecordProcessorFactory typedRecordProcessorFactory;
+  private final EngineConfiguration config;
 
-  public Engine(final TypedRecordProcessorFactory typedRecordProcessorFactory) {
+  public Engine(
+      final TypedRecordProcessorFactory typedRecordProcessorFactory,
+      final EngineConfiguration config) {
     this.typedRecordProcessorFactory = typedRecordProcessorFactory;
+    this.config = config;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -11,7 +11,7 @@ import java.time.Duration;
 
 public final class EngineConfiguration {
 
-  public static final int DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT = 10;
+  public static final int DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
   public static final Duration DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL = Duration.ofMinutes(1);
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine;
+
+public final class EngineConfiguration {}

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -7,4 +7,33 @@
  */
 package io.camunda.zeebe.engine;
 
-public final class EngineConfiguration {}
+import java.time.Duration;
+
+public final class EngineConfiguration {
+
+  public static final int DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT = 10;
+  public static final Duration DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL = Duration.ofMinutes(1);
+
+  private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
+  private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
+
+  public int getMessagesTtlCheckerBatchLimit() {
+    return messagesTtlCheckerBatchLimit;
+  }
+
+  public EngineConfiguration setMessagesTtlCheckerBatchLimit(
+      final int messagesTtlCheckerBatchLimit) {
+    this.messagesTtlCheckerBatchLimit = messagesTtlCheckerBatchLimit;
+    return this;
+  }
+
+  public Duration getMessagesTtlCheckerInterval() {
+    return messagesTtlCheckerInterval;
+  }
+
+  public EngineConfiguration setMessagesTtlCheckerInterval(
+      final Duration messagesTtlCheckerInterval) {
+    this.messagesTtlCheckerInterval = messagesTtlCheckerInterval;
+    return this;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -96,7 +96,8 @@ public final class EngineProcessors {
         typedRecordProcessorContext.getScheduledTaskDbState(),
         typedRecordProcessors,
         writers,
-        config);
+        config,
+        featureFlags);
 
     final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor =
         addProcessProcessors(
@@ -217,7 +218,8 @@ public final class EngineProcessors {
       final ScheduledTaskDbState scheduledTaskDbState,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final FeatureFlags featureFlags) {
     MessageEventProcessors.addMessageProcessors(
         bpmnBehaviors,
         typedRecordProcessors,
@@ -225,6 +227,7 @@ public final class EngineProcessors {
         scheduledTaskDbState,
         subscriptionCommandSender,
         writers,
-        config);
+        config,
+        featureFlags);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing;
 
 import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
@@ -61,6 +62,7 @@ public final class EngineProcessors {
     typedRecordProcessors.withListener(processingState);
 
     final int partitionId = typedRecordProcessorContext.getPartitionId();
+    final var config = typedRecordProcessorContext.getConfig();
 
     final DueDateTimerChecker timerChecker =
         new DueDateTimerChecker(processingState.getTimerState(), featureFlags);
@@ -93,7 +95,8 @@ public final class EngineProcessors {
         processingState,
         typedRecordProcessorContext.getScheduledTaskDbState(),
         typedRecordProcessors,
-        writers);
+        writers,
+        config);
 
     final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor =
         addProcessProcessors(
@@ -213,13 +216,15 @@ public final class EngineProcessors {
       final MutableProcessingState processingState,
       final ScheduledTaskDbState scheduledTaskDbState,
       final TypedRecordProcessors typedRecordProcessors,
-      final Writers writers) {
+      final Writers writers,
+      final EngineConfiguration config) {
     MessageEventProcessors.addMessageProcessors(
         bpmnBehaviors,
         typedRecordProcessors,
         processingState,
         scheduledTaskDbState,
         subscriptionCommandSender,
-        writers);
+        writers,
+        config);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.util.FeatureFlags;
 
 public final class MessageEventProcessors {
 
@@ -32,7 +33,8 @@ public final class MessageEventProcessors {
       final ScheduledTaskDbState scheduledTaskDbState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final FeatureFlags featureFlags) {
 
     final MutableMessageState messageState = processingState.getMessageState();
     final MutableMessageSubscriptionState subscriptionState =
@@ -97,6 +99,7 @@ public final class MessageEventProcessors {
                 processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender,
                 config.getMessagesTtlCheckerInterval(),
-                config.getMessagesTtlCheckerBatchLimit()));
+                config.getMessagesTtlCheckerBatchLimit(),
+                featureFlags.enableMessageTTLCheckerAsync()));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -30,7 +31,8 @@ public final class MessageEventProcessors {
       final MutableProcessingState processingState,
       final ScheduledTaskDbState scheduledTaskDbState,
       final SubscriptionCommandSender subscriptionCommandSender,
-      final Writers writers) {
+      final Writers writers,
+      final EngineConfiguration config) {
 
     final MutableMessageState messageState = processingState.getMessageState();
     final MutableMessageSubscriptionState subscriptionState =
@@ -93,6 +95,8 @@ public final class MessageEventProcessors {
             new MessageObserver(
                 scheduledTaskDbState.getMessageState(),
                 processingState.getPendingMessageSubscriptionState(),
-                subscriptionCommandSender));
+                subscriptionCommandSender,
+                config.getMessagesTtlCheckerInterval(),
+                config.getMessagesTtlCheckerBatchLimit()));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -41,7 +41,6 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
-    // it is safe to reuse the write because we running in the same actor/thread
     final var timeToLiveChecker =
         new MessageTimeToLiveChecker(
             messagesTtlCheckerInterval,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -27,19 +27,19 @@ import org.agrona.collections.MutableInteger;
  * a limited number of these commands in a single run of {@link #execute(TaskResultBuilder)}.
  *
  * <p>It determines whether to reschedule itself immediately, or after the configured {@link
- * MessageObserver#MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL interval}. If it reschedules itself
- * immediately, then it will continue where it left off the last time. Otherwise, it starts with the
- * first expired message deadline it can find.
+ * #executionInterval interval}. If it reschedules itself immediately, then it will continue where
+ * it left off the last time. Otherwise, it starts with the first expired message deadline it can
+ * find.
  */
 public final class MessageTimeToLiveChecker implements Task {
 
   private static final MessageRecord EMPTY_DELETE_MESSAGE_COMMAND =
       new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
 
-  private static final int EXPIRE_COMMANDS_LIMIT_DEFAULT = 10;
-
+  /** This determines the duration that the TTL checker is idle after it completes an execution. */
+  private final Duration executionInterval;
   /** This determines the maximum number of EXPIRE commands it will attempt to fit in the result. */
-  private static final int LIMIT = EXPIRE_COMMANDS_LIMIT_DEFAULT;
+  private final int batchLimit;
 
   private final ProcessingScheduleService scheduleService;
   private final MessageState messageState;
@@ -50,9 +50,14 @@ public final class MessageTimeToLiveChecker implements Task {
   private MessageState.Index lastIndex;
 
   public MessageTimeToLiveChecker(
-      final ProcessingScheduleService scheduleService, final MessageState messageState) {
-    this.scheduleService = scheduleService;
+      final Duration executionInterval,
+      final int batchLimit,
+      final ProcessingScheduleService scheduleService,
+      final MessageState messageState) {
+    this.executionInterval = executionInterval;
+    this.batchLimit = batchLimit;
     this.messageState = messageState;
+    this.scheduleService = scheduleService;
     lastIndex = null;
   }
 
@@ -80,7 +85,7 @@ public final class MessageTimeToLiveChecker implements Task {
               final boolean stillFitsInResult =
                   taskResultBuilder.appendCommandRecord(
                       expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND);
-              return stillFitsInResult && counter.incrementAndGet() < LIMIT;
+              return stillFitsInResult && counter.incrementAndGet() < batchLimit;
             });
 
     if (shouldContinueWhereLeftOff) {
@@ -88,7 +93,7 @@ public final class MessageTimeToLiveChecker implements Task {
     } else {
       lastIndex = null;
       currentTimestamp = -1;
-      scheduleService.runDelayedAsync(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, this);
+      scheduleService.runDelayedAsync(executionInterval, this);
     }
 
     return taskResultBuilder.build();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -26,4 +27,6 @@ public interface TypedRecordProcessorContext {
   InterPartitionCommandSender getPartitionCommandSender();
 
   ScheduledTaskDbState getScheduledTaskDbState();
+
+  EngineConfiguration getConfig();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -22,6 +23,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final ScheduledTaskDbState scheduledTaskDbState;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
+  private final EngineConfiguration config;
 
   public TypedRecordProcessorContextImpl(
       final int partitionId,
@@ -29,13 +31,15 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
       final ProcessingDbState processingState,
       final ScheduledTaskDbState scheduledTaskDbState,
       final Writers writers,
-      final InterPartitionCommandSender partitionCommandSender) {
+      final InterPartitionCommandSender partitionCommandSender,
+      final EngineConfiguration config) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.processingState = processingState;
     this.scheduledTaskDbState = scheduledTaskDbState;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
+    this.config = config;
   }
 
   @Override
@@ -66,5 +70,10 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   @Override
   public ScheduledTaskDbState getScheduledTaskDbState() {
     return scheduledTaskDbState;
+  }
+
+  @Override
+  public EngineConfiguration getConfig() {
+    return config;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
@@ -41,6 +42,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public final class MessageStreamProcessorTest {
+
+  private static final EngineConfiguration DEFAULT_ENGINE_CONFIGURATION = new EngineConfiguration();
 
   @Rule public final StreamProcessorRule rule = new StreamProcessorRule();
 
@@ -67,7 +70,8 @@ public final class MessageStreamProcessorTest {
               processingState,
               scheduledTaskDbState,
               spySubscriptionCommandSender,
-              processingContext.getWriters());
+              processingContext.getWriters(),
+              DEFAULT_ENGINE_CONFIGURATION);
           return typedRecordProcessors;
         });
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
 import org.agrona.DirectBuffer;
 import org.awaitility.Awaitility;
@@ -71,7 +72,8 @@ public final class MessageStreamProcessorTest {
               scheduledTaskDbState,
               spySubscriptionCommandSender,
               processingContext.getWriters(),
-              DEFAULT_ENGINE_CONFIGURATION);
+              DEFAULT_ENGINE_CONFIGURATION,
+              FeatureFlags.createDefault());
           return typedRecordProcessors;
         });
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.message;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.client.PublishMessageClient;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -180,7 +181,7 @@ public final class PublishMessageTest {
     final Record<MessageRecordValue> publishedRecord =
         messageClient.withTimeToLive(timeToLive).publish();
 
-    ENGINE_RULE.increaseTime(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL);
+    ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
 
     // then
     final Record<MessageRecordValue> deletedEvent =
@@ -224,7 +225,7 @@ public final class PublishMessageTest {
     // when
     final Record<MessageRecordValue> publishedRecord =
         messageClient.withTimeToLive(timeToLive).publish();
-    ENGINE_RULE.increaseTime(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL);
+    ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
 
     // then
     final Record<MessageRecordValue> deleteCommand =

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.state;
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.engine.processing.message.MessageObserver;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -233,7 +233,8 @@ public final class ProcessExecutionCleanStateTest {
         .withElementType(BpmnElementType.PROCESS)
         .await();
 
-    engineRule.increaseTime(timeToLive.plus(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL));
+    engineRule.increaseTime(
+        timeToLive.plus(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL));
 
     // then
     assertThatStateIsEmpty();
@@ -280,7 +281,8 @@ public final class ProcessExecutionCleanStateTest {
         .withElementType(BpmnElementType.PROCESS)
         .await();
 
-    engineRule.increaseTime(timeToLive.plus(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL));
+    engineRule.increaseTime(
+        timeToLive.plus(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL));
 
     // deploy new process without message start event to close the open subscription
     engineRule

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.engine.processing.message.MessageObserver;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -85,7 +85,8 @@ public final class ReplayStateTest {
                   engine
                       .getClock()
                       .addTime(
-                          timeToLive.plus(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL));
+                          timeToLive.plus(
+                              EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL));
 
                   return RecordingExporter.messageRecords(MessageIntent.EXPIRED).getFirst();
                 }),

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.Engine;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.api.CommandResponseWriter;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
@@ -293,7 +294,7 @@ public final class TestStreams {
             .actorSchedulingService(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
             .listener(new StreamProcessorListenerRelay(streamProcessorListeners))
-            .recordProcessors(List.of(new Engine(wrappedFactory)))
+            .recordProcessors(List.of(new Engine(wrappedFactory, new EngineConfiguration())))
             .eventApplierFactory(eventApplierFactory)
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)

--- a/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -13,7 +13,9 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public record FeatureFlags(
     boolean yieldingDueDateChecker,
     boolean enableActorMetrics,
-    boolean enableBackup /*, boolean foo*/) {
+    boolean enableBackup,
+    boolean enableMessageTTLCheckerAsync
+    /*, boolean foo*/ ) {
 
   /* To add a new feature toggle, please follow these steps:
    *
@@ -47,9 +49,12 @@ public record FeatureFlags(
 
   private static final boolean ENABLE_BACKUP = false;
 
+  private static final boolean ENABLE_MSG_TTL_CHECKER_ASYNC = false;
+
   public static FeatureFlags createDefault() {
     return new FeatureFlags(
-        YIELDING_DUE_DATE_CHECKER, ENABLE_ACTOR_METRICS, ENABLE_BACKUP /*, FOO_DEFAULT*/);
+        YIELDING_DUE_DATE_CHECKER, ENABLE_ACTOR_METRICS, ENABLE_BACKUP, ENABLE_MSG_TTL_CHECKER_ASYNC
+        /*, FOO_DEFAULT*/ );
   }
 
   /**
@@ -61,7 +66,9 @@ public record FeatureFlags(
     return new FeatureFlags(
         true, /* YIELDING_DUE_DATE_CHECKER*/
         false, /* ENABLE_ACTOR_METRICS */
-        true /* ENABLE_BACKUP */ /*, FOO_DEFAULT*/);
+        true, /* ENABLE_BACKUP */
+        true /* ENABLE_MSG_TTL_CHECKER_ASYNC */
+        /*, FOO_DEFAULT*/ );
   }
 
   @Override

--- a/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -22,6 +22,7 @@ class FeatureFlagsTest {
     assertThat(sut.yieldingDueDateChecker()).isFalse();
     assertThat(sut.enableActorMetrics()).isFalse();
     assertThat(sut.enableBackup()).isFalse();
+    assertThat(sut.enableMessageTTLCheckerAsync()).isFalse();
   }
 
   @Test
@@ -31,5 +32,6 @@ class FeatureFlagsTest {
 
     // then
     assertThat(sut.yieldingDueDateChecker()).isTrue();
+    assertThat(sut.enableMessageTTLCheckerAsync()).isTrue();
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This adds an experimental feature flag and two experimental configuration options to configure the Message Time-To-Live (TTL) Checker.

The feature flag `zeebe.broker.experimental.features.enableMessageTtlCheckerAsync` (env var: `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEMESSAGETTLCHECKERASYNC`) allows running the checker asynchronous to the stream processor.

The configuration option `zeebe.broker.experimental.engine.messages.ttlCheckerBatchLimit` (env var: `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERBATCHLIMIT`) allows configuring the limit of messages to expire in a single batch. The checker attempts to expire all messages past their TTL by splitting them into multiple batches. Once finished, checking all buffered messages, it goes idle for some time. See `ttlCheckerInterval`. The default batch limit is set to `MAX_INT` (2^31-1).

The configuration option `zeebe.broker.experimental.engine.messages.ttlCheckerInterval` (env var: `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERINTERVAL`) allows configuring the interval in between two executions of the checker during which it is idle. The default interval is set to `1m` (i.e. 1 minute), keeping the behavior the same as in previous versions.

This pull request requires reviews from both ZPA and ZDP because it affects shared modules.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11922 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
