### PR TITLE
feat(backup/gcs): validate connection and bucket name on startup

### DIFF
--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -78,6 +78,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>

--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -70,6 +70,19 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -50,6 +50,7 @@ public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionC
   public static final class Builder {
     private String bucketName;
     private String basePath;
+    private String host;
     private GcsConnectionConfig.Authentication auth;
 
     public Builder withBucketName(final String bucketName) {
@@ -59,6 +60,11 @@ public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionC
 
     public Builder withBasePath(final String basePath) {
       this.basePath = basePath;
+      return this;
+    }
+
+    public Builder withHost(String host) {
+      this.host = host;
       return this;
     }
 
@@ -73,7 +79,7 @@ public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionC
     }
 
     public GcsBackupConfig build() {
-      return new GcsBackupConfig(bucketName, basePath, new GcsConnectionConfig(auth));
+      return new GcsBackupConfig(bucketName, basePath, new GcsConnectionConfig(host, auth));
     }
   }
 }

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.gcs;
 
 import static java.util.Objects.requireNonNull;
 
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
 
 public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionConfig connection) {
@@ -20,7 +21,7 @@ public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionC
 
   private static String requireBucketName(final String bucketName) {
     if (bucketName == null || bucketName.isBlank()) {
-      throw new IllegalArgumentException("bucketName must be provided");
+      throw new ConfigurationException("bucketName must be provided");
     }
     return bucketName;
   }
@@ -40,7 +41,7 @@ public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionC
     }
 
     if (sanitized.isBlank()) {
-      throw new IllegalArgumentException(
+      throw new ConfigurationException(
           "After removing leading and trailing '/' characters from basePath '%s', the remainder is empty and not a valid base path"
               .formatted(basePath));
     }

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+public abstract class GcsBackupStoreException extends RuntimeException {
+  public GcsBackupStoreException(final String message) {
+    super(message);
+  }
+
+  public GcsBackupStoreException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public static class ConfigurationException extends GcsBackupStoreException {
+    public ConfigurationException(String message) {
+      super(message);
+    }
+
+    public ConfigurationException(String message, Exception cause) {
+      super(message, cause);
+    }
+
+    public static final class BucketDoesNotExistException extends ConfigurationException {
+
+      public BucketDoesNotExistException(String bucketName) {
+        super("Bucket %s does not exist".formatted(bucketName));
+      }
+    }
+  }
+}

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsConnectionConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsConnectionConfig.java
@@ -15,9 +15,10 @@ import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
 import java.io.IOException;
 import java.util.Objects;
 
-record GcsConnectionConfig(Authentication auth) {
+record GcsConnectionConfig(String host, Authentication auth) {
 
-  GcsConnectionConfig(Authentication auth) {
+  GcsConnectionConfig(String host, Authentication auth) {
+    this.host = host;
     this.auth = Objects.requireNonNullElseGet(auth, Auto::new);
   }
 

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIntegrationTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIntegrationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import com.google.cloud.storage.BucketInfo;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException.BucketDoesNotExistException;
+import io.camunda.zeebe.backup.gcs.util.GcsContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class ConfigIntegrationTest {
+  @Container private static final GcsContainer GCS = new GcsContainer();
+
+  @Test
+  void shouldSuccessfullyValidateConfiguration() throws Exception {
+    // given
+    final var bucketName = RandomStringUtils.randomAlphabetic(12);
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withHost(GCS.externalEndpoint())
+            .withBucketName(bucketName)
+            .withoutAuthentication()
+            .build();
+
+    try (final var client = GcsBackupStore.buildClient(config)) {
+      client.create(BucketInfo.of(bucketName));
+    }
+
+    // then
+    Assertions.assertThatCode(() -> GcsBackupStore.validateConfig(config))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailValidationIfBucketDoesNotExist() {
+    // given
+    final var bucketName = RandomStringUtils.randomAlphabetic(12);
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withHost(GCS.externalEndpoint())
+            .withBucketName(bucketName)
+            .withoutAuthentication()
+            .build();
+
+    // then
+    Assertions.assertThatThrownBy(() -> GcsBackupStore.validateConfig(config))
+        .isInstanceOf(BucketDoesNotExistException.class)
+        .hasMessageContaining(config.bucketName());
+  }
+}

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.gcs;
 
 import com.google.cloud.storage.BucketInfo;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException.BucketDoesNotExistException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
 import io.camunda.zeebe.backup.gcs.util.GcsContainer;
@@ -26,7 +27,7 @@ final class ConfigTest {
 
     // then
     Assertions.assertThatThrownBy(config::build)
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("bucketName");
   }
 
@@ -39,7 +40,7 @@ final class ConfigTest {
 
     // then
     Assertions.assertThatThrownBy(config::build)
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("bucketName");
   }
 
@@ -80,7 +81,7 @@ final class ConfigTest {
 
     // then
     Assertions.assertThatThrownBy(config::build)
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("basePath");
   }
 

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
@@ -7,7 +7,11 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import com.google.cloud.storage.BucketInfo;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException.BucketDoesNotExistException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
+import io.camunda.zeebe.backup.gcs.util.GcsContainer;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -104,5 +108,52 @@ final class ConfigTest {
     // then
     Assertions.assertThat(config.connection().auth())
         .isInstanceOf(GcsConnectionConfig.Authentication.None.class);
+  }
+
+  @Test
+  void shouldSuccessfullyValidateConfiguration() throws Exception {
+    // given
+    final var bucketName = RandomStringUtils.randomAlphabetic(12);
+
+    // when
+    try (final var gcs = new GcsContainer()) {
+      gcs.start();
+      final var config =
+          new GcsBackupConfig.Builder()
+              .withHost(gcs.externalEndpoint())
+              .withBucketName(bucketName)
+              .withoutAuthentication()
+              .build();
+
+      try (final var client = GcsBackupStore.buildClient(config)) {
+        client.create(BucketInfo.of(bucketName));
+      }
+
+      // then
+      Assertions.assertThatCode(() -> GcsBackupStore.validateConfig(config))
+          .doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  void shouldFailValidationIfBucketDoesNotExist() {
+    // given
+    final var bucketName = RandomStringUtils.randomAlphabetic(12);
+
+    // when
+    try (final var gcs = new GcsContainer()) {
+      gcs.start();
+      final var config =
+          new GcsBackupConfig.Builder()
+              .withHost(gcs.externalEndpoint())
+              .withBucketName(bucketName)
+              .withoutAuthentication()
+              .build();
+
+      // then
+      Assertions.assertThatThrownBy(() -> GcsBackupStore.validateConfig(config))
+          .isInstanceOf(BucketDoesNotExistException.class)
+          .hasMessageContaining(config.bucketName());
+    }
   }
 }

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/util/GcsContainer.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/util/GcsContainer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs.util;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public final class GcsContainer extends GenericContainer<GcsContainer> {
+  private static final DockerImageName IMAGE = DockerImageName.parse("fsouza/fake-gcs-server");
+  private static final int PORT = 4443;
+
+  public GcsContainer() {
+    this("1");
+  }
+
+  public GcsContainer(String version) {
+    super(IMAGE.withTag(version));
+    this.withExposedPorts(PORT).withCommand("-scheme http");
+  }
+
+  @SuppressWarnings("HttpUrlsUsage")
+  public String externalEndpoint() {
+    return "http://%s:%d".formatted(getHost(), getMappedPort(PORT));
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.broker.system;
 import static io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector.MINIMUM_SNAPSHOT_PERIOD;
 
 import io.atomix.cluster.AtomixCluster;
-import io.camunda.zeebe.backup.s3.S3BackupConfig;
-import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -22,6 +20,7 @@ import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.SecurityCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -175,17 +174,7 @@ public final class SystemContext {
     if (backup.getStore() == BackupStoreType.S3) {
       final var s3Config = backup.getS3();
       try {
-        final S3BackupConfig storeConfig =
-            new Builder()
-                .withBucketName(s3Config.getBucketName())
-                .withEndpoint(s3Config.getEndpoint())
-                .withRegion(s3Config.getRegion())
-                .withCredentials(s3Config.getAccessKey(), s3Config.getSecretKey())
-                .withApiCallTimeout(s3Config.getApiCallTimeout())
-                .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
-                .withCompressionAlgorithm(s3Config.getCompression())
-                .withBasePath(s3Config.getBasePath())
-                .build();
+        final var storeConfig = S3BackupStoreConfig.toStoreConfig(s3Config);
         S3BackupStore.validateConfig(storeConfig);
       } catch (final Exception e) {
         throw new InvalidConfigurationException("Cannot configure S3 backup store.", e);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system;
 import static io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector.MINIMUM_SNAPSHOT_PERIOD;
 
 import io.atomix.cluster.AtomixCluster;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -19,7 +20,7 @@ import io.camunda.zeebe.broker.system.configuration.DiskCfg.FreeSpaceCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.SecurityCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
@@ -166,19 +167,19 @@ public final class SystemContext {
   }
 
   private void validateBackupCfg(final BackupStoreCfg backup) {
-    if (backup.getStore() == BackupStoreType.NONE) {
-      LOG.warn("No backup store is configured. Backups will not be taken");
-      return;
-    }
-
-    if (backup.getStore() == BackupStoreType.S3) {
-      final var s3Config = backup.getS3();
-      try {
-        final var storeConfig = S3BackupStoreConfig.toStoreConfig(s3Config);
-        S3BackupStore.validateConfig(storeConfig);
-      } catch (final Exception e) {
-        throw new InvalidConfigurationException("Cannot configure S3 backup store.", e);
+    try {
+      switch (backup.getStore()) {
+        case NONE -> LOG.warn("No backup store is configured. Backups will not be taken");
+        case S3 -> S3BackupStore.validateConfig(S3BackupStoreConfig.toStoreConfig(backup.getS3()));
+        case GCS -> GcsBackupStore.validateConfig(
+            GcsBackupStoreConfig.toStoreConfig(backup.getGcs()));
+        default -> throw new UnsupportedOperationException(
+            "Does not support validating configuration of backup store %s"
+                .formatted(backup.getStore()));
       }
+    } catch (final Exception e) {
+      throw new InvalidConfigurationException(
+          "Failed configuring backup store %s".formatted(backup.getStore()), e);
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration.backup;
 
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 
 public class BackupStoreCfg implements ConfigurationEntry {
@@ -38,6 +39,12 @@ public class BackupStoreCfg implements ConfigurationEntry {
 
   public void setStore(final BackupStoreType store) {
     this.store = store;
+  }
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    s3.init(globalConfig, brokerBase);
+    gcs.init(globalConfig, brokerBase);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
@@ -14,7 +14,7 @@ public class BackupStoreCfg implements ConfigurationEntry {
   private BackupStoreType store = BackupStoreType.NONE;
 
   private S3BackupStoreConfig s3 = new S3BackupStoreConfig();
-  private GCSBackupStoreConfig gcs = new GCSBackupStoreConfig();
+  private GcsBackupStoreConfig gcs = new GcsBackupStoreConfig();
 
   public S3BackupStoreConfig getS3() {
     return s3;
@@ -24,11 +24,11 @@ public class BackupStoreCfg implements ConfigurationEntry {
     this.s3 = s3;
   }
 
-  public GCSBackupStoreConfig getGcs() {
+  public GcsBackupStoreConfig getGcs() {
     return gcs;
   }
 
-  public void setGcs(final GCSBackupStoreConfig gcs) {
+  public void setGcs(final GcsBackupStoreConfig gcs) {
     this.gcs = gcs;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GCSBackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GCSBackupStoreConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration.backup;
 
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import java.util.Objects;
 
@@ -37,6 +38,19 @@ public class GCSBackupStoreConfig implements ConfigurationEntry {
 
   public void setAuth(final GcsBackupStoreAuth auth) {
     this.auth = auth;
+  }
+
+  public static GcsBackupConfig toStoreConfig(GCSBackupStoreConfig config) {
+    final var storeConfig =
+        new GcsBackupConfig.Builder()
+            .withBucketName(config.getBucketName())
+            .withBasePath(config.getBasePath());
+    final var authenticated =
+        switch (config.getAuth()) {
+          case NONE -> storeConfig.withoutAuthentication();
+          case AUTO -> storeConfig.withAutoAuthentication();
+        };
+    return authenticated.build();
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 public class GcsBackupStoreConfig implements ConfigurationEntry {
   private String bucketName;
   private String basePath;
+  private String host;
   private GcsBackupStoreAuth auth = GcsBackupStoreAuth.AUTO;
 
   public String getBucketName() {
@@ -32,6 +33,14 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
     this.basePath = basePath;
   }
 
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
   public GcsBackupStoreAuth getAuth() {
     return auth;
   }
@@ -44,7 +53,8 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
     final var storeConfig =
         new GcsBackupConfig.Builder()
             .withBucketName(config.getBucketName())
-            .withBasePath(config.getBasePath());
+            .withBasePath(config.getBasePath())
+            .withHost(config.getHost());
     final var authenticated =
         switch (config.getAuth()) {
           case NONE -> storeConfig.withoutAuthentication();
@@ -64,26 +74,29 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
     final GcsBackupStoreConfig that = (GcsBackupStoreConfig) o;
     return Objects.equals(bucketName, that.bucketName)
         && Objects.equals(basePath, that.basePath)
-        && Objects.equals(auth, that.auth);
+        && Objects.equals(host, that.host)
+        && auth == that.auth;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bucketName, basePath, auth);
+    return Objects.hash(bucketName, basePath, host, auth);
   }
 
   @Override
   public String toString() {
-    return "GCSBackupStoreConfig{"
+    return "GcsBackupStoreConfig{"
         + "bucketName='"
         + bucketName
         + '\''
         + ", basePath='"
         + basePath
         + '\''
-        + ", auth='"
-        + auth
+        + ", host='"
+        + host
         + '\''
+        + ", auth="
+        + auth
         + '}';
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import java.util.Objects;
 
-public class GCSBackupStoreConfig implements ConfigurationEntry {
+public class GcsBackupStoreConfig implements ConfigurationEntry {
   private String bucketName;
   private String basePath;
   private GcsBackupStoreAuth auth = GcsBackupStoreAuth.AUTO;
@@ -40,7 +40,7 @@ public class GCSBackupStoreConfig implements ConfigurationEntry {
     this.auth = auth;
   }
 
-  public static GcsBackupConfig toStoreConfig(GCSBackupStoreConfig config) {
+  public static GcsBackupConfig toStoreConfig(GcsBackupStoreConfig config) {
     final var storeConfig =
         new GcsBackupConfig.Builder()
             .withBucketName(config.getBucketName())
@@ -61,7 +61,7 @@ public class GCSBackupStoreConfig implements ConfigurationEntry {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final GCSBackupStoreConfig that = (GCSBackupStoreConfig) o;
+    final GcsBackupStoreConfig that = (GcsBackupStoreConfig) o;
     return Objects.equals(bucketName, that.bucketName)
         && Objects.equals(basePath, that.basePath)
         && Objects.equals(auth, that.auth);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration.backup;
 
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import java.time.Duration;
 import java.util.Objects;
@@ -98,6 +99,19 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
 
   public String getBasePath() {
     return basePath;
+  }
+
+  public static S3BackupConfig toStoreConfig(S3BackupStoreConfig config) {
+    return new S3BackupConfig.Builder()
+        .withBucketName(config.getBucketName())
+        .withEndpoint(config.getEndpoint())
+        .withRegion(config.getRegion())
+        .withCredentials(config.getAccessKey(), config.getSecretKey())
+        .withApiCallTimeout(config.getApiCallTimeout())
+        .forcePathStyleAccess(config.isForcePathStyleAccess())
+        .withCompressionAlgorithm(config.getCompression())
+        .withBasePath(config.getBasePath())
+        .build();
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -9,10 +9,10 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.GCSBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
@@ -92,17 +92,9 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final BackupStoreCfg backupCfg,
       final ActorFuture<Void> installed) {
     try {
-      final var gcsConfig = backupCfg.getGcs();
-      final var storeConfig =
-          new GcsBackupConfig.Builder()
-              .withBucketName(gcsConfig.getBucketName())
-              .withBasePath(gcsConfig.getBasePath());
-      final var authenticated =
-          switch (gcsConfig.getAuth()) {
-            case NONE -> storeConfig.withoutAuthentication();
-            case AUTO -> storeConfig.withAutoAuthentication();
-          };
-      final var gcsStore = new GcsBackupStore(authenticated.build());
+      final var brokerGcsConfig = backupCfg.getGcs();
+      final var storeGcsConfig = GCSBackupStoreConfig.toStoreConfig(brokerGcsConfig);
+      final var gcsStore = new GcsBackupStore(storeGcsConfig);
       context.setBackupStore(gcsStore);
       installed.complete(null);
     } catch (final Exception error) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.GCSBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
@@ -93,7 +93,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final ActorFuture<Void> installed) {
     try {
       final var brokerGcsConfig = backupCfg.getGcs();
-      final var storeGcsConfig = GCSBackupStoreConfig.toStoreConfig(brokerGcsConfig);
+      final var storeGcsConfig = GcsBackupStoreConfig.toStoreConfig(brokerGcsConfig);
       final var gcsStore = new GcsBackupStore(storeGcsConfig);
       context.setBackupStore(gcsStore);
       installed.complete(null);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -11,9 +11,9 @@ import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
-import io.camunda.zeebe.backup.s3.S3BackupConfig;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -78,19 +78,8 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final BackupStoreCfg backupCfg,
       final ActorFuture<Void> installed) {
     try {
-      final var s3Config = backupCfg.getS3();
-      final S3BackupConfig storeConfig =
-          new S3BackupConfig.Builder()
-              .withBucketName(s3Config.getBucketName())
-              .withEndpoint(s3Config.getEndpoint())
-              .withRegion(s3Config.getRegion())
-              .withCredentials(s3Config.getAccessKey(), s3Config.getSecretKey())
-              .withApiCallTimeout(s3Config.getApiCallTimeout())
-              .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
-              .withCompressionAlgorithm(s3Config.getCompression())
-              .withBasePath(s3Config.getBasePath())
-              .build();
-      final S3BackupStore backupStore = new S3BackupStore(storeConfig);
+      final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupCfg.getS3());
+      final var backupStore = new S3BackupStore(storeConfig);
       context.setBackupStore(backupStore);
       installed.complete(null);
     } catch (final Exception error) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -422,7 +422,7 @@ final class SystemContextTest {
     // when - then
     assertThatCode(() -> initSystemContext(brokerCfg))
         .isInstanceOf(InvalidConfigurationException.class)
-        .hasMessageContaining("Cannot configure S3 backup store");
+        .hasMessageContaining("Failed configuring backup store S3");
   }
 
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
-import io.camunda.zeebe.broker.system.configuration.backup.GCSBackupStoreConfig.GcsBackupStoreAuth;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import java.util.HashMap;
 import java.util.Map;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
@@ -55,6 +55,23 @@ final class BackupStoreCfgTest {
   }
 
   @Test
+  void canConfigureGcsHost() {
+    // given
+    final var configuredHost = "localhost";
+    final var env =
+        Map.of(
+            "zeebe.broker.data.backup.store",
+            "gcs",
+            "zeebe.broker.data.backup.gcs.host",
+            configuredHost);
+
+    // when
+    final var cfg = TestConfigReader.readConfig("empty", env);
+    // then
+    assertThat(cfg.getData().getBackup().getGcs().getHost()).isEqualTo(configuredHost);
+  }
+
+  @Test
   void shouldSetPartialS3Config() {
     // given
     final S3BackupStoreConfig expectedConfig = new S3BackupStoreConfig();

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -347,6 +347,12 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 
+          # When set, this overrides the host that the GCS client connects to.
+          # By default, this is not set because the client can automatically discover the correct host to
+          # connect to.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_HOST
+          # host:
+
           # Configures which authentication method is used for connecting to GCS. Can be either 'auto' or 'none'.
           # Choosing 'auto' means that the GCS client uses application default credentials which automatically
           # discovers appropriate credentials from the runtime environment: https://cloud.google.com/docs/authentication/application-default-credentials

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -279,6 +279,12 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
           # basePath:
 
+          # When set, this overrides the host that the GCS client connects to.
+          # By default, this is not set because the client can automatically discover the correct host to
+          # connect to.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_GCS_HOST
+          # host:
+
           # Configures which authentication method is used for connecting to GCS. Can be either 'auto' or 'none'.
           # Choosing 'auto' means that the GCS client uses application default credentials which automatically
           # discovers appropriate credentials from the runtime environment: https://cloud.google.com/docs/authentication/application-default-credentials

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.GCSBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -49,7 +49,7 @@ final class BackupStoreComponent {
   }
 
   private static GcsBackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var storeConfig = GCSBackupStoreConfig.toStoreConfig(backupStoreCfg.getGcs());
+    final var storeConfig = GcsBackupStoreConfig.toStoreConfig(backupStoreCfg.getGcs());
     return new GcsBackupStore(storeConfig);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -10,10 +10,10 @@ package io.camunda.zeebe.restore;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig.Builder;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
-import io.camunda.zeebe.backup.s3.S3BackupConfig;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -44,18 +44,7 @@ final class BackupStoreComponent {
   }
 
   private static S3BackupStore buildS3BackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var s3Config = backupStoreCfg.getS3();
-    final S3BackupConfig storeConfig =
-        new S3BackupConfig.Builder()
-            .withBucketName(s3Config.getBucketName())
-            .withEndpoint(s3Config.getEndpoint())
-            .withRegion(s3Config.getRegion())
-            .withCredentials(s3Config.getAccessKey(), s3Config.getSecretKey())
-            .withApiCallTimeout(s3Config.getApiCallTimeout())
-            .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
-            .withCompressionAlgorithm(s3Config.getCompression())
-            .withBasePath(s3Config.getBasePath())
-            .build();
+    final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupStoreCfg.getS3());
     return new S3BackupStore(storeConfig);
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -8,11 +8,11 @@
 package io.camunda.zeebe.restore;
 
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.gcs.GcsBackupConfig.Builder;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.GCSBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -49,16 +49,7 @@ final class BackupStoreComponent {
   }
 
   private static GcsBackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
-    final var gcsConfig = backupStoreCfg.getGcs();
-    final var builder =
-        new Builder()
-            .withBucketName(gcsConfig.getBucketName())
-            .withBasePath(gcsConfig.getBasePath());
-    final var authenticated =
-        switch (gcsConfig.getAuth()) {
-          case NONE -> builder.withoutAuthentication();
-          case AUTO -> builder.withAutoAuthentication();
-        };
-    return new GcsBackupStore(authenticated.build());
+    final var storeConfig = GCSBackupStoreConfig.toStoreConfig(backupStoreCfg.getGcs());
+    return new GcsBackupStore(storeConfig);
   }
 }


### PR DESCRIPTION
This adds a new configuration option:
```yaml
zeebe.broker.data.backup:
  store: gcs
  gcs:
    host: http://localhost:4443
```
For now, this is mostly useful for testing. The first usage is a new test that verifies that _configuration validation_ checks that the specified `bucketName` already exists.
Instead of mocking the GCS client, we immediately start with integration tests using [fake-gcs-server
](https://github.com/fsouza/fake-gcs-server) which appears to be the best option for emulating GCS.

This _configuration validation_ happens at startup, in the `SystemContext` to make sure that any configured backup store is actually usable.

closes #11977 