### PR TITLE
fix(engine): skip unnecessary blacklist check

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -23,6 +23,8 @@ import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
@@ -130,9 +132,13 @@ public class Engine implements RecordProcessor {
         return processingResultBuilder.build();
       }
 
-      final boolean isNotOnBlacklist =
-          !processingState.getBlackListState().isOnBlacklist(typedCommand);
-      if (isNotOnBlacklist) {
+      // There is no blacklist check needed if the intent is not instance related
+      // nor if the intent is to create new instances, which can't be blacklisted yet
+      final boolean noBlacklistCheckNeeded =
+          !(record.getIntent() instanceof ProcessInstanceRelatedIntent)
+              || record.getIntent() instanceof ProcessInstanceCreationIntent;
+      if (noBlacklistCheckNeeded
+          || !processingState.getBlackListState().isOnBlacklist(typedCommand)) {
         currentProcessor.processRecord(record);
       }
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -116,6 +116,7 @@ public class ProcessingDbState implements MutableProcessingState {
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     messageSubscriptionState.onRecovered(context);
     processMessageSubscriptionState.onRecovered(context);
+    blackListState.onRecovered(context);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BlackListState.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
-public interface BlackListState {
+public interface BlackListState extends StreamProcessorLifecycleAware {
 
   boolean isOnBlacklist(final TypedRecord record);
+
+  boolean isEmpty();
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
@@ -134,6 +134,28 @@ public final class BlackListStateTest {
     assertThat(blackListState.isOnBlacklist(differentProcessInstanceRecord)).isFalse();
   }
 
+  @Test
+  public void blacklistIsEmptyIsTrueIfNothingIsBlacklisted() {
+    // given
+
+    // when
+    final boolean blackListIsEmpty = blackListState.isEmpty();
+
+    // then
+    assertThat(blackListIsEmpty).isTrue();
+  }
+
+  @Test
+  public void blacklistIsEmptyIsFalseIfSomethingGotBlacklisted() {
+    // given
+
+    // when
+    blackListState.blacklistProcessInstance(1001);
+
+    // then
+    assertThat(blackListState.isEmpty()).isFalse();
+  }
+
   private TypedRecordImpl createRecord() {
     return createRecord(1000L);
   }


### PR DESCRIPTION
## Description

Covers these criteria from #12041:
- Cache whether there are blacklisted process instances so that Zeebe avoids the lookup in RocksDB if not
- when creating a new process instance, the check is unnecessary.

## Follow-up:

- [x]  @Zelldon MessageSubscriptionIntent sets all types to shouldBlacklist=true, create  abug, blacklisting may happen on other partition, while subscription will never complete -> https://github.com/camunda/zeebe/issues/12316

## Related issues

relates to #12041

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
