### PR TITLE
feat(auth): Identity Authentication of GRPC requests in Zeebe Gateway

### DIFF
--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -41,6 +41,12 @@ zeebe:
         # Enables TLS authentication between clients and the gateway
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED.
         enabled: false
+        authentication:
+          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
+          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
+          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
+          mode: none
 
     network:
       # Controls the default host the broker should bind to. Can be overwritten on a

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -75,6 +75,26 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_PRIVATEKEYPATH.
         # privateKeyPath:
 
+        # authentication:
+          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
+          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
+          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
+          # mode: none
+
+          # identity:
+            # The URL to the auth provider backend, used to validate tokens.
+            # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL.
+            # issuerBackendUrl: http://keycloak:8080/auth/realms/camunda-platform
+
+            # The required audience of the auth token.
+            # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE.
+            # audience: zeebe-api
+
+            # The identity auth type to apply, one of `keycloak` or `auth0`.
+            # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE.
+            # type: keycloak
+
       # longPolling:
         # Enables long polling for available jobs
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_LONGPOLLING_ENABLED.

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -157,6 +157,26 @@
         # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH.
         # privateKeyPath:
 
+        # authentication:
+          # Controls which authentication mode is active, supported modes are 'none' and 'identity'.
+          # If 'identity' is set, authentication will be done using camunda-identity, which needs to
+          # be configured in the corresponding subsection. See also https://docs.camunda.io/docs/self-managed/identity/what-is-identity/ .
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE.
+          # mode: none
+
+          # identity:
+            # The URL to the auth provider backend, used to validate tokens.
+            # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL.
+            # issuerBackendUrl: http://keycloak:8080/auth/realms/camunda-platform
+
+            # The required audience of the auth token.
+            # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE.
+            # audience: zeebe-api
+
+            # The identity auth type to apply, one of `keycloak` or `auth0`.
+            # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE.
+            # type: keycloak
+
       # Configure compression algorithm for all messages sent between the gateway and
       # the brokers. Available options are NONE, GZIP and SNAPPY.
       # This feature is useful when the network latency between the nodes is very high (for example when nodes are deployed in different data centers).

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -156,6 +156,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>identity-sdk</artifactId>
+      <version>${version.identity}</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
       <scope>test</scope>
@@ -297,6 +303,31 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>camunda-identity</id>
+      <name>Camunda Identity Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>camunda-identity-snapshots</id>
+      <name>Camunda Identity Snapshot Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/camunda-identity-snapshots/</url>
+    </repository>
+  </repositories>
 
   <build>
     <plugins>

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -11,12 +11,14 @@ import io.camunda.zeebe.gateway.health.GatewayHealthManager;
 import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.health.impl.GatewayHealthManagerImpl;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg.AuthMode;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.ContextInjectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.InterceptorRepository;
