### PR TITLE
[Backport stable/8.2] test(qa): relax timeout for taking backups on GCS

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsBackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsBackupAcceptanceIT.java
@@ -119,7 +119,7 @@ final class GcsBackupAcceptanceIT {
   private static void waitUntilBackupIsCompleted(
       final BackupActuator actuator, final long backupId) {
     Awaitility.await("until a backup exists with the id %d".formatted(backupId))
-        .atMost(Duration.ofSeconds(30))
+        .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // 404 NOT_FOUND throws exception
         .untilAsserted(
             () -> {
@@ -170,7 +170,7 @@ final class GcsBackupAcceptanceIT {
 
     // then
     Awaitility.await("Backup is deleted")
-        .timeout(Duration.ofSeconds(10))
+        .timeout(Duration.ofSeconds(30))
         .untilAsserted(
             () ->
                 assertThatThrownBy(() -> actuator.status(backupId))

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsRestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsRestoreAcceptanceIT.java
@@ -105,7 +105,7 @@ final class GcsRestoreAcceptanceIT {
     final var response = actuator.take(BACKUP_ID);
     assertThat(response).isInstanceOf(TakeBackupResponse.class);
     Awaitility.await("until a backup exists with the given ID")
-        .atMost(Duration.ofSeconds(3000))
+        .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // 404 NOT_FOUND throws exception
         .untilAsserted(
             () -> {
@@ -133,7 +133,7 @@ final class GcsRestoreAcceptanceIT {
     final var response = actuator.take(BACKUP_ID);
     assertThat(response).isInstanceOf(TakeBackupResponse.class);
     Awaitility.await("until a backup exists with the given ID")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // 404 NOT_FOUND throws exception
         .untilAsserted(
             () -> {


### PR DESCRIPTION
# Description
Backport of #12419 to `stable/8.2`.

relates to testcontainers/testcontainers-java#3081 #12330 #12330