### PR TITLE
fix(backup/s3): allow not configuring s3 credentials

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration.backup;
 
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import java.time.Duration;
 import java.util.Objects;
@@ -102,16 +103,19 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
   }
 
   public static S3BackupConfig toStoreConfig(S3BackupStoreConfig config) {
-    return new S3BackupConfig.Builder()
-        .withBucketName(config.getBucketName())
-        .withEndpoint(config.getEndpoint())
-        .withRegion(config.getRegion())
-        .withCredentials(config.getAccessKey(), config.getSecretKey())
-        .withApiCallTimeout(config.getApiCallTimeout())
-        .forcePathStyleAccess(config.isForcePathStyleAccess())
-        .withCompressionAlgorithm(config.getCompression())
-        .withBasePath(config.getBasePath())
-        .build();
+    final var builder =
+        new Builder()
+            .withBucketName(config.getBucketName())
+            .withEndpoint(config.getEndpoint())
+            .withRegion(config.getRegion())
+            .withApiCallTimeout(config.getApiCallTimeout())
+            .forcePathStyleAccess(config.isForcePathStyleAccess())
+            .withCompressionAlgorithm(config.getCompression())
+            .withBasePath(config.getBasePath());
+    if (config.getAccessKey() != null && config.getSecretKey() != null) {
+      builder.withCredentials(config.getAccessKey(), config.getSecretKey());
+    }
+    return builder.build();
   }
 
   @Override

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAuthenticationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAuthenticationIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.backup;
+
+import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.zeebe.containers.ZeebeContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+final class S3BackupAuthenticationIT {
+  private static final Network NETWORK = Network.newNetwork();
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @Container
+  private static final MinioContainer MINIO =
+      new MinioContainer().withNetwork(NETWORK).withDomain("minio.local", BUCKET_NAME);
+
+  @Test
+  @RegressionTest("https://github.com/camunda/zeebe/issues/12433")
+  void shouldConnectWithoutConfiguredCredentials() {
+    // given
+    final var zeebe =
+        new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+            .withNetwork(NETWORK)
+            .dependsOn(MINIO)
+            .withoutTopologyCheck()
+            .withEnv("MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE", "*")
+            .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "S3")
+            .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME", BUCKET_NAME)
+            .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ENDPOINT", MINIO.internalEndpoint())
+            .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_REGION", MINIO.region())
+            // Set env variables discovered by the AWS SDK, not Zeebe
+            .withEnv("AWS_ACCESS_KEY_ID", MINIO.accessKey())
+            .withEnv("AWS_SECRET_ACCESS_KEY", MINIO.secretKey());
+
+    // when
+    zeebe.start();
+
+    // then
+    Assertions.assertThat(zeebe.isStarted()).isTrue();
+
+    // cleanup
+    zeebe.close();
+  }
+}


### PR DESCRIPTION
This fixes a regression introduced in dfd3b9e and again allows to not configure s3 credentials and let the AWS SDK discover them instead.

Closes #12433