### PR TITLE
[Backport stable/8.2] deps(maven): bump testcontainers-bom from 1.17.6 to 1.18.0

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -145,12 +145,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -170,7 +164,6 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
-            <dep>com.amazonaws:aws-java-sdk-core</dep>
             <dep>com.github.luben:zstd-jni</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1007,24 +1007,6 @@
         <scope>import</scope>
       </dependency>
 
-      <!--
-        Sad workaround for https://github.com/testcontainers/testcontainers-java/issues/4279; when
-        this is not needed and removed, make sure to remove it from child modules including this as
-        well
-      -->
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-core</artifactId>
-        <version>1.12.446</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
       <!-- Dependencies present for convergence only -->
       <!-- between duct-tape (from testcontainers) and kotlin-stdlib (from identity-sdk) -->
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,7 +88,7 @@
     <version.wiremock>2.35.0</version.wiremock>
     <version.conscrypt>2.5.2</version.conscrypt>
     <version.asm>9.3</version.asm>
-    <version.testcontainers>1.17.6</version.testcontainers>
+    <version.testcontainers>1.18.0</version.testcontainers>
     <version.netflix.concurrency>0.4.0</version.netflix.concurrency>
     <version.zeebe-test-container>3.5.2</version.zeebe-test-container>
     <version.feel-scala>1.16.0</version.feel-scala>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -264,12 +264,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-asserts</artifactId>
       <scope>test</scope>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -66,16 +66,6 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <ignoredUnusedDeclaredDependencies>
-            <dep>com.amazonaws:aws-java-sdk-core</dep>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Backport of https://github.com/camunda/zeebe/pull/12251 to get rid of the AWS SDK v1