### PR TITLE
Long polling notification refactoring

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -69,9 +69,6 @@ public final class EngineProcessors {
     final TypedRecordProcessors typedRecordProcessors =
         TypedRecordProcessors.processors(processingState.getKeyGenerator(), writers);
 
-    // TODO: use streamer in processors instead of state
-    processingState.getJobState().setJobStreamer(jobStreamer);
-
     // register listener that handles migrations immediately, so it is the first to be called
     typedRecordProcessors.withListener(new DbMigrationController(processingState));
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -45,8 +45,11 @@ public class BpmnJobActivationBehavior {
     this.jobMetrics = jobMetrics;
   }
 
-  public void publishWork(
-      final JobRecord jobRecord, final long elementInstanceKey, final long activationTimeStamp) {
-    // TODO: add conditional logic for job pushing or notifying
+  public void publishWork(final JobRecord jobRecord) {
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          jobStreamer.notifyWorkAvailable(jobRecord.getType());
+          return true;
+        });
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -46,9 +46,10 @@ public class BpmnJobActivationBehavior {
   }
 
   public void publishWork(final JobRecord jobRecord) {
+    final String jobType = jobRecord.getType();
     sideEffectWriter.appendSideEffect(
         () -> {
-          jobStreamer.notifyWorkAvailable(jobRecord.getType());
+          jobStreamer.notifyWorkAvailable(jobType);
           return true;
         });
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -180,7 +180,7 @@ public final class BpmnJobBehavior {
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);
 
-    // TODO: call JobActivationbehavior#publishWork
+    jobActivationBehavior.publishWork(jobRecord);
   }
 
   private DirectBuffer encodeHeaders(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -15,9 +15,11 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
+import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -42,6 +44,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
   private final ElementInstanceState elementInstanceState;
   private final TypedResponseWriter responseWriter;
   private final BpmnJobActivationBehavior jobActivationBehavior;
+  private final JobState jobState;
 
   public ResolveIncidentProcessor(
       final ProcessingState processingState,
@@ -55,6 +58,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
     incidentState = processingState.getIncidentState();
     elementInstanceState = processingState.getElementInstanceState();
     this.jobActivationBehavior = jobActivationBehavior;
+    jobState = processingState.getJobState();
   }
 
   @Override
@@ -70,7 +74,13 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
 
     stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, incident);
     responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
-    // TODO: call JobActivationbehavior#publishWork
+
+    final long jobKey = incident.getJobKey();
+    final boolean isJobRelatedIncident = jobKey > 0;
+    if (isJobRelatedIncident) {
+      final JobRecord failedJobRecord = jobState.getJob(jobKey);
+      jobActivationBehavior.publishWork(failedJobRecord);
+    }
 
     // if it fails, a new incident is raised
     attemptToContinueProcessProcessing(command, incident);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -75,12 +75,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
     stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, incident);
     responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
 
-    final long jobKey = incident.getJobKey();
-    final boolean isJobRelatedIncident = jobKey > 0;
-    if (isJobRelatedIncident) {
-      final JobRecord failedJobRecord = jobState.getJob(jobKey);
-      jobActivationBehavior.publishWork(failedJobRecord);
-    }
+    publishIncidentRelatedJob(incident.getJobKey());
 
     // if it fails, a new incident is raised
     attemptToContinueProcessProcessing(command, incident);
@@ -146,6 +141,14 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
         return Either.right(ProcessInstanceIntent.COMPLETE_ELEMENT);
       default:
         return Either.left(String.format(ELEMENT_NOT_IN_SUPPORTED_STATE_MSG, instanceState));
+    }
+  }
+
+  private void publishIncidentRelatedJob(final long jobKey) {
+    final boolean isJobRelatedIncident = jobKey > 0;
+    if (isJobRelatedIncident) {
+      final JobRecord failedJobRecord = jobState.getJob(jobKey);
+      jobActivationBehavior.publishWork(failedJobRecord);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -135,7 +135,11 @@ public final class JobFailProcessor implements CommandProcessor<JobRecord> {
           });
     }
     commandControl.accept(JobIntent.FAILED, failedJob);
