### PR TITLE
Use kryo for backwards compatibility

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AtomixPartitionMessagingService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AtomixPartitionMessagingService.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.utils.serializer.serializers.DefaultSerializers;
 import io.camunda.zeebe.broker.system.partitions.PartitionMessagingService;
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -39,35 +40,20 @@ public class AtomixPartitionMessagingService implements PartitionMessagingServic
   @Override
   public void subscribe(
       final String subject, final Consumer<ByteBuffer> consumer, final Executor executor) {
-    communicationService.subscribe(subject, ByteBuffer::wrap, consumer, executor);
+    communicationService.subscribe(subject, DefaultSerializers.BASIC::decode, consumer, executor);
   }
 
   @Override
   public void broadcast(final String subject, final ByteBuffer payload) {
     final var reachableMembers =
         otherMembers.stream().filter(this::isReachable).collect(Collectors.toUnmodifiableSet());
-    communicationService.multicast(subject, payload, this::serializeBuffer, reachableMembers, true);
+    communicationService.multicast(
+        subject, payload, DefaultSerializers.BASIC::encode, reachableMembers, true);
   }
 
   @Override
   public void unsubscribe(final String subject) {
     communicationService.unsubscribe(subject);
-  }
-
-  private byte[] serializeBuffer(final ByteBuffer payload) {
-    if (payload.hasArray()
-        && payload.arrayOffset() == 0
-        && payload.position() == 0
-        && payload.remaining() == payload.array().length) {
-      return payload.array();
-    }
-
-    final var serialized = new byte[payload.remaining()];
-    payload.mark();
-    payload.get(serialized);
-    payload.reset();
-
-    return serialized;
   }
 
   private Set<MemberId> getOtherMemberIds(

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
@@ -11,13 +11,13 @@ import static io.camunda.zeebe.broker.transport.partitionapi.InterPartitionComma
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.utils.serializer.serializers.DefaultSerializers;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.scheduler.Actor;
 import java.util.Map;
-import java.util.function.Function;
 import org.slf4j.Logger;
 
 /**
@@ -60,7 +60,10 @@ public final class InterPartitionCommandReceiverActor extends Actor
   @Override
   protected void onActorStarting() {
     communicationService.subscribe(
-        TOPIC_PREFIX + partitionId, Function.identity(), this::tryHandleMessage, actor::run);
+        TOPIC_PREFIX + partitionId,
+        DefaultSerializers.BASIC::decode,
+        this::tryHandleMessage,
+        actor::run);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.transport.partitionapi;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.utils.serializer.serializers.DefaultSerializers;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.protocol.InterPartitionMessageEncoder;
@@ -19,7 +20,6 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Objects;
-import java.util.function.Function;
 import org.agrona.collections.Int2IntHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
@@ -77,7 +77,7 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
     communicationService.unicast(
         TOPIC_PREFIX + receiverPartitionId,
         message,
-        Function.identity(),
+        DefaultSerializers.BASIC::encode,
         MemberId.from("" + partitionLeader),
         true);
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
-import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -189,12 +188,7 @@ final class InterPartitionCommandCheckpointTest {
 
     final var messageCaptor = ArgumentCaptor.forClass(byte[].class);
     verify(communicationService)
-        .unicast(
-            eq(TOPIC_PREFIX + 1),
-            messageCaptor.capture(),
-            eq(Function.identity()),
-            any(),
-            eq(true));
+        .unicast(eq(TOPIC_PREFIX + 1), messageCaptor.capture(), any(), any(), eq(true));
     receiver.handleMessage(new MemberId("0"), messageCaptor.getValue());
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
-import java.util.function.Function;
 import org.agrona.ExpandableArrayBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -246,7 +245,7 @@ final class InterPartitionCommandReceiverTest {
         .unicast(
             eq(TOPIC_PREFIX + receiverPartitionId),
             messageCaptor.capture(),
-            eq(Function.identity()),
+            any(),
             any(),
             eq(true));
 

--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.util.VersionUtil;
@@ -35,6 +36,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
@@ -68,6 +70,10 @@ final class RollingUpdateTest {
           .withReplicationFactor(3)
           .withNetwork(network)
           .build();
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  private final ContainerLogsDumper logsPrinter = new ContainerLogsDumper(cluster::getNodes);
 
   @BeforeEach
   public void setup() {
@@ -330,6 +336,8 @@ final class RollingUpdateTest {
         .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT", "1s")
         .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_FAILURETIMEOUT", "2s")
         .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES", "2")
+        // ensure we have an exporter present to test sharing exporter state across nodes
+        .withEnv("ZEEBE_BROKER_EXECUTIONMETRICSEXPORTERENABLED", "true")
         .withEnv("ZEEBE_LOG_LEVEL", "DEBUG");
     broker.setDockerImageName(PREVIOUS_VERSION.asCanonicalNameString());
   }


### PR DESCRIPTION
## Description

This PR reverts the removal of unnecessary Kryo copy/usage from the `InterPartitionCommandSender`, `InterPartitionCommandReceiver`, and `PartitionMessagingService`, as this causes errors during rolling update. While we should figure out a way to deal with this properly, it's not super urgent for now. 

However, for new features, we should try to avoid using Kryo in the first place.

## Related issues

closes #11989 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
