### PR TITLE
feat(clients/java): Introduce a method for polling jobs for activation in the `JobClient`

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -102,6 +102,24 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client;
 
-import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
@@ -341,27 +340,6 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the worker registration
    */
   JobWorkerBuilderStep1 newWorker();
-
-  /**
-   * Command to activate multiple jobs of a given type.
-   *
-   * <pre>
-   * zeebeClient
-   *  .newActivateJobsCommand()
-   *  .jobType("payment")
-   *  .maxJobsToActivate(10)
-   *  .workerName("paymentWorker")
-   *  .timeout(Duration.ofMinutes(10))
-   *  .send();
-   * </pre>
-   *
-   * <p>The command will try to use {@code maxJobsToActivate} for given {@code jobType}. If less
-   * then the requested {@code maxJobsToActivate} jobs of the {@code jobType} are available for
-   * activation the returned list will have fewer elements.
-   *
-   * @return a builder for the command
-   */
-  ActivateJobsCommandStep1 newActivateJobsCommand();
 
   /**
    * Command to delete a resource.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.api.worker;
 
+import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
@@ -149,4 +150,25 @@ public interface JobClient {
    * @return a builder for the command
    */
   ThrowErrorCommandStep1 newThrowErrorCommand(ActivatedJob job);
+
+  /**
+   * Command to activate multiple jobs of a given type.
+   *
+   * <pre>
+   * jobClient
+   *  .newActivateJobsCommand()
+   *  .jobType("payment")
+   *  .maxJobsToActivate(10)
+   *  .workerName("paymentWorker")
+   *  .timeout(Duration.ofMinutes(10))
+   *  .send();
+   * </pre>
+   *
+   * <p>The command will try to use {@code maxJobsToActivate} for given {@code jobType}. If less
+   * then the requested {@code maxJobsToActivate} jobs of the {@code jobType} are available for
+   * activation the returned list will have fewer elements.
+   *
+   * @return a builder for the command
+   */
+  ActivateJobsCommandStep1 newActivateJobsCommand();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -41,7 +41,6 @@ import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
-import io.camunda.zeebe.client.impl.command.ActivateJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.BroadcastSignalCommandImpl;
 import io.camunda.zeebe.client.impl.command.CancelProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.CreateProcessInstanceCommandImpl;
@@ -340,20 +339,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
 
   @Override
   public JobWorkerBuilderStep1 newWorker() {
-    return new JobWorkerBuilderImpl(
-        config,
-        asyncStub,
-        jobClient,
-        jsonMapper,
-        executorService,
-        closeables,
-        credentialsProvider::shouldRetryRequest);
+    return new JobWorkerBuilderImpl(config, jobClient, executorService, closeables);
   }
 
   @Override
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
-    return new ActivateJobsCommandImpl(
-        asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
+    return jobClient.newActivateJobsCommand();
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import java.time.Duration;
+
 public final class ArgumentUtil {
 
   public static void ensureNotNull(final String property, final Object value) {
@@ -39,5 +41,22 @@ public final class ArgumentUtil {
     if (testValue <= comparisonValue) {
       throw new IllegalArgumentException(property + " must be greater than " + comparisonValue);
     }
+  }
+
+  public static void ensureNotNegative(final String property, final Duration testValue) {
+    if (testValue.isNegative()) {
+      throw new IllegalArgumentException(String.format("%s must be not negative", property));
+    }
+  }
+
+  public static void ensureNotZero(final String property, final Duration testValue) {
+    if (testValue.isZero()) {
+      throw new IllegalArgumentException(String.format("%s must be not zero", property));
+    }
+  }
+
+  public static void ensurePositive(final String property, final Duration testValue) {
+    ensureNotNegative(property, testValue);
+    ensureNotZero(property, testValue);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
@@ -17,11 +17,13 @@ package io.camunda.zeebe.client.impl.worker;
 
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.impl.command.ActivateJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.CompleteJobCommandImpl;
 import io.camunda.zeebe.client.impl.command.FailJobCommandImpl;
 import io.camunda.zeebe.client.impl.command.ThrowErrorCommandImpl;
@@ -77,5 +79,10 @@ public final class JobClientImpl implements JobClient {
   @Override
   public ThrowErrorCommandStep1 newThrowErrorCommand(final ActivatedJob job) {
     return newThrowErrorCommand(job.getKey());
+  }
+
+  @Override
+  public ActivateJobsCommandStep1 newActivateJobsCommand() {
+    return new ActivateJobsCommandImpl(asyncStub, config, jsonMapper, retryPredicate);
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JobWorkerBuilderImplTest {
+
+  private JobWorkerBuilderImpl jobWorkerBuilder;
+  private ZeebeClientConfiguration zeebeClientConfiguration;
+  private JobClient jobClient;
+  private ScheduledExecutorService executorService;
+  private List<Closeable> closeables;
+
+  @BeforeEach
+  void setUp() {
+    zeebeClientConfiguration = mock();
+    jobClient = mock();
+    executorService = mock();
+    closeables = Collections.emptyList();
+    jobWorkerBuilder =
+        new JobWorkerBuilderImpl(zeebeClientConfiguration, jobClient, executorService, closeables);
+  }
+
+  @Test
+  void shouldThrowErrorIfTimeoutIsNegative() {
+    // given
+    // when
+    assertThatThrownBy(
+            () ->
+                jobWorkerBuilder
+                    .jobType("some-type")
+                    .handler(mock())
+                    .timeout(Duration.ofSeconds(5).negated())
+                    .open())
+        // then
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("timeout must be not negative");
+  }
+
+  @Test
+  void shouldThrowErrorIfTimeoutIsZero() {
+    // given
+    // when
+    assertThatThrownBy(
+            () ->
+                jobWorkerBuilder.jobType("some-type").handler(mock()).timeout(Duration.ZERO).open())
+        // then
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("timeout must be not zero");
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I am introducing a new method and migrate to it in the `JobPoller`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11884 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
