### PR TITLE
More resilient network operations in CI

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -81,8 +81,8 @@ runs:
         tags: ${{ steps.get-image.outputs.result }}
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,ignore-error=true
+        cache-to: type=gha,mode=max,ignore-error=true
         platforms: ${{ inputs.platforms }}
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}

--- a/.github/actions/build-zeebe/action.yml
+++ b/.github/actions/build-zeebe/action.yml
@@ -40,6 +40,19 @@ runs:
       id: build-java
       # we do not build in parallel to avoid memory and cache corruption issues, notably observed
       # on macOS and Windows
+      env:
+        # adds some additional Maven arguments; while the docs specify we should use MAVEN_ARGS with Maven 3.9, the Maven wrapper breaks this
+        # and instead uses its own MAVEN_CONFIG environment variable
+        #
+        # -e ensures errors will also spit out a stack trace, which is always useful, and has no impact on normal builds
+        # maven.wagon.* and maven.resolver.transport set the resolver's network transport to Wagon,
+        # the old provider pre 3.9. Until Maven 3.9.2, we have to do this if we want to retry on
+        # network issues, as otherwise any issue will fail the build.
+        MAVEN_CONFIG: >
+          -e
+          -D maven.wagon.httpconnectionManager.ttlSeconds=120 -D maven.wagon.http.pool=false -Dmaven.resolver.transport=wagon
+          -D maven.wagon.http.retryHandler.class=standard -D maven.wagon.http.retryHandler.requestSentEnabled=true
+          -D maven.wagon.http.retryHandler.count=5
       run: |
         ./mvnw -B -DskipTests -DskipChecks install ${{ inputs.maven-extra-args }}
         export BUILD_DIR=$(./mvnw -pl dist/ help:evaluate -Dexpression=project.build.directory -q -DforceStdout)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -103,8 +103,8 @@ jobs:
           context: .
           tags: gcr.io/zeebe-io/zeebe:${{ steps.image-tag.outputs.image-tag }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,ignore-error=true
+          cache-to: type=gha,mode=max,ignore-error=true
           build-args: DIST=build
           target: app
   build-benchmark-images:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1952,38 +1952,6 @@
       </build>
     </profile>
 
-    <!-- profile to perform only static code analysis using sonar scanner -->
-    <profile>
-      <id>sonar</id>
-      <properties>
-        <!-- sonarscanner integration -->
-        <!-- sonar.login token must be passed at runtime to avoid sharing token -->
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.organization>camunda-cloud</sonar.organization>
-        <sonar.login>${env.SONARCLOUD_TOKEN}</sonar.login>
-        <sonar.links.issue>${project.scm.url}/issues</sonar.links.issue>
-        <sonar.cpd.exclusions>broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backpressure/Gradient2Cfg.java,broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backpressure/GradientCfg.java</sonar.cpd.exclusions>
-        <sonar.java.source>${version.java}</sonar.java.source>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.sonarsource.scanner.maven</groupId>
-            <artifactId>sonar-maven-plugin</artifactId>
-            <version>${plugin.version.sonar}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>sonar</goal>
-                </goals>
-                <phase>verify</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!--
       profile to enable flaky test analysis/extraction; running this module will extract flaky runs
       from your failed test cases as their own test case, such that the failed results can be viewed

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -37,12 +37,6 @@
             <include>**/*Tests.java</include>
             <include>**/*TestCase.java</include>
           </includes>
-          <!--
-            as our in-house CI does not enable IPv6, clients not running in a Testcontainer-managed
-            container will not be able to use IPv6; as such, ensure we always prefer IPv4 when
-            resolving host names
-          -->
-          <argLine>-XX:MaxDirectMemorySize=4g -Djava.net.preferIPv4Stack=true</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Description

This PR merges a few improvements around networking in CI, notably:

- Do not let builds fail if we cannot export Docker layers to the GHA cache. This is a nice to have, and shouldn't fail a complete build.
- Switch back to the Wagon transport for the Maven dependency resolver. [See the original blog post which prompted this](https://questdb.io/blog/maven-troubleshooting-open-source/). We can switch back with the next Maven release, assuming the fix is part of it.

There's also a few clean up commits, happy to split them into a separate PR.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
