### PR TITLE
[Backport stable/8.1] test(backup-store): close store and client after each test

### DIFF
--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.s3;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -50,6 +51,11 @@ final class LocalstackBackupStoreIT implements S3BackupStoreTests {
     config = new S3BackupConfig(RandomStringUtils.randomAlphabetic(10).toLowerCase());
     store = new S3BackupStore(config, client);
     client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
+  }
+
+  @AfterEach
+  void tearDown() {
+    store.closeAsync();
   }
 
   @Override

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.backup.s3;
 import java.net.URI;
 import java.time.Duration;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.GenericContainer;
@@ -65,6 +66,11 @@ final class MinioBackupStoreIT implements S3BackupStoreTests {
     config = new S3BackupConfig(RandomStringUtils.randomAlphabetic(10).toLowerCase());
     store = new S3BackupStore(config, client);
     client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
+  }
+
+  @AfterEach
+  void tearDown() {
+    store.closeAsync();
   }
 
   @Override


### PR DESCRIPTION
partial backport of #12405 

There is no GCS support in 8.1. So that commit is removed.