### PR TITLE
refactor(transport): allow providing job specicific metrics for stream

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import io.camunda.zeebe.broker.jobstream.JobStreamMetrics;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.jobstream.RemoteJobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.ActivatedJob;
@@ -36,7 +37,9 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     final RemoteStreamService<JobActivationProperties, ActivatedJob> remoteStreamService =
         new TransportFactory(brokerStartupContext.getActorSchedulingService())
             .createRemoteStreamServer(
-                clusterServices.getCommunicationService(), DummyActivationProperties::new);
+                clusterServices.getCommunicationService(),
+                DummyActivationProperties::new,
+                new JobStreamMetrics());
 
     remoteStreamService
         .start(brokerStartupContext.getActorSchedulingService(), concurrencyControl)

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamMetrics.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.camunda.zeebe.transport.stream.impl.RemoteStreamMetrics;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+
+public class JobStreamMetrics implements RemoteStreamMetrics {
+  private static final String NAMESPACE = "zeebe";
+
+  private static final Gauge STREAM_COUNT =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("broker_open_job_stream_count")
+          .help("Number of open job streams in broker")
+          .register();
+
+  private static final Counter PUSH_SUCCESS_COUNT =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("broker_jobs_pushed_count")
+          .help("Total number of jobs pushed to all streams")
+          .register();
+
+  private static final Counter PUSH_FAILED_COUNT =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("broker_jobs_push_fail_count")
+          .help("Total number of failures when pushing jobs to the streams")
+          .register();
+
+  @Override
+  public void addStream() {
+    STREAM_COUNT.inc();
+  }
+
+  @Override
+  public void removeStream() {
+    STREAM_COUNT.dec();
+  }
+
+  @Override
+  public void pushSucceeded() {
+    PUSH_SUCCESS_COUNT.inc();
+  }
+
+  @Override
+  public void pushFailed() {
+    PUSH_FAILED_COUNT.inc();
+  }
+}

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -48,11 +48,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-scheduler</artifactId>
       <classifier>tests</classifier>

