### PR TITLE
Disable delete resource

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -28,6 +28,11 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class ResourceDeletionProcessor implements TypedRecordProcessor<ResourceDeletionRecord> {
 
+  public static final boolean RESOURCE_DELETION_IMPLEMENTED = false;
+  private static final String ERROR_MESSAGE_NOT_IMPLEMENTED =
+      """
+          Resource deletion has not been fully implemented yet. Stay posted on the latest Camunda \
+          releases to know when this feature will become available.""";
   private static final String ERROR_MESSAGE_RESOURCE_NOT_FOUND =
       "Expected to delete resource but no resource found with key `%d`";
 
@@ -48,6 +53,16 @@ public class ResourceDeletionProcessor implements TypedRecordProcessor<ResourceD
 
   @Override
   public void processRecord(final TypedRecord<ResourceDeletionRecord> command) {
+    // Reject resource deletions for now, as the feature is not yet ready for release in Zeebe 8.2
+    // When enabling again please don't forget to un-ignore the tests.
+    if (!RESOURCE_DELETION_IMPLEMENTED) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.PROCESSING_ERROR, ERROR_MESSAGE_NOT_IMPLEMENTED);
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.PROCESSING_ERROR, ERROR_MESSAGE_NOT_IMPLEMENTED);
+      return;
+    }
+
     final var value = command.getValue();
 
     final var drgOptional = decisionState.findDecisionRequirementsByKey(value.getResourceKey());

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
@@ -12,9 +12,11 @@ import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
+@Ignore("Resoure deletion is disabled for version 8.2")
 public class ResourceDeletionRejectionTest {
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -28,9 +28,11 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMet
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.io.IOException;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
+@Ignore("Resoure deletion is disabled for version 8.2")
 public class ResourceDeletionTest {
 
   private static final String DRG_SINGLE_DECISION = "/dmn/decision-table.dmn";


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Rejects delete resource commands as it's not ready for the 8.2 release.

Migrations were not necessary. The EventAppliers we have ar updating the new column families as expected. This means these won't run out-of-sync.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11992 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
