### PR TITLE
ci: increase timeout of multiregion failover test

### DIFF
--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -31,6 +31,11 @@ on:
         default: null
         required: false
         type: string
+      maxInstanceDuration:
+        description: 'If an instance takes longer than the given duration to complete, test will fail.'
+        default: '15m'
+        required: false
+        type: string
 
   workflow_call:
     inputs:
@@ -59,6 +64,11 @@ on:
         default: null
         required: false
         type: string
+      maxInstanceDuration:
+        description: 'If an instance takes longer than the given duration to complete, test will fail.'
+        default: '15m'
+        required: false
+        type: string
 
 jobs:
   e2e:
@@ -81,7 +91,7 @@ jobs:
         {
         \"maxTestDuration\": \"${{ inputs.maxTestDuration || 'P5D' }}\",
         \"starter\": [ {\"rate\": 50, \"processId\": \"one-task-one-timer\" } ],
-        \"verifier\" : { \"maxInstanceDuration\" : \"15m\" },
+        \"verifier\" : { \"maxInstanceDuration\" : \"${{ inputs.maxInstanceDuration }}\" },
         \"fault\": ${{ inputs.fault || 'null' }}
         }
         }

--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -31,4 +31,5 @@ jobs:
       maxTestDuration: P1D
       clusterPlan: Multiregion test simulation
       fault: \"2-region-dataloss-failover\"
+      maxInstanceDuration: 40m
     secrets: inherit


### PR DESCRIPTION
## Description

Due to the nature of the test, restarts and failovers can take long. If the recovery takes longer than 15m, then the test will fail unnecessarily. Since we are not really testing for how was it can recover, it is ok to increase the maxInstanceDuration.

For context, last week's test failed because restart took over 20 minutes.

