### PR TITLE
Push jobs to registered streams

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializer.java
@@ -30,6 +30,8 @@ import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.atomix.raft.storage.serializer.ConfigurationEntryDecoder.RaftMemberDecoder;
 import io.camunda.zeebe.journal.file.RecordDataEncoder;
+import io.camunda.zeebe.util.SbeUtil;
+import java.nio.ByteOrder;
 import java.time.Instant;
 import java.util.ArrayList;
 import org.agrona.DirectBuffer;
@@ -98,15 +100,11 @@ public class RaftEntrySBESerializer implements RaftEntrySerializer {
         .version(applicationEntryEncoder.sbeSchemaVersion());
     applicationEntryEncoder.wrap(buffer, offset + entryOffset + headerEncoder.encodedLength());
     applicationEntryEncoder.lowestAsqn(entry.lowestPosition()).highestAsqn(entry.highestPosition());
-
-    // Re-implements `ApplicationEntryEncoder.putApplicationData`
-    final var dataWriter = entry.dataWriter();
-    final var dataLength = dataWriter.getLength();
-    final int headerLength = ApplicationEntryEncoder.applicationDataHeaderLength();
-    final int limit = applicationEntryEncoder.limit();
-    applicationEntryEncoder.limit(limit + headerLength + dataLength);
-    buffer.putInt(limit, dataLength, java.nio.ByteOrder.LITTLE_ENDIAN);
-    dataWriter.write(applicationEntryEncoder.buffer(), limit + headerLength);
+    SbeUtil.writeNested(
+        entry.dataWriter(),
+        ApplicationEntryEncoder.applicationDataHeaderLength(),
+        applicationEntryEncoder,
+        ByteOrder.LITTLE_ENDIAN);
 
     return entryOffset + headerEncoder.encodedLength() + applicationEntryEncoder.encodedLength();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -41,7 +41,9 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     final var requestHandler = new StreamApiHandler<>(registry, DummyActivationProperties::new);
     final var server =
         new JobStreamApiServer(clusterServices.getCommunicationService(), requestHandler);
-    final var streamer = new JobGatewayStreamer(clusterServices.getEventService(), registry);
+    final var streamer =
+        new JobGatewayStreamer(
+            clusterServices.getEventService(), clusterServices.getCommunicationService(), registry);
     final var service = new JobStreamService(server, streamer);
 
     // only register listener and apply service to context if the actors are scheduled successfully
@@ -100,7 +102,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
       DirectBuffer worker, long timeout, Collection<DirectBuffer> fetchVariables)
       implements JobActivationProperties {
 
-    DummyActivationProperties() {
+    private DummyActivationProperties() {
       this(new UnsafeBuffer(), -1L, Collections.emptyList());
     }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobGatewayStreamer.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobGatewayStreamer.java
@@ -7,29 +7,52 @@
  */
 package io.camunda.zeebe.broker.jobstream;
 
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.camunda.zeebe.protocol.impl.stream.JobStreamTopics;
+import io.camunda.zeebe.protocol.impl.stream.PushStreamRequest;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.api.JobActivationProperties;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
+/**
+ * {@link JobGatewayStreamer} is a job specific implementation of {@link GatewayStreamer}, allowing
+ * the engine to activate & push out jobs to an available stream.
+ *
+ * <p>It is itself an actor, and any jobs pushed will be pushed asynchronously.
+ *
+ * <p>NOTE: any payload pushed is sent via the stream from {@link #streamFor(DirectBuffer)} will be
+ * asynchronous, so the payload should be immutable, and the errors reported to the given {@link
+ * io.camunda.zeebe.stream.api.GatewayStreamer.ErrorHandler} may be reported on different threads.
+ */
 public final class JobGatewayStreamer extends Actor
     implements GatewayStreamer<JobActivationProperties, ActivatedJob> {
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  private final StreamPicker<JobActivationProperties> streamPicker = new RandomStreamPicker<>();
 
   private final ClusterEventService eventService;
+  private final ClusterCommunicationService transport;
   private final ImmutableStreamRegistry<JobActivationProperties> registry;
 
   public JobGatewayStreamer(
       final ClusterEventService eventService,
+      final ClusterCommunicationService transport,
       final ImmutableStreamRegistry<JobActivationProperties> registry) {
     this.eventService =
         Objects.requireNonNull(eventService, "must specify an event service for broadcasting");
+    this.transport = Objects.requireNonNull(transport, "must specify a network transport");
     this.registry = Objects.requireNonNull(registry, "must specify a job stream registry");
   }
 
@@ -37,12 +60,48 @@ public final class JobGatewayStreamer extends Actor
   public Optional<GatewayStream<JobActivationProperties, ActivatedJob>> streamFor(
       final DirectBuffer streamId) {
     final var consumers = registry.get(new UnsafeBuffer(streamId));
-    if (consumers == null || consumers.isEmpty()) {
+    if (consumers.isEmpty()) {
       final var jobType = BufferUtil.bufferAsString(streamId);
       actor.run(() -> eventService.broadcast(JobStreamTopics.JOB_AVAILABLE.topic(), jobType));
+      return Optional.empty();
     }
 
-    // TODO: for now keep returning empty, but fill out later
-    return Optional.empty();
+    final var target = streamPicker.pickStream(consumers);
+    final var gatewayStream =
+        new JobGatewayStream(
+            target.properties(), new StreamPusher<>(target.id(), this::send, actor::run));
+    return Optional.of(gatewayStream);
+  }
+
+  private CompletableFuture<Void> send(final PushStreamRequest request, final MemberId receiver) {
+    return transport
+        .send(
+            JobStreamTopics.PUSH.topic(),
+            request,
+            this::serialize,
+            Function.identity(),
+            receiver,
+            REQUEST_TIMEOUT)
+        .thenApply(ok -> null);
+  }
+
+  private byte[] serialize(final BufferWriter payload) {
+    final var bytes = new byte[payload.getLength()];
+    final var writeBuffer = new UnsafeBuffer();
+    writeBuffer.wrap(bytes);
+
+    payload.write(writeBuffer, 0);
+    return bytes;
+  }
+
+  private record JobGatewayStream(
+      JobActivationProperties metadata, StreamPusher<ActivatedJob> streamer)
+      implements GatewayStream<JobActivationProperties, ActivatedJob> {
+
+    @Override
+    public void push(
+        final ActivatedJob activatedJob, final ErrorHandler<ActivatedJob> errorHandler) {
+      streamer.pushAsync(activatedJob, errorHandler);
+    }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RandomStreamPicker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RandomStreamPicker.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.camunda.zeebe.broker.jobstream.ImmutableStreamRegistry.StreamConsumer;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+final class RandomStreamPicker<M> implements StreamPicker<M> {
+
+  @Override
+  public StreamConsumer<M> pickStream(final Set<StreamConsumer<M>> consumers) {
+    final var targets = new ArrayList<>(consumers);
+    final var index = ThreadLocalRandom.current().nextInt(consumers.size());
+
+    return targets.get(index);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamPicker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamPicker.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.camunda.zeebe.broker.jobstream.ImmutableStreamRegistry.StreamConsumer;
+import java.util.Set;
+
+@FunctionalInterface
+interface StreamPicker<M> {
+  StreamConsumer<M> pickStream(final Set<StreamConsumer<M>> consumers);
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamPusher.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamPusher.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.jobstream.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.protocol.impl.stream.PushStreamRequest;
+import io.camunda.zeebe.stream.api.GatewayStreamer.ErrorHandler;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * A naive implementation to push jobs out, which performs no retries of any kind, but reports
+ * errors on failure.
+ *
+ * @param <P> the payload type to be pushed out
+ */
+final class StreamPusher<P extends BufferWriter> {
+
+  private final StreamId streamId;
+  private final Transport transport;
+  private final Executor executor;
+
+  StreamPusher(final StreamId streamId, final Transport transport, final Executor executor) {
+    this.streamId = Objects.requireNonNull(streamId, "must specify a target stream ID");
+    this.transport = Objects.requireNonNull(transport, "must provide a network transport");
+    this.executor = Objects.requireNonNull(executor, "must provide an asynchronous executor");
+  }
+
+  public void pushAsync(final P payload, final ErrorHandler<P> errorHandler) {
+    Objects.requireNonNull(payload, "must specify a payload");
+    Objects.requireNonNull(errorHandler, "must specify a error handler");
+
+    executor.execute(() -> push(payload, errorHandler));
+  }
+
+  private void push(final P payload, final ErrorHandler<P> errorHandler) {
+    final var request = new PushStreamRequest().streamId(streamId.streamId()).payload(payload);
+    try {
+      transport
+          .send(request, streamId.receiver())
+          .whenCompleteAsync((ok, error) -> onPush(payload, errorHandler, error), executor);
+    } catch (final Exception e) {
+      errorHandler.handleError(e, payload);
+    }
+  }
+
+  private void onPush(final P payload, final ErrorHandler<P> errorHandler, final Throwable error) {
+    if (error != null) {
+      errorHandler.handleError(error, payload);
+    }
+  }
+
+  /**
+   * A small abstraction over the network transport. This allows for better testability, and also
+   * removes the need for this class to know how communication occurs (e.g. which topic the message
+   * is sent over)
+   */
+  interface Transport {
+
+    /**
+     * Sends the given request out to the given receiver. May throw errors, e.g. serialization
+     * errors.
+     *
+     * @param request the request to send
+     * @param receiver the expected target
+     * @return a future which is completed when the request has been acknowledged by the receiver,
+     *     or an error occurred
+     * @throws Exception if an error occurs before the request is sent out, i.e. serialization error
+     */
+    CompletableFuture<Void> send(final PushStreamRequest request, final MemberId receiver)
+        throws Exception;
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/StreamRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.jobstream;
 
 import io.atomix.cluster.MemberId;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -96,8 +97,7 @@ public class StreamRegistry<M> implements ImmutableStreamRegistry<M> {
 
   @Override
   public Set<StreamConsumer<M>> get(final UnsafeBuffer streamType) {
-    // TODO: we may have to return an immutable collection here.
-    return typeToConsumers.get(streamType);
+    return typeToConsumers.getOrDefault(streamType, Collections.emptySet());
   }
 
   public void clear() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/JobGatewayStreamerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/JobGatewayStreamerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.cluster.messaging.ClusterEventService;
+import io.camunda.zeebe.broker.jobstream.ImmutableStreamRegistry.StreamConsumer;
+import io.camunda.zeebe.broker.jobstream.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.stream.JobStreamTopics;
+import io.camunda.zeebe.protocol.impl.stream.PushStreamRequest;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.camunda.zeebe.stream.api.ActivatedJob;
+import io.camunda.zeebe.stream.api.JobActivationProperties;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+final class JobGatewayStreamerTest {
+  private final ClusterEventService eventService = Mockito.mock(ClusterEventService.class);
+  private final ClusterCommunicationService communicationService =
+      Mockito.mock(ClusterCommunicationService.class);
+  private final TestRegistry registry = new TestRegistry();
+
+  private final JobGatewayStreamer streamer =
+      new JobGatewayStreamer(eventService, communicationService, registry);
+
+  @RegisterExtension
+  private final ControlledActorSchedulerExtension scheduler =
+      new ControlledActorSchedulerExtension();
+
+  @BeforeEach
+  void beforeEach() {
+    scheduler.submitActor(streamer);
+    scheduler.workUntilDone();
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(
+        () -> {
+          streamer.closeAsync();
+          scheduler.workUntilDone();
+        });
+  }
+
+  @Test
+  void shouldNotifyAvailableJobsWhenNoConsumers() {
+    // given
+    final var type = BufferUtil.wrapString("foo");
+
+    // when
+    final var maybeStream = streamer.streamFor(type);
+    scheduler.workUntilDone();
+
+    // then
+    assertThat(maybeStream).isEmpty();
+    Mockito.verify(eventService, Mockito.times(1))
+        .broadcast(JobStreamTopics.JOB_AVAILABLE.topic(), "foo");
+  }
+
+  @Test
+  void shouldReportCorrectMetadata() {
+    // given
+    final var type = new UnsafeBuffer(BufferUtil.wrapString("foo"));
+    final var streamId = new StreamId(UUID.randomUUID(), MemberId.from("a"));
+    final var metadata = new TestActivationProperties();
+    registry.consumers.put(type, Set.of(new StreamConsumer<>(streamId, metadata, type)));
+
+    // when
+    final var stream = streamer.streamFor(type).orElseThrow();
+
+    // then
+    assertThat(stream.metadata()).isSameAs(metadata);
+  }
+
+  @Test
+  void shouldPush() {
+    // given - a registry which returns a set of consumers sorted by their member IDs
+    final var type = new UnsafeBuffer(BufferUtil.wrapString("foo"));
+    final var streamId = new StreamId(UUID.randomUUID(), MemberId.from("a"));
+    final var metadata = new TestActivationProperties();
+    final var payload = new TestJob(1, new JobRecord());
+    registry.consumers.put(type, Set.of(new StreamConsumer<>(streamId, metadata, type)));
+
+    // when
+    final var stream = streamer.streamFor(type).orElseThrow();
+    stream.push(payload, (job, error) -> {});
+    scheduler.workUntilDone();
+
+    // then
+    Mockito.verify(communicationService, Mockito.timeout(5_000).times(1))
+        .send(
+            Mockito.eq(JobStreamTopics.PUSH.topic()),
+            Mockito.eq(new PushStreamRequest().streamId(streamId.streamId()).payload(payload)),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.eq(streamId.receiver()),
+            Mockito.any());
+  }
+
+  private record TestJob(long jobKey, JobRecord record) implements ActivatedJob {
+
+    @Override
+    public int getLength() {
+      return 0;
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {}
+  }
+
+  private record TestRegistry(
+      Map<DirectBuffer, Set<StreamConsumer<JobActivationProperties>>> consumers)
+      implements ImmutableStreamRegistry<JobActivationProperties> {
+
+    public TestRegistry() {
+      this(new HashMap<>());
+    }
+
+    @Override
+    public Set<StreamConsumer<JobActivationProperties>> get(final UnsafeBuffer streamType) {
+      return consumers.getOrDefault(streamType, Collections.emptySet());
+    }
+  }
+
+  private record TestActivationProperties(
+      DirectBuffer worker, long timeout, Collection<DirectBuffer> fetchVariables)
+      implements JobActivationProperties {
+
+    private TestActivationProperties() {
+      this(new UnsafeBuffer(), -1L, Collections.emptyList());
+    }
+
+    @Override
+    public void wrap(final DirectBuffer buffer, final int offset, final int length) {}
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamPusherTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamPusherTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.jobstream.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.broker.jobstream.StreamPusher.Transport;
+import io.camunda.zeebe.protocol.impl.stream.PushStreamRequest;
+import io.camunda.zeebe.stream.api.GatewayStreamer.ErrorHandler;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.agrona.MutableDirectBuffer;
+import org.junit.jupiter.api.Test;
+
+final class StreamPusherTest {
+  private final StreamId streamId = new StreamId(UUID.randomUUID(), MemberId.anonymous());
+  private final TestTransport transport = new TestTransport();
+  private final Executor executor = Runnable::run;
+  private final StreamPusher<Payload> pusher = new StreamPusher<>(streamId, transport, executor);
+
+  @Test
+  void shouldPushPayload() {
+    // given
+    final var payload = new Payload(1);
+    final var errorHandler = new TestErrorHandler();
+
+    // when
+    pusher.pushAsync(payload, errorHandler);
+
+    // then
+    final var sentRequest = transport.message;
+    assertThat(errorHandler.errors).isEmpty();
+    assertThat(sentRequest).isNotNull();
+    assertThat(sentRequest.request.streamId()).isEqualTo(streamId.streamId());
+    assertThat(sentRequest.request.payloadWriter()).isEqualTo(payload);
+    assertThat(sentRequest.receiver).isEqualTo(streamId.receiver());
+  }
+
+  @Test
+  void shouldReportTransportError() {
+    // given
+    final var payload = new Payload(1);
+    final var errorHandler = new TestErrorHandler();
+    final var failure = new RuntimeException("Sync failure");
+    transport.synchronousException = failure;
+
+    // when
+    pusher.pushAsync(payload, errorHandler);
+
+    // then
+    assertThat(errorHandler.errors)
+        .hasSize(1)
+        .first()
+        .extracting(TestErrorHandler.Error::payload, TestErrorHandler.Error::error)
+        .containsExactly(payload, failure);
+  }
+
+  @Test
+  void shouldReportAsyncTransportError() {
+    // given
+    final var payload = new Payload(1);
+    final var errorHandler = new TestErrorHandler();
+    final var failure = new RuntimeException("Async failure");
+    transport.response = CompletableFuture.failedFuture(failure);
+
+    // when
+    pusher.pushAsync(payload, errorHandler);
+
+    // then
+    assertThat(errorHandler.errors)
+        .hasSize(1)
+        .first()
+        .extracting(TestErrorHandler.Error::payload, TestErrorHandler.Error::error)
+        .containsExactly(payload, failure);
+  }
+
+  @Test
+  void shouldFailOnNullPayload() {
+    // given
+    final var errorHandler = new TestErrorHandler();
+
+    // when - then
+    assertThatCode(() -> pusher.pushAsync(null, errorHandler))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void shouldFailOnNullErrorHandler() {
+    // given
+    final var payload = new Payload(1);
+
+    // when - then
+    assertThatCode(() -> pusher.pushAsync(payload, null)).isInstanceOf(NullPointerException.class);
+  }
+
+  private record Payload(int version) implements BufferWriter {
+
+    @Override
+    public int getLength() {
+      return Integer.BYTES;
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {
+      buffer.putInt(offset, version);
+    }
+  }
+
+  private record TestErrorHandler(List<Error> errors) implements ErrorHandler<Payload> {
+
+    private TestErrorHandler() {
+      this(new ArrayList<>());
+    }
+
+    @Override
+    public void handleError(final Throwable error, final Payload data) {
+      errors.add(new Error(data, error));
+    }
+
+    private record Error(Payload payload, Throwable error) {}
+  }
+
+  private static final class TestTransport implements Transport {
+    private CompletableFuture<Void> response = CompletableFuture.completedFuture(null);
+    private Message message;
+    private Exception synchronousException;
+
+    @Override
+    public CompletableFuture<Void> send(final PushStreamRequest request, final MemberId receiver)
+        throws Exception {
+      if (synchronousException != null) {
+        throw synchronousException;
+      }
+
+      message = new Message(request, receiver);
+      return response;
+    }
+
+    private record Message(PushStreamRequest request, MemberId receiver) {}
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamRegistryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/StreamRegistryTest.java
@@ -84,7 +84,7 @@ final class StreamRegistryTest {
     streamRegistry.removeAll(gateway);
 
     // then
-    assertThat(streamRegistry.get(typeFoo)).isNull();
+    assertThat(streamRegistry.get(typeFoo)).isEmpty();
     assertThat(streamRegistry.get(typeBar))
         .contains(new StreamConsumer<>(new StreamId(idOther, otherGateway), 3, typeBar));
   }
@@ -100,7 +100,7 @@ final class StreamRegistryTest {
     streamRegistry.clear();
 
     // then
-    assertThat(streamRegistry.get(typeFoo)).isNull();
-    assertThat(streamRegistry.get(typeBar)).isNull();
+    assertThat(streamRegistry.get(typeFoo)).isEmpty();
+    assertThat(streamRegistry.get(typeBar)).isEmpty();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/streamapi/StreamApiHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/streamapi/StreamApiHandlerTest.java
@@ -47,7 +47,7 @@ final class StreamApiHandlerTest {
 
     // when - then
     assertThatCode(() -> server.add(sender, request)).isInstanceOf(IndexOutOfBoundsException.class);
-    assertThat(registry.get(streamType)).isNull();
+    assertThat(registry.get(streamType)).isEmpty();
   }
 
   @Test
@@ -70,7 +70,7 @@ final class StreamApiHandlerTest {
 
     // when - then
     assertThatCode(() -> server.add(sender, request)).isInstanceOf(IllegalArgumentException.class);
-    assertThat(registry.get(streamType)).isNull();
+    assertThat(registry.get(streamType)).isEmpty();
   }
 
   @Test
@@ -87,7 +87,7 @@ final class StreamApiHandlerTest {
 
     // when - then
     assertThatCode(() -> server.add(sender, request)).isInstanceOf(IllegalArgumentException.class);
-    assertThat(registry.get(streamType)).isNull();
+    assertThat(registry.get(streamType)).isEmpty();
   }
 
   @Test
@@ -128,7 +128,7 @@ final class StreamApiHandlerTest {
 
     // then
     final var consumers = registry.get(streamType);
-    assertThat(consumers).isNullOrEmpty();
+    assertThat(consumers).isEmpty();
   }
 
   @Test
@@ -143,7 +143,7 @@ final class StreamApiHandlerTest {
 
     // then
     final var consumers = registry.get(streamType);
-    assertThat(consumers).isNullOrEmpty();
+    assertThat(consumers).isEmpty();
   }
 
   private static final class TestMetadata implements Metadata {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/JobStreamTopics.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/JobStreamTopics.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.stream;
 
 public enum JobStreamTopics {
   ADD("job-stream-add"),
+  PUSH("job-stream-push"),
   REMOVE("job-stream-remove"),
   REMOVE_ALL("job-stream-remove-all"),
   JOB_AVAILABLE("jobsAvailable");

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/PushStreamRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/PushStreamRequest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.stream;
+
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
+import io.camunda.zeebe.protocol.record.PushStreamRequestDecoder;
+import io.camunda.zeebe.protocol.record.PushStreamRequestEncoder;
+import io.camunda.zeebe.util.SbeUtil;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
+import java.util.Objects;
+import java.util.UUID;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class PushStreamRequest implements BufferReader, BufferWriter {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final PushStreamRequestEncoder messageEncoder = new PushStreamRequestEncoder();
+  private final PushStreamRequestDecoder messageDecoder = new PushStreamRequestDecoder();
+
+  private final DirectBuffer payloadReader = new UnsafeBuffer();
+  private BufferWriter payloadWriter = new DirectBufferWriter().wrap(payloadReader);
+  private UUID streamId;
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    messageDecoder.wrapAndApplyHeader(buffer, 0, headerDecoder);
+    streamId = new UUID(messageDecoder.id().high(), messageDecoder.id().low());
+    messageDecoder.wrapPayload(payloadReader);
+    payloadWriter = new DirectBufferWriter().wrap(payloadReader);
+  }
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength()
+        + messageEncoder.sbeBlockLength()
+        + PushStreamRequestEncoder.payloadHeaderLength()
+        + payloadWriter.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+
+    if (streamId != null) {
+      messageEncoder
+          .id()
+          .high(streamId.getMostSignificantBits())
+          .low(streamId.getLeastSignificantBits());
+    }
+
+    SbeUtil.writeNested(
+        payloadWriter,
+        PushStreamRequestEncoder.payloadHeaderLength(),
+        messageEncoder,
+        PushStreamRequestEncoder.BYTE_ORDER);
+  }
+
+  /** May return null if it was never read or set. */
+  public UUID streamId() {
+    return streamId;
+  }
+
+  public PushStreamRequest streamId(final UUID streamId) {
+    this.streamId = streamId;
+    return this;
+  }
+
+  /**
+   * Returns the payload after a call to {@link #wrap(DirectBuffer, int, int)} or {@link
+   * #payload(DirectBuffer)}. Otherwise, may return old or invalid data (e.g. empty buffer)
+   */
+  public DirectBuffer payload() {
+    return payloadReader;
+  }
+
+  /**
+   * May return null if {@link #payload(DirectBuffer)}, {@link #payload(BufferWriter)}, or {@link
+   * #wrap(DirectBuffer, int, int)} were never called.
+   */
+  public BufferWriter payloadWriter() {
+    return payloadWriter;
+  }
+
+  public PushStreamRequest payload(final BufferWriter payloadWriter) {
+    this.payloadWriter = payloadWriter;
+    payloadReader.wrap(0, 0);
+    return this;
+  }
+
+  public PushStreamRequest payload(final DirectBuffer payload) {
+    payloadReader.wrap(payload);
+    payloadWriter = new DirectBufferWriter().wrap(payload);
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(streamId, payloadReader, payloadWriter);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final PushStreamRequest that = (PushStreamRequest) o;
+    return Objects.equals(streamId, that.streamId)
+        && Objects.equals(payloadReader, that.payloadReader)
+        && Objects.equals(payloadWriter, that.payloadWriter);
+  }
+
+  @Override
+  public String toString() {
+    return "PushStreamRequest{"
+        + "streamId="
+        + streamId
+        + "payload=byte['"
+        + payloadWriter.getLength()
+        + "]'}";
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/stream/SerializationTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/stream/SerializationTest.java
@@ -53,4 +53,21 @@ final class SerializationTest {
     // then
     assertThat(deserialized.streamId()).isEqualTo(streamId);
   }
+
+  @Test
+  void shouldSerializePushStreamRequest() {
+    // given
+    final var streamId = UUID.randomUUID();
+    final var request =
+        new PushStreamRequest().streamId(streamId).payload(BufferUtil.wrapString("foo"));
+
+    // when
+    request.write(buffer, 0);
+    final var deserialized = new PushStreamRequest();
+    deserialized.wrap(buffer, 0, request.getLength());
+
+    // then
+    assertThat(deserialized.streamId()).isEqualTo(streamId);
+    assertThat(deserialized.payload()).isEqualTo(BufferUtil.wrapString("foo"));
+  }
 }

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -181,4 +181,9 @@
   <sbe:message name="RemoveStreamRequest" id="401" description="Removes a gateway stream from a broker">
     <field name="id" id="1" type="UUID" />
   </sbe:message>
+
+  <sbe:message name="PushStreamRequest" id="402" description="Pushes a payload over a stream">
+    <field name="id" id="1" type="UUID" />
+    <data name="payload" id="2" type="varDataEncoding"/>
+  </sbe:message>
 </sbe:messageSchema>

--- a/util/src/main/java/io/camunda/zeebe/util/SbeUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/SbeUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.nio.ByteOrder;
+import org.agrona.sbe.MessageEncoderFlyweight;
+
+public final class SbeUtil {
+  private SbeUtil() {}
+
+  /**
+   * Writes a {@link BufferWriter} instance as a nested field in an SBE message. This can be useful
+   * to avoid intermediate copies to a {@link org.agrona.DirectBuffer} instance and using the
+   * encoder to write the copy. This can also be used to write nested SBE messages as well.
+   *
+   * <p>NOTE: variable length data in SBE is written/read in order. This method should be called as
+   * well in the right order so the data is written at the right offset.
+   *
+   * @param writer the data to write
+   * @param headerLength the length of the header corresponding to the data we want to write
+   * @param message the SBE message into which we should write
+   * @param order the byte order
+   */
+  public static void writeNested(
+      final BufferWriter writer,
+      final int headerLength,
+      final MessageEncoderFlyweight message,
+      final ByteOrder order) {
+    final int dataLength = writer.getLength();
+    final var limit = message.limit();
+
+    message.limit(limit + headerLength + dataLength);
+    message.buffer().putInt(limit, dataLength, order);
+    writer.write(message.buffer(), limit + headerLength);
+  }
+}


### PR DESCRIPTION
## Description

Implements a job specific `GatewayStreamer` and `GatewayStream`, which can push jobs out to specific streams once they've been activated by the engine.

The implementation is currently very simple:

1. Jobs are pushed out asynchronously
2. The target stream is picked randomly from the set of consumers
3. There is no retry; we try with one consumer only

The `GatewayStream` also expects the jobs (i.e. payload) to be immutable, and the `ErrorHandler` to be thread-safe.

This PR does not close the issue, as we're still missing adding metrics and some logging (which will then close the issue).

## Related issues

related to #11707 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
