### PR TITLE
Aggregate equivalent client streams

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.agrona.DirectBuffer;
+
+/** Represents a registered client stream. * */
+final class AggregatedClientStream<M extends BufferWriter> {
+  private final UUID streamId;
+  private final DirectBuffer streamType;
+  private final M metadata;
+  private final ClientStreamConsumer streamConsumer;
+  private final Set<MemberId> liveConnections = new HashSet<>();
+
+  private final Map<UUID, ClientStream<M>> clientStreams = new HashMap<>();
+
+  private State state;
+
+  AggregatedClientStream(final UUID streamId, final DirectBuffer streamType, final M metadata) {
+    this.streamId = streamId;
+    this.streamType = streamType;
+    this.metadata = metadata;
+    streamConsumer = this::push;
+    state = State.OPEN;
+  }
+
+  void addClient(final ClientStream<M> clientStream) {
+    clientStreams.put(clientStream.getStreamId(), clientStream);
+  }
+
+  private void push(final DirectBuffer buffer) {
+    final var streams = clientStreams.values();
+    if (streams.isEmpty()) {
+      throw new NoSuchStreamException();
+    }
+
+    final ClientStream<M> clientStream = pickRandomStream(streams);
+    clientStream.getClientStreamConsumer().push(buffer);
+  }
+
+  private ClientStream<M> pickRandomStream(final Collection<ClientStream<M>> streams) {
+    final var targets = new ArrayList<>(streams);
+    final var index = ThreadLocalRandom.current().nextInt(streams.size());
+
+    return targets.get(index);
+  }
+
+  UUID getStreamId() {
+    return streamId;
+  }
+
+  DirectBuffer getStreamType() {
+    return streamType;
+  }
+
+  M getMetadata() {
+    return metadata;
+  }
+
+  ClientStreamConsumer getClientStreamConsumer() {
+    return streamConsumer;
+  }
+
+  /**
+   * Mark that this stream is registered with the given server. Server can send data to this stream
+   * from now on.
+   *
+   * @param serverId id of the server
+   */
+  void add(final MemberId serverId) {
+    liveConnections.add(serverId);
+  }
+
+  /**
+   * If true, the stream is registered with the given server. If false, it is also possible the
+   * stream is registered with the server, but we failed to receive the acknowledgement.
+   *
+   * @param serverId id of the server
+   * @return true if a server has acknowledged to add stream request
+   */
+  boolean isConnected(final MemberId serverId) {
+    return liveConnections.contains(serverId);
+  }
+
+  /**
+   * Mark that stream to this server is closed.
+   *
+   * @param serverId id of the server
+   */
+  void remove(final MemberId serverId) {
+    liveConnections.remove(serverId);
+  }
+
+  void close() {
+    state = State.CLOSED;
+  }
+
+  boolean isClosed() {
+    return state == State.CLOSED;
+  }
+
+  public void removeClient(final UUID streamId) {
+    clientStreams.remove(streamId);
+  }
+
+  public boolean isEmpty() {
+    return clientStreams.isEmpty();
+  }
+
+  private enum State {
+    OPEN,
+    CLOSED
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -19,9 +19,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Represents a stream which aggregates multiple logically equivalent client streams. * */
 final class AggregatedClientStream<M extends BufferWriter> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AggregatedClientStream.class);
   private final UUID streamId;
   private final DirectBuffer streamType;
   private final M metadata;
@@ -114,6 +118,8 @@ final class AggregatedClientStream<M extends BufferWriter> {
     }
 
     final ClientStream<M> clientStream = pickRandomStream(streams);
+    LOGGER.trace(
+        "Pushing data from stream [{}] to client [{}]", streamId, clientStream.getStreamId());
     clientStream.getClientStreamConsumer().push(buffer);
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -45,7 +45,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
   }
 
   void addClient(final ClientStream<M> clientStream) {
-    clientStreams.put(clientStream.getStreamId(), clientStream);
+    clientStreams.put(clientStream.streamId(), clientStream);
   }
 
   UUID getStreamId() {
@@ -118,9 +118,8 @@ final class AggregatedClientStream<M extends BufferWriter> {
     }
 
     final ClientStream<M> clientStream = pickRandomStream(streams);
-    LOGGER.trace(
-        "Pushing data from stream [{}] to client [{}]", streamId, clientStream.getStreamId());
-    clientStream.getClientStreamConsumer().push(buffer);
+    LOGGER.trace("Pushing data from stream [{}] to client [{}]", streamId, clientStream.streamId());
+    clientStream.clientStreamConsumer().push(buffer);
   }
 
   private ClientStream<M> pickRandomStream(final Collection<ClientStream<M>> streams) {

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -41,7 +41,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
     this.streamType = streamType;
     this.metadata = metadata;
     streamConsumer = this::push;
-    state = State.OPEN;
+    state = State.INITIAL;
   }
 
   void addClient(final ClientStream<M> clientStream) {
@@ -129,7 +129,15 @@ final class AggregatedClientStream<M extends BufferWriter> {
     return targets.get(index);
   }
 
+  void open(final ClientStreamRequestManager<M> requestManager, final Set<MemberId> servers) {
+    if (state == State.INITIAL) {
+      requestManager.openStream(this, servers);
+      state = State.OPEN;
+    }
+  }
+
   private enum State {
+    INITIAL,
     OPEN,
     CLOSED
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
@@ -13,43 +13,9 @@ import java.util.UUID;
 import org.agrona.DirectBuffer;
 
 /** Represents a registered client stream. * */
-final class ClientStream<M extends BufferWriter> {
-  private final UUID streamId;
-  private final AggregatedClientStream<M> serverStream;
-  private final DirectBuffer streamType;
-  private final M metadata;
-  private final ClientStreamConsumer streamConsumer;
-
-  ClientStream(
-      final UUID streamId,
-      final AggregatedClientStream<M> serverStream,
-      final DirectBuffer streamType,
-      final M metadata,
-      final ClientStreamConsumer clientStreamConsumer) {
-    this.streamId = streamId;
-    this.serverStream = serverStream;
-    this.streamType = streamType;
-    this.metadata = metadata;
-    streamConsumer = clientStreamConsumer;
-  }
-
-  UUID getStreamId() {
-    return streamId;
-  }
-
-  DirectBuffer getStreamType() {
-    return streamType;
-  }
-
-  M getMetadata() {
-    return metadata;
-  }
-
-  ClientStreamConsumer getClientStreamConsumer() {
-    return streamConsumer;
-  }
-
-  AggregatedClientStream<M> getServerStream() {
-    return serverStream;
-  }
-}
+record ClientStream<M extends BufferWriter>(
+    UUID streamId,
+    AggregatedClientStream<M> serverStream,
+    DirectBuffer streamType,
+    M metadata,
+    ClientStreamConsumer clientStreamConsumer) {}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
@@ -7,34 +7,30 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
 
 /** Represents a registered client stream. * */
 final class ClientStream<M extends BufferWriter> {
   private final UUID streamId;
+  private final AggregatedClientStream<M> serverStream;
   private final DirectBuffer streamType;
   private final M metadata;
   private final ClientStreamConsumer streamConsumer;
-  private final Set<MemberId> liveConnections = new HashSet<>();
-
-  private State state;
 
   ClientStream(
       final UUID streamId,
+      final AggregatedClientStream<M> serverStream,
       final DirectBuffer streamType,
       final M metadata,
       final ClientStreamConsumer clientStreamConsumer) {
     this.streamId = streamId;
+    this.serverStream = serverStream;
     this.streamType = streamType;
     this.metadata = metadata;
     streamConsumer = clientStreamConsumer;
-    state = State.OPEN;
   }
 
   UUID getStreamId() {
@@ -53,46 +49,7 @@ final class ClientStream<M extends BufferWriter> {
     return streamConsumer;
   }
 
-  /**
-   * Mark that this stream is registered with the given server. Server can send data to this stream
-   * from now on.
-   *
-   * @param serverId id of the server
-   */
-  void add(final MemberId serverId) {
-    liveConnections.add(serverId);
-  }
-
-  /**
-   * If true, the stream is registered with the given server. If false, it is also possible the
-   * stream is registered with the server, but we failed to receive the acknowledgement.
-   *
-   * @param serverId id of the server
-   * @return true if a server has acknowledged to add stream request
-   */
-  boolean isConnected(final MemberId serverId) {
-    return liveConnections.contains(serverId);
-  }
-
-  /**
-   * Mark that stream to this server is closed.
-   *
-   * @param serverId id of the server
-   */
-  void remove(final MemberId serverId) {
-    liveConnections.remove(serverId);
-  }
-
-  void close() {
-    state = State.CLOSED;
-  }
-
-  boolean isClosed() {
-    return state == State.CLOSED;
-  }
-
-  private enum State {
-    OPEN,
-    CLOSED
+  public AggregatedClientStream<M> getServerStream() {
+    return serverStream;
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
@@ -49,7 +49,7 @@ final class ClientStream<M extends BufferWriter> {
     return streamConsumer;
   }
 
-  public AggregatedClientStream<M> getServerStream() {
+  AggregatedClientStream<M> getServerStream() {
     return serverStream;
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -58,8 +58,7 @@ final class ClientStreamManager<M extends BufferWriter> {
     final AggregatedClientStream<M> serverStream =
         registry.addClient(streamId, streamType, metadata, clientStreamConsumer);
     LOG.debug("Added client stream [{}] to stream [{}]", streamId, serverStream.getStreamId());
-    requestManager.openStream(serverStream, servers);
-
+    serverStream.open(requestManager, servers);
     return streamId;
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -53,18 +53,17 @@ final class ClientStreamManager<M extends BufferWriter> {
       final M metadata,
       final ClientStreamConsumer clientStreamConsumer) {
     final var streamId = UUID.randomUUID();
-    final var clientStreamMeta =
-        new ClientStream<>(streamId, streamType, metadata, clientStreamConsumer);
 
     // add first in memory to handle case of new broker while we're adding
-    registry.add(clientStreamMeta);
-    requestManager.openStream(clientStreamMeta, servers);
+    final AggregatedClientStream<M> serverStream =
+        registry.addClient(streamId, streamType, metadata, clientStreamConsumer);
+    requestManager.openStream(serverStream, servers);
 
     return streamId;
   }
 
   void remove(final UUID streamId) {
-    final var clientStream = registry.remove(streamId);
+    final var clientStream = registry.removeClient(streamId);
     clientStream.ifPresent(
         stream -> {
           stream.close();

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -83,8 +83,12 @@ final class ClientStreamManager<M extends BufferWriter> {
     final var clientStream = registry.get(streamId);
     clientStream.ifPresentOrElse(
         stream -> {
-          stream.getClientStreamConsumer().push(payload);
-          responseFuture.complete(null);
+          try {
+            stream.getClientStreamConsumer().push(payload);
+            responseFuture.complete(null);
+          } catch (final Exception e) {
+            responseFuture.completeExceptionally(e);
+          }
         },
         () -> {
           // Stream does not exist. We expect to have already sent remove request to all servers.

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -57,15 +57,18 @@ final class ClientStreamManager<M extends BufferWriter> {
     // add first in memory to handle case of new broker while we're adding
     final AggregatedClientStream<M> serverStream =
         registry.addClient(streamId, streamType, metadata, clientStreamConsumer);
+    LOG.debug("Added client stream [{}] to stream [{}]", streamId, serverStream.getStreamId());
     requestManager.openStream(serverStream, servers);
 
     return streamId;
   }
 
   void remove(final UUID streamId) {
-    final var clientStream = registry.removeClient(streamId);
-    clientStream.ifPresent(
+    LOG.debug("Removing client stream [{}]", streamId);
+    final var serverStream = registry.removeClient(streamId);
+    serverStream.ifPresent(
         stream -> {
+          LOG.debug("Removing aggregated stream [{}]", stream.getStreamId());
           stream.close();
           requestManager.removeStream(stream, servers);
         });

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -53,6 +53,9 @@ final class ClientStreamRegistry<M extends BufferWriter> {
     return serverStream;
   }
 
+  /**
+   * @return aggregated stream if it can be removed
+   */
   Optional<AggregatedClientStream<M>> removeClient(final UUID streamId) {
     final var clientStream = clientStreams.remove(streamId);
     if (clientStream != null) {

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -20,9 +20,6 @@ import org.agrona.DirectBuffer;
 
 /** A registry to keeps tracks of all open streams. */
 final class ClientStreamRegistry<M extends BufferWriter> {
-
-  // This class is currently a very simple wrapper around a map. When we aggregate multiple streams
-  // into one stream, we may have to keep track of them also here.
   private final Map<UUID, ClientStream<M>> clientStreams = new HashMap<>();
   private final Map<UUID, AggregatedClientStream<M>> serverStreams = new HashMap<>();
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -7,33 +7,58 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.agrona.DirectBuffer;
 
 /** A registry to keeps tracks of all open streams. */
 final class ClientStreamRegistry<M extends BufferWriter> {
 
   // This class is currently a very simple wrapper around a map. When we aggregate multiple streams
   // into one stream, we may have to keep track of them also here.
-  private final Map<UUID, ClientStream<M>> streams = new HashMap<>();
+  private final Map<UUID, ClientStream<M>> clientStreams = new HashMap<>();
+  private final Map<UUID, AggregatedClientStream<M>> serverStreams = new HashMap<>();
 
-  void add(final ClientStream<M> clientStream) {
-    streams.put(clientStream.getStreamId(), clientStream);
+  Optional<AggregatedClientStream<M>> get(final UUID streamId) {
+    return Optional.ofNullable(serverStreams.get(streamId));
   }
 
-  Optional<ClientStream<M>> get(final UUID streamId) {
-    return Optional.ofNullable(streams.get(streamId));
+  Collection<AggregatedClientStream<M>> list() {
+    return serverStreams.values();
   }
 
-  Optional<ClientStream<M>> remove(final UUID streamId) {
-    return Optional.ofNullable(streams.remove(streamId));
+  public AggregatedClientStream<M> addClient(
+      final UUID streamId,
+      final DirectBuffer streamType,
+      final M metadata,
+      final ClientStreamConsumer clientStreamConsumer) {
+    final var serverStreamId = streamId; // TODO: generate aggregated stream id
+    final var serverStream =
+        serverStreams.computeIfAbsent(
+            serverStreamId,
+            k -> new AggregatedClientStream<>(serverStreamId, streamType, metadata));
+    final var clientStream =
+        new ClientStream<>(streamId, serverStream, streamType, metadata, clientStreamConsumer);
+    serverStream.addClient(clientStream);
+    clientStreams.put(streamId, clientStream);
+    return serverStream;
   }
 
-  Collection<ClientStream<M>> list() {
-    return streams.values();
+  public Optional<AggregatedClientStream<M>> removeClient(final UUID streamId) {
+    final var clientStream = clientStreams.remove(streamId);
+    if (clientStream != null) {
+      final var serverStream = clientStream.getServerStream();
+      serverStream.removeClient(streamId);
+      if (serverStream.isEmpty()) {
+        serverStreams.remove(serverStream.getStreamId());
+        return Optional.of(serverStream);
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -59,7 +59,7 @@ final class ClientStreamRegistry<M extends BufferWriter> {
   Optional<AggregatedClientStream<M>> removeClient(final UUID streamId) {
     final var clientStream = clientStreams.remove(streamId);
     if (clientStream != null) {
-      final var serverStream = clientStream.getServerStream();
+      final var serverStream = clientStream.serverStream();
       serverStream.removeClient(streamId);
       if (serverStream.isEmpty()) {
         serverStreams.remove(serverStream.getStreamId());

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -71,7 +71,8 @@ final class ClientStreamRegistry<M extends BufferWriter> {
     return Optional.empty();
   }
 
-  @VisibleForTesting
+  @VisibleForTesting(
+      "To inspect the registry state to see if the client is added or removed as expected")
   Optional<ClientStream<M>> getClient(final UUID clientStreamId) {
     return Optional.ofNullable(clientStreams.get(clientStreamId));
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.Collection;
@@ -68,5 +69,10 @@ final class ClientStreamRegistry<M extends BufferWriter> {
       }
     }
     return Optional.empty();
+  }
+
+  @VisibleForTesting
+  Optional<ClientStream<M>> getClient(final UUID clientStreamId) {
+    return Optional.ofNullable(clientStreams.get(clientStreamId));
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -39,7 +39,8 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     this.executor = executor;
   }
 
-  void openStream(final ClientStream<M> clientStream, final Collection<MemberId> servers) {
+  void openStream(
+      final AggregatedClientStream<M> clientStream, final Collection<MemberId> servers) {
     final var request =
         new AddStreamRequest()
             .streamType(clientStream.getStreamType())
@@ -50,7 +51,9 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   }
 
   private void doAdd(
-      final AddStreamRequest request, final MemberId brokerId, final ClientStream<M> clientStream) {
+      final AddStreamRequest request,
+      final MemberId brokerId,
+      final AggregatedClientStream<M> clientStream) {
     if (clientStream.isConnected(brokerId) || clientStream.isClosed()) {
       return;
     }
@@ -84,7 +87,8 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
         executor::run);
   }
 
-  void removeStream(final ClientStream<M> clientStream, final Collection<MemberId> servers) {
+  void removeStream(
+      final AggregatedClientStream<M> clientStream, final Collection<MemberId> servers) {
     final var request = new RemoveStreamRequest().streamId(clientStream.getStreamId());
     servers.forEach(brokerId -> executor.run(() -> doRemove(request, brokerId, clientStream)));
   }
@@ -92,7 +96,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   private void doRemove(
       final RemoveStreamRequest request,
       final MemberId brokerId,
-      final ClientStream<M> clientStream) {
+      final AggregatedClientStream<M> clientStream) {
 
     final CompletableFuture<byte[]> result =
         communicationService.send(

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -65,8 +65,8 @@ class ClientStreamManagerTest {
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
     // then
-    assertThat(stream1.getServerStream().getStreamId())
-        .isEqualTo(stream2.getServerStream().getStreamId());
+    assertThat(stream1.serverStream().getStreamId())
+        .isEqualTo(stream2.serverStream().getStreamId());
   }
 
   @Test
@@ -78,8 +78,8 @@ class ClientStreamManagerTest {
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
     // then
-    assertThat(stream1.getServerStream().getStreamId())
-        .isNotEqualTo(stream2.getServerStream().getStreamId());
+    assertThat(stream1.serverStream().getStreamId())
+        .isNotEqualTo(stream2.serverStream().getStreamId());
   }
 
   @Test
@@ -91,8 +91,8 @@ class ClientStreamManagerTest {
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
     // then
-    assertThat(stream1.getServerStream().getStreamId())
-        .isNotEqualTo(stream2.getServerStream().getStreamId());
+    assertThat(stream1.serverStream().getStreamId())
+        .isNotEqualTo(stream2.serverStream().getStreamId());
   }
 
   @Test
@@ -252,7 +252,7 @@ class ClientStreamManagerTest {
   }
 
   private UUID getServerStreamId(final UUID clientStreamId) {
-    return registry.getClient(clientStreamId).orElseThrow().getServerStream().getStreamId();
+    return registry.getClient(clientStreamId).orElseThrow().serverStream().getStreamId();
   }
 
   private record TestMetadata(int data) implements BufferWriter {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,10 +31,10 @@ import org.junit.jupiter.api.Test;
 class ClientStreamManagerTest {
 
   private final DirectBuffer streamType = BufferUtil.wrapString("foo");
-  private final BufferWriter metadata = mock(BufferWriter.class);
-  private final ClientStreamRegistry<BufferWriter> registry = new ClientStreamRegistry<>();
+  private final TestMetadata metadata = new TestMetadata(1);
+  private final ClientStreamRegistry<TestMetadata> registry = new ClientStreamRegistry<>();
   private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
-  private final ClientStreamManager<BufferWriter> clientStreamManager =
+  private final ClientStreamManager<TestMetadata> clientStreamManager =
       new ClientStreamManager<>(
           registry, new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl()));
 
@@ -54,6 +55,47 @@ class ClientStreamManagerTest {
   }
 
   @Test
+  void shouldAggregateStreamsWithSameStreamTypeAndMetadata() {
+    // when
+    final var uuid1 =
+        clientStreamManager.add(BufferUtil.wrapString("foo"), new TestMetadata(1), p -> {});
+    final var uuid2 =
+        clientStreamManager.add(BufferUtil.wrapString("foo"), new TestMetadata(1), p -> {});
+    final var stream1 = registry.getClient(uuid1).orElseThrow();
+    final var stream2 = registry.getClient(uuid2).orElseThrow();
+
+    // then
+    assertThat(stream1.getServerStream().getStreamId())
+        .isEqualTo(stream2.getServerStream().getStreamId());
+  }
+
+  @Test
+  void shouldNoAggregateStreamsWithDifferentMetadata() {
+    // when
+    final var uuid1 = clientStreamManager.add(streamType, new TestMetadata(1), p -> {});
+    final var uuid2 = clientStreamManager.add(streamType, new TestMetadata(2), p -> {});
+    final var stream1 = registry.getClient(uuid1).orElseThrow();
+    final var stream2 = registry.getClient(uuid2).orElseThrow();
+
+    // then
+    assertThat(stream1.getServerStream().getStreamId())
+        .isNotEqualTo(stream2.getServerStream().getStreamId());
+  }
+
+  @Test
+  void shouldNoAggregateStreamsWithDifferentStreamType() {
+    // when
+    final var uuid1 = clientStreamManager.add(BufferUtil.wrapString("foo"), metadata, p -> {});
+    final var uuid2 = clientStreamManager.add(BufferUtil.wrapString("bar"), metadata, p -> {});
+    final var stream1 = registry.getClient(uuid1).orElseThrow();
+    final var stream2 = registry.getClient(uuid2).orElseThrow();
+
+    // then
+    assertThat(stream1.getServerStream().getStreamId())
+        .isNotEqualTo(stream2.getServerStream().getStreamId());
+  }
+
+  @Test
   void shouldOpenStreamToExistingServers() {
     // given
     final MemberId server1 = MemberId.from("1");
@@ -65,58 +107,79 @@ class ClientStreamManagerTest {
     final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
 
     // then
-    final var clientStream = registry.get(uuid).orElseThrow();
+    final UUID serverStreamId = getServerStreamId(uuid);
+    final var stream = registry.get(serverStreamId).orElseThrow();
 
-    assertThat(clientStream.isConnected(server1)).isTrue();
-    assertThat(clientStream.isConnected(server2)).isTrue();
+    assertThat(stream.isConnected(server1)).isTrue();
+    assertThat(stream.isConnected(server2)).isTrue();
   }
 
   @Test
   void shouldOpenStreamToNewlyAddedServer() {
     // given
     final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
-    final var clientStream = registry.get(uuid).orElseThrow();
+    final var serverStream = registry.get(getServerStreamId(uuid)).orElseThrow();
 
     // when
     final MemberId server = MemberId.from("3");
     clientStreamManager.onServerJoined(server);
 
     // then
-    assertThat(clientStream.isConnected(server)).isTrue();
+    assertThat(serverStream.isConnected(server)).isTrue();
   }
 
   @Test
   void shouldOpenStreamToNewlyAddedServerForAllOpenStreams() {
     // given
-    final var stream1 = clientStreamManager.add(streamType, metadata, p -> {});
-    final var stream2 = clientStreamManager.add(streamType, metadata, p -> {});
-
+    final var stream1 = clientStreamManager.add(BufferUtil.wrapString("foo"), metadata, p -> {});
+    final var stream2 = clientStreamManager.add(BufferUtil.wrapString("bar"), metadata, p -> {});
+    final var serverStream1 = registry.get(getServerStreamId(stream1)).orElseThrow();
+    final var serverStream2 = registry.get(getServerStreamId(stream2)).orElseThrow();
     // when
     final MemberId server = MemberId.from("3");
     clientStreamManager.onServerJoined(server);
 
     // then
-    assertThat(registry.get(stream1).orElseThrow().isConnected(server)).isTrue();
-    assertThat(registry.get(stream2).orElseThrow().isConnected(server)).isTrue();
+    assertThat(serverStream1.isConnected(server)).isTrue();
+    assertThat(serverStream2.isConnected(server)).isTrue();
   }
 
   @Test
   void shouldRemoveStream() {
     // given
     final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
+    final var serverStreamId = getServerStreamId(uuid);
 
     // when
     clientStreamManager.remove(uuid);
 
     // then
-    assertThat(registry.get(uuid)).isEmpty();
+    assertThat(registry.getClient(uuid)).isEmpty();
+    assertThat(registry.get(serverStreamId)).isEmpty();
+  }
+
+  @Test
+  void shouldNotRemoveIfOtherClientStreamExist() {
+    // given
+    final var uuid1 = clientStreamManager.add(streamType, metadata, p -> {});
+    final var uuid2 = clientStreamManager.add(streamType, metadata, p -> {});
+    final var serverStreamId = getServerStreamId(uuid1);
+
+    // when
+    clientStreamManager.remove(uuid1);
+
+    // then
+    assertThat(registry.getClient(uuid1)).isEmpty();
+    assertThat(registry.getClient(uuid2)).isPresent();
+    assertThat(registry.get(serverStreamId)).isPresent();
   }
 
   @Test
   void shouldPushPayloadToClient() {
     // given
     final DirectBuffer payloadReceived = new UnsafeBuffer();
-    final var streamId = clientStreamManager.add(streamType, metadata, payloadReceived::wrap);
+    final var clientStreamId = clientStreamManager.add(streamType, metadata, payloadReceived::wrap);
+    final var streamId = getServerStreamId(clientStreamId);
 
     // when
     final var payloadPushed = BufferUtil.wrapString("data");
@@ -152,13 +215,29 @@ class ClientStreamManagerTest {
     final MemberId server = MemberId.from("1");
     clientStreamManager.onServerJoined(server);
     final var uuid = clientStreamManager.add(streamType, metadata, p -> {});
-    final var clientStream = registry.get(uuid).orElseThrow();
-    assertThat(clientStream.isConnected(server)).isTrue();
+    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
+    assertThat(stream.isConnected(server)).isTrue();
 
     // when
     clientStreamManager.onServerRemoved(server);
 
     // then
-    assertThat(clientStream.isConnected(server)).isFalse();
+    assertThat(stream.isConnected(server)).isFalse();
+  }
+
+  private UUID getServerStreamId(final UUID clientStreamId) {
+    return registry.getClient(clientStreamId).orElseThrow().getServerStream().getStreamId();
+  }
+
+  private record TestMetadata(int data) implements BufferWriter {
+    @Override
+    public int getLength() {
+      return Integer.BYTES;
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {
+      buffer.putInt(offset, data);
+    }
   }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -36,9 +36,9 @@ class ClientStreamRequestManagerTest {
   private final ClientStreamRequestManager<BufferWriter> requestManager =
       new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl());
 
-  private final ClientStream<BufferWriter> clientStream =
-      new ClientStream<>(
-          UUID.randomUUID(), BufferUtil.wrapString("foo"), new TestMetadata(), p -> {});
+  private final AggregatedClientStream<BufferWriter> clientStream =
+      new AggregatedClientStream<>(
+          UUID.randomUUID(), BufferUtil.wrapString("foo"), new TestMetadata());
 
   @BeforeEach
   void setup() {


### PR DESCRIPTION
## Description

Aggregates client streams with the same `streamType` and `metadata` to a single stream that is registered with the server. Payloads pushed to this server stream will be distributed to one of the registered client stream. Currently, the client stream is picked randomly. Later, we can employ a better strategy to chose the client stream to push the payload.

The streamId for the aggregated stream is generated randomly. When all existing client streams are removed, the corresponding server stream will also be removed. When a new client stream is registered with the same streamType and metadata, a new aggregated stream will be created with a new streamId. This is ok, because as long there is an aggregated stream in the registry, new client streams will be added to it. Not re-using the previous streamId also helps to prevent edge cases where concurrent remove (of old aggregated stream) and add (of new aggregated stream) requests caused by retried resulting in inconsistent state.

## Related issues

closes #12253 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
