### PR TITLE
Reject unsupported signal events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalBoundaryEventValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalBoundaryEventValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
+import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public final class UnsupportedSignalBoundaryEventValidator
+    implements ModelElementValidator<BoundaryEvent> {
+
+  @Override
+  public Class<BoundaryEvent> getElementType() {
+    return BoundaryEvent.class;
+  }
+
+  @Override
+  public void validate(
+      final BoundaryEvent boundaryEvent,
+      final ValidationResultCollector validationResultCollector) {
+    boundaryEvent.getEventDefinitions().stream()
+        .filter(SignalEventDefinition.class::isInstance)
+        .forEach(
+            signalBoundaryEvent ->
+                validationResultCollector.addError(
+                    0, "Elements of type signal boundary event are currently not supported"));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalEndEventValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalEndEventValidator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
+import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public final class UnsupportedSignalEndEventValidator implements ModelElementValidator<EndEvent> {
+
+  @Override
+  public Class<EndEvent> getElementType() {
+    return EndEvent.class;
+  }
+
+  @Override
+  public void validate(
+      final EndEvent endEvent, final ValidationResultCollector validationResultCollector) {
+    endEvent.getEventDefinitions().stream()
+        .filter(SignalEventDefinition.class::isInstance)
+        .forEach(
+            signalEndEvent ->
+                validationResultCollector.addError(
+                    0, "Elements of type signal end event are currently not supported"));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalEventSubprocessValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalEventSubprocessValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.CatchEvent;
+import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.StartEvent;
+import io.camunda.zeebe.model.bpmn.instance.SubProcess;
+import java.util.Collection;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public final class UnsupportedSignalEventSubprocessValidator
+    implements ModelElementValidator<SubProcess> {
+
+  @Override
+  public Class<SubProcess> getElementType() {
+    return SubProcess.class;
+  }
+
+  @Override
+  public void validate(
+      final SubProcess subProcess, final ValidationResultCollector validationResultCollector) {
+    if (!subProcess.triggeredByEvent()) {
+      return;
+    }
+
+    final Collection<StartEvent> startEvents = subProcess.getChildElementsByType(StartEvent.class);
+    startEvents.stream()
+        .map(CatchEvent::getEventDefinitions)
+        .filter(e -> e.stream().anyMatch(SignalEventDefinition.class::isInstance))
+        .forEach(
+            signalSubProcess ->
+                validationResultCollector.addError(
+                    0, "Elements of type signal event subprocess are currently not supported"));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalIntermediateCatchEventValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalIntermediateCatchEventValidator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public final class UnsupportedSignalIntermediateCatchEventValidator
+    implements ModelElementValidator<IntermediateCatchEvent> {
+
+  @Override
+  public Class<IntermediateCatchEvent> getElementType() {
+    return IntermediateCatchEvent.class;
+  }
+
+  @Override
+  public void validate(
+      final IntermediateCatchEvent intermediateCatchEvent,
+      final ValidationResultCollector validationResultCollector) {
+    intermediateCatchEvent.getEventDefinitions().stream()
+        .filter(SignalEventDefinition.class::isInstance)
+        .forEach(
+            signalIntermediateCatchEvent ->
+                validationResultCollector.addError(
+                    0,
+                    "Elements of type signal intermediate catch event are currently not supported"));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalThrowEventValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedSignalThrowEventValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
+import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public final class UnsupportedSignalThrowEventValidator
+    implements ModelElementValidator<IntermediateThrowEvent> {
+
+  @Override
+  public Class<IntermediateThrowEvent> getElementType() {
+    return IntermediateThrowEvent.class;
+  }
+
+  @Override
+  public void validate(
+      final IntermediateThrowEvent intermediateThrowEvent,
+      final ValidationResultCollector validationResultCollector) {
+    intermediateThrowEvent.getEventDefinitions().stream()
+        .filter(SignalEventDefinition.class::isInstance)
+        .forEach(
+            signalEndEvent ->
+                validationResultCollector.addError(
+                    0, "Elements of type signal throw event are currently not supported"));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -176,6 +176,8 @@ public final class ZeebeRuntimeValidators {
             .build(expressionLanguage),
         // Checks signal name expressions of start event signals
         new ProcessSignalStartEventSignalNameValidator(expressionLanguage),
+        // Check that unsupported signal boundary events cannot be deployed
+        new UnsupportedSignalBoundaryEventValidator(),
         // Check that unsupported signal end events cannot be deployed
         new UnsupportedSignalEndEventValidator(),
         // Check that unsupported signal throw events cannot be deployed

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -175,6 +175,8 @@ public final class ZeebeRuntimeValidators {
             .hasValidExpression(Signal::getName, ExpressionVerification::isOptional)
             .build(expressionLanguage),
         // Checks signal name expressions of start event signals
-        new ProcessSignalStartEventSignalNameValidator(expressionLanguage));
+        new ProcessSignalStartEventSignalNameValidator(expressionLanguage),
+        // Check that unsupported signal end events cannot be deployed
+        new UnsupportedSignalEndEventValidator());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -180,6 +180,8 @@ public final class ZeebeRuntimeValidators {
         new UnsupportedSignalBoundaryEventValidator(),
         // Check that unsupported signal intermediate catch events cannot be deployed
         new UnsupportedSignalIntermediateCatchEventValidator(),
+        // Check that unsupported signal event subprocess cannot be deployed
+        new UnsupportedSignalEventSubprocessValidator(),
         // Check that unsupported signal end events cannot be deployed
         new UnsupportedSignalEndEventValidator(),
         // Check that unsupported signal throw events cannot be deployed

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -177,6 +177,8 @@ public final class ZeebeRuntimeValidators {
         // Checks signal name expressions of start event signals
         new ProcessSignalStartEventSignalNameValidator(expressionLanguage),
         // Check that unsupported signal end events cannot be deployed
-        new UnsupportedSignalEndEventValidator());
+        new UnsupportedSignalEndEventValidator(),
+        // Check that unsupported signal throw events cannot be deployed
+        new UnsupportedSignalThrowEventValidator());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -178,6 +178,8 @@ public final class ZeebeRuntimeValidators {
         new ProcessSignalStartEventSignalNameValidator(expressionLanguage),
         // Check that unsupported signal boundary events cannot be deployed
         new UnsupportedSignalBoundaryEventValidator(),
+        // Check that unsupported signal intermediate catch events cannot be deployed
+        new UnsupportedSignalIntermediateCatchEventValidator(),
         // Check that unsupported signal end events cannot be deployed
         new UnsupportedSignalEndEventValidator(),
         // Check that unsupported signal throw events cannot be deployed

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SignalEventValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SignalEventValidationTest.java
@@ -306,6 +306,34 @@ public final class SignalEventValidationTest {
             """);
   }
 
+  @Test
+  public void shouldRejectSignalEventSubprocess() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+
+    // when
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess(processId)
+            .eventSubProcess(
+                "signal_event_subprocess",
+                sub -> sub.startEvent("signal_event", s -> s.signal("signal")))
+            .startEvent()
+            .done();
+
+    final Record<DeploymentRecordValue> deployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(deployment)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            'process.xml': - Element: signal_event_subprocess
+                - ERROR: Elements of type signal event subprocess are currently not supported
+            """);
+  }
+
   @Ignore("Should be re-enabled when signal boundary events are supported")
   @Test
   public void shouldDeploySignalStartAndBoundaryEventEvenWithSameSignal() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SignalEventValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SignalEventValidationTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -230,6 +231,7 @@ public final class SignalEventValidationTest {
             """);
   }
 
+  @Ignore("Should be re-enabled when signal boundary events are supported")
   @Test
   public void shouldDeploySignalStartAndMultipleBoundaryEvents() {
     // given
@@ -258,6 +260,8 @@ public final class SignalEventValidationTest {
         .isNotNegative();
   }
 
+  @Ignore(
+      "Should be re-enabled when signal event-subprocess & signal boundary events are supported")
   @Test
   public void shouldDeployEventSubProcessWithMultipleSignalEvents() {
     // given
@@ -297,6 +301,7 @@ public final class SignalEventValidationTest {
         .isNotNegative();
   }
 
+  @Ignore("Should be re-enabled when signal boundary events are supported")
   @Test
   public void shouldDeploySignalStartAndBoundaryEventEvenWithSameSignal() {
     // given


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Rejects deployments of processes containing any of the following (currently) unsupported signal events:
- signal end event
- signal throw event
- signal boundary event
- signal intermediate catch event
- signal event subprocess

This is necessary because these events are currently unsupported and would result in unexpected behavior when executed.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12008 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
