### PR TITLE
[Backport stable/8.2] ci: remove jvm args for smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,6 @@ jobs:
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
             arch: arm64
-    env:
-      JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64M
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe


### PR DESCRIPTION
# Description
Backport of #12470 to `stable/8.2`.

relates to #12469