### PR TITLE
deps: dump dmn-engine from 1.7.4 to 1.8.0

### DIFF
--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
@@ -50,7 +50,7 @@ class DmnEvaluationTest {
         .isNotNull()
         .describedAs(
             "Expect that the evaluation failed because the DRG does not contain the referred decision")
-        .contains("no decision found for 'not_in_drg'");
+        .contains("no decision found with id 'not_in_drg'");
 
     assertThat(result.getFailedDecisionId())
         .describedAs(

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,7 +92,7 @@
     <version.netflix.concurrency>0.4.0</version.netflix.concurrency>
     <version.zeebe-test-container>3.5.2</version.zeebe-test-container>
     <version.feel-scala>1.16.0</version.feel-scala>
-    <version.dmn-scala>1.7.4</version.dmn-scala>
+    <version.dmn-scala>1.8.0</version.dmn-scala>
     <version.rest-assured>5.3.0</version.rest-assured>
     <version.spring>6.0.7</version.spring>
     <version.spring-boot>3.0.4</version.spring-boot>


### PR DESCRIPTION
## Description

Dumps the `dmn-engine` from 1.7.4 to [1.8.0](https://github.com/camunda/dmn-scala/releases/tag/1.8.0).

## Related issues

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
