### PR TITLE
ci(integration): split module and integration test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,11 @@ env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
-  integration-tests:
-    name: Integration tests
+  module-integration-tests:
+    name: Module integration tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
-    timeout-minutes: 45
+    timeout-minutes: 15
     env:
-      TC_CLOUD_LOGS_VERBOSE: true
-      TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
-      TC_CLOUD_CONCURRENCY: 2
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
       registry:
@@ -55,24 +52,17 @@ jobs:
           version: current-test
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
-      - name: Prepare Testcontainers Cloud agent
-        if: env.TC_CLOUD_TOKEN != ''
-        run: |
-          curl -L -o agent https://app.testcontainers.cloud/download/testcontainers-cloud-agent_linux_x86-64
-          chmod +x agent
-          ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' > .testcontainers-agent.log 2>&1 &
-          ./agent wait
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build
         run: >
-          ./mvnw -B -T2 --no-snapshot-updates
+          ./mvnw -B -T3 --no-snapshot-updates
           -D forkCount=5
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests
-          -pl '!qa/update-tests'
+          -pl '!qa/integration-tests,!qa/update-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Duplicate Test Check
@@ -83,11 +73,11 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: always()
         with:
-          name: Integration Tests
-  qa-update-tests:
-    name: QA Update tests
+          name: Module integration Tests
+  qa-integration-tests:
+    name: QA Integration tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
-    timeout-minutes: 45
+    timeout-minutes: 20
     env:
       TC_CLOUD_LOGS_VERBOSE: true
       TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
@@ -127,7 +117,69 @@ jobs:
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build
         run: >
-          ./mvnw -B -T2 --no-snapshot-updates
+          ./mvnw -B --no-snapshot-updates
+          -D forkCount=10
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -P parallel-tests,extract-flaky-tests
+          -pl 'qa/integration-tests'
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Duplicate Test Check
+        uses: ./.github/actions/check-duplicate-tests
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: always()
+        with:
+          name: QA integration Tests
+  qa-update-tests:
+    name: QA Update tests
+    runs-on: [ self-hosted, linux, amd64, "16" ]
+    timeout-minutes: 20
+    env:
+      TC_CLOUD_LOGS_VERBOSE: true
+      TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
+      TC_CLOUD_CONCURRENCY: 2
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          maven-cache: 'true'
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C
+      - uses: ./.github/actions/build-docker
+        with:
+          repository: localhost:5000/camunda/zeebe
+          version: current-test
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      - name: Prepare Testcontainers Cloud agent
+        if: env.TC_CLOUD_TOKEN != ''
+        run: |
+          curl -L -o agent https://app.testcontainers.cloud/download/testcontainers-cloud-agent_linux_x86-64
+          chmod +x agent
+          ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' > .testcontainers-agent.log 2>&1 &
+          ./agent wait
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Maven Test Build
+        run: >
+          ./mvnw -B --no-snapshot-updates
+          -D forkCount=10
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
@@ -488,7 +540,8 @@ jobs:
     name: Test summary
     runs-on: ubuntu-latest
     needs:
-      - integration-tests
+      - module-integration-tests
+      - qa-integration-tests
       - qa-update-tests
       - unit-tests
       - smoke-tests
@@ -508,7 +561,8 @@ jobs:
     name: "Event File"
     runs-on: ubuntu-latest
     needs:
-      - integration-tests
+      - module-integration-tests
+      - qa-integration-tests
       - qa-update-tests
       - unit-tests
       - smoke-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,65 +23,39 @@ env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
-  module-integration-tests:
-    name: Module integration tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
-    timeout-minutes: 15
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-zeebe
-        with:
-          maven-cache: 'true'
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C
-      - uses: ./.github/actions/build-docker
-        with:
-          repository: localhost:5000/camunda/zeebe
-          version: current-test
-          push: true
-          distball: ${{ steps.build-zeebe.outputs.distball }}
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
-      - name: Maven Test Build
-        run: >
-          ./mvnw -B -T3 --no-snapshot-updates
-          -D forkCount=5
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests
-          -pl '!qa/integration-tests,!qa/update-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Duplicate Test Check
-        uses: ./.github/actions/check-duplicate-tests
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: always()
-        with:
-          name: Module integration Tests
-  qa-integration-tests:
-    name: QA Integration tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+  integration-tests:
+    name: "[IT] ${{ matrix.name }}"
     timeout-minutes: 20
+    runs-on: [ self-hosted, linux, amd64, "16" ]
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [ modules, qa-integration, qa-update ]
+        include:
+          - group: modules
+            name: "Module Integration Tests"
+            maven-modules: "'!qa/integration-tests,!qa/update-tests'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+            tcc-enabled: 'false'
+          - group: qa-integration
+            name: "QA Integration Tests"
+            maven-modules: "qa/integration-tests"
+            maven-build-threads: 1
+            maven-test-fork-count: 10
+            tcc-enabled: 'true'
+            tcc-concurrency: 2
+          - group: qa-update
+            name: "QA Update Tests"
+            maven-modules: "qa/update-tests"
+            maven-build-threads: 1
+            maven-test-fork-count: 10
+            tcc-enabled: 'true'
+            tcc-concurrency: 2
     env:
       TC_CLOUD_LOGS_VERBOSE: true
