### PR TITLE
[Backport stable/8.2] Omit RocksDB musl check from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_STANDALONE_GATEWAY=false \
     ZEEBE_RESTORE=false
 ENV PATH "${ZB_HOME}/bin:${PATH}"
+# Disable RocksDB runtime check for musl, which launches `ldd` as a shell process
+# We know there's no need to check for musl on this image
+ENV ROCKSDB_MUSL_LIBC=false
 
 WORKDIR ${ZB_HOME}
 EXPOSE 26500 26501 26502


### PR DESCRIPTION
# Description
Backport of #12256 to `stable/8.2`.

relates to 