### PR TITLE
ci(macOS): use maven cache to mitigate lookup hiccups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,8 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+          # On MacOS we observed maven lookup issues more frequently, this mitigates the frequency
+          maven-cache: ${{ runner.os == 'macOS' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## Description

This is a mitigation to reduce the frequency of jacoco related download hiccups that I only experienced on the macOs runner so far, by avoiding downloads using the cache of a previous successful run. It's just a potential temporary workaround until we root-caused the actual cause for the lookup issues.

```
Error:  Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.9:prepare-agent (coverage-initialize) on project zeebe-parent: Execution coverage-initialize of goal org.jacoco:jacoco-maven-plugin:0.8.9:prepare-agent failed: Plugin org.jacoco:jacoco-maven-plugin:0.8.9 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.jacoco:org.jacoco.agent:jar:runtime:0.8.9, org.jacoco:org.jacoco.core:jar:0.8.9, org.jacoco:org.jacoco.report:jar:0.8.9: Could not find artifact org.jacoco:org.jacoco.agent:jar:runtime:0.8.9 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```
