### PR TITLE
[Backport stable/8.1] Cut TCC provisioning by half

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 45
     env:
       TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
-      TC_CLOUD_CONCURRENCY: 4
+      TC_CLOUD_CONCURRENCY: 2
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
       registry:
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 45
     env:
       TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
-      TC_CLOUD_CONCURRENCY: 4
+      TC_CLOUD_CONCURRENCY: 2
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
       registry:


### PR DESCRIPTION
# Description
Backport of #12304 to `stable/8.1`.

relates to 