### PR TITLE
deps(maven): update to identity 8.2.0-rc1 release

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -59,7 +59,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpcomponents>4.4.16</version.httpcomponents>
-    <version.identity>8.2.0-alpha5</version.identity>
+    <version.identity>8.2.0-rc1</version.identity>
     <version.jackson>2.14.2</version.jackson>
     <version.java-grpc-prometheus>0.6.0</version.java-grpc-prometheus>
     <version.jna>5.13.0</version.jna>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -422,8 +422,7 @@
           <systemProperties>
             <property>
               <name>identity.docker.image.version</name>
-              <!-- Can be set to ${version.identity} after 8.2.0. -->
-              <value>SNAPSHOT</value>
+              <value>${version.identity}</value>
             </property>
           </systemProperties>
         </configuration>


### PR DESCRIPTION
## Description
With the release available make use of the same version of the docker image for testing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #12000 