### PR TITLE
[Backport stable/8.2] Support numbers as error/escalation codes

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ErrorTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ErrorTransformer.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
-import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
-import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableError;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
@@ -38,12 +36,7 @@ public class ErrorTransformer implements ModelElementTransformer<Error> {
 
               error.setErrorCodeExpression(errorCodeExpression);
               if (errorCodeExpression.isStatic()) {
-                final EvaluationResult errorCodeResult =
-                    expressionLanguage.evaluateExpression(errorCodeExpression, variable -> null);
-
-                if (errorCodeResult.getType() == ResultType.STRING) {
-                  error.setErrorCode(BufferUtil.wrapString(errorCodeResult.getString()));
-                }
+                error.setErrorCode(BufferUtil.wrapString(element.getErrorCode()));
               }
 
               context.addError(error);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EscalationTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EscalationTransformer.java
@@ -7,10 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
-import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
-import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEscalation;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
@@ -35,13 +33,7 @@ public class EscalationTransformer implements ModelElementTransformer<Escalation
 
       escalation.setEscalationCodeExpression(escalationCodeExpression);
       if (escalationCodeExpression.isStatic()) {
-        final EvaluationResult escalationCodeResult =
-            expressionLanguage.evaluateExpression(escalationCodeExpression, variable -> null);
-
-        if (escalationCodeResult.getType() == ResultType.STRING) {
-          final String escalationCode = escalationCodeResult.getString();
-          escalation.setEscalationCode(BufferUtil.wrapString(escalationCode));
-        }
+        escalation.setEscalationCode(BufferUtil.wrapString(element.getEscalationCode()));
       }
     }
     context.addEscalation(escalation);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorCatchEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/error/ErrorCatchEventTest.java
@@ -237,6 +237,7 @@ public final class ErrorCatchEventTest {
     final List<Record<VariableRecordValue>> variableRecords =
         RecordingExporter.variableRecords()
             .withProcessInstanceKey(processInstanceKey)
+            .limit(r -> r.getValue().getName().equals("foo"))
             .collect(Collectors.toList());
 
     final List<Record<ProcessInstanceRecordValue>> errorEvents =


### PR DESCRIPTION
# Description
Backport of #12327 to `stable/8.2`.

relates to #12326