### PR TITLE
Allow disabling flush without specifying a delay

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import java.time.Duration;
-import java.util.Objects;
 
 public final class RaftCfg implements ConfigurationEntry {
   public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = true;
@@ -47,7 +46,7 @@ public final class RaftCfg implements ConfigurationEntry {
   public record FlushConfig(boolean enabled, Duration delayTime) {
     public FlushConfig(final boolean enabled, final Duration delayTime) {
       this.enabled = enabled;
-      this.delayTime = Objects.requireNonNull(delayTime, "must specify a valid delay");
+      this.delayTime = delayTime == null ? Duration.ZERO : delayTime;
     }
   }
 }


### PR DESCRIPTION
## Description

Allow users to configure disabling flush by itself without having to specify a delay. Previously this was not possible because the config is a record, and we enforced that the delay must not be null.

The fix is to provide a default value if the delay time is null, if only to continue allowing the usage of the config without worrying about null values.

Unfortunately it's not possible to use a second constructor to provide a null value, primarily because it would require us annotating it with `@ConstructorBinding`, which is part of the `spring-boot` library, and so we'd have to add a whole dependency just for that. A simple null check is good enough in this case.

## Related issues

closes #12328

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
