### PR TITLE
feat(clients/go): exponential backoff supplier

### DIFF
--- a/clients/go/go.sum
+++ b/clients/go/go.sum
@@ -23,7 +23,6 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
@@ -117,8 +116,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
-github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/clients/go/pkg/worker/backoffSupplier.go
+++ b/clients/go/pkg/worker/backoffSupplier.go
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package worker
+
+import "time"
+
+type BackoffSupplier interface {
+	SupplyRetryDelay(currentRetryDelay time.Duration) time.Duration
+}

--- a/clients/go/pkg/worker/backoffSupplier.go
+++ b/clients/go/pkg/worker/backoffSupplier.go
@@ -1,10 +1,17 @@
-/*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.1. You may not use this file
- * except in compliance with the Zeebe Community License 1.1.
- */
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import "time"

--- a/clients/go/pkg/worker/exponentialBackoffSupplier.go
+++ b/clients/go/pkg/worker/exponentialBackoffSupplier.go
@@ -22,14 +22,14 @@ type ExponentialBackoffBuilder interface {
 	Build() BackoffSupplier
 }
 
-type ExponentialBackoffBuilderImpl struct {
+type exponentialBackoffBuilderImpl struct {
 	minDelay, maxDelay          time.Duration
 	backoffFactor, jitterFactor float64
 	random                      *rand.Rand
 }
 
-func NewExponentialBackoffBuilder() ExponentialBackoffBuilderImpl {
-	return ExponentialBackoffBuilderImpl{
+func NewExponentialBackoffBuilder() exponentialBackoffBuilderImpl {
+	return exponentialBackoffBuilderImpl{
 		maxDelay:      time.Second * 5,
 		minDelay:      time.Millisecond * 50,
 		backoffFactor: 1.6,
@@ -38,32 +38,32 @@ func NewExponentialBackoffBuilder() ExponentialBackoffBuilderImpl {
 	}
 }
 
-func (e ExponentialBackoffBuilderImpl) MaxDelay(maxDelay time.Duration) ExponentialBackoffBuilder {
+func (e exponentialBackoffBuilderImpl) MaxDelay(maxDelay time.Duration) ExponentialBackoffBuilder {
 	e.maxDelay = maxDelay
 	return e
 }
 
-func (e ExponentialBackoffBuilderImpl) MinDelay(minDelay time.Duration) ExponentialBackoffBuilder {
+func (e exponentialBackoffBuilderImpl) MinDelay(minDelay time.Duration) ExponentialBackoffBuilder {
 	e.minDelay = minDelay
 	return e
 }
 
-func (e ExponentialBackoffBuilderImpl) BackoffFactor(backoffFactor float64) ExponentialBackoffBuilder {
+func (e exponentialBackoffBuilderImpl) BackoffFactor(backoffFactor float64) ExponentialBackoffBuilder {
 	e.backoffFactor = backoffFactor
 	return e
 }
 
-func (e ExponentialBackoffBuilderImpl) JitterFactor(jitterFactor float64) ExponentialBackoffBuilder {
+func (e exponentialBackoffBuilderImpl) JitterFactor(jitterFactor float64) ExponentialBackoffBuilder {
 	e.jitterFactor = jitterFactor
 	return e
 }
 
-func (e ExponentialBackoffBuilderImpl) Random(random *rand.Rand) ExponentialBackoffBuilder {
+func (e exponentialBackoffBuilderImpl) Random(random *rand.Rand) ExponentialBackoffBuilder {
 	e.random = random
 	return e
 }
 
-func (e ExponentialBackoffBuilderImpl) Build() BackoffSupplier {
+func (e exponentialBackoffBuilderImpl) Build() BackoffSupplier {
 	return ExponentialBackoff{
 		minDelay:      e.minDelay,
 		maxDelay:      e.maxDelay,

--- a/clients/go/pkg/worker/exponentialBackoffSupplier.go
+++ b/clients/go/pkg/worker/exponentialBackoffSupplier.go
@@ -35,7 +35,7 @@ func NewExponentialBackoffBuilder() ExponentialBackoff {
 		minDelay:      time.Millisecond * 50,
 		backoffFactor: 1.6,
 		jitterFactor:  0.1,
-		random:        rand.New(rand.NewSource(time.Now().Unix())),
+		random:        rand.New(rand.NewSource(time.Now().Unix())), //nolint G404, we dont need a secure random number generator
 	}
 }
 

--- a/clients/go/pkg/worker/exponentialBackoffSupplier.go
+++ b/clients/go/pkg/worker/exponentialBackoffSupplier.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package worker
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+type ExponentialBackoffBuilder interface {
+	MaxDelay(time.Duration) ExponentialBackoffBuilder
+	MinDelay(time.Duration) ExponentialBackoffBuilder
+	BackoffFactor(float64) ExponentialBackoffBuilder
+	JitterFactor(float64) ExponentialBackoffBuilder
+	Random(*rand.Rand) ExponentialBackoffBuilder
+	Build() BackoffSupplier
+}
+
+type ExponentialBackoffBuilderImpl struct {
+	minDelay, maxDelay          time.Duration
+	backoffFactor, jitterFactor float64
+	random                      *rand.Rand
+}
+
+func NewExponentialBackoffBuilder() ExponentialBackoffBuilderImpl {
+	return ExponentialBackoffBuilderImpl{
+		maxDelay:      time.Second * 5,
+		minDelay:      time.Millisecond * 50,
+		backoffFactor: 1.6,
+		jitterFactor:  0.1,
+		random:        rand.New(rand.NewSource(time.Now().Unix())),
+	}
+}
+
+func (e ExponentialBackoffBuilderImpl) MaxDelay(maxDelay time.Duration) ExponentialBackoffBuilder {
+	e.maxDelay = maxDelay
+	return e
+}
+
+func (e ExponentialBackoffBuilderImpl) MinDelay(minDelay time.Duration) ExponentialBackoffBuilder {
+	e.minDelay = minDelay
+	return e
+}
+
+func (e ExponentialBackoffBuilderImpl) BackoffFactor(backoffFactor float64) ExponentialBackoffBuilder {
+	e.backoffFactor = backoffFactor
+	return e
+}
+
+func (e ExponentialBackoffBuilderImpl) JitterFactor(jitterFactor float64) ExponentialBackoffBuilder {
+	e.jitterFactor = jitterFactor
+	return e
+}
+
+func (e ExponentialBackoffBuilderImpl) Random(random *rand.Rand) ExponentialBackoffBuilder {
+	e.random = random
+	return e
+}
+
+func (e ExponentialBackoffBuilderImpl) Build() BackoffSupplier {
+	return ExponentialBackoff{
+		minDelay:      e.minDelay,
+		maxDelay:      e.maxDelay,
+		backoffFactor: e.backoffFactor,
+		jitterFactor:  e.jitterFactor,
+		random:        e.random,
+	}
+}
+
+type ExponentialBackoff struct {
+	minDelay, maxDelay          time.Duration
+	backoffFactor, jitterFactor float64
+	random                      *rand.Rand
+}
+
+func (e ExponentialBackoff) SupplyRetryDelay(currentRetryDelay time.Duration) time.Duration {
+	y := float64(currentRetryDelay.Milliseconds()) * e.backoffFactor
+	delay := math.Max(math.Min(float64(e.maxDelay.Milliseconds()), y), float64(e.minDelay.Milliseconds()))
+	jitter := e.computeJitter(delay)
+	retryDelay := math.Round(delay + jitter)
+	return time.Duration(retryDelay * float64(time.Millisecond))
+}
+
+func (e ExponentialBackoff) computeJitter(value float64) float64 {
+	minFactor := value * -e.jitterFactor
+	maxFactor := value * e.jitterFactor
+
+	return (e.random.Float64() * (maxFactor - minFactor)) + minFactor
+}

--- a/clients/go/pkg/worker/exponentialBackoffSupplier.go
+++ b/clients/go/pkg/worker/exponentialBackoffSupplier.go
@@ -1,10 +1,17 @@
-/*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.1. You may not use this file
- * except in compliance with the Zeebe Community License 1.1.
- */
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (
@@ -22,14 +29,8 @@ type ExponentialBackoffBuilder interface {
 	Build() BackoffSupplier
 }
 
-type exponentialBackoffBuilderImpl struct {
-	minDelay, maxDelay          time.Duration
-	backoffFactor, jitterFactor float64
-	random                      *rand.Rand
-}
-
-func NewExponentialBackoffBuilder() exponentialBackoffBuilderImpl {
-	return exponentialBackoffBuilderImpl{
+func NewExponentialBackoffBuilder() ExponentialBackoff {
+	return ExponentialBackoff{
 		maxDelay:      time.Second * 5,
 		minDelay:      time.Millisecond * 50,
 		backoffFactor: 1.6,
@@ -38,32 +39,32 @@ func NewExponentialBackoffBuilder() exponentialBackoffBuilderImpl {
 	}
 }
 
-func (e exponentialBackoffBuilderImpl) MaxDelay(maxDelay time.Duration) ExponentialBackoffBuilder {
+func (e ExponentialBackoff) MaxDelay(maxDelay time.Duration) ExponentialBackoffBuilder {
 	e.maxDelay = maxDelay
 	return e
 }
 
-func (e exponentialBackoffBuilderImpl) MinDelay(minDelay time.Duration) ExponentialBackoffBuilder {
+func (e ExponentialBackoff) MinDelay(minDelay time.Duration) ExponentialBackoffBuilder {
 	e.minDelay = minDelay
 	return e
 }
 
-func (e exponentialBackoffBuilderImpl) BackoffFactor(backoffFactor float64) ExponentialBackoffBuilder {
+func (e ExponentialBackoff) BackoffFactor(backoffFactor float64) ExponentialBackoffBuilder {
 	e.backoffFactor = backoffFactor
 	return e
 }
 
-func (e exponentialBackoffBuilderImpl) JitterFactor(jitterFactor float64) ExponentialBackoffBuilder {
+func (e ExponentialBackoff) JitterFactor(jitterFactor float64) ExponentialBackoffBuilder {
 	e.jitterFactor = jitterFactor
 	return e
 }
 
-func (e exponentialBackoffBuilderImpl) Random(random *rand.Rand) ExponentialBackoffBuilder {
+func (e ExponentialBackoff) Random(random *rand.Rand) ExponentialBackoffBuilder {
 	e.random = random
 	return e
 }
 
-func (e exponentialBackoffBuilderImpl) Build() BackoffSupplier {
+func (e ExponentialBackoff) Build() BackoffSupplier {
 	return ExponentialBackoff{
 		minDelay:      e.minDelay,
 		maxDelay:      e.maxDelay,

--- a/clients/go/pkg/worker/exponentialBackoffSupplier_test.go
+++ b/clients/go/pkg/worker/exponentialBackoffSupplier_test.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package worker
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestExponentialBackoffSupplier_ShouldReturnDelayWithinBounds(t *testing.T) {
+	iterations := 10
+
+	minDelay := time.Millisecond * 50
+	maxDelay := time.Second * 5
+	e := NewExponentialBackoffBuilder().
+		JitterFactor(0).
+		MinDelay(minDelay).
+		MaxDelay(maxDelay).
+		BackoffFactor(1.6).
+		Build()
+
+	var retryDelays []time.Duration
+	for i := 0; i < iterations; i++ {
+		if len(retryDelays) == 0 {
+			retryDelays = []time.Duration{e.SupplyRetryDelay(0)}
+		}
+		retryDelays = append(retryDelays, e.SupplyRetryDelay(retryDelays[i]))
+	}
+
+	// then - minDelay is equal to the first retryDelay
+	// then - maxDelay is equal to the last retryDelay
+	assert.Equal(t, minDelay, retryDelays[0])
+	assert.Equal(t, maxDelay, retryDelays[10])
+}
+
+func TestExponentialBackoffSupplier_IsStrictlyIncreasing(t *testing.T) {
+	iterations := 100
+	t.Run("Backoff is strictly increasing", func(t *testing.T) {
+		e := NewExponentialBackoffBuilder().
+			JitterFactor(0).
+			Build()
+		var retryDelays []time.Duration
+		for i := 0; i < iterations; i++ {
+			if len(retryDelays) == 0 {
+				retryDelays = []time.Duration{e.SupplyRetryDelay(0)}
+			}
+			retryDelays = append(retryDelays, e.SupplyRetryDelay(retryDelays[i]))
+		}
+		for i, delay := range retryDelays {
+			// Skip first delay
+			if i == 0 {
+				continue
+			}
+			// then - as we used 0 for jitter factor, we can guarantee all are increasing or at least equal
+			assert.GreaterOrEqual(t, delay, retryDelays[i-1], "backoff is strictly increasing")
+		}
+
+	})
+}
+
+func TestExponentialBackoffSupplier_ShouldBeRandomizedWithJitter(t *testing.T) {
+	t.Run("backoff should be randomized with jitter", func(t *testing.T) {
+		iterations := 100
+		maxDelay := time.Second * 5
+		minDelay := time.Millisecond * 50
+		jitterFactor := 0.2
+		e := NewExponentialBackoffBuilder().
+			MaxDelay(maxDelay).
+			MinDelay(minDelay).
+			JitterFactor(jitterFactor).
+			BackoffFactor(1.5).
+			Build()
+
+		maxDelayMillis := float64(maxDelay.Milliseconds())
+		lowerMaxBound := math.Round(maxDelayMillis + maxDelayMillis*-jitterFactor)
+		upperMaxBound := math.Round(maxDelayMillis + maxDelayMillis*jitterFactor)
+
+		lowerMaxBoundDuration := time.Duration(lowerMaxBound * float64(time.Millisecond))
+		upperMaxBoundDuration := time.Duration(upperMaxBound * float64(time.Millisecond))
+
+		var retryDelays []time.Duration
+		// when
+		for i := 0; i < iterations; i++ {
+			if len(retryDelays) == 0 {
+				retryDelays = []time.Duration{e.SupplyRetryDelay(maxDelay)}
+			}
+			retryDelays = append(retryDelays, e.SupplyRetryDelay(retryDelays[i]))
+		}
+
+		// then
+		for i, delay := range retryDelays {
+			// retryDelay is in bounds
+			betweenBounds := delay > lowerMaxBoundDuration && delay < upperMaxBoundDuration
+			assert.True(t, betweenBounds, "is between lower and upper bound")
+
+			// Skip first delay
+			if i == 0 {
+				continue
+			}
+			// then - as we used 0 for jitter factor, we can guarantee all are sorted
+			assert.IsIncreasing(t, delay, retryDelays[i-1], "backoff is strictly increasing")
+		}
+
+	})
+}

--- a/clients/go/pkg/worker/exponentialBackoffSupplier_test.go
+++ b/clients/go/pkg/worker/exponentialBackoffSupplier_test.go
@@ -1,10 +1,17 @@
-/*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.1. You may not use this file
- * except in compliance with the Zeebe Community License 1.1.
- */
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worker
 
 import (

--- a/clients/go/pkg/worker/jobPoller.go
+++ b/clients/go/pkg/worker/jobPoller.go
@@ -16,117 +16,131 @@
 package worker
 
 import (
-	"context"
-	"fmt"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"io"
-	"log"
-	"sync"
-	"time"
+    "context"
+    "fmt"
+    "github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+    "github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+    "google.golang.org/grpc/codes"
+    "google.golang.org/grpc/status"
+    "io"
+    "log"
+    "sync"
+    "time"
 )
 
 type jobPoller struct {
-	client         pb.GatewayClient
-	request        *pb.ActivateJobsRequest
-	requestTimeout time.Duration
-	maxJobsActive  int
-	pollInterval   time.Duration
+    client              pb.GatewayClient
+    request             *pb.ActivateJobsRequest
+    requestTimeout      time.Duration
+    maxJobsActive       int
+    initialPollInterval time.Duration
+    pollInterval        time.Duration
 
-	jobQueue       chan entities.Job
-	workerFinished chan bool
-	closeSignal    chan struct{}
-	remaining      int
-	threshold      int
-	metrics        JobWorkerMetrics
-	shouldRetry    func(context.Context, error) bool
+    jobQueue       chan entities.Job
+    workerFinished chan bool
+    closeSignal    chan struct{}
+    remaining      int
+    threshold      int
+    metrics        JobWorkerMetrics
+    shouldRetry    func(context.Context, error) bool
+
+    backoffSupplier BackoffSupplier
 }
 
 func (poller *jobPoller) poll(closeWait *sync.WaitGroup) {
-	defer closeWait.Done()
+    defer closeWait.Done()
 
-	// initial poll
-	poller.activateJobs()
+    // initial poll
+    poller.activateJobs()
 
-	for {
-		select {
-		// either a job was finished
-		case <-poller.workerFinished:
-			poller.remaining--
-			poller.setJobsRemainingCountMetric(poller.remaining)
-		// or the poll interval exceeded
-		case <-time.After(poller.pollInterval):
-		// or poller should stop
-		case <-poller.closeSignal:
-			poller.setJobsRemainingCountMetric(0)
-			return
-		}
+    for {
+        select {
+        // either a job was finished
+        case <-poller.workerFinished:
+            poller.remaining--
+            poller.setJobsRemainingCountMetric(poller.remaining)
+            poller.pollInterval = poller.initialPollInterval
+        // or the poll interval exceeded
+        case <-time.After(poller.pollInterval):
+        // or poller should stop
+        case <-poller.closeSignal:
+            poller.setJobsRemainingCountMetric(0)
+            return
+        }
 
-		if poller.shouldActivateJobs() {
-			poller.activateJobs()
-		}
-	}
+        if poller.shouldActivateJobs() {
+            poller.activateJobs()
+        }
+    }
 }
 
 func (poller *jobPoller) shouldActivateJobs() bool {
-	return poller.remaining <= poller.threshold
+    return poller.remaining <= poller.threshold
 }
 
 func (poller *jobPoller) activateJobs() {
-	ctx, cancel := context.WithTimeout(context.Background(), poller.requestTimeout)
-	defer cancel()
+    ctx, cancel := context.WithTimeout(context.Background(), poller.requestTimeout)
+    defer cancel()
 
-	poller.request.MaxJobsToActivate = int32(poller.maxJobsActive - poller.remaining)
-	stream, err := poller.openStream(ctx)
-	if err != nil {
-		log.Println(err.Error())
-		return
-	}
+    poller.request.MaxJobsToActivate = int32(poller.maxJobsActive - poller.remaining)
+    stream, err := poller.openStream(ctx)
+    if err != nil {
+        log.Println(err.Error())
+        return
+    }
 
-	for {
-		response, err := stream.Recv()
-		if err != nil {
-			if poller.shouldRetry(ctx, err) {
-				// the headers are outdated and need to be rebuilt
-				stream, err = poller.openStream(ctx)
-				if err != nil {
-					log.Printf("Failed to reopen job polling stream: %v\n", err)
-					break
-				}
-				continue
-			}
+    for {
+        response, err := stream.Recv()
+        if err != nil {
+            if poller.shouldRetry(ctx, err) {
+                // the headers are outdated and need to be rebuilt
+                stream, err = poller.openStream(ctx)
+                if err != nil {
+                    log.Printf("Failed to reopen job polling stream: %v\n", err)
+                    break
+                }
+                continue
+            }
 
-			if err != io.EOF && status.Code(err) != codes.ResourceExhausted {
-				log.Printf("Failed to activate jobs for worker '%s': %v\n", poller.request.Worker, err)
-			}
+            if err != io.EOF && status.Code(err) != codes.ResourceExhausted {
+                log.Printf("Failed to activate jobs for worker '%s': %v\n", poller.request.Worker, err)
+            }
+            
+            switch status.Code(err) {
+            case codes.ResourceExhausted, codes.Unavailable, codes.Internal:
+                poller.backoff()
+            }
 
-			break
-		}
+            break
+        }
 
-		poller.remaining += len(response.Jobs)
-		poller.setJobsRemainingCountMetric(poller.remaining)
-		for _, job := range response.Jobs {
-			poller.jobQueue <- entities.Job{ActivatedJob: job}
-		}
-	}
+        poller.remaining += len(response.Jobs)
+        poller.setJobsRemainingCountMetric(poller.remaining)
+        for _, job := range response.Jobs {
+            poller.jobQueue <- entities.Job{ActivatedJob: job}
+        }
+    }
 }
 
 func (poller *jobPoller) openStream(ctx context.Context) (pb.Gateway_ActivateJobsClient, error) {
-	stream, err := poller.client.ActivateJobs(ctx, poller.request)
-	if err != nil {
-		if poller.shouldRetry(ctx, err) {
-			return poller.openStream(ctx)
-		}
-		return nil, fmt.Errorf("worker '%s' failed to open job stream: %w", poller.request.Worker, err)
-	}
+    stream, err := poller.client.ActivateJobs(ctx, poller.request)
+    if err != nil {
+        if poller.shouldRetry(ctx, err) {
+            return poller.openStream(ctx)
+        }
+        return nil, fmt.Errorf("worker '%s' failed to open job stream: %w", poller.request.Worker, err)
+    }
 
-	return stream, nil
+    return stream, nil
 }
 
 func (poller *jobPoller) setJobsRemainingCountMetric(count int) {
-	if poller.metrics != nil {
-		poller.metrics.SetJobsRemainingCount(poller.request.GetType(), count)
-	}
+    if poller.metrics != nil {
+        poller.metrics.SetJobsRemainingCount(poller.request.GetType(), count)
+    }
+}
+
+func (poller *jobPoller) backoff() {
+    prevInterval := poller.pollInterval
+    poller.pollInterval = poller.backoffSupplier.SupplyRetryDelay(prevInterval)
 }

--- a/clients/go/vendor/modules.txt
+++ b/clients/go/vendor/modules.txt
@@ -357,6 +357,14 @@ google.golang.org/protobuf/types/descriptorpb
 google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/timestamppb
+<<<<<<< HEAD
+=======
+# gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
+## explicit; go 1.11
+# gopkg.in/yaml.v2 v2.4.0
+## explicit; go 1.15
+gopkg.in/yaml.v2
+>>>>>>> d955725e6a (feat(clients/go): exponential backoff supplier)
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3

--- a/clients/go/vendor/modules.txt
+++ b/clients/go/vendor/modules.txt
@@ -357,14 +357,6 @@ google.golang.org/protobuf/types/descriptorpb
 google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/timestamppb
-<<<<<<< HEAD
-=======
-# gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
-## explicit; go 1.11
-# gopkg.in/yaml.v2 v2.4.0
-## explicit; go 1.15
-gopkg.in/yaml.v2
->>>>>>> d955725e6a (feat(clients/go): exponential backoff supplier)
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I've added a exponential backoff supplier similar as it is done for the Java client. Actually the math behind it is "blindly" copied and only slightly modified. F.ex I make use of time.Duration.

I'm a bit unsure if we should just add it as a default backoff supplier or leave the default without backoff? 

I have no clue how the formatting issue occurred, but it seems some earlier commits did not respect `editorconfig`? I use Goland and it seems to have correctly detected the configuration of the `editorconfig` in the repository. This makes the review a bit cumbersome. Let me know if I should remove the autoformatting.

Additionally, I've ran `go mod tidy -go=1.16 && go mod tidy -go=1.17` and `go mod vendor` since the files were not up to date?


## Related issues

<!-- Which issues are closed by this PR or are related -->
- implements exponential backoff supplier for go-client

closes #6150


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
