### PR TITLE
[Backport stable/8.2] feat(dist): Remove the `-xms` parameter

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -287,8 +287,7 @@
           <assembleDirectory>${project.build.directory}/camunda-zeebe</assembleDirectory>
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
-          <extraJvmArguments>-Xms128m
-            -XX:+ExitOnOutOfMemoryError
+          <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
             -Dfile.encoding=UTF-8</extraJvmArguments>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>


### PR DESCRIPTION
# Description
Backport of #12482 to `stable/8.2`.

relates to #12416