### PR TITLE
Use larger fixed length prefix extractor

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -184,8 +184,10 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
     final var tableConfig = createTableFormatConfig(closeables, blockCacheMemory);
 
     return columnFamilyOptions
-        // to extract our column family type (used as prefix) and seek faster
-        .useFixedLengthPrefixExtractor(Long.BYTES)
+        // to seek faster
+        //  1. LONG to extract our column family type (used as prefix)
+        //  2. LONG to extract most key prefixes (e.g. scopeKey)
+        .useFixedLengthPrefixExtractor(2 * Long.BYTES)
         .setMemtablePrefixBloomSizeRatio(memtablePrefixFilterMemory)
         // memtables
         // merge at least 3 memtables per L0 file, otherwise all memtables are flushed as individual


### PR DESCRIPTION
## Description

In my recent benchmarks and profiling, we have seen again that the most performance issues or impact are coming from our iterating over data (or column families), even if no data exist.

[See related comment here ](https://github.com/camunda/zeebe/issues/12241#issuecomment-1511337058)

I have recently checked some configurations, and wiki pages and stumbled over [`#useFixedLengthPrefixExtractor`](https://javadoc.io/static/org.rocksdb/rocksdbjni/5.5.5/org/rocksdb/ColumnFamilyOptionsInterface.html#useFixedLengthPrefixExtractor(int)). I think this was mention once from @oleschoenburg as well. 

We have already configured the prefix extractor to a LONG. If we iterate we normally do this via a prefix, mostly a long (e.g. scopeKey) which needs to be considered. The column family itself is already long, which means if we use another long in the fixed extractor we can consider the additional key.

The prefix extractor is used during iteration, if more bytes can be considered during seek and iteration it makes the internal search more performant. There are some data structures and logics applied to the size of the extractor and how the data is organized.

Based on my JMH benchmarks I did with #12241 I was able to show that it improved the performance by a lot

```
Result "io.camunda.zeebe.engine.perf.EnginePerformanceTest.measureProcessExecutionTime":
  552.536 ±(99.9%) 89.015 ops/s [Average]
  (min, avg, max) = (177.826, 552.536, 1122.175), stdev = 376.894
  CI (99.9%): [463.521, 641.550] (assumes normal distribution)


# Run complete. Total time: 00:05:09

Benchmark                                           Mode  Cnt    Score    Error  Units
EnginePerformanceTest.measureProcessExecutionTime  thrpt  200  552.536 ± 89.015  ops/s
```

Where the base is ~230, see [other results here](https://github.com/camunda/zeebe/issues/12241#issuecomment-1511196808).

We need to run some more benchmarks to understand better the performance impact and maybe down sides (?) but it looks like a good think to do ? 

I might still miss some knowledge about RocksDB so please take it with a grain of salt. Would be happy for any input you have @romansmirnov @oleschoenburg @npepinpe 

Zeebe Benchmarks:

 * [Normal benchmark](https://grafana.dev.zeebe.io/d/NzsO1mUnk/zeebe-overview?orgId=1&refresh=10s&var-DS_PROMETHEUS=Prometheus&var-cluster=All&var-namespace=zell-set-prefix-filter-benchmark&var-pod=All&var-partition=All) 
 * [Maxing out performance benchmark](https://grafana.dev.zeebe.io/d/NzsO1mUnk/zeebe-overview?orgId=1&refresh=10s&var-DS_PROMETHEUS=Prometheus&var-cluster=All&var-namespace=zell-max-out-fixed-extractor&var-pod=All&var-partition=All)
 * [Large State benchmark](https://grafana.dev.zeebe.io/d/NzsO1mUnk/zeebe-overview?orgId=1&refresh=10s&var-DS_PROMETHEUS=Prometheus&var-cluster=All&var-namespace=zell-large-state-fixed-extractor&var-pod=All&var-partition=All)


**Related resources:**


 * https://github.com/EighteenZi/rocksdb_wiki/blob/64377d5bb29fab79730668fca73a8020ed758d99/Prefix-Seek-API-Changes.md
 * https://github.com/EighteenZi/rocksdb_wiki/blob/64377d5bb29fab79730668fca73a8020ed758d99/RocksDB-Tuning-Guide.md?plain=1#L187
 * https://github.com/EighteenZi/rocksdb_wiki/blob/64377d5bb29fab79730668fca73a8020ed758d99/RocksDB-Basics.md?plain=1#L51
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
