### PR TITLE
fix(cluster): do no use channel created for a different address

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -117,10 +117,7 @@ class ChannelPool {
                           closed -> {
                             synchronized (channelPool) {
                               // Remove channel from the pool after it is closed.
-                              final var currentFuture = channelPool.get(offset);
-                              if (finalFuture == currentFuture) {
-                                channelPool.set(offset, null);
-                              }
+                              removeChannel(channelPool, offset, finalFuture);
                             }
                           });
                 } else {
@@ -171,6 +168,17 @@ class ChannelPool {
           }
         });
     return future;
+  }
+
+  private static void removeChannel(
+      final List<CompletableFuture<Channel>> channelPool,
+      final int offset,
+      final CompletableFuture<Channel> finalFuture) {
+    final var currentFuture = channelPool.get(offset);
+    // check if new channel is already replaced before removing it.
+    if (finalFuture == currentFuture) {
+      channelPool.set(offset, null);
+    }
   }
 
   private void completeFuture(

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/ChannelPoolTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/ChannelPoolTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.utils.net.Address;
+import io.netty.channel.Channel;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class ChannelPoolTest {
+  private static final String MESSAGE_TYPE = "test";
+  private final Function<Address, CompletableFuture<Channel>> factory =
+      a -> {
+        final var channel = mock(Channel.class);
+        when(channel.isActive()).thenReturn(true);
+        return CompletableFuture.completedFuture(channel);
+      };
+  private final ChannelPool channelPool = new ChannelPool(factory, 8);
+
+  @Test
+  void shouldNotUseOldChannelWhenIPChanged() throws UnknownHostException {
+    // given
+    final Address addressWithOldIP =
+        new Address("foo.bar", 1234, InetAddress.getByName("10.1.1.1"));
+    final var channelForOldIP = channelPool.getChannel(addressWithOldIP, MESSAGE_TYPE).join();
+
+    // when
+    final Address addressWithNewIP =
+        new Address("foo.bar", 1234, InetAddress.getByName("10.1.1.2"));
+    final var channelForNewIP = channelPool.getChannel(addressWithNewIP, "test").join();
+
+    // then
+    assertThat(channelForOldIP).isNotEqualTo(channelForNewIP);
+  }
+
+  @Test
+  void shouldNotUseIncorrectChannelWhenIPReused() throws UnknownHostException {
+    // given
+    final Address nodeWithSameIP = new Address("foo.bar", 1234, InetAddress.getByName("10.1.1.1"));
+    final var channelForOldNode = channelPool.getChannel(nodeWithSameIP, MESSAGE_TYPE).join();
+
+    // when
+    final Address newNodeWithSameIP =
+        new Address("foo.foo", 1234, InetAddress.getByName("10.1.1.1"));
+    final var channelForNewNode = channelPool.getChannel(newNodeWithSameIP, MESSAGE_TYPE).join();
+
+    // then
+    assertThat(channelForOldNode).isNotEqualTo(channelForNewNode);
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -640,11 +640,11 @@ public class NettyMessagingServiceTest {
         .withMessageContaining("timed out in");
 
     // when
+    verify(channelRef.get(), timeout(1000).atLeast(1)).close();
     nettyWithOwnPool.sendAndReceive(address2, subject, "fail".getBytes());
 
     // then
     // closing causes an CloseException which causes another close
-    verify(channelRef.get(), timeout(1000).atLeast(1)).close();
     Awaitility.await("channels should be recreated").until(channelsOpen::get, c -> c == 2);
   }
 


### PR DESCRIPTION
## Description

When only using IP to find a channel pool, we observed that a channel pool created for a node is re-used by another node which got its old ip. This could lead to unexpected situations, where messages are sent to wrong node.

To fix this, we now use both address and ip to find a channel pool. In a setup where restarts and ip re-assignment is common, it is safer this way.

## Related issues

closes #12173 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
