### PR TITLE
Add simple gateway stream management

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -133,7 +133,7 @@ final class ExporterContainer implements Controller {
 
   @Override
   public ScheduledTask scheduleCancellableTask(final Duration delay, final Runnable task) {
-    final var scheduledTimer = actor.runDelayed(delay, task);
+    final var scheduledTimer = actor.schedule(delay, task);
     return scheduledTimer::cancel;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -101,7 +101,7 @@ public final class AsyncSnapshotDirector extends Actor
   protected void onActorStarting() {
     final var firstSnapshotTime =
         RandomDuration.getRandomDurationMinuteBased(MINIMUM_SNAPSHOT_PERIOD, snapshotRate);
-    actor.runDelayed(firstSnapshotTime, this::scheduleSnapshotOnRate);
+    actor.schedule(firstSnapshotTime, this::scheduleSnapshotOnRate);
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -265,7 +265,7 @@ public final class LongPollingActivateJobsHandler implements ActivateJobsHandler
       final InflightActivateJobsRequest request) {
     final Duration requestTimeout = request.getLongPollingTimeout(longPollingTimeout);
     final ScheduledTimer timeout =
-        actor.runDelayed(
+        actor.schedule(
             requestTimeout,
             () -> {
               request.timeout();

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.scheduler;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Loggers;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -130,6 +132,16 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
   @Override
   public void run(final Runnable action) {
     actor.run(action);
+  }
+
+  @Override
+  public <T> ActorFuture<T> call(final Callable<T> callable) {
+    return actor.call(callable);
+  }
+
+  @Override
+  public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
+    return actor.schedule(delay, runnable);
   }
 
   public static ActorBuilder newActor() {

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -66,29 +66,6 @@ public class ActorControl implements ConcurrencyControl {
    * Callables actions are called while the actor is in the following actor lifecycle phases: {@link
    * ActorLifecyclePhase#STARTED}
    *
-   * @param callable
-   * @return
-   */
-  @SuppressWarnings("unchecked")
-  public <T> ActorFuture<T> call(final Callable<T> callable) {
-    final ActorThread runner = ActorThread.current();
-    if (runner != null && runner.getCurrentTask() == task) {
-      throw new UnsupportedOperationException(
-          "Incorrect usage of actor.call(...) cannot be called from current actor.");
-    }
-
-    final ActorJob job = new ActorJob();
-    final ActorFuture<T> future = job.setCallable(callable);
-    job.onJobAddedToTask(task);
-    task.submit(job);
-
-    return future;
-  }
-
-  /**
-   * Callables actions are called while the actor is in the following actor lifecycle phases: {@link
-   * ActorLifecyclePhase#STARTED}
-   *
    * @param action
    * @return
    */
@@ -100,19 +77,6 @@ public class ActorControl implements ConcurrencyControl {
         };
 
     return call(c);
-  }
-
-  /**
-   * The runnable is is executed while the actor is in the following actor lifecycle phases: {@link
-   * ActorLifecyclePhase#STARTED}
-   *
-   * @param delay
-   * @param runnable
-   * @return
-   */
-  public ScheduledTimer runDelayed(final Duration delay, final Runnable runnable) {
-    ensureCalledFromWithinActor("runDelayed(...)");
-    return scheduleTimer(delay, false, runnable);
   }
 
   /**
@@ -184,6 +148,44 @@ public class ActorControl implements ConcurrencyControl {
   @Override
   public void run(final Runnable action) {
     scheduleRunnable(action);
+  }
+
+  /**
+   * Callables actions are called while the actor is in the following actor lifecycle phases: {@link
+   * ActorLifecyclePhase#STARTED}
+   *
+   * @param callable
+   * @return
+   */
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> ActorFuture<T> call(final Callable<T> callable) {
+    final ActorThread runner = ActorThread.current();
+    if (runner != null && runner.getCurrentTask() == task) {
+      throw new UnsupportedOperationException(
+          "Incorrect usage of actor.call(...) cannot be called from current actor.");
+    }
+
+    final ActorJob job = new ActorJob();
+    final ActorFuture<T> future = job.setCallable(callable);
+    job.onJobAddedToTask(task);
+    task.submit(job);
+
+    return future;
+  }
+
+  /**
+   * The runnable is is executed while the actor is in the following actor lifecycle phases: {@link
+   * ActorLifecyclePhase#STARTED}
+   *
+   * @param delay
+   * @param runnable
+   * @return
+   */
+  @Override
+  public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
+    ensureCalledFromWithinActor("runDelayed(...)");
+    return scheduleTimer(delay, false, runnable);
   }
 
   /**

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.scheduler;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 
 /**
@@ -32,6 +34,18 @@ public interface ConcurrencyControl {
    * @param action action to be invoked
    */
   void run(final Runnable action);
+
+  /**
+   * Schedules a callable to be executed
+   *
+   * @param callable callable to be executed
+   * @return a future with the result
+   * @param <T> type of the result
+   */
+  <T> ActorFuture<T> call(final Callable<T> callable);
+
+  /** Schedule a task to be executed after a delay */
+  ScheduledTimer schedule(final Duration delay, final Runnable runnable);
 
   /**
    * Create a new future object

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/BackOffRetryStrategy.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/BackOffRetryStrategy.java
@@ -70,6 +70,6 @@ public final class BackOffRetryStrategy implements RetryStrategy {
       final Duration nextBackOff = backOffDuration.multipliedBy(2);
       backOffDuration = nextBackOff.compareTo(maxBackOff) < 0 ? nextBackOff : maxBackOff;
     }
-    actor.runDelayed(backOffDuration, this::run);
+    actor.schedule(backOffDuration, this::run);
   }
 }

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
@@ -34,7 +34,7 @@ public final class TimedActionsTest {
         new Actor() {
           @Override
           protected void onActorStarted() {
-            actor.runDelayed(Duration.ofMillis(10), action);
+            actor.schedule(Duration.ofMillis(10), action);
           }
         };
 
@@ -55,7 +55,7 @@ public final class TimedActionsTest {
         new Actor() {
           @Override
           protected void onActorStarted() {
-            actor.runDelayed(Duration.ofMillis(10), action);
+            actor.schedule(Duration.ofMillis(10), action);
           }
         };
 
@@ -105,7 +105,7 @@ public final class TimedActionsTest {
     // given
     final Runnable action = mock(Runnable.class);
     final TimerActor actor =
-        new TimerActor(actorControl -> actorControl.runDelayed(Duration.ofMillis(10), action));
+        new TimerActor(actorControl -> actorControl.schedule(Duration.ofMillis(10), action));
 
     // when
     schedulerRule.getClock().setCurrentTime(100);
@@ -125,7 +125,7 @@ public final class TimedActionsTest {
     // given
     final Runnable action = mock(Runnable.class);
     final var actor =
-        new TimerActor(actorControl -> actorControl.runDelayed(Duration.ofMillis(10), action));
+        new TimerActor(actorControl -> actorControl.schedule(Duration.ofMillis(10), action));
 
     // when
     schedulerRule.getClock().setCurrentTime(100);

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/ActorLifecyclePhasesAndTimersTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/ActorLifecyclePhasesAndTimersTest.java
@@ -30,7 +30,7 @@ public final class ActorLifecyclePhasesAndTimersTest {
         new LifecycleRecordingActor() {
           @Override
           public void onActorStarting() {
-            actor.runDelayed(Duration.ofMillis(10), action);
+            actor.schedule(Duration.ofMillis(10), action);
             blockPhase();
           }
         };
@@ -55,7 +55,7 @@ public final class ActorLifecyclePhasesAndTimersTest {
         new LifecycleRecordingActor() {
           @Override
           public void onActorStarting() {
-            actor.runDelayed(Duration.ofMillis(10), action);
+            actor.schedule(Duration.ofMillis(10), action);
             blockPhase(future);
           }
         };
@@ -82,7 +82,7 @@ public final class ActorLifecyclePhasesAndTimersTest {
         new LifecycleRecordingActor() {
           @Override
           public void onActorStarted() {
-            actor.runDelayed(Duration.ofMillis(10), action);
+            actor.schedule(Duration.ofMillis(10), action);
           }
         };
     schedulerRule.submitActor(actor);
@@ -106,7 +106,7 @@ public final class ActorLifecyclePhasesAndTimersTest {
           @Override
           public void onActorCloseRequested() {
             blockPhase();
-            actor.runDelayed(Duration.ofMillis(10), action);
+            actor.schedule(Duration.ofMillis(10), action);
           }
         };
     schedulerRule.submitActor(actor);
@@ -131,7 +131,7 @@ public final class ActorLifecyclePhasesAndTimersTest {
           @Override
           public void onActorClosing() {
             blockPhase();
-            actor.runDelayed(Duration.ofMillis(10), action);
+            actor.schedule(Duration.ofMillis(10), action);
           }
         };
     schedulerRule.submitActor(actor);

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestConcurrencyControl.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestConcurrencyControl.java
@@ -8,7 +8,10 @@
 package io.camunda.zeebe.scheduler.testing;
 
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 
 /**
@@ -42,6 +45,24 @@ public class TestConcurrencyControl implements ConcurrencyControl {
   @Override
   public void run(final Runnable action) {
     action.run();
+  }
+
+  @Override
+  public <T> ActorFuture<T> call(final Callable<T> callable) {
+    final T call;
+    try {
+      call = callable.call();
+    } catch (final Exception e) {
+      return TestActorFuture.failedFuture(e);
+    }
+    return TestActorFuture.completedFuture(call);
+  }
+
+  @Override
+  public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
+    // Schedule immediately
+    runnable.run();
+    return () -> {};
   }
 
   @Override

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -47,7 +47,7 @@ public class ProcessingScheduleServiceImpl
 
   @Override
   public void runDelayed(final Duration delay, final Runnable followUpTask) {
-    useActorControl(() -> actorControl.runDelayed(delay, followUpTask));
+    useActorControl(() -> actorControl.schedule(delay, followUpTask));
   }
 
   @Override

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -284,7 +284,7 @@ public final class ProcessingStateMachine {
           loggedEvent,
           metadata,
           recoverableException);
-      actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processCommand(currentRecord));
+      actor.schedule(PROCESSING_RETRY_DELAY, () -> processCommand(currentRecord));
     } catch (final UnrecoverableException unrecoverableException) {
       throw unrecoverableException;
     } catch (final ExceededBatchRecordSizeException exceededBatchRecordSizeException) {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -277,7 +277,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private void healthCheckTick() {
     lastTickTime = ActorClock.currentTimeMillis();
-    actor.runDelayed(HEALTH_CHECK_TICK_DURATION, this::healthCheckTick);
+    actor.schedule(HEALTH_CHECK_TICK_DURATION, this::healthCheckTick);
   }
 
   private void chainSteps(final int index, final Step[] steps, final Runnable last) {

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -304,6 +304,18 @@ class ProcessingScheduleServiceTest {
     }
 
     @Override
+    protected void onActorStarting() {
+      final var openFuture = processingScheduleService.open(actor);
+      actor.runOnCompletionBlockingCurrentPhase(
+          openFuture,
+          (v, t) -> {
+            if (t != null) {
+              actor.fail(t);
+            }
+          });
+    }
+
+    @Override
     public void runDelayed(final Duration delay, final Runnable task) {
       actor.submit(() -> processingScheduleService.runDelayed(delay, task));
     }
@@ -316,18 +328,6 @@ class ProcessingScheduleServiceTest {
     @Override
     public void runAtFixedRate(final Duration delay, final Task task) {
       actor.submit(() -> processingScheduleService.runAtFixedRate(delay, task));
-    }
-
-    @Override
-    protected void onActorStarting() {
-      final var openFuture = processingScheduleService.open(actor);
-      actor.runOnCompletionBlockingCurrentPhase(
-          openFuture,
-          (v, t) -> {
-            if (t != null) {
-              actor.fail(t);
-            }
-          });
     }
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
@@ -83,7 +83,7 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
             timeout);
     actor.call(
         () -> {
-          final var scheduledTimer = actor.runDelayed(timeout, () -> timeoutFuture(requestContext));
+          final var scheduledTimer = actor.schedule(timeout, () -> timeoutFuture(requestContext));
           requestContext.setScheduledTimer(scheduledTimer);
           tryToSend(requestContext);
         });
@@ -132,7 +132,7 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
               requestContext.hashCode(),
               RETRY_DELAY);
         }
-        actor.runDelayed(RETRY_DELAY, () -> tryToSend(requestContext));
+        actor.schedule(RETRY_DELAY, () -> tryToSend(requestContext));
       } else {
         if (LOG.isTraceEnabled()) {
           LOG.trace(
@@ -187,7 +187,7 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
               RETRY_DELAY);
         }
         // no valid response - retry in respect of the timeout
-        actor.runDelayed(RETRY_DELAY, () -> tryToSend(requestContext));
+        actor.schedule(RETRY_DELAY, () -> tryToSend(requestContext));
       }
     } else {
       // normally the root exception is a completion exception
@@ -205,7 +205,7 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
         }
 
         // no registered subscription yet
-        actor.runDelayed(RETRY_DELAY, () -> tryToSend(requestContext));
+        actor.schedule(RETRY_DELAY, () -> tryToSend(requestContext));
       } else {
         if (LOG.isTraceEnabled()) {
           LOG.trace(

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.api;
+
+import io.camunda.zeebe.util.buffer.BufferReader;
+
+/**
+ * Represents a consumer of a stream which can consume data of type P. The data is typically pushed
+ * from a broker, and consumed by gateway.
+ *
+ * @param <P> the payload type that can be pushed to the stream
+ */
+public interface ClientStreamConsumer<P extends BufferReader> {
+
+  /**
+   * Consumes the payload received from the server to the client. Implementation of this method can
+   * be asynchronous.
+   *
+   * @param payload the data to be consumed by the client
+   */
+  void push(P payload);
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.api;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.UUID;
+import org.agrona.DirectBuffer;
+
+/**
+ * Allows to add and remove client streams.
+ *
+ * <p>When a client stream is added, it opens a stream to all servers. When a server pushes data to
+ * this stream, the client receives it via {@link ClientStreamConsumer#push(BufferReader)}
+ */
+public interface ClientStreamer<M extends BufferWriter, P extends BufferReader> {
+
+  /**
+   * Registers a client and opens a stream for the given streamType and associated Metadata with all
+   * available servers. The stream is also opened for servers that are not currently reachable, but
+   * available later.
+   *
+   * <p>NOTE: The stream to a server can be added asynchronously. So there might be a delay until
+   * the consumer receives the first data.
+   *
+   * @param streamType type of the stream
+   * @param metadata metadata associated with the stream
+   * @param clientStreamConsumer consumer which process data received from the server
+   * @return a unique id of the stream
+   */
+  ActorFuture<UUID> add(
+      final DirectBuffer streamType,
+      final M metadata,
+      final ClientStreamConsumer<P> clientStreamConsumer);
+
+  /**
+   * Removes a stream that is added via {@link ClientStreamer#add(DirectBuffer, BufferWriter,
+   * ClientStreamConsumer)}. After the returned future is completed, the {@link
+   * ClientStreamConsumer} will not receive any more data.
+   *
+   * @param streamId unique id of the stream
+   * @return a future which will be completed after the stream is removed
+   */
+  ActorFuture<Void> remove(final UUID streamId);
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.agrona.DirectBuffer;
+
+/** Represents a registered client stream. * */
+final class ClientStream<M extends BufferWriter, P extends BufferReader> {
+  private final UUID streamId;
+  private final DirectBuffer streamType;
+  private final M metadata;
+  private final ClientStreamConsumer<P> streamConsumer;
+  private final Set<MemberId> liveConnections = new HashSet<>();
+
+  ClientStream(
+      final UUID streamId,
+      final DirectBuffer streamType,
+      final M metadata,
+      final ClientStreamConsumer<P> clientStreamConsumer) {
+    this.streamId = streamId;
+    this.streamType = streamType;
+    this.metadata = metadata;
+    streamConsumer = clientStreamConsumer;
+  }
+
+  UUID getStreamId() {
+    return streamId;
+  }
+
+  DirectBuffer getStreamType() {
+    return streamType;
+  }
+
+  M getMetadata() {
+    return metadata;
+  }
+
+  ClientStreamConsumer<P> getClientStreamConsumer() {
+    return streamConsumer;
+  }
+
+  /**
+   * Mark that this stream is registered with the given server. Server can send data to this stream
+   * from now on.
+   *
+   * @param serverId id of the server
+   */
+  void add(final MemberId serverId) {
+    liveConnections.add(serverId);
+  }
+
+  /**
+   * If true, the stream is registered with the given server. If false, it is also possible the
+   * stream is registered with the server, but we failed to receive the acknowledgement.
+   *
+   * @param serverId id of the server
+   * @return true if a server has acknowledged to add stream request
+   */
+  boolean isConnected(final MemberId serverId) {
+    return liveConnections.contains(serverId);
+  }
+
+  /**
+   * Mark that stream to this server is closed.
+   *
+   * @param serverId id of the server
+   */
+  void remove(final MemberId serverId) {
+    liveConnections.remove(serverId);
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -35,7 +35,7 @@ final class ClientStreamManager<M extends BufferWriter, P extends BufferReader> 
    *
    * @param serverId id of the server that is added or restarted
    */
-  void onServeJoined(final MemberId serverId) {
+  void onServerJoined(final MemberId serverId) {
     servers.add(serverId);
     registry.list().forEach(c -> requestManager.openStream(c, Collections.singleton(serverId)));
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.agrona.DirectBuffer;
+
+final class ClientStreamManager<M extends BufferWriter, P extends BufferReader> {
+  private final ClientStreamRegistry<M, P> registry;
+  private final ClientStreamRequestManager<M, P> requestManager;
+  private final Set<MemberId> servers = new HashSet<>();
+
+  ClientStreamManager(
+      final ClientStreamRegistry<M, P> registry,
+      final ClientStreamRequestManager<M, P> requestManager) {
+    this.registry = registry;
+    this.requestManager = requestManager;
+  }
+
+  /**
+   * When a new server is added to the cluster, or an existing server restarted, existing client
+   * streams must be registered (again) with the server.
+   *
+   * @param serverId id of the server that is added or restarted
+   */
+  void onServeJoined(final MemberId serverId) {
+    servers.add(serverId);
+    registry.list().forEach(c -> requestManager.openStream(c, Collections.singleton(serverId)));
+  }
+
+  UUID add(
+      final DirectBuffer streamType,
+      final M metadata,
+      final ClientStreamConsumer<P> clientStreamConsumer) {
+    final var streamId = UUID.randomUUID();
+    final var clientStreamMeta =
+        new ClientStream<>(streamId, streamType, metadata, clientStreamConsumer);
+
+    // add first in memory to handle case of new broker while we're adding
+    registry.add(clientStreamMeta);
+    requestManager.openStream(clientStreamMeta, servers);
+
+    return streamId;
+  }
+
+  void remove(final UUID streamId) {
+    final var clientStream = registry.remove(streamId);
+    requestManager.removeStream(clientStream, servers);
+  }
+
+  void removeAll() {
+    requestManager.removeAll(servers);
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/** A registry to keeps tracks of all open streams. */
+final class ClientStreamRegistry<M extends BufferWriter, P extends BufferReader> {
+
+  // This class is currently a very simple wrapper around a map. When we aggregate multiple streams
+  // into one stream, we may have to keep track of them also here.
+  private final Map<UUID, ClientStream<M, P>> streams = new HashMap<>();
+
+  void add(final ClientStream<M, P> clientStream) {
+    streams.put(clientStream.getStreamId(), clientStream);
+  }
+
+  ClientStream<M, P> get(final UUID streamId) {
+    return streams.get(streamId);
+  }
+
+  ClientStream<M, P> remove(final UUID streamId) {
+    return streams.remove(streamId);
+  }
+
+  Collection<ClientStream<M, P>> list() {
+    return streams.values();
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -66,7 +66,7 @@ final class ClientStreamRequestManager<M extends BufferWriter, P extends BufferR
             brokerId,
             REQUEST_TIMEOUT);
 
-    result.whenComplete(
+    result.whenCompleteAsync(
         (ignored, error) -> {
           if (error != null) {
             LOG.warn(
@@ -82,7 +82,8 @@ final class ClientStreamRequestManager<M extends BufferWriter, P extends BufferR
             LOG.debug("Opened stream {} to node {}", clientStream, brokerId);
             clientStream.add(brokerId);
           }
-        });
+        },
+        executor::run);
   }
 
   void removeStream(final ClientStream<M, P> clientStream, final Collection<MemberId> servers) {

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.transport.stream.impl.messages.AddStreamRequest;
+import io.camunda.zeebe.transport.stream.impl.messages.RemoveStreamRequest;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Handles sending add/remove stream request to the servers. */
+final class ClientStreamRequestManager<M extends BufferWriter, P extends BufferReader> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClientStreamRequestManager.class);
+  private static final byte[] REMOVE_ALL_REQUEST = new byte[0];
+  private static final Duration RETRY_DELAY = Duration.ofSeconds(1);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  private final ClusterCommunicationService communicationService;
+  private final ConcurrencyControl executor;
+
+  ClientStreamRequestManager(
+      final ClusterCommunicationService communicationService, final ConcurrencyControl executor) {
+    this.communicationService = communicationService;
+    this.executor = executor;
+  }
+
+  void openStream(final ClientStream<M, P> clientStream, final Collection<MemberId> servers) {
+    final var request =
+        new AddStreamRequest()
+            .streamType(clientStream.getStreamType())
+            .streamId(clientStream.getStreamId())
+            .metadata(clientStream.getMetadata());
+
+    servers.forEach(brokerId -> executor.run(() -> doAdd(request, brokerId, clientStream)));
+  }
+
+  private void doAdd(
+      final AddStreamRequest request,
+      final MemberId brokerId,
+      final ClientStream<M, P> clientStream) {
+    if (clientStream.isConnected(brokerId)) {
+      return;
+    }
+
+    final CompletableFuture<byte[]> result =
+        communicationService.send(
+            StreamTopics.ADD.topic(),
+            request,
+            BufferUtil::bufferAsArray,
+            Function.identity(),
+            brokerId,
+            REQUEST_TIMEOUT);
+
+    result.whenComplete(
+        (ignored, error) -> {
+          if (error != null) {
+            LOG.warn(
+                "Failed to open stream {} to node {}. Will retry in {}",
+                clientStream,
+                brokerId,
+                RETRY_DELAY);
+            // TODO: define some abort conditions. We may not have to retry indefinitely.
+            // For now we retry always. Eventually the request will succeed. Duplicate add request
+            // are fine.
+            executor.schedule(RETRY_DELAY, () -> doAdd(request, brokerId, clientStream));
+          } else {
+            LOG.debug("Opened stream {} to node {}", clientStream, brokerId);
+            clientStream.add(brokerId);
+          }
+        });
+  }
+
+  void removeStream(final ClientStream<M, P> clientStream, final Collection<MemberId> servers) {
+    final var request = new RemoveStreamRequest().streamId(clientStream.getStreamId());
+    servers.forEach(brokerId -> executor.run(() -> doRemove(request, brokerId, clientStream)));
+  }
+
+  private void doRemove(
+      final RemoveStreamRequest request,
+      final MemberId brokerId,
+      final ClientStream<M, P> clientStream) {
+
+    final CompletableFuture<byte[]> result =
+        communicationService.send(
+            StreamTopics.REMOVE.topic(),
+            request,
+            BufferUtil::bufferAsArray,
+            Function.identity(),
+            brokerId,
+            REQUEST_TIMEOUT);
+
+    result.whenCompleteAsync(
+        (ignored, error) -> {
+          if (error != null && clientStream.isConnected(brokerId)) {
+            // TODO: use backoff delay
+            executor.schedule(RETRY_DELAY, () -> doRemove(request, brokerId, clientStream));
+          } else {
+            clientStream.remove(brokerId);
+          }
+        },
+        executor::run);
+  }
+
+  void removeAll(final Collection<MemberId> servers) {
+    servers.forEach(this::doRemoveAll);
+  }
+
+  private void doRemoveAll(final MemberId brokerId) {
+    // Do not wait for response, as this is expected to be called while shutting down.
+    communicationService.send(
+        StreamTopics.REMOVE_ALL.topic(),
+        REMOVE_ALL_REQUEST,
+        Function.identity(),
+        Function.identity(),
+        brokerId,
+        REQUEST_TIMEOUT);
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -110,6 +110,7 @@ final class ClientStreamRequestManager<M extends BufferWriter, P extends BufferR
             // TODO: use backoff delay
             executor.schedule(RETRY_DELAY, () -> doRemove(request, brokerId, clientStream));
           } else {
+            LOG.debug("Removed stream {} to node {}", clientStream, brokerId);
             clientStream.remove(brokerId);
           }
         },

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -124,12 +124,7 @@ final class ClientStreamRequestManager<M extends BufferWriter, P extends BufferR
 
   private void doRemoveAll(final MemberId brokerId) {
     // Do not wait for response, as this is expected to be called while shutting down.
-    communicationService.send(
-        StreamTopics.REMOVE_ALL.topic(),
-        REMOVE_ALL_REQUEST,
-        Function.identity(),
-        Function.identity(),
-        brokerId,
-        REQUEST_TIMEOUT);
+    communicationService.unicast(
+        StreamTopics.REMOVE_ALL.topic(), REMOVE_ALL_REQUEST, Function.identity(), brokerId, true);
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
+import io.camunda.zeebe.transport.stream.api.ClientStreamer;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.UUID;
+import org.agrona.DirectBuffer;
+
+public class ClientStreamService<M extends BufferWriter, P extends BufferReader> extends Actor
+    implements ClientStreamer<M, P> {
+
+  private final ClientStreamManager<M, P> clientStreamManager;
+
+  public ClientStreamService(final ClusterCommunicationService communicationService) {
+    // ClientStreamRequestManager must use same actor as this because it is mutating shared
+    // ClientStream objects.
+    clientStreamManager =
+        new ClientStreamManager<>(
+            new ClientStreamRegistry<>(),
+            new ClientStreamRequestManager<>(communicationService, actor));
+  }
+
+  @Override
+  public ActorFuture<UUID> add(
+      final DirectBuffer streamType,
+      final M metadata,
+      final ClientStreamConsumer<P> clientStreamConsumer) {
+    return actor.call(() -> clientStreamManager.add(streamType, metadata, clientStreamConsumer));
+  }
+
+  @Override
+  public ActorFuture<Void> remove(final UUID streamId) {
+    return actor.call(() -> clientStreamManager.remove(streamId));
+  }
+
+  @Override
+  protected void onActorCloseRequested() {
+    clientStreamManager.removeAll();
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.time.Duration;
 import java.util.Objects;
@@ -65,19 +66,10 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
         .send(
             StreamTopics.PUSH.topic(),
             request,
-            this::serialize,
+            BufferUtil::bufferAsArray,
             Function.identity(),
             receiver,
             REQUEST_TIMEOUT)
         .thenApply(ok -> null);
-  }
-
-  private byte[] serialize(final BufferWriter payload) {
-    final var bytes = new byte[payload.getLength()];
-    final var writeBuffer = new UnsafeBuffer();
-    writeBuffer.wrap(bytes);
-
-    payload.write(writeBuffer, 0);
-    return bytes;
   }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.concurrent.CompletableFuture;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClientStreamManagerTest {
+
+  private final DirectBuffer streamType = BufferUtil.wrapString("foo");
+  private final BufferWriter metadata = mock(BufferWriter.class);
+  private final ClientStreamRegistry<BufferWriter, BufferReader> registry =
+      new ClientStreamRegistry<>();
+  private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
+  private final ClientStreamManager<BufferWriter, BufferReader> clientStreamManager =
+      new ClientStreamManager<>(
+          registry, new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl()));
+
+  @BeforeEach
+  void setup() {
+
+    when(mockTransport.send(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+  }
+
+  @Test
+  void shouldAddStream() {
+    // when
+    final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
+
+    // then
+    assertThat(registry.get(uuid)).isNotNull();
+  }
+
+  @Test
+  void shouldOpenStreamToExistingServers() {
+    // given
+    final MemberId server1 = MemberId.from("1");
+    clientStreamManager.onServeJoined(server1);
+    final MemberId server2 = MemberId.from("2");
+    clientStreamManager.onServeJoined(server2);
+
+    // when
+    final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
+
+    // then
+    final var clientStream = registry.get(uuid);
+
+    assertThat(clientStream.isConnected(server1)).isTrue();
+    assertThat(clientStream.isConnected(server2)).isTrue();
+  }
+
+  @Test
+  void shouldOpenStreamToNewlyAddedServer() {
+    // given
+    final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
+    final var clientStream = registry.get(uuid);
+
+    // when
+    final MemberId server = MemberId.from("3");
+    clientStreamManager.onServeJoined(server);
+
+    // then
+    assertThat(clientStream.isConnected(server)).isTrue();
+  }
+
+  @Test
+  void shouldOpenStreamToNewlyAddedServerForAllOpenStreams() {
+    // given
+    final var stream1 = clientStreamManager.add(streamType, metadata, p -> {});
+    final var stream2 = clientStreamManager.add(streamType, metadata, p -> {});
+
+    // when
+    final MemberId server = MemberId.from("3");
+    clientStreamManager.onServeJoined(server);
+
+    // then
+    assertThat(registry.get(stream1).isConnected(server)).isTrue();
+    assertThat(registry.get(stream2).isConnected(server)).isTrue();
+  }
+
+  @Test
+  void shouldRemoveStream() {
+    // given
+    final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
+
+    // when
+    clientStreamManager.remove(uuid);
+
+    // then
+    assertThat(registry.get(uuid)).isNull();
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -54,9 +54,9 @@ class ClientStreamManagerTest {
   void shouldOpenStreamToExistingServers() {
     // given
     final MemberId server1 = MemberId.from("1");
-    clientStreamManager.onServeJoined(server1);
+    clientStreamManager.onServerJoined(server1);
     final MemberId server2 = MemberId.from("2");
-    clientStreamManager.onServeJoined(server2);
+    clientStreamManager.onServerJoined(server2);
 
     // when
     final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
@@ -76,7 +76,7 @@ class ClientStreamManagerTest {
 
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServeJoined(server);
+    clientStreamManager.onServerJoined(server);
 
     // then
     assertThat(clientStream.isConnected(server)).isTrue();
@@ -90,7 +90,7 @@ class ClientStreamManagerTest {
 
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServeJoined(server);
+    clientStreamManager.onServerJoined(server);
 
     // then
     assertThat(registry.get(stream1).isConnected(server)).isTrue();

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -121,6 +122,23 @@ class ClientStreamRequestManagerTest {
     verify(mockTransport, times(2))
         .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(server), any());
     assertThat(clientStream.isConnected(server)).isFalse();
+  }
+
+  @Test
+  void shouldSendRemoveAllRequestToAllServers() {
+    // given
+    final MemberId server1 = MemberId.from("1");
+    final MemberId server2 = MemberId.from("2");
+    final var servers = Set.of(server1, server2);
+
+    // when
+    requestManager.removeAll(servers);
+
+    // then
+    verify(mockTransport)
+        .unicast(eq(StreamTopics.REMOVE_ALL.topic()), any(), any(), eq(server1), anyBoolean());
+    verify(mockTransport)
+        .unicast(eq(StreamTopics.REMOVE_ALL.topic()), any(), any(), eq(server2), anyBoolean());
   }
 
   private static class TestMetadata implements BufferWriter {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.agrona.MutableDirectBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClientStreamRequestManagerTest {
+
+  private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
+  private final ClientStreamRequestManager<BufferWriter, BufferReader> requestManager =
+      new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl());
+
+  private final ClientStream<BufferWriter, BufferReader> clientStream =
+      new ClientStream<>(
+          UUID.randomUUID(), BufferUtil.wrapString("foo"), new TestMetadata(), p -> {});
+
+  @BeforeEach
+  void setup() {
+    when(mockTransport.send(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+  }
+
+  @Test
+  void shouldSendAddRequestToAllServers() {
+    // given
+    final MemberId server1 = MemberId.from("1");
+    final MemberId server2 = MemberId.from("2");
+    final var servers = Set.of(server1, server2);
+    // when
+    requestManager.openStream(clientStream, servers);
+
+    // then
+    verify(mockTransport)
+        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(server1), any());
+    verify(mockTransport)
+        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(server2), any());
+
+    assertThat(clientStream.isConnected(server1)).isTrue();
+    assertThat(clientStream.isConnected(server2)).isTrue();
+  }
+
+  @Test
+  void shouldRetryWhenAddRequestFails() {
+    // given
+    final MemberId server = MemberId.from("1");
+    final var servers = Set.of(server);
+    when(mockTransport.send(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Expected")))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    requestManager.openStream(clientStream, servers);
+
+    // then
+    verify(mockTransport, times(2))
+        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(server), any());
+    assertThat(clientStream.isConnected(server)).isTrue();
+  }
+
+  @Test
+  void shouldSendRemoveRequestToAllServers() {
+    // given
+    final MemberId server1 = MemberId.from("1");
+    final MemberId server2 = MemberId.from("2");
+    final var servers = Set.of(server1, server2);
+    requestManager.openStream(clientStream, servers);
+
+    // when
+    requestManager.removeStream(clientStream, servers);
+
+    // then
+    verify(mockTransport)
+        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(server1), any());
+    verify(mockTransport)
+        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(server2), any());
+
+    assertThat(clientStream.isConnected(server1)).isFalse();
+    assertThat(clientStream.isConnected(server2)).isFalse();
+  }
+
+  @Test
+  void shouldRetryWhenRemoveRequestFails() {
+    // given
+    final MemberId server = MemberId.from("1");
+    final var servers = Set.of(server);
+    requestManager.openStream(clientStream, servers);
+
+    when(mockTransport.send(any(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Expected")))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    requestManager.removeStream(clientStream, servers);
+
+    // then
+    verify(mockTransport, times(2))
+        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(server), any());
+    assertThat(clientStream.isConnected(server)).isFalse();
+  }
+
+  private static class TestMetadata implements BufferWriter {
+    @Override
+    public int getLength() {
+      return Integer.BYTES;
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {
+      buffer.putInt(offset, 0);
+    }
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -87,8 +87,9 @@ class ClientStreamRequestManagerTest {
     // given
     final MemberId server1 = MemberId.from("1");
     final MemberId server2 = MemberId.from("2");
+    clientStream.add(server1);
+    clientStream.add(server2);
     final var servers = Set.of(server1, server2);
-    requestManager.openStream(clientStream, servers);
 
     // when
     requestManager.removeStream(clientStream, servers);
@@ -107,15 +108,14 @@ class ClientStreamRequestManagerTest {
   void shouldRetryWhenRemoveRequestFails() {
     // given
     final MemberId server = MemberId.from("1");
-    final var servers = Set.of(server);
-    requestManager.openStream(clientStream, servers);
+    clientStream.add(server);
 
     when(mockTransport.send(any(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Expected")))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     // when
-    requestManager.removeStream(clientStream, servers);
+    requestManager.removeStream(clientStream, Set.of(server));
 
     // then
     verify(mockTransport, times(2))

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/SerializationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/SerializationTest.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.transport.stream.impl.messages;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.util.UUID;
+import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.junit.jupiter.api.Test;
@@ -27,6 +29,28 @@ final class SerializationTest {
             .streamId(streamId)
             .streamType(BufferUtil.wrapString("foo"))
             .metadata(BufferUtil.wrapString("bar"));
+
+    // when
+    request.write(buffer, 0);
+    final var deserialized = new AddStreamRequest();
+    deserialized.wrap(buffer, 0, request.getLength());
+
+    // then
+    assertThat(deserialized.streamId()).isEqualTo(streamId);
+    assertThat(deserialized.streamType()).isEqualTo(BufferUtil.wrapString("foo"));
+    assertThat(deserialized.metadata()).isEqualTo(BufferUtil.wrapString("bar"));
+  }
+
+  @Test
+  void shouldSerializeAddStreamRequestWithMetadataWriter() {
+    // given
+    final var streamId = UUID.randomUUID();
+    final DirectBuffer metadata = BufferUtil.wrapString("bar");
+    final var request =
+        new AddStreamRequest()
+            .streamId(streamId)
+            .streamType(BufferUtil.wrapString("foo"))
+            .metadata(new DirectBufferWriter().wrap(metadata));
 
     // when
     request.write(buffer, 0);

--- a/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
@@ -186,6 +186,16 @@ public final class BufferUtil {
     return array;
   }
 
+  public static byte[] bufferAsArray(final BufferWriter buffer) {
+
+    final var bytes = new byte[buffer.getLength()];
+    final var writeBuffer = new UnsafeBuffer();
+    writeBuffer.wrap(bytes);
+
+    buffer.write(writeBuffer, 0);
+    return bytes;
+  }
+
   public static MutableDirectBuffer wrapArray(final byte[] array) {
     return new UnsafeBuffer(array);
   }


### PR DESCRIPTION
## Description

- When a client stream is added, the stream manager opens a stream with all servers. 
- When a server is added, it is most likely that this server is restarted. So all previously opened stream would be unknown this new server. So all existing client stream is registered with this server.
- When a client stream is added, it is immediately added to an in-memory registry and the operation is considered successful. Adding stream to the servers is done asynchronously. Attempt to add a stream to a server is retried indefinitely until the server acknowledges.
- A placeholder interface for `ClientStreamConsumer` is also added. This is supposed to be used to push jobs back to the client.

Other changes included:
- To allow easier unit testing, all implementation that requires an actor accepts a `ConcurrencyControl` interface instead of directly extending `Actor`. To do this, we had to add some missing methods such as `call` and `runDelayed` to the interface. Adding `runDelayed` resulted in conflicts with other classes that implements runDelayed with a different return type. So `runDelayed` in `ConcurrencyControl` is renamed to `schedule`. This change resulted in a lot of noise in this PR, because all usage of `ActorControl#runDelayed` had to be renamed. https://github.com/camunda/zeebe/pull/12116/commits/f7bbb00d4dc6c93cc162c4926786b375cde6aeff

Out of scope for this PR:
- Aggregating multiple client streams with same metadata and streamType to a single stream.
- Detecting or repairing missing streams in client vs server. Currently, it fully relies on MembershipService to notify when a node is added or removed. However, there are some edge-cases which we have to handle. 
- Optimal handling of retries. We might have to stop retrying sending add/remove request to a server at some point. Currently, it is retried indefinitely. It might also be good to retry with a backoff.

## Related issues

relates #11713 

Can close the issue after some of the above out of scope items are also implemented.
