### PR TITLE
Opensearch Exporter AWS Request Signing

### DIFF
--- a/exporters/opensearch-exporter/pom.xml
+++ b/exporters/opensearch-exporter/pom.xml
@@ -88,6 +88,21 @@
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-client-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
     </dependency>
 
@@ -175,6 +190,11 @@
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- This dependency is indirectly used by the awssk auth plugin. It requires these
+                 classes on the classpath in order to resolve the AWS credentials -->
+            <dep>software.amazon.awssdk:sts</dep>
+          </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
 

--- a/exporters/opensearch-exporter/pom.xml
+++ b/exporters/opensearch-exporter/pom.xml
@@ -81,6 +81,11 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
 
     <dependency>

--- a/exporters/opensearch-exporter/pom.xml
+++ b/exporters/opensearch-exporter/pom.xml
@@ -86,6 +86,11 @@
       <artifactId>auth</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
 
     <dependency>

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -148,8 +148,7 @@ class OpensearchClient implements AutoCloseable {
     try {
       final var request = new Request("POST", "/_bulk");
       final var body = new EntityTemplate(bulkIndexRequest);
-      body.setContentType("application/x-ndjson");
-      request.setEntity(body);
+      request.setJsonEntity(new String(body.getContent().readAllBytes()));
 
       response = sendRequest(request, BulkIndexResponse.class);
     } catch (final IOException e) {

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -317,6 +317,11 @@ public class OpensearchExporterConfiguration {
     public String serviceName;
     public String region;
 
+    public boolean isPresent() {
+      return (serviceName != null && !serviceName.isEmpty())
+          && (region != null && !region.isEmpty());
+    }
+
     @Override
     public String toString() {
       return "AwsConfiguration{serviceName=" + serviceName + ", region=" + region + '}';

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -314,17 +314,24 @@ public class OpensearchExporterConfiguration {
 
   public static class AwsConfiguration {
 
-    public String serviceName;
-    public String region;
+    private static final String AWS_REGION_ENV_VARIABLE = "AWS_REGION";
+    private static final String AWS_OPENSEARCH_SERVICE_NAME = "es";
 
-    public boolean isPresent() {
-      return (serviceName != null && !serviceName.isEmpty())
-          && (region != null && !region.isEmpty());
-    }
+    public boolean enabled = false;
+    // The service name is defined by AWS. This is currently "es" and is not likely to change.
+    // If it does change this configuration can still be overridden.
+    public String serviceName = AWS_OPENSEARCH_SERVICE_NAME;
+    // The AWS_REGION gets injected into the pod by AWS. If we are running on AWS this should always
+    // be available.
+    public String region = System.getenv(AWS_REGION_ENV_VARIABLE);
 
     @Override
     public String toString() {
-      return "AwsConfiguration{serviceName=" + serviceName + ", region=" + region + '}';
+      if (enabled) {
+        return "AwsConfiguration{serviceName=" + serviceName + ", region=" + region + '}';
+      } else {
+        return "AwsConfiguration{Disabled}";
+      }
     }
   }
 }

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RestClientFactory.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RestClientFactory.java
@@ -86,14 +86,14 @@ final class RestClientFactory {
       setupBasicAuthentication(config, builder);
       log.info("Basic authentication is enabled.");
     } else {
-      log.info("Basic authentication is disabled. No configuration is present.");
+      log.info("Basic authentication is disabled.");
     }
 
-    if (config.aws.isPresent()) {
+    if (config.aws.enabled) {
       configureAws(builder, config.aws);
       log.info("AWS Signing is enabled.");
     } else {
-      log.info("AWS Signing is disabled. No configuration is present.");
+      log.info("AWS Signing is disabled.");
     }
 
     if (allowAllSelfSignedCertificates) {

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RestClientFactory.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RestClientFactory.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.zeebe.exporter.opensearch;
 
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.AwsConfiguration;
+import io.camunda.zeebe.exporter.opensearch.aws.AwsSignHttpRequestInterceptor;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
@@ -21,9 +24,15 @@ import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
 
 final class RestClientFactory {
   private static final RestClientFactory INSTANCE = new RestClientFactory();
+  private final Logger log = LoggerFactory.getLogger(getClass().getPackageName());
 
   private RestClientFactory() {}
 
@@ -75,6 +84,16 @@ final class RestClientFactory {
 
     if (config.hasAuthenticationPresent()) {
       setupBasicAuthentication(config, builder);
+      log.info("Basic authentication is enabled.");
+    } else {
+      log.info("Basic authentication is disabled. No configuration is present.");
+    }
+
+    if (config.aws.isPresent()) {
+      configureAws(builder, config.aws);
+      log.info("AWS Signing is enabled.");
+    } else {
+      log.info("AWS Signing is disabled. No configuration is present.");
     }
 
     if (allowAllSelfSignedCertificates) {
@@ -101,6 +120,22 @@ final class RestClientFactory {
             config.getAuthentication().getUsername(), config.getAuthentication().getPassword()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
+  }
+
+  /**
+   * Adds an interceptor to sign requests to AWS. The signing credentials can be provided in
+   * multiple ways. See {@link DefaultCredentialsProvider} for more details.
+   */
+  public void configureAws(
+      final HttpAsyncClientBuilder builder, final AwsConfiguration awsConfiguration) {
+    final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
+    credentialsProvider.resolveCredentials();
+    final Aws4Signer signer = Aws4Signer.create();
+
+    final HttpRequestInterceptor signInterceptor =
+        new AwsSignHttpRequestInterceptor(
+            awsConfiguration.serviceName, signer, credentialsProvider, awsConfiguration.region);
+    builder.addInterceptorLast(signInterceptor);
   }
 
   private HttpHost[] parseUrl(final OpensearchExporterConfiguration config) {

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/aws/AwsSignHttpRequestInterceptor.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/aws/AwsSignHttpRequestInterceptor.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.aws;
+
+import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import org.apache.http.Header;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * An {@link HttpRequestInterceptor} that signs requests using any AWS {@link Signer} and {@link
+ * AwsCredentialsProvider}.
+ *
+ * <p>This interceptor was taken from the <a
+ * href="https://github.com/awsdocs/amazon-opensearch-service-developer-guide/blob/master/sample_code/java/aws-request-signing-apache-interceptor/src/main/java/com/amazonaws/http/AwsRequestSigningApacheInterceptor.java">Amazon
+ * Opensearch developer guide</a>
+ */
+public class AwsSignHttpRequestInterceptor implements HttpRequestInterceptor {
+  /** The service that we're connecting to. */
+  private final String service;
+
+  /** The particular signer implementation. */
+  private final Signer signer;
+
+  /** The source of AWS credentials for signing. */
+  private final AwsCredentialsProvider awsCredentialsProvider;
+
+  /** The region signing region. */
+  private final Region region;
+
+  /**
+   * @param service service that we're connecting to
+   * @param signer particular signer implementation
+   * @param awsCredentialsProvider source of AWS credentials for signing
+   * @param region signing region
+   */
+  public AwsSignHttpRequestInterceptor(
+      final String service,
+      final Signer signer,
+      final AwsCredentialsProvider awsCredentialsProvider,
+      final Region region) {
+    this.service = service;
+    this.signer = signer;
+    this.awsCredentialsProvider = awsCredentialsProvider;
+    this.region = Objects.requireNonNull(region);
+  }
+
+  /**
+   * @param service service that we're connecting to
+   * @param signer particular signer implementation
+   * @param awsCredentialsProvider source of AWS credentials for signing
+   * @param region signing region
+   */
+  public AwsSignHttpRequestInterceptor(
+      final String service,
+      final Signer signer,
+      final AwsCredentialsProvider awsCredentialsProvider,
+      final String region) {
+    this(service, signer, awsCredentialsProvider, Region.of(region));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void process(final HttpRequest request, final HttpContext context)
+      throws HttpException, IOException {
+    final URIBuilder uriBuilder;
+    try {
+      uriBuilder = new URIBuilder(request.getRequestLine().getUri());
+    } catch (final URISyntaxException e) {
+      throw new IOException("Invalid URI", e);
+    }
+
+    // Copy Apache HttpRequest to AWS Request
+    final SdkHttpFullRequest.Builder requestBuilder =
+        SdkHttpFullRequest.builder()
+            .method(SdkHttpMethod.fromValue(request.getRequestLine().getMethod()))
+            .uri(buildUri(context, uriBuilder));
+
+    if (request instanceof final HttpEntityEnclosingRequest httpEntityEnclosingRequest) {
+      if (httpEntityEnclosingRequest.getEntity() != null) {
+        final InputStream content = httpEntityEnclosingRequest.getEntity().getContent();
+        requestBuilder.contentStreamProvider(() -> content);
+      }
+    }
+    requestBuilder.rawQueryParameters(nvpToMapParams(uriBuilder.getQueryParams()));
+    requestBuilder.headers(headerArrayToMap(request.getAllHeaders()));
+
+    final ExecutionAttributes attributes = new ExecutionAttributes();
+    attributes.putAttribute(
+        AwsSignerExecutionAttribute.AWS_CREDENTIALS, awsCredentialsProvider.resolveCredentials());
+    attributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, service);
+    attributes.putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, region);
+
+    // Sign it
+    final SdkHttpFullRequest signedRequest = signer.sign(requestBuilder.build(), attributes);
+
+    // Now copy everything back
+    request.setHeaders(mapToHeaderArray(signedRequest.headers()));
+    if (request instanceof final HttpEntityEnclosingRequest httpEntityEnclosingRequest) {
+      if (httpEntityEnclosingRequest.getEntity() != null) {
+        final BasicHttpEntity basicHttpEntity = new BasicHttpEntity();
+        basicHttpEntity.setContent(
+            signedRequest
+                .contentStreamProvider()
+                .orElseThrow(() -> new IllegalStateException("There must be content"))
+                .newStream());
+        // wrap into repeatable entity to support retries
+        httpEntityEnclosingRequest.setEntity(new BufferedHttpEntity(basicHttpEntity));
+      }
+    }
+  }
+
+  private URI buildUri(final HttpContext context, final URIBuilder uriBuilder) throws IOException {
+    try {
+      final HttpHost host = (HttpHost) context.getAttribute(HTTP_TARGET_HOST);
+
+      if (host != null) {
+        uriBuilder.setHost(host.getHostName());
+        uriBuilder.setScheme(host.getSchemeName());
+        uriBuilder.setPort(host.getPort());
+      }
+
+      return uriBuilder.build();
+    } catch (final URISyntaxException e) {
+      throw new IOException("Invalid URI", e);
+    }
+  }
+
+  /**
+   * @param params list of HTTP query params as NameValuePairs
+   * @return a multimap of HTTP query params
+   */
+  private static Map<String, List<String>> nvpToMapParams(final List<NameValuePair> params) {
+    final Map<String, List<String>> parameterMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    for (final NameValuePair nvp : params) {
+      final List<String> argsList =
+          parameterMap.computeIfAbsent(nvp.getName(), k -> new ArrayList<>());
+      argsList.add(nvp.getValue());
+    }
+    return parameterMap;
+  }
+
+  /**
+   * @param headers modelled Header objects
+   * @return a Map of header entries
+   */
+  private static Map<String, List<String>> headerArrayToMap(final Header[] headers) {
+    final Map<String, List<String>> headersMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    for (final Header header : headers) {
+      if (!skipHeader(header)) {
+        headersMap.put(
+            header.getName(),
+            headersMap.getOrDefault(
+                header.getName(), new LinkedList<>(Collections.singletonList(header.getValue()))));
+      }
+    }
+    return headersMap;
+  }
+
+  /**
+   * @param header header line to check
+   * @return true if the given header should be excluded when signing
+   */
+  private static boolean skipHeader(final Header header) {
+    return ("content-length".equalsIgnoreCase(header.getName())
+            && "0".equals(header.getValue())) // Strip Content-Length: 0
+        || "host".equalsIgnoreCase(header.getName()); // Host comes from endpoint
+  }
+
+  /**
+   * @param mapHeaders Map of header entries
+   * @return modelled Header objects
+   */
+  private static Header[] mapToHeaderArray(final Map<String, List<String>> mapHeaders) {
+    final Header[] headers = new Header[mapHeaders.size()];
+    int i = 0;
+    for (final Map.Entry<String, List<String>> headerEntry : mapHeaders.entrySet()) {
+      for (final String value : headerEntry.getValue()) {
+        headers[i++] = new BasicHeader(headerEntry.getKey(), value);
+      }
+    }
+    return headers;
+  }
+}

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/aws/AwsSignHttpRequestInterceptor.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/aws/AwsSignHttpRequestInterceptor.java
@@ -137,6 +137,8 @@ public class AwsSignHttpRequestInterceptor implements HttpRequestInterceptor {
                 .contentStreamProvider()
                 .orElseThrow(() -> new IllegalStateException("There must be content"))
                 .newStream());
+        // reset the position of the input stream as it has been read
+        basicHttpEntity.getContent().reset();
         // wrap into repeatable entity to support retries
         httpEntityEnclosingRequest.setEntity(new BufferedHttpEntity(basicHttpEntity));
       }

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/aws/AwsSignHttpRequestInterceptorTest.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/aws/AwsSignHttpRequestInterceptorTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.RequestLine;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.nio.entity.NStringEntity;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.regions.Region;
+
+class AwsSignHttpRequestInterceptorTest {
+  private static final String AWS_SERVICE_NAME = "servicename";
+  private static final Region AWS_REGION = Region.EU_WEST_1;
+  private static final String AWS_SECRET_ACCESS_KEY = "awsSecretAcessKey";
+  private static final String AWS_ACCESS_KEY_ID = "awsAccessKeyId";
+  private static final HttpCoreContext CONTEXT = new HttpCoreContext();
+  private static AwsSignHttpRequestInterceptor interceptor;
+
+  @BeforeAll
+  static void beforeAll() {
+    final var mockCredentialsProvider = mock(AwsCredentialsProvider.class);
+    final var mockAwsCredentials = mock(AwsCredentials.class);
+    when(mockCredentialsProvider.resolveCredentials()).thenReturn(mockAwsCredentials);
+    when(mockAwsCredentials.accessKeyId()).thenReturn(AWS_ACCESS_KEY_ID);
+    when(mockAwsCredentials.secretAccessKey()).thenReturn(AWS_SECRET_ACCESS_KEY);
+    StaticCredentialsProvider.create(AnonymousCredentialsProvider.create().resolveCredentials());
+    final var signer = Aws4Signer.create();
+    interceptor =
+        new AwsSignHttpRequestInterceptor(
+            AWS_SERVICE_NAME, signer, mockCredentialsProvider, AWS_REGION);
+    CONTEXT.setTargetHost(HttpHost.create("localhost"));
+  }
+
+  @Test
+  void shouldInterceptPutRequest() throws Exception {
+    // given
+    final HttpEntityEnclosingRequest request =
+        new BasicHttpEntityEnclosingRequest(new MockRequestLine("PUT", "/index_template/foo"));
+    final var content = "{\"foo\": \"bar\"}";
+    final var entity = new NStringEntity(content, ContentType.APPLICATION_JSON);
+    request.setEntity(entity);
+
+    // when
+    interceptor.process(request, CONTEXT);
+
+    // then
+    assertThat(request.getRequestLine().getMethod()).isEqualTo("PUT");
+    assertAwsHeaders(request);
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    request.getEntity().writeTo(outputStream);
+    assertEquals(content, outputStream.toString());
+  }
+
+  @Test
+  void shouldInterceptPostRequest() throws Exception {
+    // given
+    final HttpEntityEnclosingRequest request =
+        new BasicHttpEntityEnclosingRequest(new MockRequestLine("POST", "/_bulk"));
+    final var content = "{\"foo\": \"bar\"}";
+    final var entity = new NStringEntity(content, ContentType.APPLICATION_JSON);
+    request.setEntity(entity);
+
+    // when
+    interceptor.process(request, CONTEXT);
+
+    // then
+    assertThat(request.getRequestLine().getMethod()).isEqualTo("POST");
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    request.getEntity().writeTo(outputStream);
+    assertEquals(content, outputStream.toString());
+    assertAwsHeaders(request);
+  }
+
+  @Test
+  void shouldCreateRepeatableEntity() throws Exception {
+    final HttpEntityEnclosingRequest request =
+        new BasicHttpEntityEnclosingRequest(new MockRequestLine("POST", "/"));
+
+    final String payload = "{\"test\": \"val\"}";
+    request.setEntity(new StringEntity(payload));
+    final HttpCoreContext context = new HttpCoreContext();
+    context.setTargetHost(HttpHost.create("localhost"));
+    interceptor.process(request, context);
+
+    assertTrue(request.getEntity().isRepeatable());
+  }
+
+  @Test
+  void shouldThrowBadRequest() {
+    final HttpRequest badRequest = new BasicHttpRequest("GET", "?#!@*%");
+    assertThrows(IOException.class, () -> interceptor.process(badRequest, new BasicHttpContext()));
+  }
+
+  private static void assertAwsHeaders(final HttpEntityEnclosingRequest request) {
+    final var authorizationHeader = request.getFirstHeader("Authorization");
+
+    final var dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+    final var currentDate = LocalDate.now().format(dateFormatter);
+    final var credentialsString =
+        "Credential="
+            + AWS_ACCESS_KEY_ID
+            + "/"
+            + currentDate
+            + "/"
+            + AWS_REGION.id()
+            + "/"
+            + AWS_SERVICE_NAME
+            + "/aws4_request";
+
+    assertThat(authorizationHeader.getValue())
+        .describedAs("Starts with algorithm")
+        .startsWith("AWS4-HMAC-SHA256")
+        .describedAs("Contains Credentials")
+        .contains(credentialsString)
+        .describedAs("Contains SignedHeaders")
+        .contains("SignedHeaders=host;x-amz-date")
+        .describedAs("Contains Signature")
+        // As the signature is a random hash we can't verify the value
+        .contains("Signature=");
+  }
+
+  private static class MockRequestLine implements RequestLine {
+    private final String uri;
+    private final String method;
+
+    MockRequestLine(final String method, final String uri) {
+      this.method = method;
+      this.uri = uri;
+    }
+
+    @Override
+    public String getMethod() {
+      return method;
+    }
+
+    @Override
+    public ProtocolVersion getProtocolVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getUri() {
+      return uri;
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds a request interceptor that signs the request according to the [AWS guidelines](https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html).

It also slightly modifies the configuration of AWS. It came to my attention that the service name will always be `es` as this is decided by AWS. Besides this AWS will inject the region as an env variable into the pod. As a result I chose to make these the default values for these options. Ofcourse they can still be manually overridden if necessary.

Some of the decisions made are explained in the commit messages, so it might help to review by commit.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12013 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
