### PR TITLE
feature(client/JsonMapper):enhancement for JsonMapper to parse more c…

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/JsonMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/JsonMapper.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client.api;
 
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -64,6 +65,8 @@ public interface JsonMapper {
    *     serialization/deserialization error
    */
   <T> T fromJson(final String json, final Class<T> typeClass);
+
+  <T> T fromJson(final String json, final Type type);
 
   /**
    * Deserializes a JSON string into a string to object map.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
@@ -18,12 +18,14 @@ package io.camunda.zeebe.client.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.InternalClientException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 public final class ZeebeObjectMapper implements JsonMapper {
@@ -40,7 +42,7 @@ public final class ZeebeObjectMapper implements JsonMapper {
     this(new ObjectMapper());
   }
 
-  public ZeebeObjectMapper(ObjectMapper objectMapper) {
+  public ZeebeObjectMapper(final ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
     this.objectMapper
         .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
@@ -54,6 +56,18 @@ public final class ZeebeObjectMapper implements JsonMapper {
     } catch (final IOException e) {
       throw new InternalClientException(
           String.format("Failed to deserialize json '%s' to class '%s'", json, typeClass), e);
+    }
+  }
+
+  @Override
+  public <T> T fromJson(final String json,final Type type){
+
+    final JavaType objJavaType = objectMapper.constructType(type);
+    try {
+      return objectMapper.readValue(json, objJavaType);
+    } catch (final IOException e) {
+      throw new InternalClientException(
+          String.format("Failed to deserialize json '%s' to class '%s'", json, objJavaType), e);
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.client.impl.response.ActivatedJobImpl;
 import io.camunda.zeebe.client.util.ClientTest;


### PR DESCRIPTION
…omplicated json

There is a issue happend in camunda-community-hub/spring-zeebe repository that the jackson incorrectly parse the variables to a wrong type. The url:https://github.com/camunda-community-hub/spring-zeebe/issues/327
And the current objectMapper cannot support comlicated json parse.

Maybe can overload fromJson function to support to input the JavaType instead of only the Class.

When it comes to parse complicated json string, we first choose the TypeReference.But according to my current knowledge, it is hard to dynamicly parse the json in some case that users define what type of variables they want to get in spring or spring boot, by TypeReference. For JavaType, we can grab the workers' variables' parameterizedType by using AOP or java reflect , convert them to JavaType and finally parse json to the correct object.

<!-- Please explain the changes you made here. -->

<!-- Which issues are closed by this PR or are related -->

closes #12183 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [√ ] I've reviewed my own code
* [√ ] I've written a clear changelist description
* [√ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ √] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [√ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
