### PR TITLE
fix(test): fallback to keycloak 19 for identity auth test

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -54,7 +54,7 @@ public class GatewayAuthenticationIdentityIT {
 
   @Container
   private static final GenericContainer KEYCLOAK =
-      new GenericContainer<>("quay.io/keycloak/keycloak:20.0.5")
+      new GenericContainer<>("quay.io/keycloak/keycloak:19.0.3")
           .withEnv("KC_HEALTH_ENABLED", "true")
           .withEnv("KEYCLOAK_ADMIN", KEYCLOAK_USER)
           .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)


### PR DESCRIPTION
## Description

Identity had to revert the recently added keycloak 20 support https://github.com/camunda-cloud/identity/commit/1e479b127779b8018f9514c43d9b4b14eb826829 the test would fail now due to the latest identity SNAPSHOT container not being compatible with keycloak 20 anymore.
