### PR TITLE
feat(backup/gcs): save backup contents

### DIFF
--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -119,6 +119,12 @@
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobWriteOption;
+import io.camunda.zeebe.backup.api.NamedFileSet;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+final class FileSetManager {
+  private final Storage client;
+  private final BucketInfo bucketInfo;
+
+  FileSetManager(final Storage client, final BucketInfo bucketInfo) {
+    this.client = client;
+    this.bucketInfo = bucketInfo;
+  }
+
+  void save(final String prefix, final NamedFileSet fileSet) {
+    for (final var namedFile : fileSet.namedFiles().entrySet()) {
+      final var fileName = namedFile.getKey();
+      final var filePath = namedFile.getValue();
+      try {
+        client.createFrom(
+            blobInfo(prefix, fileName),
+            filePath,
+            BlobWriteOption.doesNotExist(),
+            BlobWriteOption.crc32cMatch());
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+
+  private BlobInfo blobInfo(String prefix, String fileName) {
+    return BlobInfo.newBuilder(bucketInfo, prefix + fileName)
+        .setContentType("application/octet-stream")
+        .build();
+  }
+}

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -7,19 +7,8 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
-
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.Storage.BlobTargetOption;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
@@ -29,10 +18,7 @@ import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException.BucketDoesNotExistException;
-import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.gcs.manifest.Manifest;
-import io.camunda.zeebe.backup.gcs.manifest.Manifest.InProgressManifest;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
@@ -41,17 +27,9 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 public final class GcsBackupStore implements BackupStore {
-  public static final ObjectMapper MAPPER =
-      new ObjectMapper()
-          .registerModule(new Jdk8Module())
-          .registerModule(new JavaTimeModule())
-          .disable(WRITE_DATES_AS_TIMESTAMPS)
-          .setSerializationInclusion(Include.NON_ABSENT);
-
-  private final Storage client;
-  private final BucketInfo bucketInfo;
   private final String prefix;
   private final Executor executor;
+  private final ManifestManager manifestManager;
   private final FileSetManager fileSetManager;
 
   public GcsBackupStore(final GcsBackupConfig config) {
@@ -59,99 +37,44 @@ public final class GcsBackupStore implements BackupStore {
   }
 
   public GcsBackupStore(final GcsBackupConfig config, final Storage client) {
-    this.client = client;
-    bucketInfo = BucketInfo.of(config.bucketName());
+    final var bucketInfo = BucketInfo.of(config.bucketName());
     prefix = Optional.ofNullable(config.basePath()).map(basePath -> basePath + "/").orElse("");
     executor = Executors.newWorkStealingPool(4);
+    manifestManager = new ManifestManager(client, bucketInfo);
     fileSetManager = new FileSetManager(client, bucketInfo);
   }
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    return CompletableFuture.runAsync(() -> saveSync(backup), executor);
-  }
-
-  private void saveSync(final Backup backup) {
-    final var manifest = createInitialManifest(backup);
-    saveSnapshotFiles(backup);
-    saveSegmentFiles(backup);
-    completeManifest(manifest);
-  }
-
-  record CurrentManifest(Blob blob, InProgressManifest manifest) {}
-
-  private CurrentManifest createInitialManifest(final Backup backup) {
-    final var manifestBlobInfo = manifestBlobInfo(backup.id());
-    final var manifest = Manifest.create(backup);
-    try {
-      final var blob =
-          client.create(
-              manifestBlobInfo,
-              MAPPER.writeValueAsBytes(manifest),
-              BlobTargetOption.doesNotExist());
-      return new CurrentManifest(blob, manifest);
-    } catch (final StorageException e) {
-      if (e.getCode() == 412) { // 412 Precondition Failed, blob must already exist
-        throw new UnexpectedManifestState(
-            "Manifest for backup %s already exists".formatted(backup.id()));
-      } else {
-        throw e;
-      }
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private void completeManifest(final CurrentManifest currentManifest) {
-    final var blob = currentManifest.blob();
-    final var completed = currentManifest.manifest().complete();
-    try {
-      client.create(
-          blob.asBlobInfo(),
-          MAPPER.writeValueAsBytes(completed),
-          BlobTargetOption.generationMatch(blob.getGeneration()));
-    } catch (final StorageException e) {
-      if (e.getCode() == 412) { // 412 Precondition Failed, blob have changed
-        throw new UnexpectedManifestState(
-            "Manifest for backup %s was modified unexpectedly".formatted(completed.id()));
-      }
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private void saveSnapshotFiles(final Backup backup) {
-    fileSetManager.save(filePrefix(backup.id()) + "snapshot/", backup.snapshot());
-  }
-
-  private void saveSegmentFiles(final Backup backup) {
-    fileSetManager.save(filePrefix(backup.id()) + "segments/", backup.segments());
+    return CompletableFuture.runAsync(
+        () -> {
+          final var manifest =
+              manifestManager.createInitialManifest(manifestPrefix(backup.id()), backup);
+          fileSetManager.save(contentPrefix(backup.id()) + "snapshot/", backup.snapshot());
+          fileSetManager.save(contentPrefix(backup.id()) + "segments/", backup.segments());
+          manifestManager.completeManifest(manifest);
+        },
+        executor);
   }
 
   @Override
   public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
-    return CompletableFuture.supplyAsync(() -> getStatusSync(id));
-  }
-
-  private BackupStatus getStatusSync(final BackupIdentifier id) {
-    final var blob = client.get(manifestBlobInfo(id).getBlobId());
-    if (blob == null) {
-      return new BackupStatusImpl(
-          id,
-          Optional.empty(),
-          BackupStatusCode.DOES_NOT_EXIST,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty());
-    }
-
-    final var content = blob.getContent();
-    try {
-      final var manifest = MAPPER.readValue(content, Manifest.class);
-      return Manifest.toStatus(manifest);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    return CompletableFuture.supplyAsync(
+        () -> {
+          final var manifest = manifestManager.getManifest(manifestPrefix(id));
+          if (manifest == null) {
+            return new BackupStatusImpl(
+                id,
+                Optional.empty(),
+                BackupStatusCode.DOES_NOT_EXIST,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+          } else {
+            return Manifest.toStatus(manifest);
+          }
+        },
+        executor);
   }
 
   @Override
@@ -180,22 +103,16 @@ public final class GcsBackupStore implements BackupStore {
     throw new UnsupportedOperationException();
   }
 
-  private String manifestPrefix(BackupIdentifier id) {
+  private String manifestPrefix(final BackupIdentifier id) {
     return prefix + "manifests/" + backupPath(id);
   }
 
-  private String filePrefix(BackupIdentifier id) {
-    return prefix + backupPath(id);
+  private String contentPrefix(final BackupIdentifier id) {
+    return prefix + "contents/" + backupPath(id);
   }
 
-  private String backupPath(BackupIdentifier id) {
+  private String backupPath(final BackupIdentifier id) {
     return "%s/%s/%s/".formatted(id.partitionId(), id.checkpointId(), id.nodeId());
-  }
-
-  private BlobInfo manifestBlobInfo(BackupIdentifier id) {
-    return BlobInfo.newBuilder(bucketInfo, manifestPrefix(id) + "manifest.json")
-        .setContentType("application/json")
-        .build();
   }
 
   public static Storage buildClient(final GcsBackupConfig config) {

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -50,9 +50,14 @@ public final class GcsBackupStore implements BackupStore {
         () -> {
           final var manifest =
               manifestManager.createInitialManifest(manifestPrefix(backup.id()), backup);
-          fileSetManager.save(contentPrefix(backup.id()) + "snapshot/", backup.snapshot());
-          fileSetManager.save(contentPrefix(backup.id()) + "segments/", backup.segments());
-          manifestManager.completeManifest(manifest);
+          try {
+            fileSetManager.save(contentPrefix(backup.id()) + "snapshot/", backup.snapshot());
+            fileSetManager.save(contentPrefix(backup.id()) + "segments/", backup.segments());
+            manifestManager.completeManifest(manifest);
+          } catch (final Exception e) {
+            manifestManager.failManifest(manifest, e.getMessage());
+            throw e;
+          }
         },
         executor);
   }

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.StorageException;
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
+import io.camunda.zeebe.backup.gcs.manifest.Manifest;
+import io.camunda.zeebe.backup.gcs.manifest.Manifest.InProgressManifest;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public final class ManifestManager {
+  public static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(new JavaTimeModule())
+          .disable(WRITE_DATES_AS_TIMESTAMPS)
+          .setSerializationInclusion(Include.NON_ABSENT);
+
+  private final BucketInfo bucketInfo;
+  private final Storage client;
+
+  ManifestManager(final Storage client, final BucketInfo bucketInfo) {
+    this.bucketInfo = bucketInfo;
+    this.client = client;
+  }
+
+  CurrentManifest createInitialManifest(final String prefix, final Backup backup) {
+    final var manifestBlobInfo = manifestBlobInfo(prefix);
+    final var manifest = Manifest.create(backup);
+    try {
+      final var blob =
+          client.create(
+              manifestBlobInfo,
+              MAPPER.writeValueAsBytes(manifest),
+              BlobTargetOption.doesNotExist());
+      return new CurrentManifest(blob, manifest);
+    } catch (final StorageException e) {
+      if (e.getCode() == 412) { // 412 Precondition Failed, blob must already exist
+        throw new UnexpectedManifestState(
+            "Manifest for backup %s already exists".formatted(backup.id()));
+      } else {
+        throw e;
+      }
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  void completeManifest(final CurrentManifest currentManifest) {
+    final var blob = currentManifest.blob();
+    final var completed = currentManifest.manifest().complete();
+    try {
+      client.create(
+          blob.asBlobInfo(),
+          MAPPER.writeValueAsBytes(completed),
+          BlobTargetOption.generationMatch(blob.getGeneration()));
+    } catch (final StorageException e) {
+      if (e.getCode() == 412) { // 412 Precondition Failed, blob have changed
+        throw new UnexpectedManifestState(
+            "Manifest for backup %s was modified unexpectedly".formatted(completed.id()));
+      }
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  Manifest getManifest(final String prefix) {
+    final var blob = client.get(manifestBlobInfo(prefix).getBlobId());
+    if (blob == null) {
+      return null;
+    } else {
+      try {
+        return MAPPER.readValue(blob.getContent(), Manifest.class);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+
+  private BlobInfo manifestBlobInfo(final String prefix) {
+    return BlobInfo.newBuilder(bucketInfo, prefix + "manifest.json")
+        .setContentType("application/json")
+        .build();
+  }
+
+  record CurrentManifest(Blob blob, InProgressManifest manifest) {}
+}

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/FileSet.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/FileSet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs.manifest;
+
+import io.camunda.zeebe.backup.api.NamedFileSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public record FileSet(List<NamedFile> files) {
+
+  public FileSet {
+    Objects.requireNonNull(files);
+    final var countByName =
+        files.stream().collect(Collectors.groupingBy(NamedFile::name, Collectors.counting()));
+
+    for (final var occurrence : countByName.entrySet()) {
+      if (occurrence.getValue() > 1) {
+        throw new IllegalArgumentException(
+            "File name '%s' must be unique but occurred '%s' times in %s"
+                .formatted(occurrence.getKey(), occurrence.getValue(), files));
+      }
+    }
+  }
+
+  static FileSet of(final NamedFileSet fileSet) {
+    if (fileSet == null) {
+      return new FileSet(List.of());
+    }
+
+    return new FileSet(fileSet.namedFiles().keySet().stream().map(NamedFile::new).toList());
+  }
+
+  record NamedFile(String name) {
+    NamedFile {
+      Objects.requireNonNull(name);
+    }
+  }
+}

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/Manifest.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/Manifest.java
@@ -24,17 +24,19 @@ import java.util.Optional;
 @JsonDeserialize(as = ManifestImpl.class)
 public sealed interface Manifest {
 
-  static InProgressManifest create(Backup backup) {
+  static InProgressManifest create(final Backup backup) {
     final var creationTime = Instant.now();
     return new ManifestImpl(
         BackupIdentifierImpl.from(backup.id()),
         BackupDescriptorImpl.from(backup.descriptor()),
         IN_PROGRESS,
+        FileSet.of(backup.snapshot()),
+        FileSet.of(backup.segments()),
         creationTime,
         creationTime);
   }
 
-  static BackupStatus toStatus(Manifest manifest) {
+  static BackupStatus toStatus(final Manifest manifest) {
     return switch (manifest.statusCode()) {
       case IN_PROGRESS -> new BackupStatusImpl(
           manifest.id(),

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/ManifestImpl.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/ManifestImpl.java
@@ -21,6 +21,8 @@ record ManifestImpl(
     BackupIdentifierImpl id,
     BackupDescriptorImpl descriptor,
     StatusCode statusCode,
+    FileSet snapshot,
+    FileSet segments,
     Instant createdAt,
     Instant modifiedAt,
     String failureReason)
@@ -38,19 +40,23 @@ record ManifestImpl(
       final BackupIdentifierImpl id,
       final BackupDescriptorImpl descriptor,
       final StatusCode statusCode,
+      final FileSet snapshot,
+      final FileSet segments,
       final Instant createdAt,
       final Instant modifiedAt) {
-    this(id, descriptor, statusCode, createdAt, modifiedAt, null);
+    this(id, descriptor, statusCode, snapshot, segments, createdAt, modifiedAt, null);
   }
 
   @Override
   public CompletedManifest complete() {
-    return new ManifestImpl(id, descriptor, COMPLETED, createdAt, Instant.now());
+    return new ManifestImpl(
+        id, descriptor, COMPLETED, snapshot, segments, createdAt, Instant.now());
   }
 
   @Override
   public FailedManifest fail(final String failureReason) {
-    return new ManifestImpl(id, descriptor, FAILED, createdAt, Instant.now(), failureReason);
+    return new ManifestImpl(
+        id, descriptor, FAILED, snapshot, segments, createdAt, Instant.now(), failureReason);
   }
 
   @Override

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestSta
 import io.camunda.zeebe.backup.gcs.util.GcsContainer;
 import io.camunda.zeebe.backup.testkit.SavingBackup;
 import io.camunda.zeebe.backup.testkit.UpdatingBackupStatus;
-import java.io.IOException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,12 +64,6 @@ public class GcsBackupStoreIT implements SavingBackup, UpdatingBackupStatus {
   @Override
   public Class<? extends Exception> getBackupInInvalidStateExceptionClass() {
     return UnexpectedManifestState.class;
-  }
-
-  @Override
-  @Disabled
-  public void backupFailsIfFilesAreMissing(final Backup backup) throws IOException {
-    SavingBackup.super.backupFailsIfFilesAreMissing(backup);
   }
 
   @Override

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestStateCastingTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestStateCastingTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs.manifest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class ManifestStateCastingTest {
+  @Test
+  public void shouldFailOnAsInProgress() {
+    // given
+    final var manifest =
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
+
+    final var complete = manifest.complete();
+
+    // when expect thrown
+    assertThatThrownBy(complete::asInProgress)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'COMPLETED'");
+  }
+
+  @Test
+  public void shouldFailOnAsCompleted() {
+    // given
+    final var manifest =
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new NamedFileSetImpl(Map.of()),
+                new NamedFileSetImpl(Map.of())));
+
+    // when expect thrown
+    assertThatThrownBy(manifest::asCompleted)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'IN_PROGRESS'");
+  }
+
+  @Test
+  public void shouldFailOnAsFailed() {
+    // given
+    final var manifest =
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
+
+    // when expect thrown
+    assertThatThrownBy(manifest::asFailed)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'IN_PROGRESS'");
+  }
+}

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestStateTransitionTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestStateTransitionTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.gcs.manifest;
+
+import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.COMPLETED;
+import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.FAILED;
+import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.IN_PROGRESS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class ManifestStateTransitionTest {
+  @Test
+  public void shouldStartInProgress() {
+    // given
+
+    // when
+    final var manifest =
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
+
+    // then
+    assertThat(manifest.statusCode()).isEqualTo(IN_PROGRESS);
+    assertThat(manifest.createdAt().getEpochSecond()).isGreaterThan(0);
+    assertThat(manifest.modifiedAt().getEpochSecond()).isGreaterThan(0);
+    assertThat(manifest.createdAt()).isEqualTo(manifest.modifiedAt());
+  }
+
+  @Test
+  public void shouldUpdateManifestToCompleted() {
+    // given
+    final var created =
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
+
+    // when
+    final var completed = created.complete();
+
+    // then
+    assertThat(completed.statusCode()).isEqualTo(COMPLETED);
+    assertThat(completed.createdAt().getEpochSecond()).isGreaterThan(0);
+    assertThat(completed.modifiedAt().getEpochSecond()).isGreaterThan(0);
+    assertThat(completed.createdAt()).isBefore(completed.modifiedAt());
+    assertThat(completed.createdAt()).isEqualTo(created.modifiedAt());
+    assertThat(completed.modifiedAt()).isNotEqualTo(created.modifiedAt());
+  }
+
+  @Test
+  public void shouldUpdateManifestToFailed() {
+    // given
+    final var created =
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
+
+    // when
+    final var failed = created.fail("expected failure reason");
+
+    // then
+    assertThat(failed.statusCode()).isEqualTo(FAILED);
+    assertThat(failed.createdAt().getEpochSecond()).isGreaterThan(0);
+    assertThat(failed.modifiedAt().getEpochSecond()).isGreaterThan(0);
+    assertThat(failed.createdAt()).isBefore(failed.modifiedAt());
+    assertThat(failed.createdAt()).isEqualTo(created.modifiedAt());
+    assertThat(failed.modifiedAt()).isNotEqualTo(created.modifiedAt());
+    assertThat(failed.failureReason()).isEqualTo("expected failure reason");
+  }
+
+  @Test
+  public void shouldUpdateManifestFromCompletedToFailed() {
+    // given
+    final var created =
+        Manifest.create(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                null,
+                null));
+
+    final var completed = created.complete();
+
+    // when
+    final var failed = completed.fail("expected failure reason");
+
+    // then
+    assertThat(failed.statusCode()).isEqualTo(FAILED);
+    assertThat(failed.createdAt().getEpochSecond()).isGreaterThan(0);
+    assertThat(failed.modifiedAt().getEpochSecond()).isGreaterThan(0);
+    assertThat(failed.createdAt()).isBefore(failed.modifiedAt());
+    assertThat(failed.createdAt()).isEqualTo(created.modifiedAt());
+    assertThat(failed.modifiedAt()).isNotEqualTo(created.modifiedAt());
+    assertThat(failed.failureReason()).isEqualTo("expected failure reason");
+  }
+}

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.backup.gcs.manifest;
 
-import static io.camunda.zeebe.backup.gcs.GcsBackupStore.MAPPER;
+import static io.camunda.zeebe.backup.gcs.ManifestManager.MAPPER;
 import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.COMPLETED;
 import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.FAILED;
 import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.IN_PROGRESS;

--- a/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
+++ b/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
@@ -71,8 +71,8 @@ public final class TestBackupProvider implements ArgumentsProvider {
     return new BackupImpl(
         id,
         new BackupDescriptorImpl(Optional.of("test-snapshot-id"), 4, 5, "test"),
-        new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)),
-        new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)));
+        new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)),
+        new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)));
   }
 
   public Backup minimalBackupWithId(final BackupIdentifierImpl id) throws IOException {


### PR DESCRIPTION
Building on top of #12068, this closes https://github.com/camunda/zeebe/issues/12070.

Manifest are extended and now look like this:

```diff
{
  "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
  "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT" },
  "statusCode": "IN_PROGRESS",
++  "snapshot": { "files": [ { "name": "snapshotFile1" }, { "name": "snapshotFile2" } ] },
++  "segments": { "files": [ { "name": "segmentFile1" } ] },
  "createdAt": "2023-03-14T10:45:08Z",
  "modifiedAt": "2023-03-14T10:45:08Z"
}
```

This is similar to the S3 backup store but a little bit better because we don't use file names as map keys and can easily extend the schema to track metadata (e.g. whether the file was compressed or not).


I've also decided to introduce a `FileSetManager` and `ManifestManager` as specialized classes that only know how handle filesets and manifests respectively. My goal here was to keep the `GcsBackupStore` class short and easy to follow.