### PR TITLE
[Backport stable/8.2] fix: handle failure to resolve address more gracefully

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -22,6 +22,7 @@ import io.atomix.utils.concurrent.OrderedFuture;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.util.collection.Tuple;
 import io.netty.channel.Channel;
+import java.net.ConnectException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -92,7 +93,7 @@ class ChannelPool {
     if (inetAddress == null) {
       final CompletableFuture<Channel> failedFuture = new OrderedFuture<>();
       failedFuture.completeExceptionally(
-          new IllegalStateException("Failed to resolve address %s".formatted(address)));
+          new ConnectException("Failed to resolve address %s".formatted(address)));
       return failedFuture;
     }
     final List<CompletableFuture<Channel>> channelPool = getChannelPool(address, inetAddress);

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -694,7 +694,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     final InetAddress resolvedAddress = address.address(true);
     if (resolvedAddress == null) {
       future.completeExceptionally(
-          new IllegalStateException(
+          new ConnectException(
               "Failed to bootstrap client (address "
                   + address.toString()
                   + " cannot be resolved)"));


### PR DESCRIPTION
# Description
Backport of #12486 to `stable/8.2`.

relates to 