-    // TODO: call JobActivationbehavior#publishWork
     jobMetrics.jobFailed(failedJob.getType());
+
+    final boolean retryImmediately = retries > 0 && retryBackOff <= 0;
+    if (retryImmediately) {
+      jobActivationBehavior.publishWork(failedJob);
+    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -39,7 +39,9 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
 
     if (state == State.FAILED) {
       commandControl.accept(JobIntent.RECURRED_AFTER_BACKOFF, command.getValue());
-      // TODO: call JobActivationbehavior#publishWork
+
+      final JobRecord failedJobRecord = jobState.getJob(jobKey);
+      jobActivationBehavior.publishWork(failedJobRecord);
     } else {
       final String textState;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -38,10 +38,10 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
     final JobState.State state = jobState.getState(jobKey);
 
     if (state == State.FAILED) {
-      commandControl.accept(JobIntent.RECURRED_AFTER_BACKOFF, command.getValue());
+      final JobRecord recurredJob = command.getValue();
 
-      final JobRecord failedJobRecord = jobState.getJob(jobKey);
-      jobActivationBehavior.publishWork(failedJobRecord);
+      commandControl.accept(JobIntent.RECURRED_AFTER_BACKOFF, recurredJob);
+      jobActivationBehavior.publishWork(recurredJob);
     } else {
       final String textState;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -41,11 +41,11 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
     final JobState.State state = jobState.getState(jobKey);
 
     if (state == State.ACTIVATED) {
-      commandControl.accept(JobIntent.TIMED_OUT, command.getValue());
-      jobMetrics.jobTimedOut(command.getValue().getType());
+      final JobRecord timedOutJob = command.getValue();
 
-      final JobRecord timedOutJobRecord = jobState.getJob(jobKey);
-      jobActivationBehavior.publishWork(timedOutJobRecord);
+      commandControl.accept(JobIntent.TIMED_OUT, timedOutJob);
+      jobMetrics.jobTimedOut(timedOutJob.getType());
+      jobActivationBehavior.publishWork(timedOutJob);
     } else {
       final String textState;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -43,7 +43,9 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
     if (state == State.ACTIVATED) {
       commandControl.accept(JobIntent.TIMED_OUT, command.getValue());
       jobMetrics.jobTimedOut(command.getValue().getType());
-      // TODO: call JobActivationbehavior#publishWork
+
+      final JobRecord timedOutJobRecord = jobState.getJob(jobKey);
+      jobActivationBehavior.publishWork(timedOutJobRecord);
     } else {
       final String textState;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplier.java
@@ -40,8 +40,8 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
   @Override
   public void applyState(final long incidentKey, final IncidentRecord value) {
     final var jobKey = value.getJobKey();
-    if (jobKey > 0) {
-      // incident belonged to job
+    final boolean isJobRelatedIncident = jobKey > 0;
+    if (isJobRelatedIncident) {
       final var stateOfJob = jobState.getState(jobKey);
       if (RESOLVABLE_JOB_STATES.contains(stateOfJob)) {
         final var job = jobState.getJob(jobKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.mutable;
 
-import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 
@@ -36,7 +35,4 @@ public interface MutableJobState extends JobState {
   void resolve(long key, JobRecord updatedValue);
 
   JobRecord updateJobRetries(long jobKey, int retries);
-
-  // TODO: stop using job streamer on state
-  void setJobStreamer(final JobStreamer jobStreamer);
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Jobs were broadcasted from `DbJobState` class whenever they become available. This PR takes it out of `DbJobState` and puts into `BpmnJobActivationBehavior` to be able to handle job push in the same place as job polling mechanism. Then, it is used in related processors to still be able to broadcast jobs to keep supporting polling mechanism.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12083

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
