### PR TITLE
JobStreamer API is available to engine processors

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -97,6 +97,7 @@ public final class EngineProcessors {
             subscriptionCommandSender,
             partitionsCount,
             timerChecker,
+            jobStreamer,
             jobMetrics,
             decisionBehavior);
 
@@ -159,6 +160,7 @@ public final class EngineProcessors {
       final SubscriptionCommandSender subscriptionCommandSender,
       final int partitionsCount,
       final DueDateTimerChecker timerChecker,
+      final JobStreamer jobStreamer,
       final JobMetrics jobMetrics,
       final DecisionBehavior decisionBehavior) {
     return new BpmnBehaviorsImpl(
@@ -168,7 +170,8 @@ public final class EngineProcessors {
         decisionBehavior,
         subscriptionCommandSender,
         partitionsCount,
-        timerChecker);
+        timerChecker,
+        jobStreamer);
   }
 
   private static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
@@ -146,7 +147,12 @@ public final class EngineProcessors {
     JobEventProcessors.addJobProcessors(
         typedRecordProcessors, processingState, bpmnBehaviors, writers, jobMetrics);
 
-    addIncidentProcessors(processingState, bpmnStreamProcessor, typedRecordProcessors, writers);
+    addIncidentProcessors(
+        processingState,
+        bpmnStreamProcessor,
+        typedRecordProcessors,
+        writers,
+        bpmnBehaviors.jobActivationBehavior());
     addResourceDeletionProcessors(typedRecordProcessors, writers, processingState);
     addSignalBroadcastProcessors(typedRecordProcessors, bpmnBehaviors, writers, processingState);
     addCommandDistributionProcessors(typedRecordProcessors, writers, processingState);
@@ -237,9 +243,14 @@ public final class EngineProcessors {
       final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
       final TypedRecordProcessors typedRecordProcessors,
-      final Writers writers) {
+      final Writers writers,
+      final BpmnJobActivationBehavior jobActivationBehavior) {
     IncidentEventProcessors.addProcessors(
-        typedRecordProcessors, processingState, bpmnStreamProcessor, writers);
+        typedRecordProcessors,
+        processingState,
+        bpmnStreamProcessor,
+        writers,
+        jobActivationBehavior);
   }
 
   private static void addMessageProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -49,4 +49,6 @@ public interface BpmnBehaviors {
   VariableBehavior variableBehavior();
 
   ElementActivationBehavior elementActivationBehavior();
+
+  BpmnJobActivationBehavior jobActivationBehavior();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -133,6 +133,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             expressionBehavior,
             stateBehavior,
             incidentBehavior,
+            jobActivationBehavior,
             jobMetrics);
 
     multiInstanceOutputCollectionBehavior =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
@@ -41,7 +42,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final EventTriggerBehavior eventTriggerBehavior;
   private final VariableBehavior variableBehavior;
   private final ElementActivationBehavior elementActivationBehavior;
