### PR TITLE
feat(backup/gcs): save backup manifests

### DIFF
--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -85,6 +85,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-testkit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -60,6 +60,31 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -86,31 +111,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -14,8 +14,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
@@ -23,10 +27,17 @@ import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException.BucketDoesNotExistException;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
+import io.camunda.zeebe.backup.gcs.manifest.Manifest;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 public final class GcsBackupStore implements BackupStore {
   public static final ObjectMapper MAPPER =
@@ -37,19 +48,81 @@ public final class GcsBackupStore implements BackupStore {
           .setSerializationInclusion(Include.NON_ABSENT);
 
   private final GcsBackupConfig config;
+  private final Storage client;
+  private final BucketInfo bucketInfo;
+  private final Executor executor;
 
   public GcsBackupStore(final GcsBackupConfig config) {
+    this(config, buildClient(config));
+  }
+
+  public GcsBackupStore(final GcsBackupConfig config, final Storage client) {
     this.config = config;
+    this.client = client;
+    bucketInfo = BucketInfo.of(config.bucketName());
+    executor = Executors.newWorkStealingPool(4);
   }
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    throw new UnsupportedOperationException();
+    return CompletableFuture.runAsync(() -> saveSync(backup), executor);
+  }
+
+  private void saveSync(final Backup backup) {
+    final var inProgress = Manifest.create(backup);
+    final var blobInfo = manifestBlobInfo(backup.id());
+    final Blob initial;
+
+    try {
+
+      initial =
+          client.create(
+              blobInfo, MAPPER.writeValueAsBytes(inProgress), BlobTargetOption.doesNotExist());
+    } catch (final StorageException e) {
+      throw new UnexpectedManifestState(
+          "Manifest for backup %s already exists".formatted(backup.id()));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+
+    final var completed = inProgress.complete();
+    try {
+      client.create(
+          blobInfo,
+          MAPPER.writeValueAsBytes(completed),
+          BlobTargetOption.generationMatch(initial.getGeneration()));
+    } catch (final StorageException e) {
+      throw new UnexpectedManifestState(
+          "Manifest for backup %s was modified unexpectedly".formatted(backup.id()));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
   public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
-    throw new UnsupportedOperationException();
+    return CompletableFuture.supplyAsync(() -> getStatusSync(id));
+  }
+
+  private BackupStatus getStatusSync(final BackupIdentifier id) {
+    final var blob = client.get(manifestBlobInfo(id).getBlobId());
+    if (blob == null) {
+      return new BackupStatusImpl(
+          id,
+          Optional.empty(),
+          BackupStatusCode.DOES_NOT_EXIST,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty());
+    }
+
+    final var content = blob.getContent();
+    try {
+      final var manifest = MAPPER.readValue(content, Manifest.class);
+      return Manifest.toStatus(manifest);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -84,6 +157,16 @@ public final class GcsBackupStore implements BackupStore {
         .setCredentials(config.connection().auth().credentials())
         .build()
         .getService();
+  }
+
+  private BlobInfo manifestBlobInfo(BackupIdentifier id) {
+    final var base =
+        Optional.ofNullable(config.basePath()).map(basePath -> basePath + "/").orElse("");
+    final var name =
+        "manifests/%s/%s/%s/manifest.json"
+            .formatted(id.partitionId(), id.checkpointId(), id.nodeId());
+
+    return BlobInfo.newBuilder(bucketInfo, base + name).setContentType("application/json").build();
   }
 
   public static void validateConfig(GcsBackupConfig config) throws Exception {

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -7,6 +7,14 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import io.camunda.zeebe.backup.api.Backup;
@@ -21,6 +29,13 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 public final class GcsBackupStore implements BackupStore {
+  public static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(new JavaTimeModule())
+          .disable(WRITE_DATES_AS_TIMESTAMPS)
+          .setSerializationInclusion(Include.NON_ABSENT);
+
   private final GcsBackupConfig config;
 
   public GcsBackupStore(final GcsBackupConfig config) {

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
@@ -28,6 +28,10 @@ public abstract class GcsBackupStoreException extends RuntimeException {
     public UnexpectedManifestState(final StatusCode expected, final StatusCode actual) {
       super("Expected manifest in state '%s', but was in '%s'".formatted(expected, actual));
     }
+
+    public UnexpectedManifestState(final String message) {
+      super(message);
+    }
   }
 
   public static class ConfigurationException extends GcsBackupStoreException {

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/Manifest.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/Manifest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.IN_PROGRE
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import java.time.Instant;
@@ -19,10 +20,14 @@ import java.time.Instant;
 @JsonDeserialize(as = ManifestImpl.class)
 public sealed interface Manifest {
 
-  static InProgressManifest createManifest(
-      final BackupIdentifierImpl id, final BackupDescriptorImpl descriptor) {
+  static InProgressManifest create(Backup backup) {
     final var creationTime = Instant.now();
-    return new ManifestImpl(id, descriptor, IN_PROGRESS, creationTime, creationTime);
+    return new ManifestImpl(
+        BackupIdentifierImpl.from(backup.id()),
+        BackupDescriptorImpl.from(backup.descriptor()),
+        IN_PROGRESS,
+        creationTime,
+        creationTime);
   }
 
   BackupIdentifierImpl id();

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import com.google.cloud.storage.BucketInfo;
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
+import io.camunda.zeebe.backup.gcs.util.GcsContainer;
+import io.camunda.zeebe.backup.testkit.SavingBackup;
+import java.io.IOException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class GcsBackupStoreIT implements SavingBackup {
+  @Container private static final GcsContainer GCS = new GcsContainer();
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  private GcsBackupStore store;
+
+  @BeforeAll
+  static void createBucket() {
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withBucketName(BUCKET_NAME)
+            .withBasePath(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+            .withHost(GCS.externalEndpoint())
+            .withoutAuthentication()
+            .build();
+    try (final var client = GcsBackupStore.buildClient(config)) {
+      client.create(BucketInfo.of(BUCKET_NAME));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @BeforeEach
+  void setup() {
+    store =
+        new GcsBackupStore(
+            new GcsBackupConfig.Builder()
+                .withBucketName(BUCKET_NAME)
+                .withBasePath(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+                .withHost(GCS.externalEndpoint())
+                .withoutAuthentication()
+                .build());
+  }
+
+  @Override
+  public BackupStore getStore() {
+    return store;
+  }
+
+  @Override
+  public Class<? extends Exception> getBackupInInvalidStateExceptionClass() {
+    return UnexpectedManifestState.class;
+  }
+
+  @Override
+  @Disabled
+  public void backupFailsIfFilesAreMissing(final Backup backup) throws IOException {
+    SavingBackup.super.backupFailsIfFilesAreMissing(backup);
+  }
+}

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.gcs.util.GcsContainer;
 import io.camunda.zeebe.backup.testkit.SavingBackup;
+import io.camunda.zeebe.backup.testkit.UpdatingBackupStatus;
 import java.io.IOException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -22,7 +23,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-public class GcsBackupStoreIT implements SavingBackup {
+public class GcsBackupStoreIT implements SavingBackup, UpdatingBackupStatus {
   @Container private static final GcsContainer GCS = new GcsContainer();
   private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
@@ -39,7 +40,7 @@ public class GcsBackupStoreIT implements SavingBackup {
             .build();
     try (final var client = GcsBackupStore.buildClient(config)) {
       client.create(BucketInfo.of(BUCKET_NAME));
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new RuntimeException(e);
     }
   }
@@ -70,5 +71,17 @@ public class GcsBackupStoreIT implements SavingBackup {
   @Disabled
   public void backupFailsIfFilesAreMissing(final Backup backup) throws IOException {
     SavingBackup.super.backupFailsIfFilesAreMissing(backup);
+  }
+
+  @Override
+  @Disabled
+  public void backupCanBeMarkedAsFailed(final Backup backup) {
+    UpdatingBackupStatus.super.backupCanBeMarkedAsFailed(backup);
+  }
+
+  @Override
+  @Disabled
+  public void markingAsFailedUpdatesTimestamp(final Backup backup) {
+    UpdatingBackupStatus.super.markingAsFailedUpdatesTimestamp(backup);
   }
 }

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestTest.java
@@ -7,35 +7,25 @@
  */
 package io.camunda.zeebe.backup.gcs.manifest;
 
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static io.camunda.zeebe.backup.gcs.GcsBackupStore.MAPPER;
 import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.COMPLETED;
 import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.FAILED;
 import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.IN_PROGRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.InvalidPersistedManifestState;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
+import io.camunda.zeebe.backup.gcs.manifest.Manifest.InProgressManifest;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class ManifestTest {
-
-  static final ObjectMapper MAPPER =
-      new ObjectMapper()
-          .registerModule(new Jdk8Module())
-          .registerModule(new JavaTimeModule())
-          .disable(WRITE_DATES_AS_TIMESTAMPS)
-          .setSerializationInclusion(Include.NON_ABSENT);
 
   @Test
   public void shouldDeserialize() throws JsonProcessingException {

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestTest.java
@@ -18,9 +18,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.InvalidPersistedManifestState;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
-import io.camunda.zeebe.backup.gcs.manifest.Manifest.InProgressManifest;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -98,9 +98,12 @@ public class ManifestTest {
   public void shouldSerializeFailedManifest() throws JsonProcessingException {
     // given
     final var created =
-        Manifest.createManifest(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"));
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
     final var failed = created.fail("expected failure reason");
     final var expectedJsonString =
         """
@@ -303,9 +306,12 @@ public class ManifestTest {
   public void shouldFailOnAsInProgress() {
     // given
     final var manifest =
-        Manifest.createManifest(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"));
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
 
     final var complete = manifest.complete();
 
@@ -319,9 +325,12 @@ public class ManifestTest {
   public void shouldFailOnAsCompleted() {
     // given
     final var manifest =
-        Manifest.createManifest(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"));
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
 
     // when expect thrown
     assertThatThrownBy(manifest::asCompleted)
@@ -333,9 +342,12 @@ public class ManifestTest {
   public void shouldFailOnAsFailed() {
     // given
     final var manifest =
-        Manifest.createManifest(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"));
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
 
     // when expect thrown
     assertThatThrownBy(manifest::asFailed)
@@ -349,9 +361,12 @@ public class ManifestTest {
 
     // when
     final var manifest =
-        Manifest.createManifest(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"));
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
 
     // then
     assertThat(manifest.statusCode()).isEqualTo(IN_PROGRESS);
@@ -364,9 +379,12 @@ public class ManifestTest {
   public void shouldUpdateManifestToCompleted() {
     // given
     final var created =
-        Manifest.createManifest(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"));
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
 
     // when
     final var completed = created.complete();
@@ -384,9 +402,12 @@ public class ManifestTest {
   public void shouldUpdateManifestToFailed() {
     // given
     final var created =
-        Manifest.createManifest(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"));
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
 
     // when
     final var failed = created.fail("expected failure reason");
@@ -405,9 +426,12 @@ public class ManifestTest {
   public void shouldUpdateManifestToFailedFromComplete() {
     // given
     final var created =
-        Manifest.createManifest(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"));
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
 
     final var completed = created.complete();
 


### PR DESCRIPTION
This adds two steps to the `BackupStore#save` implementation:
1. Creating an `in-progress` manifest at `<basePath>/manifests/<partitionId>/<checkpointId>/<nodeId>/manifest.json`
2. Updating the manifest to `completed`

Additionally, I've implemented the `BackupStore#getStatus` method because that allowed me to enable the `SavingBackup` tests from the testkit :tada:. The only exception is `backupFailsIfFilesAreMissing` which is disabled until saving a backup actually includes the backup content.

Since the GCS client is synchronous, I've added a small threadpool that is used to run `BackupStore` api calls.

closes #11980
closes #12069