### PR TITLE
Fix handling of closed streams and restarted servers

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
@@ -23,6 +23,8 @@ final class ClientStream<M extends BufferWriter> {
   private final ClientStreamConsumer streamConsumer;
   private final Set<MemberId> liveConnections = new HashSet<>();
 
+  private State state;
+
   ClientStream(
       final UUID streamId,
       final DirectBuffer streamType,
@@ -32,6 +34,7 @@ final class ClientStream<M extends BufferWriter> {
     this.streamType = streamType;
     this.metadata = metadata;
     streamConsumer = clientStreamConsumer;
+    state = State.OPEN;
   }
 
   UUID getStreamId() {
@@ -78,5 +81,18 @@ final class ClientStream<M extends BufferWriter> {
    */
   void remove(final MemberId serverId) {
     liveConnections.remove(serverId);
+  }
+
+  void close() {
+    state = State.CLOSED;
+  }
+
+  boolean isClosed() {
+    return state == State.CLOSED;
+  }
+
+  private enum State {
+    OPEN,
+    CLOSED
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -60,7 +60,11 @@ final class ClientStreamManager<M extends BufferWriter> {
 
   void remove(final UUID streamId) {
     final var clientStream = registry.remove(streamId);
-    clientStream.ifPresent(stream -> requestManager.removeStream(stream, servers));
+    clientStream.ifPresent(
+        stream -> {
+          stream.close();
+          requestManager.removeStream(stream, servers);
+        });
   }
 
   void removeAll() {

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -43,6 +43,11 @@ final class ClientStreamManager<M extends BufferWriter> {
     registry.list().forEach(c -> requestManager.openStream(c, Collections.singleton(serverId)));
   }
 
+  void onServerRemoved(final MemberId serverId) {
+    servers.remove(serverId);
+    registry.list().forEach(clientStream -> clientStream.remove(serverId));
+  }
+
   UUID add(
       final DirectBuffer streamType,
       final M metadata,

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -51,7 +51,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
   private void doAdd(
       final AddStreamRequest request, final MemberId brokerId, final ClientStream<M> clientStream) {
-    if (clientStream.isConnected(brokerId)) {
+    if (clientStream.isConnected(brokerId) || clientStream.isClosed()) {
       return;
     }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamService.java
@@ -79,4 +79,8 @@ public class ClientStreamService<M extends BufferWriter> extends Actor
   public void onServerJoined(final MemberId memberId) {
     actor.run(() -> clientStreamManager.onServerJoined(memberId));
   }
+
+  public void onServerRemoved(final MemberId memberId) {
+    actor.run(() -> clientStreamManager.onServerRemoved(memberId));
+  }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -145,4 +145,20 @@ class ClientStreamManagerTest {
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(NoSuchStreamException.class);
   }
+
+  @Test
+  void shouldRemoveServerFromClientStream() {
+    // given
+    final MemberId server = MemberId.from("1");
+    clientStreamManager.onServerJoined(server);
+    final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
+    final var clientStream = registry.get(uuid).orElseThrow();
+    assertThat(clientStream.isConnected(server)).isTrue();
+
+    // when
+    clientStreamManager.onServerRemoved(server);
+
+    // then
+    assertThat(clientStream.isConnected(server)).isFalse();
+  }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -97,6 +98,20 @@ class ClientStreamRequestManagerTest {
         .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(server), any());
 
     assertThat(clientStream.isConnected(server)).isTrue();
+  }
+
+  @Test
+  void shouldNotSendAddRequestIfStreamIsClosed() {
+    // given
+    clientStream.close();
+
+    // when
+    final MemberId server = MemberId.from("1");
+    requestManager.openStream(clientStream, Set.of(server));
+
+    // then
+    verify(mockTransport, never())
+        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(server), any());
   }
 
   @Test

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -83,6 +83,23 @@ class ClientStreamRequestManagerTest {
   }
 
   @Test
+  void shouldSendAddRequestAgainAfterAServerIsReAdded() {
+    // given
+    final MemberId server = MemberId.from("1");
+    requestManager.openStream(clientStream, Set.of(server));
+
+    // when
+    clientStream.remove(server);
+    requestManager.openStream(clientStream, Set.of(server));
+
+    // then
+    verify(mockTransport, times(2))
+        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(server), any());
+
+    assertThat(clientStream.isConnected(server)).isTrue();
+  }
+
+  @Test
   void shouldSendRemoveRequestToAllServers() {
     // given
     final MemberId server1 = MemberId.from("1");


### PR DESCRIPTION
## Description

This PR fixes some edge cases that were no considered as part of  #12116 :

- Do not sent AddRequest for closed stream. It is possible that the client stream is closed, while AddRequest is being retried. In this case it is possible for the server to receive add request after remove request. To prevent this, we now mark a clientstream as closed and it is checked before retrying add request.
- Remove server from client stream when a server is removed. Previously, ClientStreamManager only acted on server joined. But request manager check if the server is already added before sending an add request. This is problematic, as we never removed server. So a restart server would never get an add request. To fix this, now ClientStreamManager removes server from all open streams.

## Related issues

closes #11713

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
