### PR TITLE
ci(test): skip test artifact upload on success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: always()
+        if: failure()
         with:
           name: "[IT] ${{ matrix.name }}"
   unit-tests:
@@ -146,7 +146,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: always()
+        if: failure()
         with:
           name: "unit tests"
   smoke-tests:
@@ -204,7 +204,7 @@ jobs:
           verify
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: always()
+        if: failure()
         with:
           name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
   property-tests:
@@ -240,7 +240,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: always()
+        if: failure()
         with:
           name: Property Tests
   go-client:
@@ -319,7 +319,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: always()
+        if: failure()
         with:
           name: Java 8 Client
   codeql:


### PR DESCRIPTION
## Description

It's only needed on failure, we can save time otherwise.

## Related issues

related #12028