### PR TITLE
fix(backup/gcs): listing backups when no `basePath` is set

### DIFF
--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -21,18 +21,6 @@
 
   <name>Zeebe Backup Store for GCS</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>26.11.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -28,14 +28,14 @@ final class FileSetManager {
    *
    * <ul>
    *   <li>{@code basePath}
-   *   <li>"contents
+   *   <li>{@code "contents"}
    *   <li>{@code partitionId}
    *   <li>{@code checkpointId}
    *   <li>{@code nodeId}
    *   <li>{@code fileSetName}
    * </ul>
    */
-  private static final String PATH_FORMAT = "%s/contents/%s/%s/%s/%s/";
+  private static final String PATH_FORMAT = "%scontents/%s/%s/%s/%s/";
 
   private final Storage client;
   private final BucketInfo bucketInfo;

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -27,16 +27,20 @@ public record GcsBackupConfig(String bucketName, String basePath, GcsConnectionC
   }
 
   private static String sanitizeBasePath(final String basePath) {
-    if (basePath == null || basePath.isBlank()) {
+    if (basePath == null) {
+      return null;
+    }
+
+    var sanitized = basePath.trim();
+    if (sanitized.isEmpty() || sanitized.equals("/")) {
       return null;
     }
 
     // Remove one leading and one trailing slash if present.
-    String sanitized = basePath;
-    if (basePath.startsWith("/")) {
-      sanitized = basePath.substring(1);
+    while (sanitized.startsWith("/")) {
+      sanitized = sanitized.substring(1);
     }
-    if (basePath.endsWith("/")) {
+    while (sanitized.endsWith("/")) {
       sanitized = sanitized.substring(0, sanitized.length() - 1);
     }
 

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -48,7 +48,7 @@ public final class GcsBackupStore implements BackupStore {
 
   public GcsBackupStore(final GcsBackupConfig config, final Storage client) {
     final var bucketInfo = BucketInfo.of(config.bucketName());
-    final var basePath = Optional.ofNullable(config.basePath()).orElse("");
+    final var basePath = Optional.ofNullable(config.basePath()).map(s -> s + "/").orElse("");
     this.client = client;
     executor = Executors.newWorkStealingPool(4);
     manifestManager = new ManifestManager(client, bucketInfo, basePath);

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -60,7 +60,7 @@ public final class ManifestManager {
    *   <li>{@code "manifests"}
    * </ul>
    */
-  private static final String MANIFESTS_ROOT_PATH_FORMAT = "%s/manifests/";
+  private static final String MANIFESTS_ROOT_PATH_FORMAT = "%smanifests/";
   /**
    * The path format consists of the following elements:
    *

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigTest.java
@@ -41,6 +41,20 @@ final class ConfigTest {
   }
 
   @Test
+  void shouldAcceptSingleSlashAsBasePath() {
+    // given
+    final var bucketName = "test";
+    final var basePath = "/";
+
+    // when
+    final var config =
+        new GcsBackupConfig.Builder().withBucketName(bucketName).withBasePath(basePath).build();
+
+    // then
+    Assertions.assertThat(config.basePath()).isNull();
+  }
+
+  @Test
   void shouldRemoveLeadingSlashesFromBasePath() {
     // given
     final var bucketName = "test";

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,6 +119,7 @@
     <version.jnr-posix>3.1.16</version.jnr-posix>
     <version.zpt>8.1.9</version.zpt>
     <version.feign>12.2</version.feign>
+    <version.google-sdk>26.11.0</version.google-sdk>
     <version.awssdk>2.20.38</version.awssdk>
     <version.toxiproxy>2.1.7</version.toxiproxy>
     <version.validation-api>3.0.2</version.validation-api>
@@ -988,6 +989,14 @@
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
         <version>${version.jnr-posix}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>${version.google-sdk}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -411,6 +411,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-gcs</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsBackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsBackupAcceptanceIT.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.PartitionBackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.StateCode;
 import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeNode;
 import io.zeebe.containers.ZeebePort;
@@ -80,12 +79,7 @@ final class GcsBackupAcceptanceIT {
   final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(cluster::getNodes);
 
   @Container
-  private final ContainerEngine engine =
-      ContainerEngine.builder()
-          .withDebugReceiverPort(SocketUtil.getNextAddress().getPort())
-          .withAutoAcknowledge(true)
-          .withCluster(cluster)
-          .build();
+  private final ContainerEngine engine = ContainerEngine.builder().withCluster(cluster).build();
 
   @AfterAll
   static void afterAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsRestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsRestoreAcceptanceIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import com.google.cloud.storage.BucketInfo;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.qa.util.testcontainers.GcsContainer;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
+import io.camunda.zeebe.shared.management.openapi.models.StateCode;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
+import io.zeebe.containers.ZeebeContainer;
+import java.time.Duration;
+import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+final class GcsRestoreAcceptanceIT {
+
+  private static final Network NETWORK = Network.newNetwork();
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  private static final long BACKUP_ID = 1;
+
+  @Container private static final GcsContainer GCS = new GcsContainer(NETWORK, "gcs.local");
+
+  @Container
+  private final ZeebeContainer zeebe =
+      new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+          .withNetwork(NETWORK)
+          .dependsOn(GCS)
+          .withoutTopologyCheck()
+          .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "GCS")
+          .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_BUCKETNAME", BUCKET_NAME)
+          .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_AUTH", "none")
+          .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_HOST", GCS.internalEndpoint());
+
+  // No `@Container` annotation because we want to start this on demand
+  @SuppressWarnings("resource")
+  private final GenericContainer<?> restore =
+      new GenericContainer<>(ZeebeTestContainerDefaults.defaultTestImage())
+          .withNetwork(NETWORK)
+          .dependsOn(GCS)
+          .withStartupCheckStrategy(
+              new OneShotStartupCheckStrategy().withTimeout(Duration.ofMinutes(1)))
+          .withEnv("ZEEBE_RESTORE", "true")
+          .withEnv("ZEEBE_RESTORE_FROM_BACKUP_ID", Long.toString(BACKUP_ID))
+          .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "GCS")
+          .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_BUCKETNAME", BUCKET_NAME)
+          .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_AUTH", "none")
+          .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_HOST", GCS.internalEndpoint());
+
+  @RegisterExtension
+  @SuppressWarnings("unused")
+  final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(() -> Map.of("restore", restore));
+
+  @BeforeAll
+  static void setupBucket() throws Exception {
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withoutAuthentication()
+            .withHost(GCS.externalEndpoint())
+            .withBucketName(BUCKET_NAME)
+            .build();
+
+    try (final var client = GcsBackupStore.buildClient(config)) {
+      client.create(BucketInfo.of(BUCKET_NAME));
+    }
+  }
+
+  @Test
+  void shouldRunRestore() {
+    // given
+    final var actuator = BackupActuator.of(zeebe);
+    try (final var client =
+        ZeebeClient.newClientBuilder()
+            .gatewayAddress(zeebe.getExternalGatewayAddress())
+            .usePlaintext()
+            .build()) {
+      client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+    }
+    final var response = actuator.take(BACKUP_ID);
+    assertThat(response).isInstanceOf(TakeBackupResponse.class);
+    Awaitility.await("until a backup exists with the given ID")
+        .atMost(Duration.ofSeconds(3000))
+        .ignoreExceptions() // 404 NOT_FOUND throws exception
+        .untilAsserted(
+            () -> {
+              final var status = actuator.status(BACKUP_ID);
+              assertThat(status)
+                  .extracting(BackupInfo::getBackupId, BackupInfo::getState)
+                  .containsExactly(1L, StateCode.COMPLETED);
+            });
+
+    // then
+    assertThatNoException().isThrownBy(restore::start);
+  }
+
+  @Test
+  void shouldFailForNonExistingBackup() {
+    // given
+    final var actuator = BackupActuator.of(zeebe);
+    try (final var client =
+        ZeebeClient.newClientBuilder()
+            .gatewayAddress(zeebe.getExternalGatewayAddress())
+            .usePlaintext()
+            .build()) {
+      client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+    }
+    final var response = actuator.take(BACKUP_ID);
+    assertThat(response).isInstanceOf(TakeBackupResponse.class);
+    Awaitility.await("until a backup exists with the given ID")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions() // 404 NOT_FOUND throws exception
+        .untilAsserted(
+            () -> {
+              final var status = actuator.status(BACKUP_ID);
+              assertThat(status)
+                  .extracting(BackupInfo::getBackupId, BackupInfo::getState)
+                  .containsExactly(1L, StateCode.COMPLETED);
+            });
+
+    // then -- restore container exits with an error code
+    // we can't check the exit code directly, but we can observe that testcontainers was unable
+    // to start the container.
+    assertThatExceptionOfType(ContainerLaunchException.class)
+        .isThrownBy(
+            () ->
+                restore
+                    .withStartupAttempts(1)
+                    .withEnv("ZEEBE_RESTORE_FROM_BACKUP_ID", "1234")
+                    .withStartupCheckStrategy(
+                        new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(10)))
+                    .start());
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import feign.FeignException;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
+import io.camunda.zeebe.shared.management.openapi.models.PartitionBackupInfo;
+import io.camunda.zeebe.shared.management.openapi.models.StateCode;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.zeebe.containers.ZeebeBrokerNode;
+import io.zeebe.containers.ZeebeNode;
+import io.zeebe.containers.ZeebePort;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import io.zeebe.containers.engine.ContainerEngine;
+import java.time.Duration;
+import org.agrona.CloseHelper;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.groups.Tuple;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Acceptance tests for the backup management API. Tests here should interact with the backups
+ * primarily via the management API, and occasionally assert results on the configured backup store.
+ *
+ * <p>The tests run against a cluster of 2 brokers and 1 gateway, no embedded gateways, two
+ * partitions and replication factor of 1. This allows us to test that requests are correctly fanned
+ * out across the gateway, since each broker is guaranteed to be leader of a partition.
+ *
+ * <p>NOTE: this does not test the consistency of backups, nor that partition leaders correctly
+ * maintain consistency via checkpoint records. Other test suites should be set up for this.
+ */
+@Testcontainers
+final class S3BackupAcceptanceIT {
+  private static final Network NETWORK = Network.newNetwork();
+
+  private final String bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @Container
+  private final MinioContainer minio =
+      new MinioContainer().withNetwork(NETWORK).withDomain("minio.local", bucketName);
+
+  private final ZeebeCluster cluster =
+      ZeebeCluster.builder()
+          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+          .withNetwork(NETWORK)
+          .withBrokersCount(2)
+          .withGatewaysCount(1)
+          .withReplicationFactor(1)
+          .withPartitionsCount(2)
+          .withEmbeddedGateway(false)
+          .withBrokerConfig(this::configureBroker)
+          .withNodeConfig(this::configureNode)
+          .build();
+
+  @RegisterExtension
+  @SuppressWarnings("unused")
+  final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(cluster::getNodes);
+
+  @Container
+  private final ContainerEngine engine =
+      ContainerEngine.builder()
+          .withDebugReceiverPort(SocketUtil.getNextAddress().getPort())
+          .withAutoAcknowledge(true)
+          .withCluster(cluster)
+          .build();
+
+  private S3BackupStore store;
+
+  @AfterAll
+  static void afterAll() {
+    CloseHelper.quietCloseAll(NETWORK);
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    final var config =
+        new Builder()
+            .withBucketName(bucketName)
+            .withEndpoint(minio.externalEndpoint())
+            .withRegion(minio.region())
+            .withCredentials(minio.accessKey(), minio.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(25))
+            .forcePathStyleAccess(true)
+            .build();
+    store = new S3BackupStore(config);
+
+    try (final var client = S3BackupStore.buildClient(config)) {
+      client.createBucket(builder -> builder.bucket(config.bucketName()).build()).join();
+    }
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(() -> store.closeAsync().join());
+  }
+
+  @Test
+  void shouldTakeBackup() {
+    // given
+    final var actuator = BackupActuator.of(cluster.getAvailableGateway());
+    try (final var client = engine.createClient()) {
+      client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+    }
+
+    // when
+    final var response = actuator.take(1);
+
+    // then
+    assertThat(response).isInstanceOf(TakeBackupResponse.class);
+    waitUntilBackupIsCompleted(actuator, 1L);
+  }
+
+  private static void waitUntilBackupIsCompleted(
+      final BackupActuator actuator, final long backupId) {
+    Awaitility.await("until a backup exists with the id %d".formatted(backupId))
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions() // 404 NOT_FOUND throws exception
+        .untilAsserted(
+            () -> {
+              final var status = actuator.status(backupId);
+              assertThat(status)
+                  .extracting(BackupInfo::getBackupId, BackupInfo::getState)
+                  .containsExactly(backupId, StateCode.COMPLETED);
+              assertThat(status.getDetails())
+                  .flatExtracting(PartitionBackupInfo::getPartitionId)
+                  .containsExactlyInAnyOrder(1, 2);
+            });
+  }
+
+  @Test
+  void shouldListBackups() {
+    // given
+    final var actuator = BackupActuator.of(cluster.getAvailableGateway());
+    try (final var client = engine.createClient()) {
+      client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+    }
+
+    // when
+    actuator.take(1);
+    actuator.take(2);
+
+    waitUntilBackupIsCompleted(actuator, 1L);
+    waitUntilBackupIsCompleted(actuator, 2L);
+
+    // then
+    final var status = actuator.list();
+    assertThat(status)
+        .hasSize(2)
+        .extracting(BackupInfo::getBackupId, BackupInfo::getState)
+        .containsExactly(
+            Tuple.tuple(1L, StateCode.COMPLETED), Tuple.tuple(2L, StateCode.COMPLETED));
+  }
+
+  @Test
+  void shouldDeleteBackup() {
+    // given
+    final var actuator = BackupActuator.of(cluster.getAvailableGateway());
+    final long backupId = 1;
+    actuator.take(backupId);
+    waitUntilBackupIsCompleted(actuator, backupId);
+
+    // when
+    actuator.delete(backupId);
+
+    // then
+    Awaitility.await("Backup is deleted")
+        .timeout(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(() -> actuator.status(backupId))
+                    .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
+                    .extracting(FeignException::status)
+                    .isEqualTo(404));
+  }
+
+  private void configureBroker(final ZeebeBrokerNode<?> broker) {
+    broker
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "S3")
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME", bucketName)
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ENDPOINT", minio.internalEndpoint())
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_REGION", minio.region())
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ACCESSKEY", minio.accessKey())
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_SECRETKEY", minio.secretKey())
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS", "true");
+  }
+
+  private void configureNode(final ZeebeNode<?> node) {
+    node.withEnv("MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE", "*").dependsOn(minio);
+    node.addExposedPort(ZeebePort.MONITORING.getPort());
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3RestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3RestoreAcceptanceIT.java
@@ -37,7 +37,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-final class RestoreAcceptanceIT {
+final class S3RestoreAcceptanceIT {
   private static final Network NETWORK = Network.newNetwork();
   private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/GcsContainer.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/GcsContainer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.testcontainers;
+
+import java.util.List;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+public final class GcsContainer extends GenericContainer<GcsContainer> {
+  private static final DockerImageName IMAGE = DockerImageName.parse("fsouza/fake-gcs-server");
+  private static final String IMAGE_TAG = "1";
+  private static final int PORT = 4443;
+  private final String domain;
+
+  public GcsContainer(final Network network, final String domain) {
+    super(IMAGE.withTag(IMAGE_TAG));
+    this.domain = domain;
+    setCommand("-scheme", "http", "-external-url", internalEndpoint());
+    setExposedPorts(List.of(PORT));
+    setNetworkAliases(List.of(domain));
+    setNetwork(network);
+  }
+
+  public String internalEndpoint() {
+    return "http://" + domain + ":" + PORT;
+  }
+
+  public String externalEndpoint() {
+    return "http://%s:%d".formatted(getHost(), getMappedPort(PORT));
+  }
+}


### PR DESCRIPTION
This fixes one bug where not setting a `basePath` would result in bad list requests so that backups could not be found.

Additionally, this adds more integration tests. All backup store tests from the testkit are now also run when no `basePath` is configured and the backup/restore acceptance tests are duplicated to also run on GCS.