### PR TITLE
Allow client stream consumers to be async

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import org.agrona.DirectBuffer;
 
 /**
@@ -21,5 +22,5 @@ public interface ClientStreamConsumer {
    *
    * @param payload the data to be consumed by the client
    */
-  void push(DirectBuffer payload);
+  ActorFuture<Void> push(DirectBuffer payload);
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -26,7 +26,6 @@ final class AggregatedClientStream<M extends BufferWriter> {
   private static final Logger LOGGER = LoggerFactory.getLogger(AggregatedClientStream.class);
   private final UUID streamId;
   private final LogicalId<M> logicalId;
-  private final AsyncStreamConsumer streamConsumer;
   private final Set<MemberId> liveConnections = new HashSet<>();
 
   private final Int2ObjectHashMap<ClientStream<M>> clientStreams = new Int2ObjectHashMap<>();
@@ -38,7 +37,6 @@ final class AggregatedClientStream<M extends BufferWriter> {
     this.streamId = streamId;
     this.logicalId = logicalId;
 
-    streamConsumer = this::push;
     state = State.INITIAL;
   }
 
@@ -56,10 +54,6 @@ final class AggregatedClientStream<M extends BufferWriter> {
 
   M getMetadata() {
     return logicalId.metadata();
-  }
-
-  AsyncStreamConsumer getClientStreamConsumer() {
-    return streamConsumer;
   }
 
   int nextLocalId() {
@@ -119,7 +113,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
     return logicalId;
   }
 
-  private void push(final DirectBuffer buffer, final ActorFuture<Void> future) {
+  void push(final DirectBuffer buffer, final ActorFuture<Void> future) {
     final var streams = clientStreams.values();
     if (streams.isEmpty()) {
       throw new NoSuchStreamException();
@@ -174,10 +168,6 @@ final class AggregatedClientStream<M extends BufferWriter> {
   }
 
   record LogicalId<M>(DirectBuffer streamType, M metadata) {}
-
-  interface AsyncStreamConsumer {
-    void push(DirectBuffer data, ActorFuture<Void> futureToComplete);
-  }
 
   private enum State {
     INITIAL,

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -8,8 +8,7 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
-import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -27,7 +26,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
   private static final Logger LOGGER = LoggerFactory.getLogger(AggregatedClientStream.class);
   private final UUID streamId;
   private final LogicalId<M> logicalId;
-  private final ClientStreamConsumer streamConsumer;
+  private final AsyncStreamConsumer streamConsumer;
   private final Set<MemberId> liveConnections = new HashSet<>();
 
   private final Int2ObjectHashMap<ClientStream<M>> clientStreams = new Int2ObjectHashMap<>();
@@ -59,7 +58,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
     return logicalId.metadata();
   }
 
-  ClientStreamConsumer getClientStreamConsumer() {
+  AsyncStreamConsumer getClientStreamConsumer() {
     return streamConsumer;
   }
 
@@ -120,7 +119,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
     return logicalId;
   }
 
-  private void push(final DirectBuffer buffer) {
+  private void push(final DirectBuffer buffer, final ActorFuture<Void> future) {
     final var streams = clientStreams.values();
     if (streams.isEmpty()) {
       throw new NoSuchStreamException();
@@ -129,44 +128,42 @@ final class AggregatedClientStream<M extends BufferWriter> {
     final var targets = new ArrayList<>(streams);
     final var index = ThreadLocalRandom.current().nextInt(streams.size());
 
-    final var result = tryPush(targets, index, 1, buffer);
-    if (result.isLeft()) {
-      throw result.getLeft();
-    }
+    tryPush(targets, index, 1, buffer, future);
   }
 
-  private Either<RuntimeException, Boolean> tryPush(
+  private void tryPush(
       final ArrayList<ClientStream<M>> targets,
       final int index,
       final int currentCount,
-      final DirectBuffer buffer) {
+      final DirectBuffer buffer,
+      final ActorFuture<Void> future) {
     // Try with clients in a round-robin starting from the randomly picked startIndex
     final var clientStream = targets.get(index);
-    try {
-      LOGGER.trace(
-          "Pushing data from stream [{}] to client [{}]", streamId, clientStream.streamId());
-      clientStream.clientStreamConsumer().push(buffer);
-      return Either.right(true);
-    } catch (final Exception pushFailed) {
-      if (currentCount >= targets.size()) {
-        final StreamExhaustedException error =
-            new StreamExhaustedException(
-                "Failed to push data to all available clients. No more clients left to retry.");
-        error.addSuppressed(pushFailed);
-        return Either.left(error);
-      } else {
-        LOGGER.warn(
-            "Failed to push data to client [{}], retrying with next client.",
-            clientStream.streamId(),
-            pushFailed);
-        return tryPush(targets, (index + 1) % targets.size(), currentCount + 1, buffer)
-            .mapLeft(
-                retryError -> {
-                  retryError.addSuppressed(pushFailed);
-                  return retryError;
-                });
-      }
-    }
+
+    LOGGER.trace("Pushing data from stream [{}] to client [{}]", streamId, clientStream.streamId());
+    clientStream
+        .clientStreamConsumer()
+        .push(buffer)
+        .onComplete(
+            (ok, pushFailed) -> {
+              if (pushFailed == null) {
+                future.complete(null);
+              } else {
+                if (currentCount >= targets.size()) {
+                  final StreamExhaustedException error =
+                      new StreamExhaustedException(
+                          "Failed to push data to all available clients. No more clients left to retry.");
+                  error.addSuppressed(pushFailed);
+                  future.completeExceptionally(error);
+                } else {
+                  LOGGER.warn(
+                      "Failed to push data to client [{}], retrying with next client.",
+                      clientStream.streamId(),
+                      pushFailed);
+                  tryPush(targets, (index + 1) % targets.size(), currentCount + 1, buffer, future);
+                }
+              }
+            });
   }
 
   void open(final ClientStreamRequestManager<M> requestManager, final Set<MemberId> servers) {
@@ -177,6 +174,10 @@ final class AggregatedClientStream<M extends BufferWriter> {
   }
 
   record LogicalId<M>(DirectBuffer streamType, M metadata) {}
+
+  interface AsyncStreamConsumer {
+    void push(DirectBuffer data, ActorFuture<Void> futureToComplete);
+  }
 
   private enum State {
     INITIAL,

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -85,7 +85,7 @@ final class ClientStreamManager<M extends BufferWriter> {
     clientStream.ifPresentOrElse(
         stream -> {
           try {
-            stream.getClientStreamConsumer().push(payload, responseFuture);
+            stream.push(payload, responseFuture);
           } catch (final Exception e) {
             responseFuture.completeExceptionally(e);
           }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +77,7 @@ final class ClientStreamManager<M extends BufferWriter> {
   }
 
   public void onPayloadReceived(
-      final PushStreamRequest pushStreamRequest, final CompletableFuture<Void> responseFuture) {
+      final PushStreamRequest pushStreamRequest, final ActorFuture<Void> responseFuture) {
     final var streamId = pushStreamRequest.streamId();
     final var payload = pushStreamRequest.payload();
 
@@ -85,8 +85,7 @@ final class ClientStreamManager<M extends BufferWriter> {
     clientStream.ifPresentOrElse(
         stream -> {
           try {
-            stream.getClientStreamConsumer().push(payload);
-            responseFuture.complete(null);
+            stream.getClientStreamConsumer().push(payload, responseFuture);
           } catch (final Exception e) {
             responseFuture.completeExceptionally(e);
           }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
@@ -42,7 +42,7 @@ class AggregatedClientStreamTest {
 
     // when
     final TestActorFuture<Void> future = new TestActorFuture<>();
-    stream.getClientStreamConsumer().push(null, future);
+    stream.push(null, future);
 
     // then
     assertThat(future).failsWithin(Duration.ofMillis(100));
@@ -66,7 +66,7 @@ class AggregatedClientStreamTest {
 
     // when
     final TestActorFuture<Void> future = new TestActorFuture<>();
-    stream.getClientStreamConsumer().push(null, future);
+    stream.push(null, future);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(100));

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
@@ -128,6 +129,7 @@ class StreamIntegrationTest {
               payload.wrap(p, 0, p.capacity());
               payloads.get().add(payload.data());
               latch.countDown();
+              return TestActorFuture.completedFuture(null);
             })
         .join();
 
@@ -146,7 +148,8 @@ class StreamIntegrationTest {
   @Test
   void shouldReturnErrorWhenClientStreamIsClosed() throws InterruptedException {
     // given
-    final var clientStreamId = clientStreamer.add(streamType, metadata, p -> {}).join();
+    final var clientStreamId =
+        clientStreamer.add(streamType, metadata, p -> TestActorFuture.completedFuture(null)).join();
     Awaitility.await().until(() -> remoteStreamer.streamFor(streamType).isPresent());
     final var serverStream = remoteStreamer.streamFor(streamType).orElseThrow();
 


### PR DESCRIPTION
## Description

Allow `ClientStreamConsumer` to push the payload asynchronously. 
- `ClientStreamConsumer#push` returns an `ActorFuture`
- AggregatedClientStream and ClientStreamManager is adjusted for these changes.
  - `AggregatedClientStream#push` accepts an ActorFuture as parameter instead of creating one and returning to make unit testing easy. Creating a `CompletableActorFuture` prevents us from unit testing it because the caller is not an actor.

## Related issues

related to #https://github.com/camunda/zeebe/pull/12484#pullrequestreview-1394262504 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
