### PR TITLE
[Backport 8.1]: skip unnecessary blacklist check

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -105,6 +105,7 @@ public class ProcessingDbState implements MutableProcessingState {
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     messageSubscriptionState.onRecovered(context);
     processMessageSubscriptionState.onRecovered(context);
+    blackListState.onRecovered(context);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BlackListState.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.api.TypedRecord;
 
-public interface BlackListState {
+public interface BlackListState extends StreamProcessorLifecycleAware {
 
   boolean isOnBlacklist(final TypedRecord record);
+
+  boolean isEmpty();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.metrics.BlacklistMetrics;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
@@ -34,6 +35,7 @@ public final class DbBlackListState implements MutableBlackListState {
   private final ColumnFamily<DbLong, DbNil> blackListColumnFamily;
   private final DbLong processInstanceKey;
   private final BlacklistMetrics blacklistMetrics;
+  private boolean empty = true;
 
   public DbBlackListState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -46,10 +48,16 @@ public final class DbBlackListState implements MutableBlackListState {
     blacklistMetrics = new BlacklistMetrics(partitionId);
   }
 
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    empty = blackListColumnFamily.isEmpty();
+  }
+
   private void blacklist(final long key) {
     if (key >= 0) {
       LOG.warn(BLACKLIST_INSTANCE_MESSAGE, key);
 
+      empty = false;
       processInstanceKey.wrapLong(key);
       blackListColumnFamily.insert(processInstanceKey, DbNil.INSTANCE);
       blacklistMetrics.countBlacklistedInstance();
@@ -57,6 +65,10 @@ public final class DbBlackListState implements MutableBlackListState {
   }
 
   private boolean isOnBlacklist(final long key) {
+    if (empty) {
+      return false;
+    }
+
     processInstanceKey.wrapLong(key);
     return blackListColumnFamily.exists(processInstanceKey);
   }
@@ -71,6 +83,11 @@ public final class DbBlackListState implements MutableBlackListState {
       }
     }
     return false;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return empty;
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BlackListStateTest.java
@@ -134,6 +134,28 @@ public final class BlackListStateTest {
     assertThat(blackListState.isOnBlacklist(differentProcessInstanceRecord)).isFalse();
   }
 
+  @Test
+  public void blacklistIsEmptyIsTrueIfNothingIsBlacklisted() {
+    // given
+
+    // when
+    final boolean blackListIsEmpty = blackListState.isEmpty();
+
+    // then
+    assertThat(blackListIsEmpty).isTrue();
+  }
+
+  @Test
+  public void blacklistIsEmptyIsFalseIfSomethingGotBlacklisted() {
+    // given
+
+    // when
+    blackListState.blacklistProcessInstance(1001);
+
+    // then
+    assertThat(blackListState.isEmpty()).isFalse();
+  }
+
   private TypedRecordImpl createRecord() {
     return createRecord(1000L);
   }


### PR DESCRIPTION
## Description

Backport  #12306
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes to https://github.com/camunda/zeebe/issues/12041

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
