### PR TITLE
Ignore dependabot commits when checking commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,6 +3,9 @@ module.exports = {
 
     helpUrl: 'https://github.com/camunda/zeebe/blob/main/CONTRIBUTING.md/#commit-message-guidelines',
 
+    // Ignore commits created by dependabot. We cannot guarantee that these don't violate our commit rules.
+    ignores: [(msg) => /Signed-off-by: dependabot\[bot\]/m.test(msg)],
+
     // Rules are made up by a name and a configuration array. The configuration array contains:
     // - Level [0..2]: 0 disables the rule. For 1 it will be considered a warning for 2 an error.
     // - Applicable always|never: never inverts the rule.


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

We don't have the power to change dependabot commit messages. We do have the power to prevent some commits from failing commitlint. This PR checks if a commit contains:

```
Signed-off-by: dependabot[bot] <support@github.com>
```

If it does we ignore this from failing the commitlint check.

I've verified that this works by adding this text to one of my own commits. It passed commitlint without a problem:
https://github.com/camunda/zeebe/actions/runs/4678315161/jobs/8286899973?pr=12381

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
