### PR TITLE
Receive payloads on client stream

### DIFF
--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -81,6 +81,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
-import io.camunda.zeebe.util.buffer.BufferReader;
+import org.agrona.DirectBuffer;
 
 /**
  * Represents a consumer of a stream which can consume data of type P. The data is typically pushed
@@ -15,7 +15,7 @@ import io.camunda.zeebe.util.buffer.BufferReader;
  *
  * @param <P> the payload type that can be pushed to the stream
  */
-public interface ClientStreamConsumer<P extends BufferReader> {
+public interface ClientStreamConsumer {
 
   /**
    * Consumes the payload received from the server to the client. Implementation of this method can
@@ -23,5 +23,5 @@ public interface ClientStreamConsumer<P extends BufferReader> {
    *
    * @param payload the data to be consumed by the client
    */
-  void push(P payload);
+  void push(DirectBuffer payload);
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -10,10 +10,8 @@ package io.camunda.zeebe.transport.stream.api;
 import org.agrona.DirectBuffer;
 
 /**
- * Represents a consumer of a stream which can consume data of type P. The data is typically pushed
- * from a broker, and consumed by gateway.
- *
- * @param <P> the payload type that can be pushed to the stream
+ * Represents a consumer of a stream which can consume data pushed from the server. The data is
+ * typically pushed from a broker, and consumed by gateway.
  */
 public interface ClientStreamConsumer {
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.transport.stream.api;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
@@ -17,9 +16,9 @@ import org.agrona.DirectBuffer;
  * Allows to add and remove client streams.
  *
  * <p>When a client stream is added, it opens a stream to all servers. When a server pushes data to
- * this stream, the client receives it via {@link ClientStreamConsumer#push(BufferReader)}
+ * this stream, the client receives it via {@link ClientStreamConsumer#push(DirectBuffer)}
  */
-public interface ClientStreamer<M extends BufferWriter, P extends BufferReader> {
+public interface ClientStreamer<M extends BufferWriter> {
 
   /**
    * Registers a client and opens a stream for the given streamType and associated Metadata with all
@@ -37,7 +36,7 @@ public interface ClientStreamer<M extends BufferWriter, P extends BufferReader> 
   ActorFuture<UUID> add(
       final DirectBuffer streamType,
       final M metadata,
-      final ClientStreamConsumer<P> clientStreamConsumer);
+      final ClientStreamConsumer clientStreamConsumer);
 
   /**
    * Removes a stream that is added via {@link ClientStreamer#add(DirectBuffer, BufferWriter,

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.HashSet;
 import java.util.Set;
@@ -17,18 +16,18 @@ import java.util.UUID;
 import org.agrona.DirectBuffer;
 
 /** Represents a registered client stream. * */
-final class ClientStream<M extends BufferWriter, P extends BufferReader> {
+final class ClientStream<M extends BufferWriter> {
   private final UUID streamId;
   private final DirectBuffer streamType;
   private final M metadata;
-  private final ClientStreamConsumer<P> streamConsumer;
+  private final ClientStreamConsumer streamConsumer;
   private final Set<MemberId> liveConnections = new HashSet<>();
 
   ClientStream(
       final UUID streamId,
       final DirectBuffer streamType,
       final M metadata,
-      final ClientStreamConsumer<P> clientStreamConsumer) {
+      final ClientStreamConsumer clientStreamConsumer) {
     this.streamId = streamId;
     this.streamType = streamType;
     this.metadata = metadata;
@@ -47,7 +46,7 @@ final class ClientStream<M extends BufferWriter, P extends BufferReader> {
     return metadata;
   }
 
-  ClientStreamConsumer<P> getClientStreamConsumer() {
+  ClientStreamConsumer getClientStreamConsumer() {
     return streamConsumer;
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collections;
 import java.util.HashSet;
@@ -17,14 +16,13 @@ import java.util.Set;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
 
-final class ClientStreamManager<M extends BufferWriter, P extends BufferReader> {
-  private final ClientStreamRegistry<M, P> registry;
-  private final ClientStreamRequestManager<M, P> requestManager;
+final class ClientStreamManager<M extends BufferWriter> {
+  private final ClientStreamRegistry<M> registry;
+  private final ClientStreamRequestManager<M> requestManager;
   private final Set<MemberId> servers = new HashSet<>();
 
   ClientStreamManager(
-      final ClientStreamRegistry<M, P> registry,
-      final ClientStreamRequestManager<M, P> requestManager) {
+      final ClientStreamRegistry<M> registry, final ClientStreamRequestManager<M> requestManager) {
     this.registry = registry;
     this.requestManager = requestManager;
   }
@@ -43,7 +41,7 @@ final class ClientStreamManager<M extends BufferWriter, P extends BufferReader> 
   UUID add(
       final DirectBuffer streamType,
       final M metadata,
-      final ClientStreamConsumer<P> clientStreamConsumer) {
+      final ClientStreamConsumer clientStreamConsumer) {
     final var streamId = UUID.randomUUID();
     final var clientStreamMeta =
         new ClientStream<>(streamId, streamType, metadata, clientStreamConsumer);

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -80,7 +80,7 @@ final class ClientStreamManager<M extends BufferWriter> {
           // But just in case that request is lost, we send remove request again. To keep it simple,
           // we do not retry. Otherwise, it is possible that we send it multiple times unnecessary.
           requestManager.removeStreamUnreliable(streamId, servers);
-          responseFuture.completeExceptionally(new StreamDoesNotExistException());
+          responseFuture.completeExceptionally(new NoSuchStreamException());
         });
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -17,8 +17,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class ClientStreamManager<M extends BufferWriter> {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientStreamManager.class);
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamRequestManager<M> requestManager;
   private final Set<MemberId> servers = new HashSet<>();
@@ -80,6 +83,7 @@ final class ClientStreamManager<M extends BufferWriter> {
           // But just in case that request is lost, we send remove request again. To keep it simple,
           // we do not retry. Otherwise, it is possible that we send it multiple times unnecessary.
           requestManager.removeStreamUnreliable(streamId, servers);
+          LOG.warn("Expected to push payload to stream {}, but no stream found.", streamId);
           responseFuture.completeExceptionally(new NoSuchStreamException());
         });
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /** A registry to keeps tracks of all open streams. */
@@ -24,12 +25,12 @@ final class ClientStreamRegistry<M extends BufferWriter> {
     streams.put(clientStream.getStreamId(), clientStream);
   }
 
-  ClientStream<M> get(final UUID streamId) {
-    return streams.get(streamId);
+  Optional<ClientStream<M>> get(final UUID streamId) {
+    return Optional.ofNullable(streams.get(streamId));
   }
 
-  ClientStream<M> remove(final UUID streamId) {
-    return streams.remove(streamId);
+  Optional<ClientStream<M>> remove(final UUID streamId) {
+    return Optional.ofNullable(streams.remove(streamId));
   }
 
   Collection<ClientStream<M>> list() {

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.HashMap;
@@ -15,25 +14,25 @@ import java.util.Map;
 import java.util.UUID;
 
 /** A registry to keeps tracks of all open streams. */
-final class ClientStreamRegistry<M extends BufferWriter, P extends BufferReader> {
+final class ClientStreamRegistry<M extends BufferWriter> {
 
   // This class is currently a very simple wrapper around a map. When we aggregate multiple streams
   // into one stream, we may have to keep track of them also here.
-  private final Map<UUID, ClientStream<M, P>> streams = new HashMap<>();
+  private final Map<UUID, ClientStream<M>> streams = new HashMap<>();
 
-  void add(final ClientStream<M, P> clientStream) {
+  void add(final ClientStream<M> clientStream) {
     streams.put(clientStream.getStreamId(), clientStream);
   }
 
-  ClientStream<M, P> get(final UUID streamId) {
+  ClientStream<M> get(final UUID streamId) {
     return streams.get(streamId);
   }
 
-  ClientStream<M, P> remove(final UUID streamId) {
+  ClientStream<M> remove(final UUID streamId) {
     return streams.remove(streamId);
   }
 
-  Collection<ClientStream<M, P>> list() {
+  Collection<ClientStream<M>> list() {
     return streams.values();
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -123,5 +124,14 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     // Do not wait for response, as this is expected to be called while shutting down.
     communicationService.unicast(
         StreamTopics.REMOVE_ALL.topic(), REMOVE_ALL_REQUEST, Function.identity(), brokerId, true);
+  }
+
+  /** Send remove stream request to servers without waiting for ack and without retry * */
+  void removeStreamUnreliable(final UUID streamId, final Collection<MemberId> servers) {
+    final var request = new RemoveStreamRequest().streamId(streamId);
+    servers.forEach(
+        serverId ->
+            communicationService.unicast(
+                StreamTopics.REMOVE.topic(), request, BufferUtil::bufferAsArray, serverId, true));
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
@@ -12,15 +12,14 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamer;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
 
-public class ClientStreamService<M extends BufferWriter, P extends BufferReader> extends Actor
-    implements ClientStreamer<M, P> {
+public class ClientStreamService<M extends BufferWriter> extends Actor
+    implements ClientStreamer<M> {
 
-  private final ClientStreamManager<M, P> clientStreamManager;
+  private final ClientStreamManager<M> clientStreamManager;
 
   public ClientStreamService(final ClusterCommunicationService communicationService) {
     // ClientStreamRequestManager must use same actor as this because it is mutating shared
@@ -35,7 +34,7 @@ public class ClientStreamService<M extends BufferWriter, P extends BufferReader>
   public ActorFuture<UUID> add(
       final DirectBuffer streamType,
       final M metadata,
-      final ClientStreamConsumer<P> clientStreamConsumer) {
+      final ClientStreamConsumer clientStreamConsumer) {
     return actor.call(() -> clientStreamManager.add(streamType, metadata, clientStreamConsumer));
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
@@ -12,14 +12,18 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamer;
+import io.camunda.zeebe.transport.stream.impl.messages.MessageUtil;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.agrona.DirectBuffer;
 
 public class ClientStreamService<M extends BufferWriter> extends Actor
     implements ClientStreamer<M> {
 
   private final ClientStreamManager<M> clientStreamManager;
+  private final ClusterCommunicationService communicationService;
 
   public ClientStreamService(final ClusterCommunicationService communicationService) {
     // ClientStreamRequestManager must use same actor as this because it is mutating shared
@@ -28,6 +32,34 @@ public class ClientStreamService<M extends BufferWriter> extends Actor
         new ClientStreamManager<>(
             new ClientStreamRegistry<>(),
             new ClientStreamRequestManager<>(communicationService, actor));
+    this.communicationService = communicationService;
+  }
+
+  @Override
+  protected void onActorStarted() {
+    // TODO: Define an PushResponse to inform server if push was successful or not. Currently, an
+    // exception will be received by the server response handler.
+    communicationService.subscribe(
+        StreamTopics.PUSH.topic(),
+        MessageUtil::parsePushRequest,
+        request -> {
+          final CompletableFuture<Void> future = new CompletableFuture<>();
+          actor.run(
+              () -> {
+                try {
+                  clientStreamManager.onPayloadReceived(request, future);
+                } catch (final Exception e) {
+                  future.completeExceptionally(e);
+                }
+              });
+          return future;
+        },
+        ignore -> new byte[0]);
+  }
+
+  @Override
+  protected void onActorCloseRequested() {
+    clientStreamManager.removeAll();
   }
 
   @Override
@@ -41,10 +73,5 @@ public class ClientStreamService<M extends BufferWriter> extends Actor
   @Override
   public ActorFuture<Void> remove(final UUID streamId) {
     return actor.call(() -> clientStreamManager.remove(streamId));
-  }
-
-  @Override
-  protected void onActorCloseRequested() {
-    clientStreamManager.removeAll();
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -73,5 +74,9 @@ public class ClientStreamService<M extends BufferWriter> extends Actor
   @Override
   public ActorFuture<Void> remove(final UUID streamId) {
     return actor.call(() -> clientStreamManager.remove(streamId));
+  }
+
+  public void onServerJoined(final MemberId memberId) {
+    actor.run(() -> clientStreamManager.onServerJoined(memberId));
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/NoSuchStreamException.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/NoSuchStreamException.java
@@ -7,4 +7,4 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-public class StreamDoesNotExistException extends RuntimeException {}
+public class NoSuchStreamException extends RuntimeException {}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/StreamDoesNotExistException.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/StreamDoesNotExistException.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+public class StreamDoesNotExistException extends RuntimeException {}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/MessageUtil.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/MessageUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl.messages;
+
+import io.camunda.zeebe.util.buffer.BufferReader;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class MessageUtil {
+
+  private MessageUtil() {
+    // avoid instantiation of util class
+  }
+
+  public static PushStreamRequest parsePushRequest(final byte[] bytes) {
+    return parseRequest(bytes, new PushStreamRequest());
+  }
+
+  public static RemoveStreamRequest parseRemoveRequest(final byte[] bytes) {
+    return parseRequest(bytes, new RemoveStreamRequest());
+  }
+
+  public static AddStreamRequest parseAddRequest(final byte[] bytes) {
+    return parseRequest(bytes, new AddStreamRequest());
+  }
+
+  private static <R extends BufferReader> R parseRequest(final byte[] bytes, final R request) {
+    final var buffer = new UnsafeBuffer(bytes);
+    request.wrap(buffer, 0, buffer.capacity());
+
+    return request;
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -143,6 +143,6 @@ class ClientStreamManagerTest {
     assertThat(future)
         .failsWithin(Duration.ofMillis(100))
         .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(StreamDoesNotExistException.class);
+        .withCauseInstanceOf(NoSuchStreamException.class);
   }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -65,7 +65,7 @@ class ClientStreamManagerTest {
     final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
 
     // then
-    final var clientStream = registry.get(uuid);
+    final var clientStream = registry.get(uuid).orElseThrow();
 
     assertThat(clientStream.isConnected(server1)).isTrue();
     assertThat(clientStream.isConnected(server2)).isTrue();
@@ -75,7 +75,7 @@ class ClientStreamManagerTest {
   void shouldOpenStreamToNewlyAddedServer() {
     // given
     final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
-    final var clientStream = registry.get(uuid);
+    final var clientStream = registry.get(uuid).orElseThrow();
 
     // when
     final MemberId server = MemberId.from("3");
@@ -96,8 +96,8 @@ class ClientStreamManagerTest {
     clientStreamManager.onServerJoined(server);
 
     // then
-    assertThat(registry.get(stream1).isConnected(server)).isTrue();
-    assertThat(registry.get(stream2).isConnected(server)).isTrue();
+    assertThat(registry.get(stream1).orElseThrow().isConnected(server)).isTrue();
+    assertThat(registry.get(stream2).orElseThrow().isConnected(server)).isTrue();
   }
 
   @Test
@@ -109,7 +109,7 @@ class ClientStreamManagerTest {
     clientStreamManager.remove(uuid);
 
     // then
-    assertThat(registry.get(uuid)).isNull();
+    assertThat(registry.get(uuid)).isEmpty();
   }
 
   @Test

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.concurrent.CompletableFuture;
@@ -27,10 +26,9 @@ class ClientStreamManagerTest {
 
   private final DirectBuffer streamType = BufferUtil.wrapString("foo");
   private final BufferWriter metadata = mock(BufferWriter.class);
-  private final ClientStreamRegistry<BufferWriter, BufferReader> registry =
-      new ClientStreamRegistry<>();
+  private final ClientStreamRegistry<BufferWriter> registry = new ClientStreamRegistry<>();
   private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
-  private final ClientStreamManager<BufferWriter, BufferReader> clientStreamManager =
+  private final ClientStreamManager<BufferWriter> clientStreamManager =
       new ClientStreamManager<>(
           registry, new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl()));
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -20,7 +20,6 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Set;
@@ -33,10 +32,10 @@ import org.junit.jupiter.api.Test;
 class ClientStreamRequestManagerTest {
 
   private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
-  private final ClientStreamRequestManager<BufferWriter, BufferReader> requestManager =
+  private final ClientStreamRequestManager<BufferWriter> requestManager =
       new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl());
 
-  private final ClientStream<BufferWriter, BufferReader> clientStream =
+  private final ClientStream<BufferWriter> clientStream =
       new ClientStream<>(
           UUID.randomUUID(), BufferUtil.wrapString("foo"), new TestMetadata(), p -> {});
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -173,7 +173,7 @@ class StreamIntegrationTest {
 
     // then
     latch.await();
-    assertThat(error.get()).hasCauseInstanceOf(StreamDoesNotExistException.class);
+    assertThat(error.get()).hasCauseInstanceOf(NoSuchStreamException.class);
   }
 
   private void pushPayload(final SerializableData data) {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.transport.TransportFactory;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests end-to-end stream management from client to server */
+class StreamIntegrationTest {
+
+  private ClientStreamService<SerializableData> clientStreamer;
+  private RemoteStreamer<SerializableData, SerializableData> remoteStreamer;
+
+  private final DirectBuffer streamType = BufferUtil.wrapString("foo");
+  private final SerializableData metadata = new SerializableData().data(1);
+  private ActorScheduler actorScheduler;
+
+  private final List<AutoCloseable> closeables = new ArrayList<>();
+
+  @BeforeEach
+  void setup() {
+    startActorScheduler();
+
+    // set up communication service
+    final ConcurrentMap<MemberId, TestCommunicationService> cluster = new ConcurrentHashMap<>();
+    final MemberId clientId = MemberId.from("client");
+    final var clientService = new TestCommunicationService(cluster, clientId);
+    final MemberId serverId = MemberId.from("server");
+    final var serverService = new TestCommunicationService(cluster, serverId);
+    cluster.put(clientId, clientService);
+    cluster.put(serverId, serverService);
+
+    // start server side streaming service
+    remoteStreamer = startRemoteStreamer(serverService);
+
+    // start client side streaming service
+    clientStreamer = startClientStreamer(clientService, serverId);
+  }
+
+  private ClientStreamService<SerializableData> startClientStreamer(
+      final TestCommunicationService clientService, final MemberId serverId) {
+    final ClientStreamService<SerializableData> clientStreamService =
+        new ClientStreamService<>(clientService);
+    actorScheduler.submitActor(clientStreamService).join();
+    closeables.add(clientStreamService);
+
+    clientStreamService.onServerJoined(serverId);
+
+    return clientStreamService;
+  }
+
+  private void startActorScheduler() {
+    actorScheduler =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(1)
+            .setIoBoundActorThreadCount(1)
+            .build();
+    actorScheduler.start();
+    closeables.add(() -> actorScheduler.stop());
+  }
+
+  private RemoteStreamer<SerializableData, SerializableData> startRemoteStreamer(
+      final TestCommunicationService serverService) {
+    // required to start and stop remote stream service
+    final TestActor testActor = new TestActor();
+    actorScheduler.submitActor(testActor).join();
+    closeables.add(testActor);
+
+    return testActor
+        .call(
+            () -> {
+              final RemoteStreamService<SerializableData, SerializableData> remoteStreamService =
+                  new TransportFactory(actorScheduler)
+                      .createRemoteStreamServer(
+                          serverService, SerializableData::new, RemoteStreamMetrics.noop());
+              closeables.add(
+                  () -> testActor.call(() -> remoteStreamService.closeAsync(testActor)).join());
+              return remoteStreamService.start(actorScheduler, testActor);
+            })
+        .join()
+        .join();
+  }
+
+  @AfterEach
+  void tearDown() {
+    Collections.reverse(closeables);
+    closeables.forEach(
+        c -> {
+          try {
+            c.close();
+          } catch (final Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  @Test
+  void shouldReceiveStreamPayloads() throws InterruptedException {
+    // given
+    final AtomicReference<List<Integer>> payloads = new AtomicReference<>(new ArrayList<>());
+    final CountDownLatch latch = new CountDownLatch(2);
+
+    clientStreamer
+        .add(
+            streamType,
+            metadata,
+            p -> {
+              final SerializableData payload = new SerializableData();
+              payload.wrap(p, 0, p.capacity());
+              payloads.get().add(payload.data());
+              latch.countDown();
+            })
+        .join();
+
+    // when
+    Awaitility.await().until(() -> remoteStreamer.streamFor(streamType).isPresent());
+
+    pushPayload(new SerializableData().data(100));
+    pushPayload(new SerializableData().data(200));
+
+    // then
+    // verify client receives payload
+    latch.await();
+    assertThat(payloads.get()).asList().containsExactly(100, 200);
+  }
+
+  @Test
+  void shouldReturnErrorWhenClientStreamIsClosed() throws InterruptedException {
+    // given
+    final var clientStreamId = clientStreamer.add(streamType, metadata, p -> {}).join();
+    Awaitility.await().until(() -> remoteStreamer.streamFor(streamType).isPresent());
+    final var serverStream = remoteStreamer.streamFor(streamType).orElseThrow();
+
+    // when
+    clientStreamer.remove(clientStreamId);
+
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    final CountDownLatch latch = new CountDownLatch(1);
+    // Use serverStream obtained before stream is removed
+    serverStream.push(
+        new SerializableData().data(100),
+        (e, p) -> {
+          error.set(e);
+          latch.countDown();
+        });
+
+    // then
+    latch.await();
+    assertThat(error.get()).hasCauseInstanceOf(StreamDoesNotExistException.class);
+  }
+
+  private void pushPayload(final SerializableData data) {
+    remoteStreamer.streamFor(streamType).orElseThrow().push(data, (p, e) -> {});
+  }
+
+  private static class SerializableData implements BufferReader, BufferWriter {
+
+    private int data;
+
+    public int data() {
+      return data;
+    }
+
+    public SerializableData data(final int data) {
+      this.data = data;
+      return this;
+    }
+
+    @Override
+    public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+      data = buffer.getInt(0);
+    }
+
+    @Override
+    public int getLength() {
+      return Integer.BYTES;
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {
+      buffer.putInt(offset, data);
+    }
+  }
+
+  private static final class TestActor extends Actor {}
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.awaitility.Awaitility;
@@ -111,14 +112,7 @@ class StreamIntegrationTest {
   @AfterEach
   void tearDown() {
     Collections.reverse(closeables);
-    closeables.forEach(
-        c -> {
-          try {
-            c.close();
-          } catch (final Exception e) {
-            throw new RuntimeException(e);
-          }
-        });
+    CloseHelper.closeAll(closeables);
   }
 
   @Test

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestCommunicationService.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestCommunicationService.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/** A mock implementation of ClusterCommunicationService */
+final class TestCommunicationService implements ClusterCommunicationService {
+
+  private final ConcurrentMap<String, BiFunction<MemberId, byte[], CompletableFuture<byte[]>>>
+      subscribers = new ConcurrentHashMap<>();
+  private final Map<MemberId, TestCommunicationService> cluster;
+
+  private final MemberId memberId;
+
+  TestCommunicationService(
+      final ConcurrentMap<MemberId, TestCommunicationService> cluster, final MemberId memberId) {
+    this.cluster = cluster;
+    this.memberId = memberId;
+    cluster.put(memberId, this);
+  }
+
+  @Override
+  public <M> void broadcast(
+      final String subject,
+      final M message,
+      final Function<M, byte[]> encoder,
+      final boolean reliable) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <M> void multicast(
+      final String subject,
+      final M message,
+      final Function<M, byte[]> encoder,
+      final Set<MemberId> memberIds,
+      final boolean reliable) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <M> void unicast(
+      final String subject,
+      final M message,
+      final Function<M, byte[]> encoder,
+      final MemberId memberId,
+      final boolean reliable) {
+    // Do nothing
+  }
+
+  @Override
+  public <M, R> CompletableFuture<R> send(
+      final String subject,
+      final M message,
+      final Function<M, byte[]> encoder,
+      final Function<byte[], R> decoder,
+      final MemberId toMemberId,
+      final Duration timeout) {
+
+    final var subscriber =
+        cluster
+            .get(toMemberId)
+            .subscribers
+            .getOrDefault(
+                subject,
+                (m, r) -> {
+                  throw new RuntimeException("No subscriber found");
+                });
+    return subscriber.apply(memberId, encoder.apply(message)).thenApply(decoder);
+  }
+
+  @Override
+  public <M, R> void subscribe(
+      final String subject,
+      final Function<byte[], M> decoder,
+      final Function<M, R> handler,
+      final Function<R, byte[]> encoder,
+      final Executor executor) {
+
+    subscribers.put(
+        subject,
+        (member, request) -> {
+          final M decodedRequest = decoder.apply(request);
+          final CompletableFuture<byte[]> encodedResult = new CompletableFuture<>();
+          executor.execute(
+              () -> {
+                final var result = handler.apply(decodedRequest);
+                encodedResult.complete(encoder.apply(result));
+              });
+          return encodedResult;
+        });
+  }
+
+  @Override
+  public <M, R> void subscribe(
+      final String subject,
+      final Function<byte[], M> decoder,
+      final Function<M, CompletableFuture<R>> handler,
+      final Function<R, byte[]> encoder) {
+    subscribers.put(
+        subject,
+        (member, request) -> {
+          final M decodedRequest = decoder.apply(request);
+          final CompletableFuture<byte[]> encodedResult = new CompletableFuture<>();
+          final var resultFuture = handler.apply(decodedRequest);
+          resultFuture.whenComplete(
+              (result, error) -> {
+                if (error != null) {
+                  encodedResult.completeExceptionally(error);
+                } else {
+                  encodedResult.complete(encoder.apply(result));
+                }
+              });
+          return encodedResult;
+        });
+  }
+
+  @Override
+  public <M> void subscribe(
+      final String subject,
+      final Function<byte[], M> decoder,
+      final Consumer<M> handler,
+      final Executor executor) {
+    subscribers.put(
+        subject,
+        (member, request) -> {
+          final M decodedRequest = decoder.apply(request);
+          final CompletableFuture<byte[]> encodedResult = new CompletableFuture<>();
+          executor.execute(
+              () -> {
+                handler.accept(decodedRequest);
+                encodedResult.complete(null);
+              });
+          return encodedResult;
+        });
+  }
+
+  @Override
+  public <M> void subscribe(
+      final String subject,
+      final Function<byte[], M> decoder,
+      final BiConsumer<MemberId, M> handler,
+      final Executor executor) {
+    subscribers.put(
+        subject,
+        (member, request) -> {
+          final M decodedRequest = decoder.apply(request);
+          final CompletableFuture<byte[]> encodedResult = new CompletableFuture<>();
+          executor.execute(
+              () -> {
+                handler.accept(member, decodedRequest);
+                encodedResult.complete(null);
+              });
+          return encodedResult;
+        });
+  }
+
+  @Override
+  public void unsubscribe(final String subject) {
+    subscribers.remove(subject);
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestCommunicationService.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestCommunicationService.java
@@ -61,9 +61,12 @@ final class TestCommunicationService implements ClusterCommunicationService {
       final String subject,
       final M message,
       final Function<M, byte[]> encoder,
-      final MemberId memberId,
+      final MemberId toMemberId,
       final boolean reliable) {
-    // Do nothing
+    final var subscriber = cluster.get(toMemberId).subscribers.get(subject);
+    if (subscriber != null) {
+      subscriber.apply(memberId, encoder.apply(message));
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR implements the first part of #11712  - adding support for receiving jobs in the transport.

`ClientStreamService` adds a subscriber to handle push requests from servers. There is only one push request topic for all streams. `ClientStreamService` forwards payload to the respective client stream based on the provided streamId in the push request. 

We assume the `ClientStreamConsumer` does the error handling itself. For example, if the grpc stream is already closed, the consumer should take care of making the job re-activatable. Any other unexpected exceptions when invoking the consumer will be forwarded back to the server. 

A integration to test interoperability of client side and server side stream management is also added.

## Related issues

related #11712 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
