### PR TITLE
Add QA tests that verify CreateProcessInstanceWithResult responses

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
@@ -175,7 +175,7 @@ public final class CreateProcessInstanceWithResultTest {
     client
         .newDeployResourceCommand()
         .addProcessModel(
-            Bpmn.createExecutableProcess("process")
+            Bpmn.createExecutableProcess(processId)
                 .startEvent()
                 .intermediateCatchEvent()
                 .message(message -> message.name("a").zeebeCorrelationKeyExpression("key"))
@@ -188,7 +188,7 @@ public final class CreateProcessInstanceWithResultTest {
     final ZeebeFuture<ProcessInstanceResult> processInstanceResult =
         client
             .newCreateInstanceCommand()
-            .bpmnProcessId("process")
+            .bpmnProcessId(processId)
             .latestVersion()
             .variables(Map.of("key", "key-1"))
             .withResult()
@@ -215,7 +215,7 @@ public final class CreateProcessInstanceWithResultTest {
     client
         .newDeployResourceCommand()
         .addProcessModel(
-            Bpmn.createExecutableProcess("process")
+            Bpmn.createExecutableProcess(processId)
                 .startEvent()
                 .serviceTask("task", t -> t.zeebeJobType("task"))
                 .endEvent()
@@ -227,7 +227,7 @@ public final class CreateProcessInstanceWithResultTest {
     final ZeebeFuture<ProcessInstanceResult> processInstanceResult =
         client
             .newCreateInstanceCommand()
-            .bpmnProcessId("process")
+            .bpmnProcessId(processId)
             .latestVersion()
             .withResult()
             .send();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

These two cases failed recently due to a bug introduced with batch processing [1].

As this affected behavior visible to users, it makes sense to introduce QA integration tests that showcase that the `CreateProcessInstanceWithResult` can actually respond when the process instance is completed by another user command.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #11848

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
