### PR TITLE
Support numbers as error/escalation codes

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ErrorTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ErrorTransformer.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
-import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
-import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableError;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
@@ -38,12 +36,7 @@ public class ErrorTransformer implements ModelElementTransformer<Error> {
 
               error.setErrorCodeExpression(errorCodeExpression);
               if (errorCodeExpression.isStatic()) {
-                final EvaluationResult errorCodeResult =
-                    expressionLanguage.evaluateExpression(errorCodeExpression, variable -> null);
-
-                if (errorCodeResult.getType() == ResultType.STRING) {
-                  error.setErrorCode(BufferUtil.wrapString(errorCodeResult.getString()));
-                }
+                error.setErrorCode(BufferUtil.wrapString(element.getErrorCode()));
               }
 
               context.addError(error);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EscalationTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EscalationTransformer.java
@@ -7,10 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
-import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
-import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEscalation;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
@@ -35,13 +33,7 @@ public class EscalationTransformer implements ModelElementTransformer<Escalation
 
       escalation.setEscalationCodeExpression(escalationCodeExpression);
       if (escalationCodeExpression.isStatic()) {
-        final EvaluationResult escalationCodeResult =
-            expressionLanguage.evaluateExpression(escalationCodeExpression, variable -> null);
-
-        if (escalationCodeResult.getType() == ResultType.STRING) {
-          final String escalationCode = escalationCodeResult.getString();
-          escalation.setEscalationCode(BufferUtil.wrapString(escalationCode));
-        }
+        escalation.setEscalationCode(BufferUtil.wrapString(element.getEscalationCode()));
       }
     }
     context.addEscalation(escalation);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorCatchEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorCatchEventTest.java
@@ -237,6 +237,7 @@ public final class ErrorCatchEventTest {
     final List<Record<VariableRecordValue>> variableRecords =
         RecordingExporter.variableRecords()
             .withProcessInstanceKey(processInstanceKey)
+            .limit(r -> r.getValue().getName().equals("foo"))
             .collect(Collectors.toList());
 
     final List<Record<ProcessInstanceRecordValue>> errorEvents =


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Escalation and Error codes defined as a `number` instead of a `string` were unable to be found when searching for catch events. For error events this breaks backwards-compatibility, as this did work before the 8.2 release.

A full root-cause can be found in [here](https://github.com/camunda/zeebe/issues/12326#issuecomment-1500213883)

This PR makes it so if an error or escalation contain a static expression, we always set the errorCode/escalationCode. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12326 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
