### PR TITLE
ci: remove jvm args for smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,6 @@ jobs:
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
             arch: arm64
-    env:
-      JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64M
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe


### PR DESCRIPTION
Removes custom JVM args that were only set for smoke tests. These seem to be no longer necessary.

closes #12469 