@@ -235,6 +237,9 @@ public final class Gateway {
     Collections.reverse(interceptors);
     interceptors.add(new ContextInjectingInterceptor(queryApi));
     interceptors.add(MONITORING_SERVER_INTERCEPTOR);
+    if (gatewayCfg.getSecurity().getAuthentication().getMode() != AuthMode.NONE) {
+      interceptors.add(new AuthenticationInterceptor(gatewayCfg.getSecurity().getAuthentication()));
+    }
 
     return ServerInterceptors.intercept(service, interceptors);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -18,9 +18,9 @@ import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
-import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.ContextInjectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
+import io.camunda.zeebe.gateway.interceptors.impl.IdentityInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.InterceptorRepository;
 import io.camunda.zeebe.gateway.query.impl.QueryApiImpl;
 import io.camunda.zeebe.scheduler.Actor;
@@ -237,8 +237,9 @@ public final class Gateway {
     Collections.reverse(interceptors);
     interceptors.add(new ContextInjectingInterceptor(queryApi));
     interceptors.add(MONITORING_SERVER_INTERCEPTOR);
-    if (gatewayCfg.getSecurity().getAuthentication().getMode() != AuthMode.NONE) {
-      interceptors.add(new AuthenticationInterceptor(gatewayCfg.getSecurity().getAuthentication()));
+    if (AuthMode.IDENTITY == gatewayCfg.getSecurity().getAuthentication().getMode()) {
+      interceptors.add(
+          new IdentityInterceptor(gatewayCfg.getSecurity().getAuthentication().getIdentity()));
     }
 
     return ServerInterceptors.intercept(service, interceptors);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/AuthenticationCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/AuthenticationCfg.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.configuration;
+
+import java.util.Objects;
+
+public final class AuthenticationCfg {
+  private AuthMode mode = AuthMode.NONE;
+  private IdentityCfg identity = new IdentityCfg();
+
+  public AuthMode getMode() {
+    return mode;
+  }
+
+  public void setMode(final AuthMode mode) {
+    this.mode = mode;
+  }
+
+  public IdentityCfg getIdentity() {
+    return identity;
+  }
+
+  public void setIdentity(final IdentityCfg identity) {
+    this.identity = identity;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mode, identity);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AuthenticationCfg that = (AuthenticationCfg) o;
+    return mode == that.mode && Objects.equals(identity, that.identity);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthenticationCfg{" + "mode=" + mode + ", identity=" + identity + '}';
+  }
+
+  public enum AuthMode {
+    NONE,
+    IDENTITY,
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/IdentityCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/IdentityCfg.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.configuration;
+
+import java.util.Objects;
+
+public final class IdentityCfg {
+  private String issuerBackendUrl;
+  private String audience = "zeebe-api";
+  private OAuthType type = OAuthType.KEYCLOAK;
+
+  public String getIssuerBackendUrl() {
+    return issuerBackendUrl;
+  }
+
+  public void setIssuerBackendUrl(final String issuerBackendUrl) {
+    this.issuerBackendUrl = issuerBackendUrl;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public void setAudience(final String audience) {
+    this.audience = audience;
+  }
+
+  public OAuthType getType() {
+    return type;
+  }
+
+  public void setType(final OAuthType type) {
+    this.type = type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(issuerBackendUrl, audience, type);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentityCfg identityCfg = (IdentityCfg) o;
+    return Objects.equals(issuerBackendUrl, identityCfg.issuerBackendUrl)
+        && Objects.equals(audience, identityCfg.audience)
+        && type == identityCfg.type;
+  }
+
+  @Override
+  public String toString() {
+    return "IdentityCfg{"
+        + "issuerBackendUrl='"
+        + issuerBackendUrl
+        + '\''
+        + ", audience='"
+        + audience
+        + '\''
+        + ", type="
+        + type
+        + '}';
+  }
+
+  public enum OAuthType {
+    KEYCLOAK,
+    AUTH0
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/SecurityCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/SecurityCfg.java
@@ -17,6 +17,7 @@ public final class SecurityCfg {
   private boolean enabled = DEFAULT_TLS_ENABLED;
   private File certificateChainPath;
   private File privateKeyPath;
+  private AuthenticationCfg authentication = new AuthenticationCfg();
 
   public boolean isEnabled() {
     return enabled;
@@ -45,9 +46,17 @@ public final class SecurityCfg {
     return this;
   }
 
+  public AuthenticationCfg getAuthentication() {
+    return authentication;
+  }
+
+  public void setAuthentication(final AuthenticationCfg authentication) {
+    this.authentication = authentication;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(enabled, certificateChainPath, privateKeyPath);
+    return Objects.hash(enabled, certificateChainPath, privateKeyPath, authentication);
   }
 
   @Override
@@ -61,19 +70,21 @@ public final class SecurityCfg {
     final SecurityCfg that = (SecurityCfg) o;
     return enabled == that.enabled
         && Objects.equals(certificateChainPath, that.certificateChainPath)
-        && Objects.equals(privateKeyPath, that.privateKeyPath);
+        && Objects.equals(privateKeyPath, that.privateKeyPath)
+        && Objects.equals(authentication, that.authentication);
   }
 
   @Override
   public String toString() {
-    return "MonitoringCfg{"
+    return "SecurityCfg{"
         + "enabled="
         + enabled
-        + ", certificateChainPath='"
+        + ", certificateChainPath="
         + certificateChainPath
-        + "'"
-        + ", privateKeyPath='"
+        + ", privateKeyPath="
         + privateKeyPath
-        + "'}";
+        + ", authentication="
+        + authentication
+        + '}';
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import io.camunda.identity.sdk.Identity;
+import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.identity.sdk.authentication.exception.TokenVerificationException;
+import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg;
+import io.camunda.zeebe.gateway.impl.configuration.IdentityCfg;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class AuthenticationInterceptor implements ServerInterceptor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationInterceptor.class);
+  private static final Metadata.Key<String> AUTH_KEY =
+      Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+  private static final Set<String> PUBLIC_FULL_METHOD_NAMES =
+      Set.of(GatewayGrpc.getTopologyMethod().getFullMethodName());
+
+  private final Identity identity;
+
+  public AuthenticationInterceptor(final AuthenticationCfg config) {
+    this(createIdentity(config.getIdentity()));
+  }
+
+  AuthenticationInterceptor(final Identity identity) {
+    this.identity = identity;
+  }
+
+  private static Identity createIdentity(final IdentityCfg config) {
+    return new Identity(
+        new IdentityConfiguration(
+            null,
+            config.getIssuerBackendUrl(),
+            null,
+            null,
+            config.getAudience(),
+            config.getType().name()));
+  }
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
+    final var methodDescriptor = call.getMethodDescriptor();
+
+    if (PUBLIC_FULL_METHOD_NAMES.contains(methodDescriptor.getFullMethodName())) {
+      return next.startCall(call, headers);
+    }
+
+    final var token = headers.get(AUTH_KEY);
+    if (token == null) {
+      LOGGER.debug(
+          "Denying call {} as no token was provided", methodDescriptor.getFullMethodName());
+      return deny(
+          call,
+          Status.UNAUTHENTICATED.augmentDescription(
+              "Expected bearer token at header with key [%s], but found nothing"
+                  .formatted(AUTH_KEY.name())));
+    }
+
+    try {
+      identity.authentication().verifyToken(token.replaceFirst("^Bearer ", ""));
+    } catch (final TokenVerificationException e) {
+      LOGGER.debug(
+          "Denying call {} as the token could not be fully verified. Error message: {}",
+          methodDescriptor.getFullMethodName(),
+          e.getMessage());
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace(
+            "Token used for call {} was [{}]", methodDescriptor.getFullMethodName(), token, e);
+      }
+
+      return deny(
+          call,
+          Status.UNAUTHENTICATED
+              .augmentDescription("Failed to parse bearer token, see cause for details")
+              .withCause(e));
+    }
+
+    return next.startCall(call, headers);
+  }
+
+  private <ReqT> ServerCall.Listener<ReqT> deny(
+      final ServerCall<ReqT, ?> call, final Status status) {
+    call.close(status, new Metadata());
+    return new ServerCall.Listener<>() {};
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -68,10 +68,6 @@ public final class IdentityInterceptor implements ServerInterceptor {
           "Denying call {} as the token could not be fully verified. Error message: {}",
           methodDescriptor.getFullMethodName(),
           e.getMessage());
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace(
-            "Token used for call {} was [{}]", methodDescriptor.getFullMethodName(), token, e);
-      }
 
       return deny(
           call,

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.gateway.interceptors.impl;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.identity.sdk.authentication.exception.TokenVerificationException;
-import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg;
 import io.camunda.zeebe.gateway.impl.configuration.IdentityCfg;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -20,18 +19,18 @@ import io.grpc.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class AuthenticationInterceptor implements ServerInterceptor {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationInterceptor.class);
+public final class IdentityInterceptor implements ServerInterceptor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(IdentityInterceptor.class);
   private static final Metadata.Key<String> AUTH_KEY =
       Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
 
   private final Identity identity;
 
-  public AuthenticationInterceptor(final AuthenticationCfg config) {
-    this(createIdentity(config.getIdentity()));
+  public IdentityInterceptor(final IdentityCfg config) {
+    this(createIdentity(config));
   }
 
-  AuthenticationInterceptor(final Identity identity) {
+  IdentityInterceptor(final Identity identity) {
     this.identity = identity;
   }
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.identity.sdk.Identity;
+import io.camunda.identity.sdk.authentication.exception.TokenVerificationException;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import io.grpc.internal.NoopServerCall;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+public class IdentityInterceptorTest {
+
+  @Test
+  public void missingTokenIsRejected() {
+    // given
+    final Identity identityMock = mock(Identity.class);
+
+    // when
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+    new IdentityInterceptor(identityMock)
+        .interceptCall(closeStatusCapturingServerCall, new Metadata(), failingNextHandler());
+
+    // then
+    assertThat(closeStatusCapturingServerCall.closeStatus)
+        .hasValueSatisfying(
+            status -> {
+              assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
+              assertThat(status.getDescription())
+                  .isEqualTo(
+                      "Expected bearer token at header with key [authorization], but found nothing");
+            });
+  }
+
+  @Test
+  public void invalidTokenIsRejected() {
+    // given
+    final Identity identityMock = mock(Identity.class, RETURNS_DEEP_STUBS);
+    when(identityMock.authentication().verifyToken(anyString()))
+        .thenThrow(TokenVerificationException.class);
+
+    // when
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+    new IdentityInterceptor(identityMock)
+        .interceptCall(closeStatusCapturingServerCall, createAuthHeader(), failingNextHandler());
+
+    // then
+    assertThat(closeStatusCapturingServerCall.closeStatus)
+        .hasValueSatisfying(
+            status -> {
+              assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
+              assertThat(status.getDescription())
+                  .isEqualTo("Failed to parse bearer token, see cause for details");
+              assertThat(status.getCause()).isInstanceOf(TokenVerificationException.class);
+            });
+  }
+
+  @Test
+  public void genericRuntimeFailure() {
+    // given
+    final Identity identityMock = mock(Identity.class, RETURNS_DEEP_STUBS);
+    when(identityMock.authentication().verifyToken(anyString())).thenThrow(RuntimeException.class);
+
+    // when
+    assertThatThrownBy(
+            () ->
+                new IdentityInterceptor(identityMock)
+                    .interceptCall(
+                        new NoopServerCall<>(), createAuthHeader(), failingNextHandler()))
+        // then
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void validTokenIsAccepted() {
+    // given
+    final Identity identityMock = mock(Identity.class, RETURNS_DEEP_STUBS);
+    when(identityMock.authentication().verifyToken(anyString())).thenReturn(null);
+
+    // when
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+    new IdentityInterceptor(identityMock)
+        .interceptCall(
+            closeStatusCapturingServerCall,
+            createAuthHeader(),
+            (call, headers) -> {
+              call.close(Status.OK, headers);
+              return null;
+            });
+
+    // then
+    assertThat(closeStatusCapturingServerCall.closeStatus)
+        .hasValueSatisfying(status -> assertThat(status.getCode()).isEqualTo(Status.OK.getCode()));
+  }
+
+  private Metadata createAuthHeader() {
+    final Metadata requestMetaData = new Metadata();
+    requestMetaData.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "BAR");
+    return requestMetaData;
+  }
+
+  private ServerCallHandler<Object, Object> failingNextHandler() {
+    return (call, headers) -> {
+      throw new RuntimeException("Should not be invoked");
+    };
+  }
+
+  private static class CloseStatusCapturingServerCall extends NoopServerCall<Object, Object> {
+    private final AtomicReference<Status> closeStatus = new AtomicReference<>();
+
+    @Override
+    public void close(final Status status, final Metadata trailers) {
+      closeStatus.set(status);
+    }
+
+    @Override
+    public MethodDescriptor<Object, Object> getMethodDescriptor() {
+      return mock(MethodDescriptor.class);
+    }
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -946,6 +946,12 @@
       </dependency>
 
       <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>${version.byte-buddy}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
         <version>${version.classgraph}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -59,6 +59,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpcomponents>4.4.16</version.httpcomponents>
+    <version.identity>8.2.0-alpha5</version.identity>
     <version.jackson>2.14.2</version.jackson>
     <version.java-grpc-prometheus>0.6.0</version.java-grpc-prometheus>
     <version.jna>5.13.0</version.jna>
@@ -98,6 +99,7 @@
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.4.0</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>
+    <version.jetbrains-annotations>17.0.0</version.jetbrains-annotations>
     <version.jqwik>1.7.2</version.jqwik>
     <version.jmock>2.12.0</version.jmock>
     <version.json-smart>2.4.8</version.json-smart>
@@ -1009,6 +1011,13 @@
       </dependency>
 
       <!-- Dependencies present for convergence only -->
+      <!-- between duct-tape (from testcontainers) and kotlin-stdlib (from identity-sdk) -->
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${version.jetbrains-annotations}</version>
+      </dependency>
+
       <!-- between log4j2 and commons-compress (from testcontainers) -->
       <dependency>
         <groupId>org.osgi</groupId>
@@ -1554,7 +1563,15 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence></dependencyConvergence>
+                  <dependencyConvergence>
+                    <!-- To be removed once these conflicts are resolved by identity. -->
+                    <!-- See https://github.com/camunda-cloud/identity/issues/1696 -->
+                    <excludes>
+                      <exclude>com.auth0:java-jwt</exclude>
+                      <exclude>org.jetbrains.kotlin:kotlin-stdlib-common</exclude>
+                      <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk8</exclude>
+                    </excludes>
+                  </dependencyConvergence>
                 </rules>
               </configuration>
             </execution>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -228,13 +228,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.dasniko</groupId>
-      <artifactId>testcontainers-keycloak</artifactId>
-      <version>2.5.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>toxiproxy</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -228,6 +228,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.dasniko</groupId>
+      <artifactId>testcontainers-keycloak</artifactId>
+      <version>2.5.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>toxiproxy</artifactId>
       <scope>test</scope>
@@ -412,6 +419,24 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <property>
+              <name>identity.docker.image.version</name>
+              <!-- Can be set to ${version.identity} after 8.2.0. -->
+              <value>SNAPSHOT</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <!--

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -210,7 +210,7 @@ public class GatewayAuthenticationIdentityIT {
     final HttpRequest request =
         HttpRequest.newBuilder().uri(URI.create(getKeycloakRealmAddress())).build();
     Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
+        .atMost(Duration.ofSeconds(120))
         .pollInterval(Duration.ofSeconds(5))
         .ignoreExceptions()
         .untilAsserted(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -54,7 +54,7 @@ public class GatewayAuthenticationIdentityIT {
 
   @Container
   private static final GenericContainer KEYCLOAK =
-      new GenericContainer<>("quay.io/keycloak/keycloak:19.0")
+      new GenericContainer<>("quay.io/keycloak/keycloak:20.0.5")
           .withEnv("KC_HEALTH_ENABLED", "true")
           .withEnv("KEYCLOAK_ADMIN", KEYCLOAK_USER)
           .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -29,7 +29,6 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -107,6 +106,8 @@ public class GatewayAuthenticationIdentityIT {
           .withGatewayConfig(
               zeebeGatewayNode ->
                   zeebeGatewayNode
+                      // as topology check would require auth, we skip it here
+                      .withoutTopologyCheck()
                       .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE", "identity")
                       .withEnv(
                           "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL",
@@ -115,19 +116,6 @@ public class GatewayAuthenticationIdentityIT {
                           "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE",
                           ZEEBE_CLIENT_AUDIENCE))
           .build();
-
-  @Test
-  void topologyMethodIsPublic() {
-    // given
-    try (final var client = createAnonymousZeebeClient()) {
-      // when
-      final var topology = client.newTopologyRequest().send();
-
-      // then
-      final var result = topology.join(5L, TimeUnit.SECONDS);
-      assertThat(result.getBrokers()).as("There is one connected broker").hasSize(1);
-    }
-  }
 
   @Test
   void deployModelFailsWithoutAuthToken() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.it.gateway;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -21,7 +21,7 @@ import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.zeebe.containers.cluster.ZeebeCluster;
+import io.zeebe.containers.ZeebeContainer;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -46,30 +46,35 @@ public class GatewayAuthenticationIdentityIT {
   public static final String KEYCLOAK_PASSWORD = "admin";
   public static final BpmnModelInstance PROCESS_MODEL =
       Bpmn.createExecutableProcess("model").startEvent().endEvent().done();
-  private static final String KEYCLOAK_CONTEXT_PATH = "/auth";
-  private static final String KEYCLOAK_PATH_CAMUNDA_REALM =
-      KEYCLOAK_CONTEXT_PATH + "/realms/camunda-platform";
+  private static final String KEYCLOAK_PATH_CAMUNDA_REALM = "/realms/camunda-platform";
   private static final String ZEEBE_CLIENT_ID = "zeebe";
   private static final String ZEEBE_CLIENT_AUDIENCE = "zeebe-api";
   private static final String ZEEBE_CLIENT_SECRET = "zecret";
   private static final Network NETWORK = Network.newNetwork();
 
   @Container
-  private static final KeycloakContainer KEYCLOAK =
-      new KeycloakContainer("quay.io/keycloak/keycloak:19.0")
-          .withContextPath(KEYCLOAK_CONTEXT_PATH)
-          .withAdminUsername(KEYCLOAK_USER)
-          .withAdminPassword(KEYCLOAK_PASSWORD)
+  private static final GenericContainer KEYCLOAK =
+      new GenericContainer<>("quay.io/keycloak/keycloak:19.0")
+          .withEnv("KC_HEALTH_ENABLED", "true")
+          .withEnv("KEYCLOAK_ADMIN", KEYCLOAK_USER)
+          .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)
           .withNetwork(NETWORK)
           .withNetworkAliases("keycloak")
-          .withExposedPorts(8080);
+          .withExposedPorts(8080)
+          .withCommand("start-dev")
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(8080)
+                  .forPath("/health/ready")
+                  .allowInsecure()
+                  .forStatusCode(200));
 
   @Container
   private static final GenericContainer<?> IDENTITY =
       new GenericContainer<>(
               DockerImageName.parse("camunda/identity").withTag(getIdentityImageTag()))
           .dependsOn(KEYCLOAK)
-          .withEnv("KEYCLOAK_URL", "http://keycloak:8080" + KEYCLOAK_CONTEXT_PATH)
+          .withEnv("KEYCLOAK_URL", "http://keycloak:8080")
           .withEnv(
               "IDENTITY_AUTH_PROVIDER_BACKEND_URL",
               "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
@@ -95,32 +100,22 @@ public class GatewayAuthenticationIdentityIT {
           .withNetworkAliases("identity");
 
   @Container
-  private final ZeebeCluster cluster =
-      ZeebeCluster.builder()
-          .withBrokersCount(1)
-          .withPartitionsCount(1)
-          .withGatewaysCount(0)
-          .withEmbeddedGateway(true)
-          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+  private static final ZeebeContainer ZEEBE =
+      new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
           .withNetwork(NETWORK)
-          .withGatewayConfig(
-              zeebeGatewayNode ->
-                  zeebeGatewayNode
-                      // as topology check would require auth, we skip it here
-                      .withoutTopologyCheck()
-                      .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE", "identity")
-                      .withEnv(
-                          "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL",
-                          "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
-                      .withEnv(
-                          "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE",
-                          ZEEBE_CLIENT_AUDIENCE))
-          .build();
+          .withoutTopologyCheck()
+          .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE", "identity")
+          .withEnv(
+              "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL",
+              "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
+          .withEnv(
+              "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE",
+              ZEEBE_CLIENT_AUDIENCE);
 
   @Test
   void deployModelFailsWithoutAuthToken() {
     // given
-    try (final var client = createAnonymousZeebeClient()) {
+    try (final var client = createZeebeClientBuilder().build()) {
       // when
       final var deploymentFuture =
           client
@@ -151,11 +146,7 @@ public class GatewayAuthenticationIdentityIT {
   void deployModelFailsWithInvalidAuthToken() {
     // given
     try (final var client =
-        cluster
-            .newClientBuilder()
-            .defaultRequestTimeout(Duration.ofMinutes(1))
-            .credentialsProvider(new InvalidAuthTokenProvider())
-            .build()) {
+        createZeebeClientBuilder().credentialsProvider(new InvalidAuthTokenProvider()).build()) {
       // when
       final var deploymentFuture =
           client
@@ -187,9 +178,7 @@ public class GatewayAuthenticationIdentityIT {
     awaitCamundaRealmAvailabilityOnKeycloak();
 
     try (final var client =
-        cluster
-            .newClientBuilder()
-            .defaultRequestTimeout(Duration.ofMinutes(1))
+        createZeebeClientBuilder()
             .credentialsProvider(
                 new OAuthCredentialsProviderBuilder()
                     .clientId(ZEEBE_CLIENT_ID)
@@ -236,8 +225,11 @@ public class GatewayAuthenticationIdentityIT {
     return "http://localhost:" + KEYCLOAK.getFirstMappedPort() + KEYCLOAK_PATH_CAMUNDA_REALM;
   }
 
-  private ZeebeClient createAnonymousZeebeClient() {
-    return cluster.newClientBuilder().defaultRequestTimeout(Duration.ofMinutes(1)).build();
+  private ZeebeClientBuilder createZeebeClientBuilder() {
+    return ZeebeClient.newClientBuilder()
+        .gatewayAddress(ZEEBE.getExternalGatewayAddress())
+        .defaultRequestTimeout(Duration.ofMinutes(1))
+        .usePlaintext();
   }
 
   private static String getIdentityImageTag() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.gateway;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.zeebe.client.CredentialsProvider;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class GatewayAuthenticationIdentityIT {
+
+  public static final String KEYCLOAK_USER = "admin";
+  public static final String KEYCLOAK_PASSWORD = "admin";
+  public static final BpmnModelInstance PROCESS_MODEL =
+      Bpmn.createExecutableProcess("model").startEvent().endEvent().done();
+  private static final String KEYCLOAK_CONTEXT_PATH = "/auth";
+  private static final String KEYCLOAK_PATH_CAMUNDA_REALM =
+      KEYCLOAK_CONTEXT_PATH + "/realms/camunda-platform";
+  private static final String ZEEBE_CLIENT_ID = "zeebe";
+  private static final String ZEEBE_CLIENT_AUDIENCE = "zeebe-api";
+  private static final String ZEEBE_CLIENT_SECRET = "zecret";
+  private static final Network NETWORK = Network.newNetwork();
+
+  @Container
+  private static final KeycloakContainer KEYCLOAK =
+      new KeycloakContainer("quay.io/keycloak/keycloak:19.0")
+          .withContextPath(KEYCLOAK_CONTEXT_PATH)
+          .withAdminUsername(KEYCLOAK_USER)
+          .withAdminPassword(KEYCLOAK_PASSWORD)
+          .withNetwork(NETWORK)
+          .withNetworkAliases("keycloak")
+          .withExposedPorts(8080);
+
+  @Container
+  private static final GenericContainer<?> IDENTITY =
+      new GenericContainer<>(
+              DockerImageName.parse("camunda/identity").withTag(getIdentityImageTag()))
+          .dependsOn(KEYCLOAK)
+          .withEnv("KEYCLOAK_URL", "http://keycloak:8080" + KEYCLOAK_CONTEXT_PATH)
+          .withEnv(
+              "IDENTITY_AUTH_PROVIDER_BACKEND_URL",
+              "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
+          .withEnv("KEYCLOAK_SETUP_USER", KEYCLOAK_USER)
+          .withEnv("KEYCLOAK_SETUP_PASSWORD", KEYCLOAK_PASSWORD)
+          .withEnv("KEYCLOAK_INIT_ZEEBE_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_0_NAME", ZEEBE_CLIENT_ID)
+          .withEnv("KEYCLOAK_CLIENTS_0_ID", ZEEBE_CLIENT_ID)
+          .withEnv("KEYCLOAK_CLIENTS_0_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_0_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("IDENTITY_RETRY_ATTEMPTS", "90")
+          .withEnv("IDENTITY_RETRY_DELAY_SECONDS", "1")
+          .withNetwork(NETWORK)
+          .withExposedPorts(8080, 8082)
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(8082)
+                  .forPath("/actuator/health")
+                  .allowInsecure()
+                  .forStatusCode(200))
+          .withNetworkAliases("identity");
+
+  @Container
+  private final ZeebeCluster cluster =
+      ZeebeCluster.builder()
+          .withBrokersCount(1)
+          .withPartitionsCount(1)
+          .withGatewaysCount(0)
+          .withEmbeddedGateway(true)
+          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+          .withNetwork(NETWORK)
+          .withGatewayConfig(
+              zeebeGatewayNode ->
+                  zeebeGatewayNode
+                      .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE", "identity")
+                      .withEnv(
+                          "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL",
+                          "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
+                      .withEnv(
+                          "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE",
+                          ZEEBE_CLIENT_AUDIENCE))
+          .build();
+
+  @Test
+  void topologyMethodIsPublic() {
+    // given
+    try (final var client = createAnonymousZeebeClient()) {
+      // when
+      final var topology = client.newTopologyRequest().send();
+
+      // then
+      final var result = topology.join(5L, TimeUnit.SECONDS);
+      assertThat(result.getBrokers()).as("There is one connected broker").hasSize(1);
+    }
+  }
+
+  @Test
+  void deployModelFailsWithoutAuthToken() {
+    // given
+    try (final var client = createAnonymousZeebeClient()) {
+      // when
+      final var deploymentFuture =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(PROCESS_MODEL, "model.bpmn")
+              .send()
+              .toCompletableFuture();
+
+      // then
+      assertThat(deploymentFuture)
+          .failsWithin(Duration.ofSeconds(1))
+          .withThrowableOfType(ExecutionException.class)
+          .withCauseInstanceOf(StatusRuntimeException.class)
+          .extracting(
+              Throwable::getCause, as(InstanceOfAssertFactories.type(StatusRuntimeException.class)))
+          .satisfies(
+              statusRuntimeException -> {
+                assertThat(statusRuntimeException.getStatus())
+                    .hasFieldOrPropertyWithValue("code", Status.UNAUTHENTICATED.getCode())
+                    .hasFieldOrPropertyWithValue(
+                        "description",
+                        "Expected bearer token at header with key [authorization], but found nothing");
+              });
+    }
+  }
+
+  @Test
+  void deployModelFailsWithInvalidAuthToken() {
+    // given
+    try (final var client =
+        cluster
+            .newClientBuilder()
+            .defaultRequestTimeout(Duration.ofMinutes(1))
+            .credentialsProvider(new InvalidAuthTokenProvider())
+            .build()) {
+      // when
+      final var deploymentFuture =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(PROCESS_MODEL, "model.bpmn")
+              .send()
+              .toCompletableFuture();
+
+      // then
+      assertThat(deploymentFuture)
+          .failsWithin(Duration.ofSeconds(1))
+          .withThrowableOfType(ExecutionException.class)
+          .withCauseInstanceOf(StatusRuntimeException.class)
+          .extracting(
+              Throwable::getCause, as(InstanceOfAssertFactories.type(StatusRuntimeException.class)))
+          .satisfies(
+              statusRuntimeException -> {
+                assertThat(statusRuntimeException.getStatus())
+                    .hasFieldOrPropertyWithValue("code", Status.UNAUTHENTICATED.getCode())
+                    .hasFieldOrPropertyWithValue(
+                        "description", "Failed to parse bearer token, see cause for details");
+              });
+    }
+  }
+
+  @Test
+  void deployModelSucceedsWithValidAuthToken() {
+    // given
+    awaitCamundaRealmAvailabilityOnKeycloak();
+
+    try (final var client =
+        cluster
+            .newClientBuilder()
+            .defaultRequestTimeout(Duration.ofMinutes(1))
+            .credentialsProvider(
+                new OAuthCredentialsProviderBuilder()
+                    .clientId(ZEEBE_CLIENT_ID)
+                    .clientSecret(ZEEBE_CLIENT_SECRET)
+                    .audience(ZEEBE_CLIENT_AUDIENCE)
+                    .authorizationServerUrl(
+                        getKeycloakRealmAddress() + "/protocol/openid-connect/token")
+                    .build())
+            .build()) {
+      // when
+      final var deploymentFuture =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(PROCESS_MODEL, "model.bpmn")
+              .send()
+              .toCompletableFuture();
+
+      // then
+      assertThat(deploymentFuture).succeedsWithin(Duration.ofSeconds(1));
+    }
+  }
+
+  /**
+   * Awaits the presence of the Camunda realm on the keycloak container. Once Keycloak and Identity
+   * booted up, Identity will eventually configure the Camunda Realm on Keycloak.
+   */
+  private static void awaitCamundaRealmAvailabilityOnKeycloak() {
+    final var httpClient = HttpClient.newHttpClient();
+    final HttpRequest request =
+        HttpRequest.newBuilder().uri(URI.create(getKeycloakRealmAddress())).build();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(5))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final HttpResponse<String> response =
+                  httpClient.send(request, BodyHandlers.ofString());
+              assertThat(response.statusCode()).isEqualTo(200);
+            });
+  }
+
+  private static String getKeycloakRealmAddress() {
+    return "http://localhost:" + KEYCLOAK.getFirstMappedPort() + KEYCLOAK_PATH_CAMUNDA_REALM;
+  }
+
+  private ZeebeClient createAnonymousZeebeClient() {
+    return cluster.newClientBuilder().defaultRequestTimeout(Duration.ofMinutes(1)).build();
+  }
+
+  private static String getIdentityImageTag() {
+    return System.getProperty("identity.docker.image.version", "SNAPSHOT");
+  }
+
+  private static class InvalidAuthTokenProvider implements CredentialsProvider {
+
+    @Override
+    public void applyCredentials(final Metadata headers) {
+      headers.put(
+          Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Bearer youShallNotPass");
+    }
+
+    @Override
+    public boolean shouldRetryRequest(final Throwable throwable) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Description

This change adds an identity based authentication interceptor to the Zeebe Gateway.
By default it is disabled but can be activated via config alongside requiring some minimal identity specific setup that defaults to values that match the [self-managed setup](https://github.com/camunda/camunda-platform).

One challenge that occurred when adding authentication was that the ResponsiveHealthIndicator actually performs a GRPC request while potentially having no authentication client setup. From my perspective it would go to far to require a full client credential setup for the sake of doing authenticated GRPC requests on it's own API. As the indicator check also doesn't perform any validation on the actual topology response but succeed just based on whether the request could be send a response received, a special case handling was added to treat a potential 401 UNAUTHENTICATED response as `Health.up`.

Follow-ups (issues to be created):

- [x] Reiterate the ResponsiveHealthIndicator implementation: consider adding a dedicated health check request AND/OR reconsider if doing a GRPC request as part of the health check is really necessary? what is the semantic of the check supposed to be? will be handled as part of https://github.com/camunda/zeebe/issues/11799
- [x] After identity releases 8.2.0 // CC release manager @npepinpe :
  - [x] [update `version.identity` in zeebe parent to `8.2.0` ](https://github.com/camunda/zeebe/pull/12216)
  - [x] [Update the `identity.docker.image.version` property value in the `integration-test` module pom to `${version.identity}` ](https://github.com/camunda/zeebe/pull/12216)
- [x] [As Zeebe will depend on identity going forward, a zeebe release depends on the identity release in future, we need to coordinate that going forward](https://github.com/camunda/engineering-leadership-team/issues/59) // CC release manager @npepinpe 
- [ ] Remove dependency convergence exclusions once https://github.com/camunda-cloud/identity/issues/1696 is resolved

To discuss with identity:

- [x] could we adjust dep setup in identity to resolve these convergence errors?:
https://github.com/camunda-cloud/identity/issues/1696
@dlavrenuek will look into this from identity side, in the meantime we would need to add exclusions
- [x] is the current exposed config setup suffice for the purpose?
yes
- [x] how could we keep the keycloak version in sync? could you e.g. add a prop file to the sdk? or could we important a bom pom that would allow us to reference the current compatible keycloak version automatically?
identity could support multiple keycloak versions, keycloak 19 will be supported as long as possible (expecting years). Identity will announce end of support for keycloak versions, in worst case the test will fail and we will notice. 

## Related issues

closes #12000

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
