### PR TITLE
Conform dependabot PRs to commitlint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(maven): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 25
@@ -30,7 +30,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(go): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
@@ -44,7 +44,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(.github): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
@@ -61,7 +61,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(maven): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 25
@@ -82,7 +82,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(go): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
@@ -100,7 +100,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(.github): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
@@ -121,7 +121,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(maven): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 25
@@ -142,7 +142,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(go): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
@@ -160,7 +160,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(.github): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
@@ -181,7 +181,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(maven): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 25
@@ -202,7 +202,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(go): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
@@ -220,7 +220,7 @@ updates:
       time: "03:00"
       timezone: "UTC"
     commit-message:
-      prefix: "deps(.github): "
+      prefix: "deps: "
     labels:
       - "dependencies"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Description

Removes the non-scopes from the dependabot commits (e.g. `deps(maven)`, `deps(go)`). Scope is optional for our commits, and I don't think specifying the type of update is all that useful. Since dependabot cannot figure out the real scope, we might as well just omit it.

An example PR which fails commit lint: https://github.com/camunda/zeebe/pull/12319

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
