### PR TITLE
ILM policy for Elasticsearch exporter

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -739,6 +739,11 @@
         #     timer: true
         #     variable: true
         #     variableDocument: true
+        #
+        #   retention:
+        #     enabled: false
+        #     minimumAge: 30d
+        #     policyName: zeebe-record-retention-policy
 
       # Opensearch Exporter ----------
       # An example configuration for the opensearch exporter:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -649,6 +649,11 @@
         #     timer: true
         #     variable: true
         #     variableDocument: true
+        #
+        #   retention:
+        #     enabled: false
+        #     minimumAge: 30d
+        #     policyName: zeebe-record-retention-policy
 
       # Opensearch Exporter ----------
       # An example configuration for the opensearch exporter:

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -19,6 +19,7 @@ those as templates in this module's resources folder.
 > **Note:** the indexes are created as required, and will not be created twice if they already exist. However,
 > once disabled, they will not be deleted, that is up to the administrator. Similarly, data is never deleted by
 > the exporter, and must, again, be deleted by the administrator when it is safe to do so.
+> A [retention](#retention) policy can be configured to automatically delete data after a certain number of days.
 
 ## Configuration
 
@@ -44,6 +45,7 @@ options, and the default values for these options.
 | requestTimeoutMs | Request timeout (in ms) for the Elasticsearch client                                    | `30000`                 |
 | index            | Refer to [Index](#Index) for the index configuration options                            |                         |
 | bulk             | Refer to [Bulk](#Bulk) for the bulk configuration options                               |                         |
+| retention        | Refer to [Retention](#Retention) for the retention configuration options                |                         |
 | authentication   | Refer to [Authentication](#Authentication) for the authentication configuration options |                         |
 
 ### Index
@@ -107,6 +109,21 @@ either:
 2. when the batch memory size exceeds 10 MB
 3. 5 seconds have elapsed since the last flush (regardless of how many records were aggregated)
 
+### Retention
+
+A retention policy can be set up to delete old data.
+When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimumAge`.
+All index templates created by this exporter apply the created ILM Policy.
+
+|   Option   |                                 Description                                  |             Default             |
+|------------|------------------------------------------------------------------------------|---------------------------------|
+| enabled    | If `true` the ILM Policy is created and applied to the index templates       | `false`                         |
+| minimumAge | Specifies how old the data must be, before the data is deleted as a duration | `30d`                           |
+| policyName | The name of the created and applied ILM policy                               | `zeebe-record-retention-policy` |
+
+> **Note**
+> The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
+
 ### Authentication
 
 Providing these authentication options will enable Basic Authentication on the Exporter.
@@ -142,6 +159,11 @@ exporters:
         delay: 5
         size: 1000
         memoryLimit: 10485760
+
+      retention:
+        enabled: true
+        minimumAge: 30d
+        policyName: zeebe-records-retention-policy
 
       authentication:
         username: elastic

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -55,7 +55,7 @@ class ElasticsearchClient implements AutoCloseable {
         bulkIndexRequest,
         RestClientFactory.of(configuration),
         new RecordIndexRouter(configuration.index),
-        new TemplateReader(configuration.index),
+        new TemplateReader(configuration),
         null);
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -23,9 +23,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.prometheus.client.Histogram;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.http.entity.EntityTemplate;
@@ -224,43 +222,9 @@ class ElasticsearchClient implements AutoCloseable {
   }
 
   static PutIndexLifecycleManagementPolicyRequest buildPutIndexLifecycleManagementPolicyRequest(
-      final Duration minimumAge) {
+      final String minimumAge) {
     return new PutIndexLifecycleManagementPolicyRequest(
-        new Policy(
-            new Phases(new Delete(formatDuration(minimumAge), new Actions(new ObjectMapper())))));
-  }
-
-  /**
-   * Format defined by
-   * https://www.elastic.co/guide/en/elasticsearch/reference/master/api-conventions.html#time-units
-   */
-  static String formatDuration(final Duration duration) {
-    final List<String> parts = new ArrayList<>();
-    final long days = duration.toDaysPart();
-    if (days > 0) {
-      parts.add(days + "d");
-    }
-    final int hours = duration.toHoursPart();
-    if (hours > 0) {
-      parts.add(hours + "h");
-    }
-    final int minutes = duration.toMinutesPart();
-    if (minutes > 0) {
-      parts.add(minutes + "m");
-    }
-    final int seconds = duration.toSecondsPart();
-    if (seconds > 0) {
-      parts.add(seconds + "s");
-    }
-    final var millis = duration.toMillisPart();
-    if (millis > 0) {
-      parts.add(millis + "ms");
-    }
-    final var nanos = duration.toNanosPart();
-    if (nanos > 0) {
-      parts.add(nanos + "nanos");
-    }
-    return String.join("", parts);
+        new Policy(new Phases(new Delete(minimumAge, new Actions(new ObjectMapper())))));
   }
 
   private <T> T sendRequest(final Request request, final Class<T> responseType) throws IOException {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -209,9 +209,10 @@ class ElasticsearchClient implements AutoCloseable {
 
   public boolean putIndexLifecycleManagementPolicy() {
     try {
-      final var request = new Request("PUT", "/_ilm/policy/" + configuration.retention.policyName);
+      final var request =
+          new Request("PUT", "/_ilm/policy/" + configuration.retention.getPolicyName());
       final var requestEntity =
-          buildPutIndexLifecycleManagementPolicyRequest(configuration.retention.minimumAge);
+          buildPutIndexLifecycleManagementPolicyRequest(configuration.retention.getMinimumAge());
       request.setJsonEntity(MAPPER.writeValueAsString(requestEntity));
       final var response = sendRequest(request, PutIndexLifecycleManagementPolicyResponse.class);
       return response.acknowledged();

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -209,12 +209,12 @@ class ElasticsearchClient implements AutoCloseable {
     }
   }
 
-  public boolean putIndexLifecycleManagementPolicy(
-      final String policyName, final Duration minimumAge) {
+  public boolean putIndexLifecycleManagementPolicy() {
     try {
-      final var request = new Request("PUT", "/_ilm/policy/" + policyName);
-      request.setJsonEntity(
-          MAPPER.writeValueAsString(buildPutIndexLifecycleManagementPolicyRequest(minimumAge)));
+      final var request = new Request("PUT", "/_ilm/policy/" + configuration.retention.policyName);
+      final var requestEntity =
+          buildPutIndexLifecycleManagementPolicyRequest(configuration.retention.minimumAge);
+      request.setJsonEntity(MAPPER.writeValueAsString(requestEntity));
       final var response = sendRequest(request, PutIndexLifecycleManagementPolicyResponse.class);
       return response.acknowledged();
     } catch (final IOException e) {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -11,13 +11,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.exporter.dto.BulkIndexResponse;
 import io.camunda.zeebe.exporter.dto.BulkIndexResponse.Error;
+import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest;
+import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Actions;
+import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Delete;
+import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Phases;
+import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Policy;
+import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyResponse;
 import io.camunda.zeebe.exporter.dto.PutIndexTemplateResponse;
 import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.prometheus.client.Histogram;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.http.entity.EntityTemplate;
@@ -199,6 +207,60 @@ class ElasticsearchClient implements AutoCloseable {
     } catch (final IOException e) {
       throw new ElasticsearchExporterException("Failed to put component template", e);
     }
+  }
+
+  public boolean putIndexLifecycleManagementPolicy(
+      final String policyName, final Duration minimumAge) {
+    try {
+      final var request = new Request("PUT", "/_ilm/policy/" + policyName);
+      request.setJsonEntity(
+          MAPPER.writeValueAsString(buildPutIndexLifecycleManagementPolicyRequest(minimumAge)));
+      final var response = sendRequest(request, PutIndexLifecycleManagementPolicyResponse.class);
+      return response.acknowledged();
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException(
+          "Failed to put index lifecycle management policy", e);
+    }
+  }
+
+  static PutIndexLifecycleManagementPolicyRequest buildPutIndexLifecycleManagementPolicyRequest(
+      final Duration minimumAge) {
+    return new PutIndexLifecycleManagementPolicyRequest(
+        new Policy(
+            new Phases(new Delete(formatDuration(minimumAge), new Actions(new ObjectMapper())))));
+  }
+
+  /**
+   * Format defined by
+   * https://www.elastic.co/guide/en/elasticsearch/reference/master/api-conventions.html#time-units
+   */
+  static String formatDuration(final Duration duration) {
+    final List<String> parts = new ArrayList<>();
+    final long days = duration.toDaysPart();
+    if (days > 0) {
+      parts.add(days + "d");
+    }
+    final int hours = duration.toHoursPart();
+    if (hours > 0) {
+      parts.add(hours + "h");
+    }
+    final int minutes = duration.toMinutesPart();
+    if (minutes > 0) {
+      parts.add(minutes + "m");
+    }
+    final int seconds = duration.toSecondsPart();
+    if (seconds > 0) {
+      parts.add(seconds + "s");
+    }
+    final var millis = duration.toMillisPart();
+    if (millis > 0) {
+      parts.add(millis + "ms");
+    }
+    final var nanos = duration.toNanosPart();
+    if (nanos > 0) {
+      parts.add(nanos + "nanos");
+    }
+    return String.join("", parts);
   }
 
   private <T> T sendRequest(final Request request, final Class<T> responseType) throws IOException {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -189,6 +189,12 @@ public class ElasticsearchExporter implements Exporter {
   }
 
   private void createIndexTemplates() {
+    final var minimumAge = configuration.retention.minimumAge;
+    if (minimumAge != null) {
+      final String policyName = configuration.retention.policyName;
+      createIndexLifecycleManagementPolicy(policyName, minimumAge);
+    }
+
     final IndexConfiguration index = configuration.index;
 
     if (index.createTemplate) {
@@ -278,6 +284,14 @@ public class ElasticsearchExporter implements Exporter {
     }
 
     indexTemplatesCreated = true;
+  }
+
+  private void createIndexLifecycleManagementPolicy(
+      final String policyName, final Duration minimumAge) {
+    if (!client.putIndexLifecycleManagementPolicy(policyName, minimumAge)) {
+      log.warn(
+          "Failed to acknowledge the creation or update of the Index Lifecycle Management Policy");
+    }
   }
 
   private void createComponentTemplate() {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -189,10 +189,8 @@ public class ElasticsearchExporter implements Exporter {
   }
 
   private void createIndexTemplates() {
-    final var minimumAge = configuration.retention.minimumAge;
-    if (minimumAge != null) {
-      final String policyName = configuration.retention.policyName;
-      createIndexLifecycleManagementPolicy(policyName, minimumAge);
+    if (configuration.retention.isEnabled()) {
+      createIndexLifecycleManagementPolicy();
     }
 
     final IndexConfiguration index = configuration.index;
@@ -286,9 +284,8 @@ public class ElasticsearchExporter implements Exporter {
     indexTemplatesCreated = true;
   }
 
-  private void createIndexLifecycleManagementPolicy(
-      final String policyName, final Duration minimumAge) {
-    if (!client.putIndexLifecycleManagementPolicy(policyName, minimumAge)) {
+  private void createIndexLifecycleManagementPolicy() {
+    if (!client.putIndexLifecycleManagementPolicy()) {
       log.warn(
           "Failed to acknowledge the creation or update of the Index Lifecycle Management Policy");
     }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -320,8 +320,18 @@ public class ElasticsearchExporterConfiguration {
   }
 
   public static class RetentionConfiguration {
-    public Duration minimumAge = null;
+
+    public boolean isEnabled = false;
+    public Duration minimumAge = Duration.ofDays(30);
     public String policyName = "zeebe-record-retention-policy";
+
+    public boolean isEnabled() {
+      return isEnabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+      isEnabled = enabled;
+    }
 
     public Duration getMinimumAge() {
       return minimumAge;
@@ -342,7 +352,9 @@ public class ElasticsearchExporterConfiguration {
     @Override
     public String toString() {
       return "RetentionConfiguration{"
-          + "minimumAge="
+          + "isEnabled="
+          + isEnabled
+          + ", minimumAge="
           + minimumAge
           + ", policyName='"
           + policyName

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.exporter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import java.time.Duration;
 
 public class ElasticsearchExporterConfiguration {
 
@@ -322,7 +321,7 @@ public class ElasticsearchExporterConfiguration {
   public static class RetentionConfiguration {
 
     public boolean isEnabled = false;
-    public Duration minimumAge = Duration.ofDays(30);
+    public String minimumAge = "30d";
     public String policyName = "zeebe-record-retention-policy";
 
     public boolean isEnabled() {
@@ -333,11 +332,11 @@ public class ElasticsearchExporterConfiguration {
       isEnabled = enabled;
     }
 
-    public Duration getMinimumAge() {
+    public String getMinimumAge() {
       return minimumAge;
     }
 
-    public void setMinimumAge(final Duration minimumAge) {
+    public void setMinimumAge(final String minimumAge) {
       this.minimumAge = minimumAge;
     }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import java.time.Duration;
 
 public class ElasticsearchExporterConfiguration {
 
@@ -23,6 +24,7 @@ public class ElasticsearchExporterConfiguration {
 
   public final IndexConfiguration index = new IndexConfiguration();
   public final BulkConfiguration bulk = new BulkConfiguration();
+  public final RetentionConfiguration retention = new RetentionConfiguration();
   private final AuthenticationConfiguration authentication = new AuthenticationConfiguration();
 
   public boolean hasAuthenticationPresent() {
@@ -45,6 +47,8 @@ public class ElasticsearchExporterConfiguration {
         + index
         + ", bulk="
         + bulk
+        + ", retention="
+        + retention
         + ", authentication="
         + authentication
         + '}';
@@ -312,6 +316,38 @@ public class ElasticsearchExporterConfiguration {
     public String toString() {
       // we don't want to expose this information
       return "AuthenticationConfiguration{Confidential information}";
+    }
+  }
+
+  public static class RetentionConfiguration {
+    public Duration minimumAge = null;
+    public String policyName = "zeebe-record-retention-policy";
+
+    public Duration getMinimumAge() {
+      return minimumAge;
+    }
+
+    public void setMinimumAge(final Duration minimumAge) {
+      this.minimumAge = minimumAge;
+    }
+
+    public String getPolicyName() {
+      return policyName;
+    }
+
+    public void setPolicyName(final String policyName) {
+      this.policyName = policyName;
+    }
+
+    @Override
+    public String toString() {
+      return "RetentionConfiguration{"
+          + "minimumAge="
+          + minimumAge
+          + ", policyName='"
+          + policyName
+          + '\''
+          + '}';
     }
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -320,16 +320,16 @@ public class ElasticsearchExporterConfiguration {
 
   public static class RetentionConfiguration {
 
-    public boolean isEnabled = false;
+    public boolean enabled = false;
     public String minimumAge = "30d";
     public String policyName = "zeebe-record-retention-policy";
 
     public boolean isEnabled() {
-      return isEnabled;
+      return enabled;
     }
 
     public void setEnabled(final boolean enabled) {
-      isEnabled = enabled;
+      this.enabled = enabled;
     }
 
     public String getMinimumAge() {
@@ -352,7 +352,7 @@ public class ElasticsearchExporterConfiguration {
     public String toString() {
       return "RetentionConfiguration{"
           + "isEnabled="
-          + isEnabled
+          + enabled
           + ", minimumAge="
           + minimumAge
           + ", policyName='"

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -39,10 +39,14 @@ public class ElasticsearchExporterConfiguration {
         + "url='"
         + url
         + '\''
+        + ", requestTimeoutMs="
+        + requestTimeoutMs
         + ", index="
         + index
         + ", bulk="
         + bulk
+        + ", authentication="
+        + authentication
         + '}';
   }
 
@@ -190,7 +194,7 @@ public class ElasticsearchExporterConfiguration {
     @Override
     public String toString() {
       return "IndexConfiguration{"
-          + "indexPrefix='"
+          + "prefix='"
           + prefix
           + '\''
           + ", createTemplate="
@@ -201,24 +205,28 @@ public class ElasticsearchExporterConfiguration {
           + event
           + ", rejection="
           + rejection
-          + ", error="
-          + error
+          + ", decision="
+          + decision
+          + ", decisionEvaluation="
+          + decisionEvaluation
+          + ", decisionRequirements="
+          + decisionRequirements
           + ", deployment="
           + deployment
-          + ", process="
-          + process
+          + ", error="
+          + error
           + ", incident="
           + incident
           + ", job="
           + job
+          + ", jobBatch="
+          + jobBatch
           + ", message="
           + message
           + ", messageSubscription="
           + messageSubscription
-          + ", variable="
-          + variable
-          + ", variableDocument="
-          + variableDocument
+          + ", process="
+          + process
           + ", processInstance="
           + processInstance
           + ", processInstanceCreation="
@@ -227,12 +235,10 @@ public class ElasticsearchExporterConfiguration {
           + processInstanceModification
           + ", processMessageSubscription="
           + processMessageSubscription
-          + ", decisionRequirements="
-          + decisionRequirements
-          + ", decision="
-          + decision
-          + ", decisionEvaluation="
-          + decisionEvaluation
+          + ", variable="
+          + variable
+          + ", variableDocument="
+          + variableDocument
           + ", checkpoint="
           + checkpoint
           + ", timer="
@@ -251,7 +257,7 @@ public class ElasticsearchExporterConfiguration {
           + signalSubscription
           + ", resourceDeletion="
           + resourceDeletion
-          + ", recordDistribution="
+          + ", commandDistribution="
           + commandDistribution
           + '}';
     }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -320,9 +320,9 @@ public class ElasticsearchExporterConfiguration {
 
   public static class RetentionConfiguration {
 
-    public boolean enabled = false;
-    public String minimumAge = "30d";
-    public String policyName = "zeebe-record-retention-policy";
+    private boolean enabled = false;
+    private String minimumAge = "30d";
+    private String policyName = "zeebe-record-retention-policy";
 
     public boolean isEnabled() {
       return enabled;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -83,6 +83,11 @@ final class TemplateReader {
     if (numberOfReplicas != null) {
       settings.put("number_of_replicas", numberOfReplicas);
     }
+
+    // update index.lifecycle in template in case a policy was configured configuration
+    if (config.retention.minimumAge != null) {
+      settings.put("index.lifecycle.name", config.retention.policyName);
+    }
   }
 
   private Template getTemplateFromClasspath(final String filename) {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -86,7 +86,7 @@ final class TemplateReader {
 
     // update index.lifecycle in template in case a retention policy is configured
     if (config.retention.isEnabled()) {
-      settings.put("index.lifecycle.name", config.retention.policyName);
+      settings.put("index.lifecycle.name", config.retention.getPolicyName());
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.exporter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.io.IOException;
@@ -25,9 +24,9 @@ final class TemplateReader {
   private static final String ZEEBE_RECORD_TEMPLATE_JSON = "/zeebe-record-template.json";
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private final ElasticsearchExporterConfiguration.IndexConfiguration config;
+  private final ElasticsearchExporterConfiguration config;
 
-  public TemplateReader(final IndexConfiguration config) {
+  public TemplateReader(final ElasticsearchExporterConfiguration config) {
     this.config = config;
   }
 
@@ -46,7 +45,7 @@ final class TemplateReader {
     final Template template = readTemplate(findResourceForTemplate(valueType));
 
     // update prefix in template in case it was changed in configuration
-    template.composedOf().set(0, config.prefix);
+    template.composedOf().set(0, config.index.prefix);
 
     template.patterns().set(0, searchPattern);
     template.template().aliases().clear();
@@ -74,13 +73,13 @@ final class TemplateReader {
 
   private void substituteConfiguration(final Map<String, Object> settings) {
     // update number of shards in template in case it was changed in configuration
-    final Integer numberOfShards = config.getNumberOfShards();
+    final Integer numberOfShards = config.index.getNumberOfShards();
     if (numberOfShards != null) {
       settings.put("number_of_shards", numberOfShards);
     }
 
     // update number of replicas in template in case it was changed in configuration
-    final Integer numberOfReplicas = config.getNumberOfReplicas();
+    final Integer numberOfReplicas = config.index.getNumberOfReplicas();
     if (numberOfReplicas != null) {
       settings.put("number_of_replicas", numberOfReplicas);
     }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -84,8 +84,8 @@ final class TemplateReader {
       settings.put("number_of_replicas", numberOfReplicas);
     }
 
-    // update index.lifecycle in template in case a policy was configured configuration
-    if (config.retention.minimumAge != null) {
+    // update index.lifecycle in template in case a retention policy is configured
+    if (config.retention.isEnabled()) {
       settings.put("index.lifecycle.name", config.retention.policyName);
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexLifecycleManagementPolicyRequest.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexLifecycleManagementPolicyRequest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.dto;
+
+public record PutIndexLifecycleManagementPolicyRequest(Policy policy) {
+  public record Policy(Phases phases) {}
+
+  public record Phases(Delete delete) {}
+
+  public record Delete(String min_age, Actions actions) {}
+
+  public record Actions(Object delete) {}
+}

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexLifecycleManagementPolicyResponse.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexLifecycleManagementPolicyResponse.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PutIndexLifecycleManagementPolicyResponse(boolean acknowledged) {}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.ilm.GetLifecycleRequest;
 import io.camunda.zeebe.exporter.TestClient.ComponentTemplatesDto.ComponentTemplateWrapper;
 import io.camunda.zeebe.exporter.TestClient.IndexTemplatesDto.IndexTemplateWrapper;
 import io.camunda.zeebe.exporter.dto.Template;
@@ -160,6 +161,30 @@ final class ElasticsearchClientIT {
 
     // then
     assertThat(testClient.getComponentTemplate()).isPresent();
+  }
+
+  @Test
+  void shouldPutIndexLifecycleManagementPolicy() throws IOException {
+    // given
+    config.retention.setEnabled(true);
+
+    // when
+    client.putIndexLifecycleManagementPolicy();
+
+    // then
+    final var lifecycle =
+        testClient
+            .getEsClient()
+            .ilm()
+            .getLifecycle(GetLifecycleRequest.of(b -> b.name(config.retention.policyName)))
+            .get(config.retention.policyName);
+    assertThat(lifecycle.policy().phases().delete()).isNotNull();
+    assertThat(lifecycle.policy().phases().delete().minAge()).isNotNull();
+    assertThat(lifecycle.policy().phases().delete().minAge().time()).isEqualTo("30d");
+    assertThat(lifecycle.policy().phases().delete().actions()).isNotNull();
+    assertThat(lifecycle.policy().phases().delete().actions().toString())
+        .describedAs("Expect that the policy's action is to delete")
+        .contains("delete");
   }
 
   private void assertIndexTemplate(final Template actualTemplate, final Template expectedTemplate) {

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -176,8 +176,8 @@ final class ElasticsearchClientIT {
         testClient
             .getEsClient()
             .ilm()
-            .getLifecycle(GetLifecycleRequest.of(b -> b.name(config.retention.policyName)))
-            .get(config.retention.policyName);
+            .getLifecycle(GetLifecycleRequest.of(b -> b.name(config.retention.getPolicyName())))
+            .get(config.retention.getPolicyName());
     assertThat(lifecycle.policy().phases().delete()).isNotNull();
     assertThat(lifecycle.policy().phases().delete().minAge()).isNotNull();
     assertThat(lifecycle.policy().phases().delete().minAge().time()).isEqualTo("30d");

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -46,7 +46,7 @@ final class ElasticsearchClientIT {
   private final ProtocolFactory recordFactory = new ProtocolFactory();
   private final ElasticsearchExporterConfiguration config =
       new ElasticsearchExporterConfiguration();
-  private final TemplateReader templateReader = new TemplateReader(config.index);
+  private final TemplateReader templateReader = new TemplateReader(config);
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);
   private final BulkIndexRequest bulkRequest = new BulkIndexRequest();
 

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.apache.http.entity.BasicHttpEntity;
@@ -106,9 +105,7 @@ final class ElasticsearchClientTest {
   @Test
   void shouldBuildPutIndexLifecycleManagementPolicyRequestCorrectly()
       throws JsonProcessingException {
-    assertThat(
-            MAPPER.writeValueAsString(
-                buildPutIndexLifecycleManagementPolicyRequest(Duration.ofDays(300).plusSeconds(3))))
+    assertThat(MAPPER.writeValueAsString(buildPutIndexLifecycleManagementPolicyRequest("300d3s")))
         .describedAs("Expect that request is mapped to json correctly")
         .isEqualTo(
             // Mapped from Object to make sure produced JSON string is formatted the same way

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -56,7 +56,7 @@ final class ElasticsearchClientTest {
       new ElasticsearchExporterConfiguration();
   private final BulkIndexRequest bulkRequest = new BulkIndexRequest();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);
-  private final TemplateReader templateReader = new TemplateReader(config.index);
+  private final TemplateReader templateReader = new TemplateReader(config);
 
   private final ElasticsearchClient client =
       new ElasticsearchClient(

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.Collections;
 import java.util.Map;
@@ -19,7 +18,8 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class TemplateReaderTest {
-  private final IndexConfiguration config = new IndexConfiguration();
+  private final ElasticsearchExporterConfiguration config =
+      new ElasticsearchExporterConfiguration();
   private final TemplateReader templateReader = new TemplateReader(config);
 
   @Test
@@ -50,7 +50,7 @@ final class TemplateReaderTest {
   @Test
   void shouldSetNumberOfShardsInComponentTemplate() {
     // given
-    config.setNumberOfShards(30);
+    config.index.setNumberOfShards(30);
 
     // when
     final var template = templateReader.readComponentTemplate();
@@ -64,7 +64,7 @@ final class TemplateReaderTest {
   @Test
   void shouldSetNumberOfReplicasInComponentTemplate() {
     // given
-    config.setNumberOfReplicas(20);
+    config.index.setNumberOfReplicas(20);
 
     // when
     final var template = templateReader.readComponentTemplate();
@@ -79,7 +79,7 @@ final class TemplateReaderTest {
   void shouldSetNumberOfShardsInIndexTemplate() {
     // given
     final var valueType = ValueType.VARIABLE;
-    config.setNumberOfShards(43);
+    config.index.setNumberOfShards(43);
 
     // when
     final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
@@ -94,7 +94,7 @@ final class TemplateReaderTest {
   void shouldSetNumberOfReplicasInIndexTemplate() {
     // given
     final var valueType = ValueType.VARIABLE;
-    config.setNumberOfReplicas(10);
+    config.index.setNumberOfReplicas(10);
 
     // when
     final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
@@ -116,7 +116,7 @@ final class TemplateReaderTest {
     // then
     assertThat(template.composedOf())
         .as("index template is composed of the component template")
-        .containsExactly(config.prefix);
+        .containsExactly(config.index.prefix);
     assertThat(template.patterns()).containsExactly("searchPattern");
     assertThat(template.template().aliases())
         .containsExactlyEntriesOf(Map.of("alias", Collections.emptyMap()));
@@ -130,13 +130,14 @@ final class TemplateReaderTest {
   @Test
   void shouldReadIndexTemplateWithDifferentPrefix() {
     // given
-    config.prefix = "foo-bar";
+    config.index.prefix = "foo-bar";
     final var valueType = ValueType.VARIABLE;
 
     // when
     final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
 
     // then
-    assertThat(template.composedOf()).allMatch(composedOf -> composedOf.equals(config.prefix));
+    assertThat(template.composedOf())
+        .allMatch(composedOf -> composedOf.equals(config.index.prefix));
   }
 }

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
@@ -140,4 +140,18 @@ final class TemplateReaderTest {
     assertThat(template.composedOf())
         .allMatch(composedOf -> composedOf.equals(config.index.prefix));
   }
+
+  @Test
+  void shouldReadIndexTemplateWithIndexLifecycleManagementPolicy() {
+    // given
+    config.retention.setEnabled(true);
+    config.retention.setPolicyName("auto-trash");
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings()).containsEntry("index.lifecycle.name", "auto-trash");
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds an Index Lifecycle Management (ILM) Policy to the indices created by the Elasticsearch Exporter, when enabled through configuration.

```
# defaults
retention:
  enabled: false
  minimumAge: 30d
  policyName: zeebe-record-retention-policy
```

When enabled, this creates an ILM using the configured `retention.policyName`:

<img width="1818" alt="Screenshot 2023-03-27 at 21 56 06" src="https://user-images.githubusercontent.com/3511026/228053395-523d1d57-00b2-44af-9ef2-a6cdef347f6d.png">

The created policy uses the configured `retention.minimumAge` as the minimum age when the data is put into the `Delete` phase (effectively deleting the data). The minimum age can be defined as shorthand Duration string using days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`. See [ES API conventions](https://www.elastic.co/guide/en/elasticsearch/reference/master/api-conventions.html#time-units). Note that microseconds `micros` is not supported. 

<img width="1818" alt="Screenshot 2023-03-27 at 21 56 37" src="https://user-images.githubusercontent.com/3511026/228053388-e17cc70d-7177-4bbb-9ad3-9b7a65122f21.png">

When enabled, the index templates are created/updated to refer to the created policy as their lifecycle. Meaning that this data is now managed by ES to be moved between the lifecycle phases according to the configured policy.

<img width="1818" alt="Screenshot 2023-03-27 at 22 00 35" src="https://user-images.githubusercontent.com/3511026/228053386-9624000c-3dbc-4a67-b16e-504b9c1f5c2e.png">

In this last screenshot, we can see live data using the lifecycle policy.

<img width="1818" alt="Screenshot 2023-03-27 at 22 00 56" src="https://user-images.githubusercontent.com/3511026/228053384-538f596a-5f47-4c20-9604-65cf8173911d.png">

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12132

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
