### PR TITLE
feat(backup/gcs): add configuration for authentication

### DIFF
--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -21,10 +21,42 @@
 
   <name>Zeebe Backup Store for GCS</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.9.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.perfmark</groupId>
+          <artifactId>perfmark-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -40,4 +72,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- Will be used soon and is already useful for bringing in dependencies on auto-generated google api libraries -->
+            <ignoredUnusedDeclaredDependency>com.google.cloud:google-cloud-storage</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+          <ignoredUsedUndeclaredDependencies>
+            <!--
+              Google libraries are used in whatever version was pulled through the main dependency
+              on google-cloud-core.
+              Explicitly defining dependencies on these libraries doesn't help and only increases
+              the risk that our definitions drift from what google-cloud-core wants to use whenever
+              dependabot updates one of these versions.
+            -->
+            <ignoredUsedUndeclaredDependency>com.google.auth:*</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>com.google.apis:*</ignoredUsedUndeclaredDependency>
+          </ignoredUsedUndeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -9,11 +9,11 @@ package io.camunda.zeebe.backup.gcs;
 
 import static java.util.Objects.requireNonNull;
 
-public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig conn) {
-  public GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig conn) {
+public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig connection) {
+  public GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig connection) {
     this.bucketName = requireBucketName(bucketName);
     this.basePath = sanitizeBasePath(basePath);
-    this.conn = requireNonNull(conn);
+    this.connection = requireNonNull(connection);
   }
 
   private static String requireBucketName(final String bucketName) {

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -7,20 +7,23 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
-public record GcsBackupConfig(String bucketName, String basePath) {
-  public GcsBackupConfig(String bucketName, String basePath) {
+import static java.util.Objects.requireNonNull;
+
+public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig conn) {
+  public GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig conn) {
     this.bucketName = requireBucketName(bucketName);
     this.basePath = sanitizeBasePath(basePath);
+    this.conn = requireNonNull(conn);
   }
 
-  private String requireBucketName(final String bucketName) {
+  private static String requireBucketName(final String bucketName) {
     if (bucketName == null || bucketName.isBlank()) {
       throw new IllegalArgumentException("bucketName must be provided");
     }
     return bucketName;
   }
 
-  private String sanitizeBasePath(final String basePath) {
+  private static String sanitizeBasePath(final String basePath) {
     if (basePath == null || basePath.isBlank()) {
       return null;
     }
@@ -45,6 +48,7 @@ public record GcsBackupConfig(String bucketName, String basePath) {
   public static final class Builder {
     private String bucketName;
     private String basePath;
+    private GcsConnectionConfig.Authentication auth;
 
     public Builder withBucketName(final String bucketName) {
       this.bucketName = bucketName;
@@ -56,8 +60,18 @@ public record GcsBackupConfig(String bucketName, String basePath) {
       return this;
     }
 
+    public Builder withoutAuthentication() {
+      this.auth = new GcsConnectionConfig.Authentication.None();
+      return this;
+    }
+
+    public Builder withDefaultApplicationCredentials() {
+      this.auth = new GcsConnectionConfig.Authentication.Default();
+      return this;
+    }
+
     public GcsBackupConfig build() {
-      return new GcsBackupConfig(bucketName, basePath);
+      return new GcsBackupConfig(bucketName, basePath, new GcsConnectionConfig(auth));
     }
   }
 }

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.backup.gcs;
 
 import static java.util.Objects.requireNonNull;
 
+import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
+
 public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig connection) {
   public GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig connection) {
     this.bucketName = requireBucketName(bucketName);
@@ -65,8 +67,8 @@ public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionC
       return this;
     }
 
-    public Builder withDefaultApplicationCredentials() {
-      this.auth = new GcsConnectionConfig.Authentication.Default();
+    public Builder withAutoAuthentication() {
+      this.auth = new Auto();
       return this;
     }
 

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsConnectionConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsConnectionConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import com.google.api.services.storage.StorageScopes;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.NoCredentials;
+import java.io.IOException;
+import java.util.Objects;
+
+record GcsConnectionConfig(Authentication auth) {
+
+  GcsConnectionConfig(Authentication auth) {
+    this.auth = Objects.requireNonNullElseGet(auth, Authentication.Default::new);
+  }
+
+  sealed interface Authentication {
+    Credentials credentials();
+
+    /** Use no authentication, only useful for testing. */
+    record None() implements Authentication {
+      @Override
+      public Credentials credentials() {
+        return NoCredentials.getInstance();
+      }
+    }
+
+    /**
+     * Use <a
+     * href="https://cloud.google.com/docs/authentication/application-default-credentials">Application
+     * Default Credentials</a> to automatically discover credentials.
+     */
+    record Default() implements Authentication {
+      @Override
+      public Credentials credentials() {
+        try {
+          return GoogleCredentials.getApplicationDefault()
+              .createScoped(StorageScopes.DEVSTORAGE_READ_WRITE);
+        } catch (IOException e) {
+          throw new IllegalStateException("Failed to retrieve application default credentials", e);
+        }
+      }
+    }
+  }
+}

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsConnectionConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsConnectionConfig.java
@@ -11,13 +11,14 @@ import com.google.api.services.storage.StorageScopes;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.NoCredentials;
+import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
 import java.io.IOException;
 import java.util.Objects;
 
 record GcsConnectionConfig(Authentication auth) {
 
   GcsConnectionConfig(Authentication auth) {
-    this.auth = Objects.requireNonNullElseGet(auth, Authentication.Default::new);
+    this.auth = Objects.requireNonNullElseGet(auth, Auto::new);
   }
 
   sealed interface Authentication {
@@ -36,7 +37,7 @@ record GcsConnectionConfig(Authentication auth) {
      * href="https://cloud.google.com/docs/authentication/application-default-credentials">Application
      * Default Credentials</a> to automatically discover credentials.
      */
-    record Default() implements Authentication {
+    record Auto() implements Authentication {
       @Override
       public Credentials credentials() {
         try {

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -88,8 +89,7 @@ final class ConfigTest {
     final var config = new GcsBackupConfig.Builder().withBucketName(bucketName).build();
 
     // then
-    Assertions.assertThat(config.connection().auth())
-        .isInstanceOf(GcsConnectionConfig.Authentication.Default.class);
+    Assertions.assertThat(config.connection().auth()).isInstanceOf(Auto.class);
   }
 
   @Test

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
@@ -78,4 +78,31 @@ final class ConfigTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("basePath");
   }
+
+  @Test
+  void shouldUseDefaultApplicationCredentialsByDefault() {
+    // given
+    final var bucketName = "test";
+
+    // when
+    final var config = new GcsBackupConfig.Builder().withBucketName(bucketName).build();
+
+    // then
+    Assertions.assertThat(config.conn().auth())
+        .isInstanceOf(GcsConnectionConfig.Authentication.Default.class);
+  }
+
+  @Test
+  void shouldUseNoAuthenticationWhenRequested() {
+    // given
+    final var bucketName = "test";
+
+    // when
+    final var config =
+        new GcsBackupConfig.Builder().withBucketName(bucketName).withoutAuthentication().build();
+
+    // then
+    Assertions.assertThat(config.conn().auth())
+        .isInstanceOf(GcsConnectionConfig.Authentication.None.class);
+  }
 }

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
@@ -88,7 +88,7 @@ final class ConfigTest {
     final var config = new GcsBackupConfig.Builder().withBucketName(bucketName).build();
 
     // then
-    Assertions.assertThat(config.conn().auth())
+    Assertions.assertThat(config.connection().auth())
         .isInstanceOf(GcsConnectionConfig.Authentication.Default.class);
   }
 
@@ -102,7 +102,7 @@ final class ConfigTest {
         new GcsBackupConfig.Builder().withBucketName(bucketName).withoutAuthentication().build();
 
     // then
-    Assertions.assertThat(config.conn().auth())
+    Assertions.assertThat(config.connection().auth())
         .isInstanceOf(GcsConnectionConfig.Authentication.None.class);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GCSBackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GCSBackupStoreConfig.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 public class GCSBackupStoreConfig implements ConfigurationEntry {
   private String bucketName;
   private String basePath;
-  private GcsBackupStoreAuth auth;
+  private GcsBackupStoreAuth auth = GcsBackupStoreAuth.AUTO;
 
   public String getBucketName() {
     return bucketName;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GCSBackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GCSBackupStoreConfig.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 public class GCSBackupStoreConfig implements ConfigurationEntry {
   private String bucketName;
   private String basePath;
+  private GcsBackupStoreAuth auth;
 
   public String getBucketName() {
     return bucketName;
@@ -30,6 +31,14 @@ public class GCSBackupStoreConfig implements ConfigurationEntry {
     this.basePath = basePath;
   }
 
+  public GcsBackupStoreAuth getAuth() {
+    return auth;
+  }
+
+  public void setAuth(final GcsBackupStoreAuth auth) {
+    this.auth = auth;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -39,12 +48,14 @@ public class GCSBackupStoreConfig implements ConfigurationEntry {
       return false;
     }
     final GCSBackupStoreConfig that = (GCSBackupStoreConfig) o;
-    return Objects.equals(bucketName, that.bucketName) && Objects.equals(basePath, that.basePath);
+    return Objects.equals(bucketName, that.bucketName)
+        && Objects.equals(basePath, that.basePath)
+        && Objects.equals(auth, that.auth);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bucketName, basePath);
+    return Objects.hash(bucketName, basePath, auth);
   }
 
   @Override
@@ -56,6 +67,14 @@ public class GCSBackupStoreConfig implements ConfigurationEntry {
         + ", basePath='"
         + basePath
         + '\''
+        + ", auth='"
+        + auth
+        + '\''
         + '}';
+  }
+
+  public enum GcsBackupStoreAuth {
+    NONE,
+    AUTO
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -104,12 +104,16 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final ActorFuture<Void> installed) {
     try {
       final var gcsConfig = backupCfg.getGcs();
-      final GcsBackupConfig storeConfig =
+      final var storeConfig =
           new GcsBackupConfig.Builder()
               .withBucketName(gcsConfig.getBucketName())
-              .withBasePath(gcsConfig.getBasePath())
-              .build();
-      final var gcsStore = new GcsBackupStore(storeConfig);
+              .withBasePath(gcsConfig.getBasePath());
+      final var authenticated =
+          switch (gcsConfig.getAuth()) {
+            case NONE -> storeConfig.withoutAuthentication();
+            case AUTO -> storeConfig.withDefaultApplicationCredentials();
+          };
+      final var gcsStore = new GcsBackupStore(authenticated.build());
       context.setBackupStore(gcsStore);
       installed.complete(null);
     } catch (final Exception error) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -111,7 +111,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final var authenticated =
           switch (gcsConfig.getAuth()) {
             case NONE -> storeConfig.withoutAuthentication();
-            case AUTO -> storeConfig.withDefaultApplicationCredentials();
+            case AUTO -> storeConfig.withAutoAuthentication();
           };
       final var gcsStore = new GcsBackupStore(authenticated.build());
       context.setBackupStore(gcsStore);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
@@ -13,15 +13,12 @@ import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import java.util.HashMap;
-import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public final class BackupStoreCfgTest {
-
-  public final Map<String, String> environment = new HashMap<>();
+final class BackupStoreCfgTest {
 
   @Test
-  public void shouldSetPartialS3Config() {
+  void shouldSetPartialS3Config() {
     // given
     final S3BackupStoreConfig expectedConfig = new S3BackupStoreConfig();
     expectedConfig.setBucketName("bucket");
@@ -31,7 +28,7 @@ public final class BackupStoreCfgTest {
     expectedConfig.setSecretKey(null);
 
     // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("backup-cfg", environment);
+    final BrokerCfg cfg = TestConfigReader.readConfig("backup-cfg", new HashMap<>());
     final BackupStoreCfg backup = cfg.getData().getBackup();
 
     // then

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
@@ -11,11 +11,48 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.GCSBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 final class BackupStoreCfgTest {
+
+  @Test
+  void canConfigureBackupStore() {
+    // given
+    final var env = Map.of("zeebe.broker.data.backup.store", "gcs");
+
+    // when
+    final var cfg = TestConfigReader.readConfig("empty", env);
+    // then
+    assertThat(cfg.getData().getBackup().getStore()).isEqualTo(BackupStoreType.GCS);
+  }
+
+  @Test
+  void shouldUseDefaultGcsAuth() {
+    // given
+    final var env = Map.<String, String>of();
+
+    // when
+    final var cfg = TestConfigReader.readConfig("empty", env);
+    // then
+    assertThat(cfg.getData().getBackup().getGcs().getAuth()).isEqualTo(GcsBackupStoreAuth.AUTO);
+  }
+
+  @Test
+  void canConfigureGcsAuth() {
+    // given
+    final var env =
+        Map.of(
+            "zeebe.broker.data.backup.store", "gcs", "zeebe.broker.data.backup.gcs.auth", "none");
+
+    // when
+    final var cfg = TestConfigReader.readConfig("empty", env);
+    // then
+    assertThat(cfg.getData().getBackup().getGcs().getAuth()).isEqualTo(GcsBackupStoreAuth.NONE);
+  }
 
   @Test
   void shouldSetPartialS3Config() {

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -347,6 +347,13 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 
+          # Configures which authentication method is used for connecting to GCS. Can be either 'default' or 'none'.
+          # Choosing 'auto' means that the GCS client uses application default credentials which automatically
+          # discovers appropriate credentials from the runtime environment: https://cloud.google.com/docs/authentication/application-default-credentials
+          # Choosing 'none' means that no authentication is attempted which is only applicable for testing with emulated GCS.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_AUTH.
+          # auth: auto
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -347,7 +347,7 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 
-          # Configures which authentication method is used for connecting to GCS. Can be either 'default' or 'none'.
+          # Configures which authentication method is used for connecting to GCS. Can be either 'auto' or 'none'.
           # Choosing 'auto' means that the GCS client uses application default credentials which automatically
           # discovers appropriate credentials from the runtime environment: https://cloud.google.com/docs/authentication/application-default-credentials
           # Choosing 'none' means that no authentication is attempted which is only applicable for testing with emulated GCS.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -279,6 +279,13 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 
+          # Configures which authentication method is used for connecting to GCS. Can be either 'default' or 'none'.
+          # Choosing 'auto' means that the GCS client uses application default credentials which automatically
+          # discovers appropriate credentials from the runtime environment: https://cloud.google.com/docs/authentication/application-default-credentials
+          # Choosing 'none' means that no authentication is attempted which is only applicable for testing with emulated GCS.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_AUTH.
+          # auth: auto
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -279,7 +279,7 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 
-          # Configures which authentication method is used for connecting to GCS. Can be either 'default' or 'none'.
+          # Configures which authentication method is used for connecting to GCS. Can be either 'auto' or 'none'.
           # Choosing 'auto' means that the GCS client uses application default credentials which automatically
           # discovers appropriate credentials from the runtime environment: https://cloud.google.com/docs/authentication/application-default-credentials
           # Choosing 'none' means that no authentication is attempted which is only applicable for testing with emulated GCS.

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.restore;
 
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig.Builder;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
@@ -61,11 +61,15 @@ final class BackupStoreComponent {
 
   private static GcsBackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
     final var gcsConfig = backupStoreCfg.getGcs();
-    final GcsBackupConfig storeConfig =
-        new GcsBackupConfig.Builder()
+    final var builder =
+        new Builder()
             .withBucketName(gcsConfig.getBucketName())
-            .withBasePath(gcsConfig.getBasePath())
-            .build();
-    return new GcsBackupStore(storeConfig);
+            .withBasePath(gcsConfig.getBasePath());
+    final var authenticated =
+        switch (gcsConfig.getAuth()) {
+          case NONE -> builder.withoutAuthentication();
+          case AUTO -> builder.withDefaultApplicationCredentials();
+        };
+    return new GcsBackupStore(authenticated.build());
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -68,7 +68,7 @@ final class BackupStoreComponent {
     final var authenticated =
         switch (gcsConfig.getAuth()) {
           case NONE -> builder.withoutAuthentication();
-          case AUTO -> builder.withDefaultApplicationCredentials();
+          case AUTO -> builder.withAutoAuthentication();
         };
     return new GcsBackupStore(authenticated.build());
   }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -120,6 +120,7 @@
     <version.jackson-databind-nullable>0.2.5</version.jackson-databind-nullable>
     <version.jackson-annotations>2.14.2</version.jackson-annotations>
     <version.swagger-annotations>2.2.7</version.swagger-annotations>
+    <version.checker-qual>3.32.0</version.checker-qual>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.1.0</plugin.version.antrun>
@@ -1071,6 +1072,12 @@
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>${version.swagger-annotations}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>${version.checker-qual}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This adds configuration to choose the authentication method for connecting to GCS.

Choosing authentication type `NONE` is only useful for testing with emulated GCS.
```yaml
zeebe.broker.data.backup:
  store: gcs
  gcs:
    auth: none
```

Choosing authentication type `AUTO` uses [application default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) which auto discovers credentials from the environment.
```yaml
zeebe.broker.data.backup:
  store: gcs
  gcs:
    auth: auto
```

Application default credentials uses workload identity federation which is useful for SaaS environments, or service accounts when `GOOGLE_APPLICATION_CREDENTIALS` points to a json key file which is useful for self managed environments where federation is not an option.


**Dependency management** looks a little bit funky at the moment, partly because this PR starts to pull in supporting libraries (`com.google.auth` and the like) without actually making use of the gcs client.
Additionally, I've opted to ignore some _used but undeclared dependencies_. This is something that we generally didn't do until now but I think makes sense here. Google's java libraries are very small and some are semi-auto-generated like
`com.google.apis:google-api-services-storage:v1-rev20220705-2.0.0`. 
Managing these as explicit dependencies seems very cumbersome and error prone. Just using them in whatever version is pulled in through the top level dependencies on `com.google.cloud:google-cloud-core` and `com.google.cloud:google-cloud-storage` looks better to me.

closes #11925 