### PR TITLE
Stabilize randomized raft tests

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -408,7 +408,7 @@ public final class ControllableRaftContexts {
   }
 
   private void waitUntilThereIsAnotherLeader(final MemberId memberId) {
-    int steps = 100;
+    int steps = 500;
 
     while (steps-- > 0) {
       final Entry<Long, MemberId> currentLeaderEntry = leadersAtTerms.lowerEntry(Long.MAX_VALUE);
@@ -424,7 +424,7 @@ public final class ControllableRaftContexts {
         LOG.info("Current leader is {}. ", leader.id());
         break;
       } else {
-        tickHeartbeatTimeout();
+        tick(Duration.ofMillis(50));
         processAllMessage();
         runUntilDone();
       }

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -191,7 +191,7 @@ public final class ControllableRaftContexts {
             storage,
             getRaftThreadContextFactory(memberId),
             () -> random,
-            RaftElectionConfig.ofDefaultElection(),
+            RaftElectionConfig.ofPriorityElection(nodeCount, Integer.parseInt(memberId.id()) + 1),
             new RaftPartitionConfig());
     raft.setEntryValidator(new NoopEntryValidator());
     return raft;


### PR DESCRIPTION
The issue in #11898 boils down to the election process depending on randomized election timeouts. 
In our randomized tests, we precisely control clock ticks and expect that election is successful in a fixed amount of steps. 
Previously the test used very coarse clock ticks which resulted in a high chance that two members tried to get elected as leader at the same time and would thus both fail to get elected. When this repeated multiple times, the test would quickly run through the fixed amount of steps and fail because no leader got elected in time.

This PR makes two changes to reduce the chance of two member repeatedly attempting to become leader at the same time:

1. Use finer grained clock ticks and increase the amount of steps
2. Enable priority election

This technically does not fix #11898 but it does close #11898 because we assume that this reduces the likelihood significantly enough that we won't see this happening again.