-
+  private final BpmnJobActivationBehavior jobActivationBehavior;
   private final BpmnSignalBehavior signalBehavior;
 
   public BpmnBehaviorsImpl(
@@ -51,7 +52,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final DecisionBehavior decisionBehavior,
       final SubscriptionCommandSender subscriptionCommandSender,
       final int partitionsCount,
-      final DueDateTimerChecker timerChecker) {
+      final DueDateTimerChecker timerChecker,
+      final JobStreamer jobStreamer) {
     expressionBehavior =
         new ExpressionProcessor(
             ExpressionLanguageFactory.createExpressionLanguage(),
@@ -118,6 +120,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             eventTriggerBehavior,
             stateBehavior,
             writers);
+
+    jobActivationBehavior =
+        new BpmnJobActivationBehavior(
+            jobStreamer, processingState.getVariableState(), writers, jobMetrics);
 
     jobBehavior =
         new BpmnJobBehavior(
@@ -230,5 +236,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public ElementActivationBehavior elementActivationBehavior() {
     return elementActivationBehavior;
+  }
+
+  @Override
+  public BpmnJobActivationBehavior jobActivationBehavior() {
+    return jobActivationBehavior;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import io.camunda.zeebe.engine.metrics.JobMetrics;
+import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+
+/**
+ * A behavior class which allows processors to activate a job. Use this anywhere a job should
+ * become activated and processed by a job worker.
+ *
+ * This behavior class will either push a job on a {@link io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream}
+ * or notify job workers that a job of a given type is available for processing. If a <code>JobStream/code>
+ * is available for a job with a given type, the job will be pushed on the <code>JobStream/code>. If
+ * no <code>JobStream/code> is available for the given job type, a notification is used.
+ *
+ * Both the job push and the job worker notification are executed through a {@link io.camunda.zeebe.stream.api.SideEffectProducer}.
+ */
+public class BpmnJobActivationBehavior {
+  private final JobStreamer jobStreamer;
+  private final VariableState variableState;
+  private final StateWriter stateWriter;
+  private final SideEffectWriter sideEffectWriter;
+  private final JobMetrics jobMetrics;
+
+  public BpmnJobActivationBehavior(
+      final JobStreamer jobStreamer,
+      final VariableState variableState,
+      final Writers writers,
+      final JobMetrics jobMetrics) {
+    this.jobStreamer = jobStreamer;
+    this.variableState = variableState;
+    stateWriter = writers.state();
+    sideEffectWriter = writers.sideEffect();
+    this.jobMetrics = jobMetrics;
+  }
+
+  public void publishWork(
+      final JobRecord jobRecord, final long elementInstanceKey, final long activationTimeStamp) {
+    // TODO: add conditional logic for job pushing or notifying
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -60,6 +60,7 @@ public final class BpmnJobBehavior {
   private final BpmnStateBehavior stateBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
   private final JobMetrics jobMetrics;
+  private final BpmnJobActivationBehavior jobActivationBehavior;
 
   public BpmnJobBehavior(
       final KeyGenerator keyGenerator,
@@ -68,6 +69,7 @@ public final class BpmnJobBehavior {
       final ExpressionProcessor expressionBehavior,
       final BpmnStateBehavior stateBehavior,
       final BpmnIncidentBehavior incidentBehavior,
+      final BpmnJobActivationBehavior jobActivationBehavior,
       final JobMetrics jobMetrics) {
     this.keyGenerator = keyGenerator;
     this.jobState = jobState;
@@ -76,6 +78,7 @@ public final class BpmnJobBehavior {
     this.stateBehavior = stateBehavior;
     this.incidentBehavior = incidentBehavior;
     this.jobMetrics = jobMetrics;
+    this.jobActivationBehavior = jobActivationBehavior;
   }
 
   public Either<Failure, ?> createNewJob(
@@ -176,6 +179,8 @@ public final class BpmnJobBehavior {
 
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);
+
+    // TODO: call JobActivationbehavior#publishWork
   }
 
   private DirectBuffer encodeHeaders(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -21,10 +22,12 @@ public final class IncidentEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
-      final Writers writers) {
+      final Writers writers,
+      final BpmnJobActivationBehavior jobActivationBehavior) {
     typedRecordProcessors.onCommand(
         ValueType.INCIDENT,
         IncidentIntent.RESOLVE,
-        new ResolveIncidentProcessor(processingState, bpmnStreamProcessor, writers));
+        new ResolveIncidentProcessor(
+            processingState, bpmnStreamProcessor, writers, jobActivationBehavior));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -53,7 +53,7 @@ public final class JobEventProcessors {
                 processingState.getKeyGenerator(),
                 jobMetrics,
                 jobBackoffChecker,
-                bpmnBehaviors.variableBehavior()))
+                bpmnBehaviors))
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,
@@ -63,13 +63,18 @@ public final class JobEventProcessors {
                 keyGenerator,
                 jobMetrics))
         .onCommand(
-            ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(processingState, jobMetrics))
+            ValueType.JOB,
+            JobIntent.TIME_OUT,
+            new JobTimeOutProcessor(
+                processingState, jobMetrics, bpmnBehaviors.jobActivationBehavior()))
         .onCommand(
             ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(processingState))
         .onCommand(
             ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(processingState, jobMetrics))
         .onCommand(
-            ValueType.JOB, JobIntent.RECUR_AFTER_BACKOFF, new JobRecurProcessor(processingState))
+            ValueType.JOB,
+            JobIntent.RECUR_AFTER_BACKOFF,
+            new JobRecurProcessor(processingState, bpmnBehaviors.jobActivationBehavior()))
         .onCommand(
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
@@ -21,9 +22,13 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
   private static final String NOT_FAILED_JOB_MESSAGE =
       "Expected to back off failed job with key '%d', but %s";
   private final JobState jobState;
+  private final BpmnJobActivationBehavior jobActivationBehavior;
 
-  public JobRecurProcessor(final ProcessingState processingState) {
+  public JobRecurProcessor(
+      final ProcessingState processingState,
+      final BpmnJobActivationBehavior jobActivationBehavior) {
     jobState = processingState.getJobState();
+    this.jobActivationBehavior = jobActivationBehavior;
   }
 
   @Override
@@ -34,6 +39,7 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
 
     if (state == State.FAILED) {
       commandControl.accept(JobIntent.RECURRED_AFTER_BACKOFF, command.getValue());
+      // TODO: call JobActivationbehavior#publishWork
     } else {
       final String textState;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
@@ -22,10 +23,15 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
       "Expected to time out activated job with key '%d', but %s";
   private final JobState jobState;
   private final JobMetrics jobMetrics;
+  private final BpmnJobActivationBehavior jobActivationBehavior;
 
-  public JobTimeOutProcessor(final ProcessingState state, final JobMetrics jobMetrics) {
+  public JobTimeOutProcessor(
+      final ProcessingState state,
+      final JobMetrics jobMetrics,
+      final BpmnJobActivationBehavior jobActivationBehavior) {
     jobState = state.getJobState();
     this.jobMetrics = jobMetrics;
+    this.jobActivationBehavior = jobActivationBehavior;
   }
 
   @Override
@@ -37,6 +43,7 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
     if (state == State.ACTIVATED) {
       commandControl.accept(JobIntent.TIMED_OUT, command.getValue());
       jobMetrics.jobTimedOut(command.getValue().getType());
+      // TODO: call JobActivationbehavior#publishWork
     } else {
       final String textState;
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR provides a behavior class for the new job push feature. The new `BpmnJobActivationBehavior` class wraps around the JobStreamer instance provided by the streaming platform.

Currently, the `BpmnJobActivationBehavior` class only defines the API without providing any logic. This PR also refactors the engine processors code to pass an instance of the new behavior class to all the processors that will rely on it to mutate the job state.

No test coverage has been added since the changes only create and pass an instance of the `BpmnJobActivationBehavior` class without any usage. So there is no change in the behavior of the engine. Behavior changes will be introduces through later issues.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12082 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
