### PR TITLE
Explicitly send the long polling notification instead of as a hidden side-effect

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobGatewayStreamer.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobGatewayStreamer.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.stream.api.ActivatedJob;
 import io.camunda.zeebe.stream.api.GatewayStreamer;
 import io.camunda.zeebe.stream.api.JobActivationProperties;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.time.Duration;
 import java.util.Objects;
@@ -57,12 +56,15 @@ public final class JobGatewayStreamer extends Actor
   }
 
   @Override
+  public void notifyWorkAvailable(final String streamType) {
+    actor.run(() -> eventService.broadcast(JobStreamTopics.JOB_AVAILABLE.topic(), streamType));
+  }
+
+  @Override
   public Optional<GatewayStream<JobActivationProperties, ActivatedJob>> streamFor(
-      final DirectBuffer streamId) {
-    final var consumers = registry.get(new UnsafeBuffer(streamId));
+      final DirectBuffer streamType) {
+    final var consumers = registry.get(new UnsafeBuffer(streamType));
     if (consumers.isEmpty()) {
-      final var jobType = BufferUtil.bufferAsString(streamId);
-      actor.run(() -> eventService.broadcast(JobStreamTopics.JOB_AVAILABLE.topic(), jobType));
       return Optional.empty();
     }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/JobGatewayStreamerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/JobGatewayStreamerTest.java
@@ -67,15 +67,11 @@ final class JobGatewayStreamerTest {
 
   @Test
   void shouldNotifyAvailableJobsWhenNoConsumers() {
-    // given
-    final var type = BufferUtil.wrapString("foo");
-
-    // when
-    final var maybeStream = streamer.streamFor(type);
+    // given - when
+    streamer.notifyWorkAvailable("foo");
     scheduler.workUntilDone();
 
     // then
-    assertThat(maybeStream).isEmpty();
     Mockito.verify(eventService, Mockito.times(1))
         .broadcast(JobStreamTopics.JOB_AVAILABLE.topic(), "foo");
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -346,10 +346,9 @@ public final class DbJobState implements JobState, MutableJobState {
 
   private void notifyJobAvailable(final DirectBuffer jobType) {
     if (jobStreamer != null) {
-      // ignore the result for now
       // TODO: remove the cloneBuffer eventually, but it's required now due to the
       //  ActivatableJobsNotificationTests
-      jobStreamer.streamFor(BufferUtil.cloneBuffer(jobType));
+      jobStreamer.notifyWorkAvailable(BufferUtil.bufferAsString(jobType));
     }
   }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/GatewayStreamer.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/GatewayStreamer.java
@@ -35,8 +35,16 @@ public interface GatewayStreamer<M extends Metadata, Payload> {
     return streamId -> Optional.empty();
   }
 
+  /**
+   * Can be used to notify listeners that there are items available to be streamed out for a given
+   * stream type.
+   *
+   * @param streamType the type of the stream which has items available
+   */
+  default void notifyWorkAvailable(final String streamType) {}
+
   /** Returns a valid stream for the given ID, or {@link Optional#empty()} if there is none. */
-  Optional<GatewayStream<M, Payload>> streamFor(final DirectBuffer streamId);
+  Optional<GatewayStream<M, Payload>> streamFor(final DirectBuffer streamType);
 
   /**
    * A {@link GatewayStream} allows consumers to push out {@link Payload} types to a stream with the


### PR DESCRIPTION
## Description

This PR updates the `GatewayStreamer` API to allow explicitly sending the long polling job notification, instead of doing it as a side effect of the `streamFor` call when no streams are available. Doing so was counter-intuitive, and would prevent future refactoring efforts.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
