### PR TITLE
[Backport stable/8.1] Revert jacoco version update

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -126,7 +126,7 @@
     <plugin.version.exec>3.1.0</plugin.version.exec>
     <plugin.version.failsafe>3.0.0</plugin.version.failsafe>
     <plugin.version.flaky-tests>2.1.1</plugin.version.flaky-tests>
-    <plugin.version.jacoco>0.8.9</plugin.version.jacoco>
+    <plugin.version.jacoco>0.8.8</plugin.version.jacoco>
     <plugin.version.maven-jar>3.3.0</plugin.version.maven-jar>
     <plugin.version.proto-backwards-compatibility>1.0.7</plugin.version.proto-backwards-compatibility>
     <plugin.version.protobuf-maven-plugin>0.6.1</plugin.version.protobuf-maven-plugin>


### PR DESCRIPTION
# Description
Backport of #12358 to `stable/8.1`.

relates to 