### PR TITLE
[Backport stable/8.2] fix(engine): skip unnecessary blacklist check

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -23,6 +23,8 @@ import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
@@ -130,9 +132,13 @@ public class Engine implements RecordProcessor {
         return processingResultBuilder.build();
       }
 
-      final boolean isNotOnBlacklist =
-          !processingState.getBlackListState().isOnBlacklist(typedCommand);
-      if (isNotOnBlacklist) {
+      // There is no blacklist check needed if the intent is not instance related
+      // nor if the intent is to create new instances, which can't be blacklisted yet
+      final boolean noBlacklistCheckNeeded =
+          !(record.getIntent() instanceof ProcessInstanceRelatedIntent)
+              || record.getIntent() instanceof ProcessInstanceCreationIntent;
+      if (noBlacklistCheckNeeded
+          || !processingState.getBlackListState().isOnBlacklist(typedCommand)) {
         currentProcessor.processRecord(record);
       }
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -116,6 +116,7 @@ public class ProcessingDbState implements MutableProcessingState {
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     messageSubscriptionState.onRecovered(context);
     processMessageSubscriptionState.onRecovered(context);
+    blackListState.onRecovered(context);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BlackListState.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
-public interface BlackListState {
+public interface BlackListState extends StreamProcessorLifecycleAware {
 
   boolean isOnBlacklist(final TypedRecord record);
+
+  boolean isEmpty();
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
@@ -134,6 +134,28 @@ public final class BlackListStateTest {
     assertThat(blackListState.isOnBlacklist(differentProcessInstanceRecord)).isFalse();
   }
 
+  @Test
+  public void blacklistIsEmptyIsTrueIfNothingIsBlacklisted() {
+    // given
+
+    // when
+    final boolean blackListIsEmpty = blackListState.isEmpty();
+
+    // then
+    assertThat(blackListIsEmpty).isTrue();
+  }
+
+  @Test
+  public void blacklistIsEmptyIsFalseIfSomethingGotBlacklisted() {
+    // given
+
+    // when
+    blackListState.blacklistProcessInstance(1001);
+
+    // then
+    assertThat(blackListState.isEmpty()).isFalse();
+  }
+
   private TypedRecordImpl createRecord() {
     return createRecord(1000L);
   }


### PR DESCRIPTION
# Description
Backport of #12306 to `stable/8.2`.

relates to camunda/zeebe#12316 #12041