### PR TITLE
[Backport stable/8.2] Remove spy/mock usage from NettyMessagingService channel pool related tests

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -132,7 +132,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     this.advertisedAddress = advertisedAddress;
     this.protocolVersion = protocolVersion;
     this.config = config;
-    this.channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
+    channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
 
     openFutures = new CopyOnWriteArrayList<>();
     initAddresses(config);
@@ -151,7 +151,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     this.advertisedAddress = advertisedAddress;
     this.protocolVersion = protocolVersion;
     this.config = config;
-    this.channelPool = channelPoolFactor.apply(this::openChannel);
+    channelPool = channelPoolFactor.apply(this::openChannel);
 
     openFutures = new CopyOnWriteArrayList<>();
     initAddresses(config);
@@ -423,7 +423,11 @@ public final class NettyMessagingService implements ManagedMessagingService {
               }
               openFutures.clear();
             } finally {
-              log.info("Stopped");
+              log.info(
+                  "Stopped messaging service bound to {}, advertising {}, and using {}",
+                  bindingAddresses,
+                  advertisedAddress,
+                  config.isTlsEnabled() ? "TLS" : "plaintext");
               if (interrupted) {
                 Thread.currentThread().interrupt();
               }

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -656,6 +656,8 @@ public class NettyMessagingServiceTest {
           .withThrowableThat()
           .havingRootCause()
           .isInstanceOf(TimeoutException.class);
+      // wait until the channel is closed before grabbing the next one
+      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
 
       // when - remote connection finally succeeds
       // give a generous time out on the second request, as creating a new channel can be slow at
@@ -667,7 +669,6 @@ public class NettyMessagingServiceTest {
 
       // then
       final var newChannel = channelPool.getChannel(address2, subject).join();
-      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
       assertThat(newChannel).isNotEqualTo(originalChannel);
     } finally {
       nettyWithOwnPool.stop().join();


### PR DESCRIPTION
# Description
Backport of #12397 to `stable/8.2`.

relates to #12263