### PR TITLE
[Backport stable/8.2] fix(engine): prevent record corruption during message TTL checking

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -33,7 +33,7 @@ import org.agrona.collections.MutableInteger;
  */
 public final class MessageTimeToLiveChecker implements Task {
 
-  private static final MessageRecord EMPTY_DELETE_MESSAGE_COMMAND =
+  private final MessageRecord emptyDeleteMessageCommand =
       new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
 
   /** This determines the duration that the TTL checker is idle after it completes an execution. */
@@ -88,7 +88,7 @@ public final class MessageTimeToLiveChecker implements Task {
 
               final boolean stillFitsInResult =
                   taskResultBuilder.appendCommandRecord(
-                      expiredMessageKey, MessageIntent.EXPIRE, EMPTY_DELETE_MESSAGE_COMMAND);
+                      expiredMessageKey, MessageIntent.EXPIRE, emptyDeleteMessageCommand);
               return stillFitsInResult && counter.incrementAndGet() < batchLimit;
             });
 


### PR DESCRIPTION
# Description
Backport of #12510 to `stable/8.2`.

relates to #12509