### PR TITLE
Message TTL Checker goes idle when needed

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -351,7 +351,12 @@ public final class DbMessageState implements MutableMessageState {
     deadlineColumnFamily.whileTrue(
         startAtKey,
         (key, value) -> {
-          final var shouldContinue = visit(timestamp, visitor, key);
+          boolean shouldContinue = false;
+          final long deadlineEntry = key.first().getValue();
+          if (deadlineEntry <= timestamp) {
+            final long messageKeyEntry = key.second().inner().getValue();
+            shouldContinue = visitor.visit(deadlineEntry, messageKeyEntry);
+          }
           stoppedByVisitor.set(!shouldContinue);
           return shouldContinue;
         });
@@ -367,17 +372,5 @@ public final class DbMessageState implements MutableMessageState {
     this.messageId.wrapBuffer(messageId);
 
     return messageIdColumnFamily.exists(nameCorrelationMessageIdKey);
-  }
-
-  private static boolean visit(
-      final long timestamp,
-      final ExpiredMessageVisitor visitor,
-      final DbCompositeKey<DbLong, DbForeignKey<DbLong>> compositeDeadlineKey) {
-    final long deadline = compositeDeadlineKey.first().getValue();
-    if (deadline <= timestamp) {
-      final long messageKey = compositeDeadlineKey.second().inner().getValue();
-      return visitor.visit(deadline, messageKey);
-    }
-    return false;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -356,8 +356,8 @@ public final class DbMessageState implements MutableMessageState {
           if (deadlineEntry <= timestamp) {
             final long messageKeyEntry = key.second().inner().getValue();
             shouldContinue = visitor.visit(deadlineEntry, messageKeyEntry);
+            stoppedByVisitor.set(!shouldContinue);
           }
-          stoppedByVisitor.set(!shouldContinue);
           return shouldContinue;
         });
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This makes the Message TTL Checker go idle when all expired messages have been visited. 

It would not go idle but instead rescheduled immediately because of a bug in the MessageState method `visitMessagesWithDeadlineBeforeTimestamp`. This method has a contract that says that it returns true if the visitor stopped the visiting, and false if it stopped for another reason. This return value is used by the Checker to determine whether it should reschedule itself immediately or whether it should go idle instead.

The method did not function correctly. For details about the bug in the method, please refer to the commit messages.

Thanks again for catching this bug @Zelldon ❤️ 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11958 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
