### PR TITLE
[Backport stable/8.1] feat: run timer due date checker concurrently to processing

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -34,6 +34,8 @@ public final class FeatureFlagsCfg {
   private boolean enableActorMetrics = DEFAULT_SETTINGS.enableActorMetrics();
   private boolean enableBackup = DEFAULT_SETTINGS.enableBackup();
   private boolean enableMessageTtlCheckerAsync = DEFAULT_SETTINGS.enableMessageTTLCheckerAsync();
+  private boolean enableTimerDueDateCheckerAsync =
+      DEFAULT_SETTINGS.enableTimerDueDateCheckerAsync();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -67,9 +69,21 @@ public final class FeatureFlagsCfg {
     this.enableMessageTtlCheckerAsync = enableMessageTtlCheckerAsync;
   }
 
+  public boolean isEnableTimerDueDateCheckerAsync() {
+    return enableTimerDueDateCheckerAsync;
+  }
+
+  public void setEnableTimerDueDateCheckerAsync(final boolean enableTimerDueDateCheckerAsync) {
+    this.enableTimerDueDateCheckerAsync = enableTimerDueDateCheckerAsync;
+  }
+
   public FeatureFlags toFeatureFlags() {
     return new FeatureFlags(
-        enableYieldingDueDateChecker, enableActorMetrics, enableBackup, enableMessageTtlCheckerAsync
+        enableYieldingDueDateChecker,
+        enableActorMetrics,
+        enableBackup,
+        enableMessageTtlCheckerAsync,
+        enableTimerDueDateCheckerAsync
         /*, enableFoo*/ );
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -105,4 +105,37 @@ final class FeatureFlagsCfgTest {
     // then
     assertThat(featureFlagsCfg.isEnableMessageTtlCheckerAsync()).isTrue();
   }
+
+  @Test
+  void shouldDisableDueDateCheckerAsyncByDefault() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableTimerDueDateCheckerAsync()).isFalse();
+  }
+
+  @Test
+  void shouldSetEnableTimerDueDateCheckerAsyncFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableTimerDueDateCheckerAsync()).isTrue();
+  }
+
+  @Test
+  void shouldSetEnableTimerDueDateCheckerAsyncFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.features.enableMessageDueDateAsync", "true");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableTimerDueDateCheckerAsync()).isTrue();
+  }
 }

--- a/broker/src/test/resources/system/feature-flags-cfg.yaml
+++ b/broker/src/test/resources/system/feature-flags-cfg.yaml
@@ -5,3 +5,4 @@ zeebe:
         enableYieldingDueDateChecker: true
         enableActorMetrics: true
         enableMessageTTLCheckerAsync: true
+        enableTimerDueDateCheckerAsync: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -850,3 +850,11 @@
         # enabling it in production.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEMESSAGETTLCHECKERASYNC
         # enableMessageTTLCheckerAsync: false
+
+        # While disabled, checking for due timers blocks all other executions that occur on the
+        # stream processor, including process execution and job activation/completion.
+        # When enabled, the Due Date Checker will run asynchronous to the Engine's stream processor.
+        # This helps improve throughput and process latency when there are a lot of timers.
+        # We recommend testing this feature in a non-production environment before enabling it in production.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLETIMERDUEDATECHECKERASYNC
+        # enableTimerDueDateCheckerAsync: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -788,3 +788,11 @@
         # enabling it in production.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEMESSAGETTLCHECKERASYNC
         # enableMessageTTLCheckerAsync: false
