### PR TITLE
[Backport stable/8.1] Introduce cache for process versions

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.BpmnFactory;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
-import io.camunda.zeebe.engine.state.NextValueManager;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -70,7 +69,7 @@ public final class DbProcessState implements MutableProcessState {
   private final ColumnFamily<DbForeignKey<DbString>, Digest> digestByIdColumnFamily;
   private final Digest digest = new Digest();
 
-  private final NextValueManager versionManager;
+  private final ProcessVersionManager versionManager;
 
   public DbProcessState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -102,9 +101,7 @@ public final class DbProcessState implements MutableProcessState {
 
     processesByKey = new Long2ObjectHashMap<>();
 
-    versionManager =
-        new NextValueManager(
-            DEFAULT_VERSION_VALUE, zeebeDb, transactionContext, ZbColumnFamilies.PROCESS_VERSION);
+    versionManager = new ProcessVersionManager(DEFAULT_VERSION_VALUE, zeebeDb, transactionContext);
   }
 
   @Override
@@ -152,11 +149,11 @@ public final class DbProcessState implements MutableProcessState {
     processId.wrapBuffer(processRecord.getBpmnProcessIdBuffer());
     final var bpmnProcessId = processRecord.getBpmnProcessId();
 
-    final var currentVersion = versionManager.getCurrentValue(bpmnProcessId);
+    final var currentVersion = versionManager.getCurrentProcessVersion(bpmnProcessId);
     final var nextVersion = processRecord.getVersion();
 
     if (nextVersion > currentVersion) {
-      versionManager.setValue(bpmnProcessId, nextVersion);
+      versionManager.setProcessVersion(bpmnProcessId, nextVersion);
     }
   }
 
@@ -219,7 +216,7 @@ public final class DbProcessState implements MutableProcessState {
         processesByProcessIdAndVersion.get(processIdBuffer);
 
     processId.wrapBuffer(processIdBuffer);
-    final long latestVersion = versionManager.getCurrentValue(processIdBuffer);
+    final long latestVersion = versionManager.getCurrentProcessVersion(processIdBuffer);
 
     DeployedProcess deployedProcess;
     if (versionMap == null) {
@@ -286,7 +283,7 @@ public final class DbProcessState implements MutableProcessState {
 
   @Override
   public int getProcessVersion(final String bpmnProcessId) {
-    return (int) versionManager.getCurrentValue(bpmnProcessId);
+    return (int) versionManager.getCurrentProcessVersion(bpmnProcessId);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.deployment;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.NextValue;
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import java.util.function.ToLongFunction;
+import org.agrona.DirectBuffer;
+import org.agrona.collections.Object2LongHashMap;
+
+public final class ProcessVersionManager {
+
+  private final long initialValue;
+
+  private final ColumnFamily<DbString, NextValue> nextValueColumnFamily;
+  private final DbString processIdKey;
+  private final NextValue nextVersion = new NextValue();
+  private final Object2LongHashMap<String> versionCache;
+
+  public ProcessVersionManager(
+      final long initialValue,
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final TransactionContext transactionContext) {
+    this.initialValue = initialValue;
+
+    processIdKey = new DbString();
+    nextValueColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PROCESS_VERSION, transactionContext, processIdKey, nextVersion);
+    versionCache = new Object2LongHashMap<>(initialValue);
+  }
+
+  public void setProcessVersion(final String processId, final long value) {
+    processIdKey.wrapString(processId);
+    nextVersion.set(value);
+    nextValueColumnFamily.upsert(processIdKey, nextVersion);
+    versionCache.put(processId, value);
+  }
+
+  public long getCurrentProcessVersion(final String processId) {
+    processIdKey.wrapString(processId);
+    return getCurrentProcessVersion();
+  }
+
+  public long getCurrentProcessVersion(final DirectBuffer processId) {
+    processIdKey.wrapBuffer(processId);
+    return getCurrentProcessVersion();
+  }
+
+  private long getCurrentProcessVersion() {
+    return versionCache.computeIfAbsent(
+        processIdKey.toString(), (ToLongFunction<String>) (key) -> getProcessVersionFromDB());
+  }
+
+  private long getProcessVersionFromDB() {
+    final NextValue readValue = nextValueColumnFamily.get(processIdKey);
+
+    long currentValue = initialValue;
+    if (readValue != null) {
+      currentValue = readValue.get();
+    }
+    return currentValue;
+  }
+}


### PR DESCRIPTION
# Description
Backport of #12475 to `stable/8.1`.

Note: This doesn't contain the rename commit https://github.com/camunda/zeebe/pull/12475/commits/ec2f789848d35e0d2eefec8c5a6526713f319201 of the NextValueManager to ProcessVersionManager, as `NextValueManager` is used in other occasions on the 8.1 branch.

relates to camunda/zeebe#12034