### PR TITLE
ci(smoke): enable native arm64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
           - os: linux
-            runner: [ self-hosted, linux, amd64 ]
+            runner: [ self-hosted, linux, arm64 ]
             arch: arm64
     env:
       JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64M
@@ -194,7 +194,6 @@ jobs:
           push: false
       - name: Run smoke test on ${{ matrix.arch }}
         env:
-          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
           # For non Linux runners there is no container available for testing, see build-docker job
           EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
         run: >


### PR DESCRIPTION
## Description

Let's try with just enabling them again :)

## Related issues

closes #11590
