### PR TITLE
fix(dist): remove confusing actuator config that doesn't work

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
  * operations will result in a 403 response.
  */
 @Component
-@WebEndpoint(id = "clock", enableByDefault = false)
+@WebEndpoint(id = "clock")
 public class ActorClockEndpoint {
   private static final String PATH_PIN = "pin";
   private static final String PATH_ADD = "add";

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -40,7 +40,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Component
-@WebEndpoint(id = "backups", enableByDefault = false)
+@WebEndpoint(id = "backups")
 public final class BackupEndpoint {
   private final BackupApi api;
 

--- a/dist/src/main/resources/application-broker.properties
+++ b/dist/src/main/resources/application-broker.properties
@@ -3,5 +3,3 @@
 # so on
 # Disable health information for the broker
 management.health.defaults.enabled=false
-# Allow partitions api - this allows to trigger snapshots and pause processing
-management.endpoint.partitions.enabled=true

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -23,11 +23,6 @@ management.endpoint.prometheus.enabled=true
 management.prometheus.metrics.export.enabled=true
 # Allow runtime configuration of log levels
 management.endpoint.loggers.enabled=true
-# Backups endpoint; as this is an experimental feature, it should be enabled only with care. The API
-# is subject to change in the future. To fully enable online backups, you will need to enable this
-# management endpoint, and also enable the backups feature flag by setting the following property
-# zeebe.broker.experimental.features.enableBackup=true.
-management.endpoint.backups.enabled=false
 # Disable specific autoconfiguration classes which are triggered automatically (e.g. creating an
 # Elastic client which spawns 16 threads)
 spring.autoconfigure.exclude=\

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
@@ -209,9 +209,7 @@ final class BackupAcceptanceIT {
   }
 
   private void configureNode(final ZeebeNode<?> node) {
-    node.withEnv("MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE", "*")
-        .withEnv("MANAGEMENT_ENDPOINTS_BACKUPS_ENABLED", "true")
-        .dependsOn(minio);
+    node.withEnv("MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE", "*").dependsOn(minio);
     node.addExposedPort(ZeebePort.MONITORING.getPort());
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
@@ -54,7 +54,6 @@ final class RestoreAcceptanceIT {
           .dependsOn(MINIO)
           .withoutTopologyCheck()
           .withEnv("MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE", "*")
-          .withEnv("MANAGEMENT_ENDPOINTS_BACKUPS_ENABLED", "true")
           .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "S3")
           .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME", BUCKET_NAME)
           .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ENDPOINT", MINIO.internalEndpoint())


### PR DESCRIPTION
This removes two properties from our default properties because they are confusing and did not work as expected.

`management.endpoint.<id>.enabled` appears to only work for built-in actuators and not for our custom ones.

This is not new and I suspect that this never worked as expected. For 8.1 we can see that the backup actuator was available even when it was [supposed to be disabled](https://github.com/camunda/zeebe/blob/clients/go/v8.1.0/dist/src/main/resources/application.properties#L30) by default: 
```shell
$ docker run --rm -p 9600:9600 camunda/zeebe:8.1.0
$ curl localhost:9600/actuator | jq '._links."backups-id"'
{
  "href": "http://localhost:9600/actuator/backups/{id}",
  "templated": true
}
```

Similar for the partitions endpoint on 1.3 which was supposed to be enabled by default but should be disabled when setting `MANAGEMENT_ENDPOINTS_PARTITIONS_ENABLED=false`:

```shell
$ docker run --rm -p 9600:9600 -e MANAGEMENT_ENDPOINTS_PARTITIONS_ENABLED=false camunda/zeebe:1.3.0
$ curl localhost:9600/actuator | jq '._links.partitions'
{
  "href": "http://localhost:9600/actuator/partitions",
  "templated": false
}
```

Here we can see that this endpoint exists anyway.


I can't find any references to this but I suspect that the enable flags only work for built-in actuators. We can still control which actuators are available by configuring `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE` which actually does work as expected.
