### PR TITLE
fix(engine): open single message or signal subscription for the same event

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -52,7 +52,7 @@ public class StartEventSubscriptionManager {
       final DeploymentRecord deploymentRecord, final StateWriter stateWriter) {
 
     for (final ProcessMetadata processRecord : deploymentRecord.processesMetadata()) {
-      if (isLatestProcess(processRecord)) {
+      if (!processRecord.isDuplicate() && isLatestProcess(processRecord)) {
         closeExistingStartEventSubscriptions(processRecord, stateWriter);
         openStartEventSubscriptions(processRecord, stateWriter);
       }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalSubscriptionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalSubscriptionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
@@ -34,10 +35,8 @@ public final class SignalSubscriptionTest {
   private static final String SIGNAL_NAME2 = "startSignal2";
   private static final String EVENT_ID2 = "startEventId2";
 
-  @Rule
-  public final EngineRule engine = EngineRule.singlePartition();
-  @Rule
-  public final BrokerClassRuleHelper brokerClassRuleHelper = new BrokerClassRuleHelper();
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final BrokerClassRuleHelper brokerClassRuleHelper = new BrokerClassRuleHelper();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
@@ -129,9 +128,9 @@ public final class SignalSubscriptionTest {
 
     // then
     assertThat(
-        RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
-            .withBpmnProcessId(processId)
-            .limit(2))
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .withBpmnProcessId(processId)
+                .limit(2))
         .extracting(r -> r.getValue().getProcessDefinitionKey(), r -> r.getValue().getSignalName())
         .contains(
             tuple(processDefinitionKey, SIGNAL_NAME1), tuple(processDefinitionKey, SIGNAL_NAME2));
@@ -149,14 +148,14 @@ public final class SignalSubscriptionTest {
     engine.deployment().withXmlResource(process).deploy();
 
     // then
+    // deploy an empty deployment, so we can use the position to limit the recorded stream
+    final var position = engine.deployment().expectRejection().deploy().getPosition();
     assertThat(
-        RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
-            .withBpmnProcessId(processId).limit(2))
-        .extracting(Record::getValue)
-        .extracting(SignalSubscriptionRecordValue::getSignalName,
-            SignalSubscriptionRecordValue::getCatchEventId)
-        .hasSize(1)
-        .containsExactly(tuple(SIGNAL_NAME1, EVENT_ID1));
+        RecordingExporter.records()
+            .limit(r -> r.getPosition() >= position)
+            .filter(r -> r.getValueType() == ValueType.SIGNAL_SUBSCRIPTION))
+        .describedAs("Expect only one signal start event subscription for duplicate deployments")
+        .hasSize(1);
   }
 
   private static BpmnModelInstance createProcessWithOneSignalStartEvent(final String processId) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalSubscriptionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalSubscriptionTest.java
@@ -151,9 +151,9 @@ public final class SignalSubscriptionTest {
     // deploy an empty deployment, so we can use the position to limit the recorded stream
     final var position = engine.deployment().expectRejection().deploy().getPosition();
     assertThat(
-        RecordingExporter.records()
-            .limit(r -> r.getPosition() >= position)
-            .filter(r -> r.getValueType() == ValueType.SIGNAL_SUBSCRIPTION))
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= position)
+                .filter(r -> r.getValueType() == ValueType.SIGNAL_SUBSCRIPTION))
         .describedAs("Expect only one signal start event subscription for duplicate deployments")
         .hasSize(1);
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageStartEventSubscriptionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageStartEventSubscriptionRecordStream.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 
 public final class MessageStartEventSubscriptionRecordStream
     extends ExporterRecordStream<
-        MessageStartEventSubscriptionRecordValue, MessageStartEventSubscriptionRecordStream> {
+    MessageStartEventSubscriptionRecordValue, MessageStartEventSubscriptionRecordStream> {
 
   public MessageStartEventSubscriptionRecordStream(
       final Stream<Record<MessageStartEventSubscriptionRecordValue>> wrappedStream) {
@@ -24,6 +24,10 @@ public final class MessageStartEventSubscriptionRecordStream
   protected MessageStartEventSubscriptionRecordStream supply(
       final Stream<Record<MessageStartEventSubscriptionRecordValue>> wrappedStream) {
     return new MessageStartEventSubscriptionRecordStream((wrappedStream));
+  }
+
+  public MessageStartEventSubscriptionRecordStream withBpmnProcessId(final String bpmnProcessId) {
+    return valueFilter(v -> bpmnProcessId.equals(v.getBpmnProcessId()));
   }
 
   public MessageStartEventSubscriptionRecordStream withProcessDefinitionKey(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageStartEventSubscriptionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageStartEventSubscriptionRecordStream.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 
 public final class MessageStartEventSubscriptionRecordStream
     extends ExporterRecordStream<
-    MessageStartEventSubscriptionRecordValue, MessageStartEventSubscriptionRecordStream> {
+        MessageStartEventSubscriptionRecordValue, MessageStartEventSubscriptionRecordStream> {
 
   public MessageStartEventSubscriptionRecordStream(
       final Stream<Record<MessageStartEventSubscriptionRecordValue>> wrappedStream) {


### PR DESCRIPTION
## Description

When a user deploys the same process multiple times without changes, no additional message or signal start event subscriptions will be opened, if there are top-level message or signal start events present in the process.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11308 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