-      TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
-      TC_CLOUD_CONCURRENCY: 2
+      TC_CLOUD_TOKEN: ${{ matrix.tcc-enabled == 'true' && secrets.TC_CLOUD_TOKEN || '' }}
+      TC_CLOUD_CONCURRENCY: ${{ matrix.tcc-concurrency }}
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
       registry:
@@ -117,13 +91,13 @@ jobs:
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build
         run: >
-          ./mvnw -B --no-snapshot-updates
-          -D forkCount=10
+          ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
+          -D forkCount=${{ matrix.maven-test-fork-count }}
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests
-          -pl 'qa/integration-tests'
+          -pl ${{ matrix.maven-modules }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Duplicate Test Check
@@ -134,68 +108,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: always()
         with:
-          name: QA integration Tests
-  qa-update-tests:
-    name: QA Update tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
-    timeout-minutes: 20
-    env:
-      TC_CLOUD_LOGS_VERBOSE: true
-      TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
-      TC_CLOUD_CONCURRENCY: 2
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-zeebe
-        with:
-          maven-cache: 'true'
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C
-      - uses: ./.github/actions/build-docker
-        with:
-          repository: localhost:5000/camunda/zeebe
-          version: current-test
-          push: true
-          distball: ${{ steps.build-zeebe.outputs.distball }}
-      - name: Prepare Testcontainers Cloud agent
-        if: env.TC_CLOUD_TOKEN != ''
-        run: |
-          curl -L -o agent https://app.testcontainers.cloud/download/testcontainers-cloud-agent_linux_x86-64
-          chmod +x agent
-          ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' > .testcontainers-agent.log 2>&1 &
-          ./agent wait
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
-      - name: Maven Test Build
-        run: >
-          ./mvnw -B --no-snapshot-updates
-          -D forkCount=10
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests
-          -pl qa/update-tests
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Duplicate Test Check
-        uses: ./.github/actions/check-duplicate-tests
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: always()
-        with:
-          name: QA Update Tests
+          name: "[IT] ${{ matrix.name }}"
   unit-tests:
     name: Unit tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
@@ -237,7 +150,7 @@ jobs:
         with:
           name: "unit tests"
   smoke-tests:
-    name: Smoke tests on ${{ matrix.os }} with ${{ matrix.arch }}
+    name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
     timeout-minutes: 20
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -295,7 +208,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: always()
         with:
-          name: Smoke Tests on ${{ matrix.os }} with ${{ matrix.arch }}
+          name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
   property-tests:
     name: Property Tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
@@ -540,9 +453,7 @@ jobs:
     name: Test summary
     runs-on: ubuntu-latest
     needs:
-      - module-integration-tests
-      - qa-integration-tests
-      - qa-update-tests
+      - integration-tests
       - unit-tests
       - smoke-tests
       - property-tests
@@ -561,9 +472,7 @@ jobs:
     name: "Event File"
     runs-on: ubuntu-latest
     needs:
-      - module-integration-tests
-      - qa-integration-tests
-      - qa-update-tests
+      - integration-tests
       - unit-tests
       - smoke-tests
       - property-tests

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverIT.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverIT.java
@@ -29,7 +29,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class RaftFailOverTest {
+public class RaftFailOverIT {
 
   @Rule @Parameter public RaftRule raftRule;
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeIT.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeIT.java
@@ -52,7 +52,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class ZeebeTest {
+public class ZeebeIT {
 
   // rough estimate of how many entries we'd need to write to fill a segment
   // segments are configured for 1kb, and one entry takes ~30 bytes (plus some metadata I guess)

--- a/atomix/pom.xml
+++ b/atomix/pom.xml
@@ -73,6 +73,18 @@
           <suppressionsLocation>src/main/resources/suppression.xml</suppressionsLocation>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/IT*.java</include>
+            <include>**/*IT.java</include>
+            <include>**/*ITCase.java</include>
+          </includes>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionIT.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 @Testcontainers
-final class CompressionTest {
+final class CompressionIT {
   private static final String ACCESS_KEY = "letmein";
   private static final String SECRET_KEY = "letmein1234";
   private static final int DEFAULT_PORT = 9000;

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
@@ -18,10 +18,8 @@ import java.util.concurrent.ExecutionException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.regions.Region;
 
-@Testcontainers
 final class ConnectionErrorTest {
   private static final String ACCESS_KEY = "letmein";
   private static final String SECRET_KEY = "letmein1234";

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CustomBasePathIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CustomBasePathIT.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 @Testcontainers
-final class CustomBasePathTest {
+final class CustomBasePathIT {
   private static final String ACCESS_KEY = "letmein";
   private static final String SECRET_KEY = "letmein1234";
   private static final int DEFAULT_PORT = 9000;


### PR DESCRIPTION
## Description
Reduces overall runtime as the module tests and qa-integration tests cannot run in parallel due to the maven module inter-dependencies. Thus extracting module ITs into a dedicated job allows us to get the overall IT stages down to ~ 10 minutes, while on main the `Integration tests` job that combines module and qa integration tests shows runtimes of about 15m.

By that chance introduced a shared IT job setup that can be configured through a matrix.

By also looking at the unit test summary I wondered why the s3 unit tests take about 2m to complete, which is where I found that some ITs were actually run as unit tests. I made sure they are run as ITs going forward [by renaming them](https://github.com/camunda/zeebe/pull/12406/commits/3b5781fc7ebe9a39a31bd1bbf11c6cfdd9824b75).

In total the whole CI run duration is not dominated by the integration test job anymore but by multiple that oscillate around 10m. 

relates to #12028 
