### PR TITLE
[Backport release-8.2.0] deps(maven): update to identity 8.2.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -59,7 +59,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpcomponents>4.4.16</version.httpcomponents>
-    <version.identity>8.2.0-rc1</version.identity>
+    <version.identity>8.2.0</version.identity>
     <version.jackson>2.14.2</version.jackson>
     <version.java-grpc-prometheus>0.6.0</version.java-grpc-prometheus>
     <version.jna>5.13.0</version.jna>


### PR DESCRIPTION
# Description
Backport of #12233 to `release-8.2.0`.

relates to camunda/zeebe#12000