### PR TITLE
[Backport stable/8.1] fix(cluster): do no use channel created for a different address

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -117,10 +117,7 @@ class ChannelPool {
                           closed -> {
                             synchronized (channelPool) {
                               // Remove channel from the pool after it is closed.
-                              final var currentFuture = channelPool.get(offset);
-                              if (finalFuture == currentFuture) {
-                                channelPool.set(offset, null);
-                              }
+                              removeChannel(channelPool, offset, finalFuture);
                             }
                           });
                 } else {
@@ -171,6 +168,17 @@ class ChannelPool {
           }
         });
     return future;
+  }
+
+  private static void removeChannel(
+      final List<CompletableFuture<Channel>> channelPool,
+      final int offset,
+      final CompletableFuture<Channel> finalFuture) {
+    final var currentFuture = channelPool.get(offset);
+    // check if new channel is already replaced before removing it.
+    if (finalFuture == currentFuture) {
+      channelPool.set(offset, null);
+    }
   }
 
   private void completeFuture(

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/ChannelPoolTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/ChannelPoolTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.utils.net.Address;
+import io.netty.channel.Channel;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class ChannelPoolTest {
+  private static final String MESSAGE_TYPE = "test";
+  private final Function<Address, CompletableFuture<Channel>> factory =
+      a -> {
+        final var channel = mock(Channel.class);
+        when(channel.isActive()).thenReturn(true);
+        return CompletableFuture.completedFuture(channel);
+      };
+  private final ChannelPool channelPool = new ChannelPool(factory, 8);
+
+  @Test
+  void shouldNotUseOldChannelWhenIPChanged() throws UnknownHostException {
+    // given
+    final Address addressWithOldIP =
+        new Address("foo.bar", 1234, InetAddress.getByName("10.1.1.1"));
+    final var channelForOldIP = channelPool.getChannel(addressWithOldIP, MESSAGE_TYPE).join();
+
+    // when
+    final Address addressWithNewIP =
+        new Address("foo.bar", 1234, InetAddress.getByName("10.1.1.2"));
+    final var channelForNewIP = channelPool.getChannel(addressWithNewIP, "test").join();
+
+    // then
+    assertThat(channelForOldIP).isNotEqualTo(channelForNewIP);
+  }
+
+  @Test
+  void shouldNotUseIncorrectChannelWhenIPReused() throws UnknownHostException {
+    // given
+    final Address nodeWithSameIP = new Address("foo.bar", 1234, InetAddress.getByName("10.1.1.1"));
+    final var channelForOldNode = channelPool.getChannel(nodeWithSameIP, MESSAGE_TYPE).join();
+
+    // when
+    final Address newNodeWithSameIP =
+        new Address("foo.foo", 1234, InetAddress.getByName("10.1.1.1"));
+    final var channelForNewNode = channelPool.getChannel(newNodeWithSameIP, MESSAGE_TYPE).join();
+
+    // then
+    assertThat(channelForOldNode).isNotEqualTo(channelForNewNode);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #12305 to `stable/8.1`.

relates to #12173