+
+        # While disabled, checking for due timers blocks all other executions that occur on the
+        # stream processor, including process execution and job activation/completion.
+        # When enabled, the Due Date Checker will run asynchronous to the Engine's stream processor.
+        # This helps improve throughput and process latency when there are a lot of timers.
+        # We recommend testing this feature in a non-production environment before enabling it in production.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLETIMERDUEDATECHECKERASYNC
+        # enableTimerDueDateCheckerAsync: false

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -65,7 +65,8 @@ public final class EngineProcessors {
     final var config = typedRecordProcessorContext.getConfig();
 
     final DueDateTimerChecker timerChecker =
-        new DueDateTimerChecker(processingState.getTimerState(), featureFlags);
+        new DueDateTimerChecker(
+            typedRecordProcessorContext.getScheduledTaskDbState().getTimerState(), featureFlags);
 
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffChecker.java
@@ -25,6 +25,7 @@ public final class JobBackoffChecker implements StreamProcessorLifecycleAware {
     backOffDueDateChecker =
         new DueDateChecker(
             BACKOFF_RESOLUTION,
+            false,
             taskResultBuilder ->
                 jobState.findBackedOffJobs(
                     ActorClock.currentTimeMillis(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -32,6 +32,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     dueDateChecker =
         new DueDateChecker(
             TIMER_RESOLUTION,
+            featureFlags.enableTimerDueDateCheckerAsync(),
             new TriggerTimersSideEffect(
                 timerInstanceState, ActorClock.current(), featureFlags.yieldingDueDateChecker()));
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -10,18 +10,26 @@ package io.camunda.zeebe.engine.state;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
+import io.camunda.zeebe.engine.state.instance.DbTimerInstanceState;
 import io.camunda.zeebe.engine.state.message.DbMessageState;
 
 /** Contains read-only state that can be accessed safely by scheduled tasks. */
 public final class ScheduledTaskDbState {
   private final MessageState messageState;
+  private final TimerInstanceState timerInstanceState;
 
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     messageState = new DbMessageState(zeebeDb, transactionContext);
+    timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
   }
 
   public MessageState getMessageState() {
     return messageState;
+  }
+
+  public TimerInstanceState getTimerState() {
+    return timerInstanceState;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateCheckerTest.java
@@ -27,7 +27,7 @@ public class DueDateCheckerTest {
   @Test
   public void shouldNotScheduleTwoTasks() {
     // given
-    final var dueDateChecker = new DueDateChecker(100, (builder) -> 0L);
+    final var dueDateChecker = new DueDateChecker(100, false, (builder) -> 0L);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
 
@@ -48,7 +48,7 @@ public class DueDateCheckerTest {
   @Test
   public void shouldScheduleForAnEarlierTasks() {
     // given
-    final var dueDateChecker = new DueDateChecker(100, (builder) -> 0L);
+    final var dueDateChecker = new DueDateChecker(100, false, (builder) -> 0L);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
 

--- a/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -14,7 +14,8 @@ public record FeatureFlags(
     boolean yieldingDueDateChecker,
     boolean enableActorMetrics,
     boolean enableBackup,
-    boolean enableMessageTTLCheckerAsync
+    boolean enableMessageTTLCheckerAsync,
+    boolean enableTimerDueDateCheckerAsync
     /*, boolean foo*/ ) {
 
   /* To add a new feature toggle, please follow these steps:
@@ -50,10 +51,15 @@ public record FeatureFlags(
   private static final boolean ENABLE_BACKUP = false;
 
   private static final boolean ENABLE_MSG_TTL_CHECKER_ASYNC = false;
+  private static final boolean ENABLE_DUE_DATE_CHECKER_ASYNC = false;
 
   public static FeatureFlags createDefault() {
     return new FeatureFlags(
-        YIELDING_DUE_DATE_CHECKER, ENABLE_ACTOR_METRICS, ENABLE_BACKUP, ENABLE_MSG_TTL_CHECKER_ASYNC
+        YIELDING_DUE_DATE_CHECKER,
+        ENABLE_ACTOR_METRICS,
+        ENABLE_BACKUP,
+        ENABLE_MSG_TTL_CHECKER_ASYNC,
+        ENABLE_DUE_DATE_CHECKER_ASYNC
         /*, FOO_DEFAULT*/ );
   }
 
@@ -67,7 +73,8 @@ public record FeatureFlags(
         true, /* YIELDING_DUE_DATE_CHECKER*/
         false, /* ENABLE_ACTOR_METRICS */
         true, /* ENABLE_BACKUP */
-        true /* ENABLE_MSG_TTL_CHECKER_ASYNC */
+        true, /* ENABLE_MSG_TTL_CHECKER_ASYNC */
+        true /* ENABLE_DUE_DATE_CHECKER_ASYNC */
         /*, FOO_DEFAULT*/ );
   }
 


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/12403.
No tricky merge conflicts, just minor differences in naming and the list of available feature flags.