### PR TITLE
feat(backup/gcs): backup can be marked as failed

### DIFF
--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -55,7 +55,7 @@ public final class GcsBackupStore implements BackupStore {
             fileSetManager.save(contentPrefix(backup.id()) + "segments/", backup.segments());
             manifestManager.completeManifest(manifest);
           } catch (final Exception e) {
-            manifestManager.failManifest(manifest, e.getMessage());
+            manifestManager.markAsFailed(manifestPrefix(backup.id()), backup.id(), e.getMessage());
             throw e;
           }
         },
@@ -100,7 +100,12 @@ public final class GcsBackupStore implements BackupStore {
   @Override
   public CompletableFuture<BackupStatusCode> markFailed(
       final BackupIdentifier id, final String failureReason) {
-    throw new UnsupportedOperationException();
+    return CompletableFuture.supplyAsync(
+        () -> {
+          manifestManager.markAsFailed(manifestPrefix(id), id, failureReason);
+          return BackupStatusCode.FAILED;
+        },
+        executor);
   }
 
   @Override

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/Manifest.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/manifest/Manifest.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.zeebe.backup.gcs.manifest;
 
+import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.FAILED;
 import static io.camunda.zeebe.backup.gcs.manifest.Manifest.StatusCode.IN_PROGRESS;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
@@ -34,6 +36,12 @@ public sealed interface Manifest {
         FileSet.of(backup.segments()),
         creationTime,
         creationTime);
+  }
+
+  static FailedManifest createFailed(final BackupIdentifier id) {
+    final var creationTime = Instant.now();
+    return new ManifestImpl(
+        BackupIdentifierImpl.from(id), null, FAILED, null, null, creationTime, creationTime);
   }
 
   static BackupStatus toStatus(final Manifest manifest) {

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
@@ -17,7 +17,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-public class ConfigIntegrationTest {
+public class ConfigIT {
   @Container private static final GcsContainer GCS = new GcsContainer();
 
   @Test

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
@@ -8,21 +8,20 @@
 package io.camunda.zeebe.backup.gcs;
 
 import com.google.cloud.storage.BucketInfo;
-import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.gcs.util.GcsContainer;
+import io.camunda.zeebe.backup.testkit.QueryingBackupStatus;
 import io.camunda.zeebe.backup.testkit.SavingBackup;
 import io.camunda.zeebe.backup.testkit.UpdatingBackupStatus;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-public class GcsBackupStoreIT implements SavingBackup, UpdatingBackupStatus {
+public class GcsBackupStoreIT implements SavingBackup, UpdatingBackupStatus, QueryingBackupStatus {
   @Container private static final GcsContainer GCS = new GcsContainer();
   private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
@@ -64,17 +63,5 @@ public class GcsBackupStoreIT implements SavingBackup, UpdatingBackupStatus {
   @Override
   public Class<? extends Exception> getBackupInInvalidStateExceptionClass() {
     return UnexpectedManifestState.class;
-  }
-
-  @Override
-  @Disabled
-  public void backupCanBeMarkedAsFailed(final Backup backup) {
-    UpdatingBackupStatus.super.backupCanBeMarkedAsFailed(backup);
-  }
-
-  @Override
-  @Disabled
-  public void markingAsFailedUpdatesTimestamp(final Backup backup) {
-    UpdatingBackupStatus.super.markingAsFailedUpdatesTimestamp(backup);
   }
 }


### PR DESCRIPTION
This implements `BackupStore#markAsFailed` and enables more tests from the testkit.

Depends on #12090, closes #12091

