### PR TITLE
[Backport stable/8.1] deps(maven): bump testcontainers-bom from 1.17.6 to 1.18.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             maven-build-threads: 1
             maven-test-fork-count: 10
             tcc-enabled: 'true'
-            tcc-concurrency: 2
+            tcc-concurrency: 3
           - group: qa-update
             name: "QA Update Tests"
             maven-modules: "qa/update-tests"

--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -134,30 +134,10 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <ignoredUnusedDeclaredDependencies>
-            <dep>com.amazonaws:aws-java-sdk-core</dep>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -942,24 +942,6 @@
         <scope>import</scope>
       </dependency>
 
-      <!--
-        Sad workaround for https://github.com/testcontainers/testcontainers-java/issues/4279; when
-        this is not needed and removed, make sure to remove it from child modules including this as
-        well
-      -->
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-core</artifactId>
-        <version>1.12.450</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
       <!-- Dependencies present for convergence only -->
       <!-- between log4j2 and commons-compress (from testcontainers) -->
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,7 +82,7 @@
     <version.wiremock>2.34.0</version.wiremock>
     <version.conscrypt>2.5.2</version.conscrypt>
     <version.asm>9.3</version.asm>
-    <version.testcontainers>1.17.6</version.testcontainers>
+    <version.testcontainers>1.18.0</version.testcontainers>
     <version.netflix.concurrency>0.3.9</version.netflix.concurrency>
     <version.zeebe-test-container>3.5.1</version.zeebe-test-container>
     <version.feel-scala>1.15.3</version.feel-scala>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,7 @@
     <version.commons-codec>1.15</version.commons-codec>
     <version.commons-text>1.10.0</version.commons-text>
     <version.cron-utils>9.2.1</version.cron-utils>
-    <version.docker-java-api>3.2.13</version.docker-java-api>
+    <version.docker-java-api>3.3.0</version.docker-java-api>
     <version.elasticsearch>7.17.5</version.elasticsearch>
     <version.error-prone>2.15.0</version.error-prone>
     <version.grpc>1.49.2</version.grpc>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -258,12 +258,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-asserts</artifactId>
       <scope>test</scope>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -60,16 +60,6 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <ignoredUnusedDeclaredDependencies>
-            <dep>com.amazonaws:aws-java-sdk-core</dep>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Backport of #12251 to get rid of the AWS SDK v1