### PR TITLE
fix(engine): prevent record corruption during message TTL checking

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -33,7 +33,7 @@ import org.agrona.collections.MutableInteger;
  */
 public final class MessageTimeToLiveChecker implements Task {
 
-  private static final MessageRecord EMPTY_DELETE_MESSAGE_COMMAND =
+  private final MessageRecord emptyDeleteMessageCommand =
       new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
 
   /** This determines the duration that the TTL checker is idle after it completes an execution. */
@@ -88,7 +88,7 @@ public final class MessageTimeToLiveChecker implements Task {
 
               final boolean stillFitsInResult =
                   taskResultBuilder.appendCommandRecord(
-                      expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND);
+                      expiredMessageKey, MessageIntent.EXPIRE, emptyDeleteMessageCommand);
               return stillFitsInResult && counter.incrementAndGet() < batchLimit;
             });
 


### PR DESCRIPTION
When multiple message TTL checker were running concurrently, for example because one broker is leader for multiple partitions, the scheduled jobs tried to write the same message record concurrently. Writing records (or really, `UnpackedObject`s) is not thread safe. Using a static instance of the empty message record would result in deserialization errors while trying to create a copy before writing to the logstream.

Usually this would kill the processing actor and stop processing for one partition. With `enableMessageTtlCheckerAsync` enabled, it would only prevent message TTL checking until a new instance of `MessageObserver` is started.

closes #12509 
