### PR TITLE
Remove spy/mock usage from NettyMessagingService channel pool related tests

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -132,7 +132,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     this.advertisedAddress = advertisedAddress;
     this.protocolVersion = protocolVersion;
     this.config = config;
-    this.channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
+    channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
 
     openFutures = new CopyOnWriteArrayList<>();
     initAddresses(config);
@@ -151,7 +151,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     this.advertisedAddress = advertisedAddress;
     this.protocolVersion = protocolVersion;
     this.config = config;
-    this.channelPool = channelPoolFactor.apply(this::openChannel);
+    channelPool = channelPoolFactor.apply(this::openChannel);
 
     openFutures = new CopyOnWriteArrayList<>();
     initAddresses(config);
@@ -423,7 +423,11 @@ public final class NettyMessagingService implements ManagedMessagingService {
               }
               openFutures.clear();
             } finally {
-              log.info("Stopped");
+              log.info(
+                  "Stopped messaging service bound to {}, advertising {}, and using {}",
+                  bindingAddresses,
+                  advertisedAddress,
+                  config.isTlsEnabled() ? "TLS" : "plaintext");
               if (interrupted) {
                 Thread.currentThread().interrupt();
               }

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -656,6 +656,8 @@ public class NettyMessagingServiceTest {
           .withThrowableThat()
           .havingRootCause()
           .isInstanceOf(TimeoutException.class);
+      // wait until the channel is closed before grabbing the next one
+      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
 
       // when - remote connection finally succeeds
       // give a generous time out on the second request, as creating a new channel can be slow at
@@ -667,7 +669,6 @@ public class NettyMessagingServiceTest {
 
       // then
       final var newChannel = channelPool.getChannel(address2, subject).join();
-      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
       assertThat(newChannel).isNotEqualTo(originalChannel);
     } finally {
       nettyWithOwnPool.stop().join();


### PR DESCRIPTION
## Description

This PR attempts to simplify the tests by removing the usage of mocks. This could cause issues since the channel bootstrapping itself from the `NettyMessagingService` will modify the service state, and uses channels as identity keys in some maps. Spying and returning the spied channel will cause invalid look ups, and simply complicated things.

It also ensures we close the messaging service we were starting in those tests, something we were not previously doing.

## Related issues

related to #12263 where the race condition was happening often (although this is now fixed thanks to Deepthi :tada:)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
