### PR TITLE
ci(.dependabot): stretch the open pr limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       prefix: "deps(maven): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 25
     target-branch: main
     ignore:
       # we will always manually update ES dependencies to minor or major releases
@@ -33,7 +33,7 @@ updates:
       prefix: "deps(go): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     target-branch: main
 
   # Enable version updates for the github actions
@@ -47,7 +47,7 @@ updates:
       prefix: "deps(.github): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     target-branch: main
 
   ##############
@@ -64,7 +64,7 @@ updates:
       prefix: "deps(maven): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 25
     target-branch: "stable/8.1"
     ignore:
       # Ignore major and minor updates, for stable branches we only want to get patches
@@ -85,7 +85,7 @@ updates:
       prefix: "deps(go): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     target-branch: "stable/8.1"
     ignore:
       # Ignore major and minor updates, for stable branches we only want to get patches
@@ -103,7 +103,7 @@ updates:
       prefix: "deps(.github): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     target-branch: "stable/8.1"
     ignore:
       # Ignore major and minor updates, for stable branches we only want to get patches
@@ -124,7 +124,7 @@ updates:
       prefix: "deps(maven): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 25
     target-branch: "stable/8.0"
     ignore:
       # Ignore major and minor updates, for stable branches we only want to get patches
@@ -145,7 +145,7 @@ updates:
       prefix: "deps(go): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     target-branch: "stable/8.0"
     ignore:
       # Ignore major and minor updates, for stable branches we only want to get patches
@@ -163,7 +163,7 @@ updates:
       prefix: "deps(.github): "
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     target-branch: "stable/8.0"
     ignore:
       # Ignore major and minor updates, for stable branches we only want to get patches


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Some dependencies are not being updated because we have too many pull requests by Dependabot open. We'll need to close/merge pull requests earlier, but we should also avoid missing out on dependency upgrades.

This stretches the limits as follows:
- maven: 5 -> 25
- go: 5 -> 10
- gha: 5 -> 10

These are still just magic numbers, chosen at my personal whim. However, I feel that they better reflect our project. What numbers are optimal is hard to say. My thoughts are as follows:
- we have many maven dependencies, so we should allow many open maven pull requests
- we have fewer go and gha dependencies, so we don't need as many open pull requests for these dependencies

There is no way to disable the limit, AFAIK.
Any limit is a magically chosen number.
These numbers feel good to me.

## Related issues

<!-- Which issues are closed by this PR or are related -->

NA

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