--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamApiHandler;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamEndpoint;
+import io.camunda.zeebe.transport.stream.impl.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamRegistry;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamServiceImpl;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamerImpl;
@@ -46,10 +47,11 @@ public final class TransportFactory {
   public <M extends BufferReader, P extends BufferWriter>
       RemoteStreamService<M, P> createRemoteStreamServer(
           final ClusterCommunicationService clusterCommunicationService,
-          final Supplier<M> metadataFactory) {
-    final RemoteStreamRegistry<M> registry = new RemoteStreamRegistry<>();
+          final Supplier<M> metadataFactory,
+          final RemoteStreamMetrics metrics) {
+    final RemoteStreamRegistry<M> registry = new RemoteStreamRegistry<>(metrics);
     return new RemoteStreamServiceImpl<>(
-        new RemoteStreamerImpl<>(clusterCommunicationService, registry),
+        new RemoteStreamerImpl<>(clusterCommunicationService, registry, metrics),
         new RemoteStreamEndpoint<>(
             clusterCommunicationService, new RemoteStreamApiHandler<>(registry, metadataFactory)));
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamMetrics.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamMetrics.java
@@ -7,46 +7,17 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
+public interface RemoteStreamMetrics {
 
-public class RemoteStreamMetrics {
-  private static final String NAMESPACE = "zeebe";
+  /** Invoked after a stream is successfully added to the registry */
+  default void addStream() {}
 
-  private static final Gauge STREAM_COUNT =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("broker_open_stream_count")
-          .help("Number of open job streams in broker")
-          .register();
+  /** Invoked after a stream is removed from registry */
+  default void removeStream() {}
 
-  private static final Counter PUSH_SUCCESS_COUNT =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("broker_stream_pushed_count")
-          .help("Total number of jobs pushed to all streams")
-          .register();
+  /** Invoked after a payload is successfully pushed to a stream */
+  default void pushSucceeded() {}
 
-  private static final Counter PUSH_FAILED_COUNT =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("broker_stream_push_fail_count")
-          .help("Total number of failures when pushing jobs to the streams")
-          .register();
-
-  void addStream() {
-    STREAM_COUNT.inc();
-  }
-
-  void removeStream() {
-    STREAM_COUNT.dec();
-  }
-
-  void pushSucceeded() {
-    PUSH_SUCCESS_COUNT.inc();
-  }
-
-  void pushFailed() {
-    PUSH_FAILED_COUNT.inc();
-  }
+  /** Invoked if pushing a payload to a stream failed */
+  default void pushFailed() {}
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamMetrics.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamMetrics.java
@@ -20,4 +20,8 @@ public interface RemoteStreamMetrics {
 
   /** Invoked if pushing a payload to a stream failed */
   default void pushFailed() {}
+
+  static RemoteStreamMetrics noop() {
+    return new RemoteStreamMetrics() {};
+  }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusher.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusher.java
@@ -26,13 +26,18 @@ import org.slf4j.LoggerFactory;
  */
 final class RemoteStreamPusher<P extends BufferWriter> {
   private static final Logger LOG = LoggerFactory.getLogger(RemoteStreamPusher.class);
-  private final RemoteStreamMetrics metrics = new RemoteStreamMetrics();
+  private final RemoteStreamMetrics metrics;
 
   private final StreamId streamId;
   private final Transport transport;
   private final Executor executor;
 
-  RemoteStreamPusher(final StreamId streamId, final Transport transport, final Executor executor) {
+  RemoteStreamPusher(
+      final StreamId streamId,
+      final Transport transport,
+      final Executor executor,
+      final RemoteStreamMetrics metrics) {
+    this.metrics = metrics;
     this.streamId = Objects.requireNonNull(streamId, "must specify a target stream ID");
     this.transport = Objects.requireNonNull(transport, "must provide a network transport");
     this.executor = Objects.requireNonNull(executor, "must provide an asynchronous executor");

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistry.java
@@ -29,12 +29,16 @@ import org.agrona.concurrent.UnsafeBuffer;
  * @param <M> the type of the properties of the stream.
  */
 public class RemoteStreamRegistry<M> implements ImmutableStreamRegistry<M> {
-  private final RemoteStreamMetrics metrics = new RemoteStreamMetrics();
+  private final RemoteStreamMetrics metrics;
 
   // Needs to be thread-safe for readers
   private final ConcurrentMap<UnsafeBuffer, Set<StreamConsumer<M>>> typeToConsumers =
       new ConcurrentHashMap<>();
   private final Map<StreamId, StreamConsumer<M>> idToConsumer = new HashMap<>();
+
+  public RemoteStreamRegistry(final RemoteStreamMetrics metrics) {
+    this.metrics = metrics;
+  }
 
   /**
    * Adds a stream receiver that can receive data from the stream with the given streamType.

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -40,11 +40,15 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
   private final RemoteStreamPicker<M> streamPicker = new RandomStreamPicker<>();
   private final ClusterCommunicationService transport;
   private final ImmutableStreamRegistry<M> registry;
+  private final RemoteStreamMetrics metrics;
 
   public RemoteStreamerImpl(
-      final ClusterCommunicationService transport, final ImmutableStreamRegistry<M> registry) {
+      final ClusterCommunicationService transport,
+      final ImmutableStreamRegistry<M> registry,
+      final RemoteStreamMetrics metrics) {
     this.transport = Objects.requireNonNull(transport, "must specify a network transport");
     this.registry = Objects.requireNonNull(registry, "must specify a job stream registry");
+    this.metrics = metrics;
   }
 
   @Override
@@ -57,7 +61,8 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
     final var target = streamPicker.pickStream(consumers);
     final RemoteStreamImpl<M, P> gatewayStream =
         new RemoteStreamImpl<>(
-            target.properties(), new RemoteStreamPusher<>(target.id(), this::send, actor::run));
+            target.properties(),
+            new RemoteStreamPusher<>(target.id(), this::send, actor::run, metrics));
     return Optional.of(gatewayStream);
   }
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
@@ -29,7 +29,8 @@ final class RemoteStreamApiHandlerTest {
   private static final UnsafeBuffer SERIALIZED_METADATA =
       new UnsafeBuffer(ByteBuffer.allocate(4).order(ByteOrder.nativeOrder()).putInt(0, 1));
 
-  private final RemoteStreamRegistry<TestMetadata> registry = new RemoteStreamRegistry<>();
+  private final RemoteStreamRegistry<TestMetadata> registry =
+      new RemoteStreamRegistry<>(new RemoteStreamMetrics() {});
   private final RemoteStreamApiHandler<TestMetadata> server =
       new RemoteStreamApiHandler<>(registry, TestMetadata::new);
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
@@ -30,7 +30,7 @@ final class RemoteStreamApiHandlerTest {
       new UnsafeBuffer(ByteBuffer.allocate(4).order(ByteOrder.nativeOrder()).putInt(0, 1));
 
   private final RemoteStreamRegistry<TestMetadata> registry =
-      new RemoteStreamRegistry<>(new RemoteStreamMetrics() {});
+      new RemoteStreamRegistry<>(RemoteStreamMetrics.noop());
   private final RemoteStreamApiHandler<TestMetadata> server =
       new RemoteStreamApiHandler<>(registry, TestMetadata::new);
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
@@ -29,7 +29,7 @@ final class RemoteStreamPusherTest {
   private final TestTransport transport = new TestTransport();
   private final Executor executor = Runnable::run;
   private final RemoteStreamPusher<Payload> pusher =
-      new RemoteStreamPusher<>(streamId, transport, executor);
+      new RemoteStreamPusher<>(streamId, transport, executor, new RemoteStreamMetrics() {});
 
   @Test
   void shouldPushPayload() {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
@@ -29,7 +29,7 @@ final class RemoteStreamPusherTest {
   private final TestTransport transport = new TestTransport();
   private final Executor executor = Runnable::run;
   private final RemoteStreamPusher<Payload> pusher =
-      new RemoteStreamPusher<>(streamId, transport, executor, new RemoteStreamMetrics() {});
+      new RemoteStreamPusher<>(streamId, transport, executor, RemoteStreamMetrics.noop());
 
   @Test
   void shouldPushPayload() {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
@@ -19,7 +19,8 @@ import org.junit.jupiter.api.Test;
 
 final class RemoteStreamRegistryTest {
 
-  private final RemoteStreamRegistry<Integer> streamRegistry = new RemoteStreamRegistry<>();
+  private final RemoteStreamRegistry<Integer> streamRegistry =
+      new RemoteStreamRegistry<>(new RemoteStreamMetrics() {});
   private final MemberId gateway = MemberId.from("gateway");
   private final MemberId otherGateway = MemberId.from("gateway-other");
   private final UnsafeBuffer typeBar = new UnsafeBuffer(BufferUtil.wrapString("bar"));

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 final class RemoteStreamRegistryTest {
 
   private final RemoteStreamRegistry<Integer> streamRegistry =
-      new RemoteStreamRegistry<>(new RemoteStreamMetrics() {});
+      new RemoteStreamRegistry<>(RemoteStreamMetrics.noop());
   private final MemberId gateway = MemberId.from("gateway");
   private final MemberId otherGateway = MemberId.from("gateway-other");
   private final UnsafeBuffer typeBar = new UnsafeBuffer(BufferUtil.wrapString("bar"));

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -41,7 +41,7 @@ final class RemoteStreamerTest {
   private final TestRegistry registry = new TestRegistry();
 
   private final RemoteStreamerImpl<TestMetadata, TestPayload> streamer =
-      new RemoteStreamerImpl<>(communicationService, registry, new RemoteStreamMetrics() {});
+      new RemoteStreamerImpl<>(communicationService, registry, RemoteStreamMetrics.noop());
 
   @RegisterExtension
   private final ControlledActorSchedulerExtension scheduler =

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -41,7 +41,7 @@ final class RemoteStreamerTest {
   private final TestRegistry registry = new TestRegistry();
 
   private final RemoteStreamerImpl<TestMetadata, TestPayload> streamer =
-      new RemoteStreamerImpl<>(communicationService, registry);
+      new RemoteStreamerImpl<>(communicationService, registry, new RemoteStreamMetrics() {});
 
   @RegisterExtension
   private final ControlledActorSchedulerExtension scheduler =


### PR DESCRIPTION
## Description

To decouple transport from engine or job related concepts, we had previously removed job from the metric names. But this could be confusing for the users. Instead now we provide an interface for stream metrics, for which a job specific implementation can be provided by the broker. Thus the metrics names contain "job" to make it easier to understand.

## Related issues

Follow up of https://github.com/camunda/zeebe/pull/12043 

