### PR TITLE
feat(transport): retry with other available client streams if push to one failed

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/StreamExhaustedException.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/StreamExhaustedException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+public class StreamExhaustedException extends RuntimeException {
+
+  public StreamExhaustedException(final String message) {
+    super(message);
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
@@ -14,23 +14,20 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
 import io.camunda.zeebe.transport.stream.impl.AggregatedClientStream.LogicalId;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
-import org.agrona.MutableDirectBuffer;
 import org.junit.jupiter.api.Test;
 
 class AggregatedClientStreamTest {
 
   private final DirectBuffer streamType = BufferUtil.wrapString("foo");
-  private final SerializableData metadata = new SerializableData().data(1234);
-  final AggregatedClientStream<SerializableData> stream =
+  private final TestSerializableData metadata = new TestSerializableData(1234);
+  final AggregatedClientStream<TestSerializableData> stream =
       new AggregatedClientStream<>(UUID.randomUUID(), new LogicalId<>(streamType, metadata));
 
   @Test
@@ -85,34 +82,5 @@ class AggregatedClientStreamTest {
 
   private void addClient(final ClientStreamIdImpl streamId, final ClientStreamConsumer consumer) {
     stream.addClient(new ClientStream<>(streamId, stream, streamType, metadata, consumer));
-  }
-
-  private static class SerializableData implements BufferReader, BufferWriter {
-
-    private int data;
-
-    public int data() {
-      return data;
-    }
-
-    public SerializableData data(final int data) {
-      this.data = data;
-      return this;
-    }
-
-    @Override
-    public void wrap(final DirectBuffer buffer, final int offset, final int length) {
-      data = buffer.getInt(0);
-    }
-
-    @Override
-    public int getLength() {
-      return Integer.BYTES;
-    }
-
-    @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {
-      buffer.putInt(offset, data);
-    }
   }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
+import io.camunda.zeebe.transport.stream.api.ClientStreamId;
+import io.camunda.zeebe.transport.stream.impl.AggregatedClientStream.LogicalId;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.junit.jupiter.api.Test;
+
+class AggregatedClientStreamTest {
+
+  private final DirectBuffer streamType = BufferUtil.wrapString("foo");
+  private final SerializableData metadata = new SerializableData().data(1234);
+  final AggregatedClientStream<SerializableData> stream =
+      new AggregatedClientStream<>(UUID.randomUUID(), new LogicalId<>(streamType, metadata));
+
+  @Test
+  void shouldRetryWithAllAvailableClientsIfPushFailed() {
+    // given
+    final List<ClientStreamId> executedClients = new ArrayList<>();
+    final List<ClientStreamId> expected =
+        List.of(
+            addFailingClient(executedClients::add),
+            addFailingClient(executedClients::add),
+            addFailingClient(executedClients::add));
+
+    // when - then
+
+    assertThatException()
+        .isThrownBy(() -> stream.getClientStreamConsumer().push(null))
+        .isInstanceOf(StreamExhaustedException.class);
+
+    assertThat(executedClients).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @Test
+  void shouldSucceedWhenOneClientSucceeds() {
+    // given
+    addFailingClient(s -> {});
+    addFailingClient(s -> {});
+
+    final AtomicBoolean pushSucceeded = new AtomicBoolean(false);
+    final ClientStreamIdImpl streamId = getNextStreamId();
+    addClient(streamId, p -> pushSucceeded.set(true));
+
+    // when - then
+
+    assertThatNoException().isThrownBy(() -> stream.getClientStreamConsumer().push(null));
+    assertThat(pushSucceeded.get()).isTrue();
+  }
+
+  private ClientStreamIdImpl getNextStreamId() {
+    return new ClientStreamIdImpl(stream.getStreamId(), stream.nextLocalId());
+  }
+
+  private ClientStreamId addFailingClient(final Consumer<ClientStreamId> consumer) {
+    final ClientStreamIdImpl streamId = getNextStreamId();
+    addClient(
+        streamId,
+        p -> {
+          consumer.accept(streamId);
+          throw new RuntimeException("fail");
+        });
+    return streamId;
+  }
+
+  private void addClient(final ClientStreamIdImpl streamId, final ClientStreamConsumer consumer) {
+    stream.addClient(new ClientStream<>(streamId, stream, streamType, metadata, consumer));
+  }
+
+  private static class SerializableData implements BufferReader, BufferWriter {
+
+    private int data;
+
+    public int data() {
+      return data;
+    }
+
+    public SerializableData data(final int data) {
+      this.data = data;
+      return this;
+    }
+
+    @Override
+    public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+      data = buffer.getInt(0);
+    }
+
+    @Override
+    public int getLength() {
+      return Integer.BYTES;
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {
+      buffer.putInt(offset, data);
+    }
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -232,8 +232,7 @@ class ClientStreamManagerTest {
     assertThat(future)
         .failsWithin(Duration.ofMillis(100))
         .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(RuntimeException.class)
-        .withMessageContaining("Expected");
+        .withCauseInstanceOf(RuntimeException.class);
   }
 
   @Test

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestSerializableData.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestSerializableData.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+class TestSerializableData implements BufferReader, BufferWriter {
+
+  private int data;
+
+  public TestSerializableData() {}
+
+  public TestSerializableData(final int data) {
+    this.data = data;
+  }
+
+  public TestSerializableData data(final int data) {
+    this.data = data;
+    return this;
+  }
+
+  public int data() {
+    return data;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    data = buffer.getInt(0);
+  }
+
+  @Override
+  public int getLength() {
+    return Integer.BYTES;
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    buffer.putInt(offset, data);
+  }
+}


### PR DESCRIPTION
## Description

When gateway fails to push job to one client, it retries with other available clients until success. If no more clients are available, the error is propagate back to the broker.

## Related issues

related to #12386 
