### PR TITLE
Add commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,18 @@
+on: [pull_request]
+name: Commitlint
+
+jobs:
+  lint-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - id: depth
+        name: Determine fetch depth for checkout
+        run: echo "depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ steps.depth.outputs.depth }}
+      - uses: wagoid/commitlint-github-action@v5
+        with:
+          commitDepth: ${{ github.event.pull_request.commits }}
+          helpURL: https://github.com/camunda/zeebe/blob/main/CONTRIBUTING.md/#commit-message-guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,13 +228,13 @@ Commit messages use [Conventional Commits](https://www.conventionalcommits.org/e
 
 ```
 <header>
-<BLANK LINE>
-<body>
+<BLANK LINE> (optional - mandatory with body)
+<body> (optional)
 <BLANK LINE> (optional - mandatory with footer)
 <footer> (optional)
 ```
 
-Zeebe uses a bot which will check your commit messages when a pull request is
+Zeebe uses a GitHub Actions workflow checking your commit messages when a pull request is
 submitted. Please make sure to address any hints from the bot.
 
 ### Commit message header
@@ -270,6 +270,9 @@ The commit header should be kept short, preferably under 72 chars but we allow a
 ### Commit message body
 
 Should describe the motivation for the change.
+This is optional, but encouraged.
+Good commit messages explain what changed AND why you changed it.
+See [I've written a clear changelist description](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#ive-written-a-clear-changelist-description).
 
 ## Contributor License Agreement
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,70 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+
+    helpUrl: 'https://github.com/camunda/zeebe/blob/main/CONTRIBUTING.md/#commit-message-guidelines',
+
+    // Rules are made up by a name and a configuration array. The configuration array contains:
+    // - Level [0..2]: 0 disables the rule. For 1 it will be considered a warning for 2 an error.
+    // - Applicable always|never: never inverts the rule.
+    // - Value: value to use for this rule.
+    rules: {
+        // error rules
+        'body-max-line-length': [2, 'always', 120],
+        'header-max-length': [2, 'always', 120],
+        'type-case': [2, 'always', 'lower-case'],
+        'type-empty': [2, 'never'],
+        'type-enum': [
+            2,
+            'always',
+            [
+                `build`, // Changes that affect the build system (e.g. Maven, Docker, etc)
+                `ci`, // Changes to our CI configuration files and scripts (e.g. Jenkins, Bors, etc)
+                `deps`, // A change to the external dependencies (was already used by Dependabot)
+                `docs`, //  A change to the documentation
+                `feat`, // A new feature (both internal or user-facing)
+                `fix`, // A bug fix (both internal or user-facing)
+                'merge', // Merges one or multiple commits
+                `perf`, // A code change that improves performance
+                `refactor`, // A code change that does not change the behavior
+                'revert', // Reverts any change
+                `style`, // A change to align the code with our style guide
+                `test`, // Adding missing tests or correcting existing tests
+            ],
+        ],
+
+        // warning rules
+
+
+        // disabled rules
+        'body-full-stop': [0, 'never', '.'],
+        'body-leading-blank': [0, 'always'],
+        'body-empty': [0, 'never'],
+        'body-max-length': [0, 'always', Infinity],
+        'body-min-length': [0, 'always', 0],
+        'body-case': [0, 'always', 'lower-case'],
+        'footer-leading-blank': [0, 'always'],
+        'footer-empty': [0, 'never'],
+        'footer-max-length': [0, 'always', Infinity],
+        'footer-max-line-length': [0, 'always', 100],
+        'footer-min-length': [0, 'always', 0],
+        'header-case': [0, 'always', 'lower-case'],
+        'header-full-stop': [0, 'never', '.'],
+        'header-min-length': [0, 'always', 0],
+        'references-empty': [0, 'never'],
+        'scope-enum': [0, 'always', []],
+        'scope-case': [0, 'always', 'lower-case'],
+        'scope-empty': [0, 'never'],
+        'scope-max-length': [0, 'always', Infinity],
+        'scope-min-length': [0, 'always', 0],
+        'subject-case': [0, 'always', 'lower-case'],
+        'subject-empty': [0, 'never'],
+        'subject-full-stop': [0, 'never', '.'],
+        'subject-max-length': [0, 'always', Infinity],
+        'subject-min-length': [0, 'always', 0],
+        'subject-exclamation-mark': [0, 'never'],
+        'type-max-length': [0, 'always', Infinity],
+        'type-min-length': [0, 'always', 0],
+        'signed-off-by': [0, 'always', 'Signed-off-by:'],
+        'trailer-exists': [0, 'always', 'Signed-off-by:'],
+    },
+};


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

> Monica: Rules help control the fun!

Adds a commitlint workflow and `commitlint.config.js` file to strictly check the commit message guidelines as defined by our `CONTRIBUTING.md`.

Also updates `CONTRIBUTING.md` to clarify that the commit message body is optional but encouraged.

## Why?

We used to have GitCop control this for us, but at some point, we changed the commit types (we dropped `chore`) and made scopes optional. GitCop did not support this, so we had to drop it.

Since then, there have been many occasions where the commit guidelines were not considered. This is no big deal, but if we apply these guidelines consistently, we maintain an easy-to-navigate and read git history.

Conventions should be automated. So should our [commit message guidelines](https://github.com/camunda/zeebe/blob/main/CONTRIBUTING.md/#commit-message-guidelines).

## How?

I first tried to use commitlint directly but ended up using the most used action for this: [wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action). This seems actively maintained and works well. The resulting error messages in the workflow run logs are also clear and helpful in resolving the errors. And can link to our actual guidelines.

The `commitlint.config.js` files contents contain exactly the rules as specified by our guidelines. All other rules that commitlint can check have been disabled.

You can find an example run [here](https://github.com/korthout/zeebe/actions/runs/4546418630):
<img width="1628" alt="Screenshot 2023-03-28 at 20 31 53" src="https://user-images.githubusercontent.com/3511026/228334790-3030301a-43f2-47a4-8715-3503c0452266.png">

## Related issues

<!-- Which issues are closed by this PR or are related -->

See: https://github.com/camunda/zeebe/blob/main/CONTRIBUTING.md/#commit-message-guidelines

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
