### PR TITLE
Add ToplogyListeners in gateway

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClient.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClient.java
@@ -10,13 +10,21 @@ package io.camunda.zeebe.gateway.impl.broker;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 public interface BrokerClient extends AutoCloseable {
 
-  void start();
+  /**
+   * Starts broker client and associated services.
+   *
+   * @return a collection of futures for each of the service, which will be completed when the
+   *     corresponding service is started.
+   */
+  Collection<ActorFuture<Void>> start();
 
   @Override
   void close();

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.gateway.impl.broker;
 
-import io.atomix.cluster.ClusterMembershipEvent;
-import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.MessagingService;
@@ -47,10 +45,6 @@ public final class BrokerClientImpl implements BrokerClient {
 
     topologyManager = new BrokerTopologyManagerImpl(membershipService::getMembers);
     membershipService.addListener(topologyManager);
-    membershipService
-        .getMembers()
-        .forEach(
-            member -> topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, member)));
 
     atomixTransportAdapter = new AtomixClientTransportAdapter(messagingService);
     requestManager =

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -17,8 +17,11 @@ import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -56,10 +59,11 @@ public final class BrokerClientImpl implements BrokerClient {
   }
 
   @Override
-  public void start() {
-    schedulingService.submitActor(topologyManager);
-    schedulingService.submitActor(atomixTransportAdapter);
-    schedulingService.submitActor(requestManager);
+  public Collection<ActorFuture<Void>> start() {
+    final var topologyManagerStarted = topologyManager.start(schedulingService);
+    final var transportStarted = schedulingService.submitActor(atomixTransportAdapter);
+    final var requestManagerStarted = schedulingService.submitActor(requestManager);
+    return List.of(topologyManagerStarted, transportStarted, requestManagerStarted);
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyListener.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyListener.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.broker.cluster;
+
+import io.atomix.cluster.MemberId;
+
+/** Listener which will be notified when a broker is added or removed from the topology. */
+public interface BrokerTopologyListener {
+
+  void brokerAdded(MemberId memberId);
+
+  void brokerRemoved(MemberId memberId);
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -16,7 +16,6 @@ import io.atomix.cluster.Member;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
-import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -72,8 +71,8 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   @Override
   protected void onActorStarted() {
-    // to make gateway topology more robust we need to check for missing events periodically
-    actor.runAtFixedRate(Duration.ofSeconds(5), this::checkForMissingEvents);
+    // Get the initial member state before the listener is registered
+    checkForMissingEvents();
   }
 
   @Override

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -19,8 +19,10 @@ import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +42,9 @@ public final class StubbedBrokerClient implements BrokerClient {
   public StubbedBrokerClient() {}
 
   @Override
-  public void start() {}
+  public Collection<ActorFuture<Void>> start() {
+    return null;
+  }
 
   @Override
   public void close() {}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.test.broker.protocol.brokerapi.ExecuteCommandRequest;
 import io.camunda.zeebe.test.broker.protocol.brokerapi.ExecuteCommandResponseBuilder;
@@ -99,7 +100,7 @@ public final class BrokerClientTest {
             atomixCluster.getEventService(),
             actorScheduler.get());
 
-    client.start();
+    client.start().forEach(ActorFuture::join);
 
     final BrokerClusterStateImpl topology = new BrokerClusterStateImpl();
     topology.addPartitionIfAbsent(START_PARTITION_ID);

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/topology/TopologyUpdateTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/topology/TopologyUpdateTest.java
@@ -80,59 +80,6 @@ public final class TopologyUpdateTest {
   }
 
   @Test
-  public void shouldAddBrokerOnTopologyEvenOnNotReceivedEvent() {
-    // given
-    final int brokerId = 0;
-    final int partition = 1;
-    final BrokerInfo broker = createBroker(brokerId);
-    broker.setFollowerForPartition(partition);
-    createMemberAddedEvent(broker);
-
-    // when
-    actorClock.addTime(Duration.ofSeconds(10));
-
-    // then
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("the partition has the expected follower")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-                    .containsExactly(brokerId));
-  }
-
-  @Test
-  public void shouldUpdateBrokerOnTopologyEvenOnNotReceivedEvent() {
-    // given
-    final int brokerId = 0;
-    final int partition = 1;
-    final BrokerInfo broker = createBroker(brokerId);
-    topologyManager.event(createMemberAddedEvent(broker));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("the partition has no follower")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-                    .isNull());
-
-    // when
-    final BrokerInfo brokerUpdate = createBroker(brokerId);
-    brokerUpdate.setFollowerForPartition(partition);
-    createMemberUpdateEvent(brokerUpdate);
-    actorClock.addTime(Duration.ofSeconds(10));
-
-    // then
-    Awaitility.await("the partition has the expected follower")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-                    .containsExactly(brokerId));
-  }
-
-  @Test
   public void shouldUpdateTopologyOnBrokerRemove() {
     // given
     final int brokerId = 0;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/topology/TopologyUpdateTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/topology/TopologyUpdateTest.java
@@ -17,95 +17,84 @@ import io.atomix.cluster.MemberConfig;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
-import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
-import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
-import java.time.Duration;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import java.util.HashSet;
 import java.util.Set;
-import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public final class TopologyUpdateTest {
-
-  private final ControlledActorClock actorClock = new ControlledActorClock();
-  @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(actorClock);
+final class TopologyUpdateTest {
+  @RegisterExtension
+  final ControlledActorSchedulerExtension actorSchedulerRule =
+      new ControlledActorSchedulerExtension();
 
   private BrokerTopologyManagerImpl topologyManager;
   private Set<Member> members;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     members = new HashSet<>();
     topologyManager = new BrokerTopologyManagerImpl(() -> members);
     actorSchedulerRule.submitActor(topologyManager);
+    actorSchedulerRule.workUntilDone();
   }
 
-  @After
-  public void tearDown() {
-    topologyManager.close();
+  @AfterEach
+  void tearDown() {
+    topologyManager.closeAsync();
+    actorSchedulerRule.workUntilDone();
   }
 
   @Test
-  public void shouldUpdateTopologyOnBrokerAdd() {
+  void shouldUpdateTopologyOnBrokerAdd() {
     // given
     final int brokerId = 1;
     final int partition = 1;
     final BrokerInfo broker = createBroker(brokerId);
-    topologyManager.event(createMemberAddedEvent(broker));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("the partition has no followers")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-                    .isNull());
+    notifyEvent(createMemberAddedEvent(broker));
+
+    assertThat(topologyManager.getTopology().getFollowersForPartition(partition)).isNull();
 
     // when
     final BrokerInfo brokerUpdated = createBroker(brokerId);
     brokerUpdated.setFollowerForPartition(partition);
-    topologyManager.event(createMemberUpdateEvent(brokerUpdated));
+    notifyEvent(createMemberUpdateEvent(brokerUpdated));
 
     // then
-    Awaitility.await("the partition has the expected follower")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-                    .containsExactly(brokerId));
+
+    assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
+        .describedAs("The partition has the expected follower")
+        .containsExactly(brokerId);
     assertThat(topologyManager.getTopology().getBrokerVersion(brokerId))
         .isEqualTo(broker.getVersion());
   }
 
   @Test
-  public void shouldUpdateTopologyOnBrokerRemove() {
+  void shouldUpdateTopologyOnBrokerRemove() {
     // given
     final int brokerId = 0;
     final int partition = 1;
     final BrokerInfo broker = createBroker(brokerId);
-    topologyManager.event(createMemberAddedEvent(broker));
+    notifyEvent(createMemberAddedEvent(broker));
+
     final BrokerInfo brokerUpdated = createBroker(brokerId);
     brokerUpdated.setFollowerForPartition(partition);
-    topologyManager.event(createMemberUpdateEvent(brokerUpdated));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("the topology has brokers")
-        .untilAsserted(() -> assertThat(topologyManager.getTopology().getBrokers()).isNotEmpty());
+    notifyEvent(createMemberUpdateEvent(brokerUpdated));
+
+    assertThat(topologyManager.getTopology().getBrokers()).isNotEmpty();
 
     // when
-    topologyManager.event(createMemberRemoveEvent(brokerUpdated));
+    notifyEvent(createMemberRemoveEvent(brokerUpdated));
 
     // then
-    Awaitility.await("the topology has no brokers anymore")
-        .untilAsserted(() -> assertThat(topologyManager.getTopology().getBrokers()).isEmpty());
+    assertThat(topologyManager.getTopology().getBrokers()).isEmpty();
 
     // when
-    topologyManager.event(createMemberAddedEvent(broker));
-    Awaitility.await("the topology has brokers")
-        .untilAsserted(() -> assertThat(topologyManager.getTopology().getBrokers()).isNotEmpty());
+    notifyEvent(createMemberAddedEvent(broker));
+
+    assertThat(topologyManager.getTopology().getBrokers()).isNotEmpty();
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
         .doesNotContain(brokerId);
@@ -114,130 +103,104 @@ public final class TopologyUpdateTest {
   }
 
   @Test
-  public void shouldUpdateLeaderWithNewTerm() {
+  void shouldUpdateLeaderWithNewTerm() {
     // given
     final int partition = 1;
     final int oldLeaderId = 0;
     final BrokerInfo oldLeader = createBroker(oldLeaderId);
     oldLeader.setLeaderForPartition(partition, 1);
-    topologyManager.event(createMemberAddedEvent(oldLeader));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("the topology has the old leader")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-                    .isEqualTo(oldLeaderId));
+    notifyEvent(createMemberAddedEvent(oldLeader));
+
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .describedAs("Topology has the old leader")
+        .isEqualTo(oldLeaderId);
 
     // when
     final int newLeaderId = 1;
     final BrokerInfo newLeader = createBroker(newLeaderId);
     newLeader.setLeaderForPartition(partition, 2);
-    topologyManager.event(createMemberAddedEvent(newLeader));
+    notifyEvent(createMemberAddedEvent(newLeader));
 
     // then
-    Awaitility.await("the new broker is in the topology")
-        .untilAsserted(
-            () -> assertThat(topologyManager.getTopology().getBrokers()).contains(newLeaderId));
+    assertThat(topologyManager.getTopology().getBrokers()).contains(newLeaderId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
         .isEqualTo(newLeaderId);
   }
 
   @Test
-  public void shouldNotUpdateLeaderWhenFromPreviousTerm() {
+  void shouldNotUpdateLeaderWhenFromPreviousTerm() {
     // given
     final int partition = 1;
     final int newLeaderId = 1;
     final BrokerInfo newLeader = createBroker(newLeaderId);
     newLeader.setLeaderForPartition(partition, 2);
-    topologyManager.event(createMemberAddedEvent(newLeader));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("the topology has the new leader")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-                    .isEqualTo(newLeaderId));
+    notifyEvent(createMemberAddedEvent(newLeader));
+
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(newLeaderId);
 
     // when
     final int oldLeaderId = 0;
     final BrokerInfo oldLeader = createBroker(oldLeaderId);
     oldLeader.setLeaderForPartition(partition, 1);
-    topologyManager.event(createMemberAddedEvent(oldLeader));
+    notifyEvent(createMemberAddedEvent(oldLeader));
 
     // then
-    Awaitility.await("the old broker is in the topology")
-        .untilAsserted(
-            () -> assertThat(topologyManager.getTopology().getBrokers()).contains(oldLeaderId));
+    assertThat(topologyManager.getTopology().getBrokers()).contains(oldLeaderId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
         .isEqualTo(newLeaderId);
   }
 
   @Test
-  public void shouldUpdateTopologyOnBrokerRemoveAndDirectlyRejoin() {
+  void shouldUpdateTopologyOnBrokerRemoveAndDirectlyRejoin() {
     // given
     final int partition = 1;
     final int leaderId = 1;
     final BrokerInfo leader = createBroker(leaderId);
     leader.setLeaderForPartition(partition, 1);
-    topologyManager.event(createMemberAddedEvent(leader));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("the topology exists")
-        .untilAsserted(() -> assertThat(topologyManager.getTopology()).isNotNull());
+    notifyEvent(createMemberAddedEvent(leader));
+
+    assertThat(topologyManager.getTopology()).isNotNull();
 
     // when
-    topologyManager.event(createMemberRemoveEvent(leader));
-    Awaitility.await("the topology has no brokers")
-        .untilAsserted(() -> assertThat(topologyManager.getTopology().getBrokers()).isEmpty());
-    topologyManager.event(createMemberAddedEvent(leader));
+    notifyEvent(createMemberRemoveEvent(leader));
+
+    assertThat(topologyManager.getTopology().getBrokers()).isEmpty();
+    notifyEvent(createMemberAddedEvent(leader));
 
     // then
-    Awaitility.await("the broker has rejoined the tropology")
-        .untilAsserted(
-            () -> assertThat(topologyManager.getTopology().getBrokers()).containsExactly(leaderId));
+    assertThat(topologyManager.getTopology().getBrokers())
+        .describedAs("the broker has rejoined the cluster")
+        .containsExactly(leaderId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isEqualTo(leaderId);
   }
 
   @Test
-  public void shouldUpdateTopologyOnPartitionHealth() {
+  void shouldUpdateTopologyOnPartitionHealth() {
     // given
     final int brokerId = 0;
     final int partition = 0;
     final BrokerInfo broker = createBroker(brokerId);
     broker.setPartitionHealthy(partition);
-    topologyManager.event(createMemberAddedEvent(broker));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("partition is detected as healthy")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
-                    .as("partition %d is healthy on broker %d", partition, brokerId)
-                    .isEqualTo(PartitionHealthStatus.HEALTHY));
+    notifyEvent(createMemberAddedEvent(broker));
+
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is healthy on broker %d", partition, brokerId)
+        .isEqualTo(PartitionHealthStatus.HEALTHY);
 
     // when
     final BrokerInfo updatedBroker = createBroker(0);
     updatedBroker.setPartitionUnhealthy(partition);
-    topologyManager.event(createMemberUpdateEvent(updatedBroker));
-    Awaitility.await("partition is detected as unhealthy")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
-                    .as("partition %d is unhealthy on broker %d", partition, brokerId)
-                    .isEqualTo(PartitionHealthStatus.UNHEALTHY));
+    notifyEvent(createMemberUpdateEvent(updatedBroker));
 
     // then
     assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is unhealthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
   }
 
   @Test
-  public void shouldUpdateTopologyMetadataWhileNotDuplicatingFollower() {
+  void shouldUpdateTopologyMetadataWhileNotDuplicatingFollower() {
     // given
     final int brokerId = 0;
     final int partition = 0;
@@ -245,28 +208,21 @@ public final class TopologyUpdateTest {
     broker.setPartitionHealthy(partition);
     broker.setFollowerForPartition(partition);
 
-    topologyManager.event(createMemberAddedEvent(broker));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("partition is detected as healthy")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
-                    .as("partition %d is healthy on broker %d", partition, brokerId)
-                    .isEqualTo(PartitionHealthStatus.HEALTHY));
+    notifyEvent(createMemberAddedEvent(broker));
+
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is healthy on broker %d", partition, brokerId)
+        .isEqualTo(PartitionHealthStatus.HEALTHY);
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
         .containsExactly(brokerId);
 
     // when
     broker.setPartitionUnhealthy(partition);
-    topologyManager.event(createMemberUpdateEvent(broker));
-    Awaitility.await("partition is detected as unhealthy")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
-                    .as("partition %d is unhealthy on broker %d", partition, brokerId)
-                    .isEqualTo(PartitionHealthStatus.UNHEALTHY));
+    notifyEvent(createMemberUpdateEvent(broker));
+
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is unhealthy on broker %d", partition, brokerId)
+        .isEqualTo(PartitionHealthStatus.UNHEALTHY);
 
     // then
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
@@ -274,35 +230,28 @@ public final class TopologyUpdateTest {
   }
 
   @Test
-  public void shouldUpdateTopologyMetadataWhileNotDuplicatingInactiveNodes() {
+  void shouldUpdateTopologyMetadataWhileNotDuplicatingInactiveNodes() {
     // given
     final int brokerId = 0;
     final int partition = 0;
     final BrokerInfo broker = createBroker(brokerId);
     broker.setPartitionHealthy(partition);
     broker.setInactiveForPartition(partition);
-    topologyManager.event(createMemberAddedEvent(broker));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("partition is detected as healthy")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
-                    .as("partition %d is healthy on broker %d", partition, brokerId)
-                    .isEqualTo(PartitionHealthStatus.HEALTHY));
+    notifyEvent(createMemberAddedEvent(broker));
+
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is healthy on broker %d", partition, brokerId)
+        .isEqualTo(PartitionHealthStatus.HEALTHY);
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
         .containsExactly(brokerId);
 
     // when
     broker.setPartitionUnhealthy(partition);
-    topologyManager.event(createMemberUpdateEvent(broker));
-    Awaitility.await("partition is detected as unhealthy")
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
-                    .as("partition %d is unhealthy on broker %d", partition, brokerId)
-                    .isEqualTo(PartitionHealthStatus.UNHEALTHY));
+    notifyEvent(createMemberUpdateEvent(broker));
+
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is unhealthy on broker %d", partition, brokerId)
+        .isEqualTo(PartitionHealthStatus.UNHEALTHY);
 
     // then
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
@@ -310,78 +259,52 @@ public final class TopologyUpdateTest {
   }
 
   @Test
-  public void shouldUpdateTopologyOnLeaderRemoval() {
+  void shouldUpdateTopologyOnLeaderRemoval() {
     // given
     final int partition = 1;
     final int brokerId = 0;
     final BrokerInfo broker = createBroker(brokerId).setLeaderForPartition(partition, partition);
 
     // when
-    topologyManager.event(createMemberUpdateEvent(broker));
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("broker 0 is leader of partition 1")
-        .atMost(Duration.ofSeconds(5))
-        .pollInterval(Duration.ofMillis(100))
-        .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-                    .isZero());
+    notifyEvent(createMemberUpdateEvent(broker));
+
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isZero();
 
     broker.setFollowerForPartition(partition);
-    topologyManager.event(createMemberUpdateEvent(broker));
+    notifyEvent(createMemberUpdateEvent(broker));
 
     // then
-    Awaitility.await("broker 0 is follower of partition 1")
-        .atMost(Duration.ofSeconds(5))
-        .pollInterval(Duration.ofMillis(100))
-        .untilAsserted(
-            () -> {
-              assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-                  .containsExactlyInAnyOrder(brokerId);
-              assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-                  .isEqualTo(NODE_ID_NULL);
-            });
+
+    assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
+        .containsExactlyInAnyOrder(brokerId);
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(NODE_ID_NULL);
   }
 
   @Test
-  public void shouldUpdateTopologyOnBrokerInactive() {
+  void shouldUpdateTopologyOnBrokerInactive() {
     // given
     final int partition = 0;
     final int brokerId = 0;
     final BrokerInfo broker = createBroker(brokerId);
     broker.setLeaderForPartition(partition, 1);
-    topologyManager.event(createMemberAddedEvent(broker));
+    notifyEvent(createMemberAddedEvent(broker));
 
     // when
-    Awaitility.given()
-        // topology is eventually available
-        .ignoreException(NullPointerException.class)
-        .await("broker 0 is leader of partition 0")
-        .atMost(Duration.ofSeconds(5))
-        .pollInterval(Duration.ofMillis(100))
-        .untilAsserted(
-            () -> {
-              assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-                  .isNullOrEmpty();
-              assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-                  .isEqualTo(brokerId);
-            });
+
+    assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
+        .isNullOrEmpty();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isEqualTo(brokerId);
+
     broker.setInactiveForPartition(partition);
-    topologyManager.event(createMemberUpdateEvent(broker));
+    notifyEvent(createMemberUpdateEvent(broker));
 
     // then
-    Awaitility.await("broker 0 is inactive for partition 0")
-        .atMost(Duration.ofSeconds(5))
-        .pollInterval(Duration.ofMillis(100))
-        .untilAsserted(
-            () -> {
-              assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-                  .contains(brokerId);
-              assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-                  .isNotEqualTo(brokerId);
-            });
+
+    assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
+        .contains(brokerId);
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isNotEqualTo(brokerId);
   }
 
   private BrokerInfo createBroker(final int brokerId) {
@@ -418,5 +341,10 @@ public final class TopologyUpdateTest {
     final Member member = new Member(new MemberConfig());
     broker.writeIntoProperties(member.properties());
     return new ClusterMembershipEvent(Type.MEMBER_REMOVED, member);
+  }
+
+  private void notifyEvent(final ClusterMembershipEvent broker) {
+    topologyManager.event(broker);
+    actorSchedulerRule.workUntilDone();
   }
 }


### PR DESCRIPTION
## Description

This PR enabled adding topology listeners in gateway. This is required for ClientStreamService.

In addition, this contains following refactoring:
- Moved TopologyUpdateTest to junit5 and replace ActorSchedulerRule with ControlledActorSchedulerExtension. This helps to remove non-deterministic waiting with Awaitility. https://github.com/camunda/zeebe/pull/12447/commits/70a0496a6b0ab09a4529b02b648cce26ef5b386a 
- https://github.com/camunda/zeebe/pull/12447/commits/0bb1ff861974c3357ab691a20bbebc3e8001c84e removes periodic checking of membership state. This is unnecessary because we can rely on membership service to notify when a broker is added or removed. We only have to check once after the startup, to ensure that the membership updates occurred before the actor is started is not lost.
- The above change resulted in flaky tests in `BrokerClientTest` because the fake topology set by the test is overwritten by the topology manager. The tests did not fail before because there was a delay of 5 seconds when topology manager checks for missing events. This is fixed in https://github.com/camunda/zeebe/pull/12447/commits/0945c3088629e5a72b260778c104418afb113b08 which allows waiting until the broker client is fully started. This is an ugly solution. Happy to discuss it. 

## Related issues

closes #12387 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
