### PR TITLE
Add `ProcessInstanceBatch` record and intent

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -51,6 +51,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
         ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.SIGNAL, SignalRecord::new);
     RECORDS_BY_TYPE.put(ValueType.COMMAND_DISTRIBUTION, CommandDistributionRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -730,6 +730,7 @@
         #     process: true
         #     processEvent: false
         #     processInstance: true
+        #     processInstanceBatch: false
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
@@ -799,6 +800,7 @@
         #     process: true
         #     processEvent: false
         #     processInstance: true
+        #     processInstanceBatch: false
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -640,6 +640,7 @@
         #     process: true
         #     processEvent: false
         #     processInstance: true
+        #     processInstanceBatch: false
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
@@ -709,6 +710,7 @@
         #     process: true
         #     processEvent: false
         #     processInstance: true
+        #     processInstanceBatch: false
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -231,6 +231,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.processInstance) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE);
       }
+      if (index.processInstanceBatch) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH);
+      }
       if (index.processInstanceCreation) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
       }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -82,6 +82,8 @@ public class ElasticsearchExporterConfiguration {
         return index.variableDocument;
       case PROCESS_INSTANCE:
         return index.processInstance;
+      case PROCESS_INSTANCE_BATCH:
+        return index.processInstanceBatch;
       case PROCESS_INSTANCE_CREATION:
         return index.processInstanceCreation;
       case PROCESS_INSTANCE_MODIFICATION:
@@ -157,6 +159,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean messageSubscription = true;
     public boolean process = true;
     public boolean processInstance = true;
+    public boolean processInstanceBatch = false;
     public boolean processInstanceCreation = true;
     public boolean processInstanceModification = true;
     public boolean processMessageSubscription = true;
@@ -232,6 +235,8 @@ public class ElasticsearchExporterConfiguration {
           + process
           + ", processInstance="
           + processInstance
+          + ", processInstanceBatch="
+          + processInstanceBatch
           + ", processInstanceCreation="
           + processInstanceCreation
           + ", processInstanceModification="

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-batch-template.json
@@ -1,0 +1,36 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-batch_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-batch": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "batchElementInstanceKey": {
+              "type": "long"
+            },
+            "index": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -52,6 +52,7 @@ final class TestSupport {
       case JOB -> config.job = value;
       case DEPLOYMENT -> config.deployment = value;
       case PROCESS_INSTANCE -> config.processInstance = value;
+      case PROCESS_INSTANCE_BATCH -> config.processInstanceBatch = value;
       case INCIDENT -> config.incident = value;
       case MESSAGE -> config.message = value;
       case MESSAGE_SUBSCRIPTION -> config.messageSubscription = value;

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -225,6 +225,9 @@ public class OpensearchExporter implements Exporter {
       if (index.processInstance) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE);
       }
+      if (index.processInstanceBatch) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH);
+      }
       if (index.processInstanceCreation) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
       }

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -78,6 +78,8 @@ public class OpensearchExporterConfiguration {
         return index.variableDocument;
       case PROCESS_INSTANCE:
         return index.processInstance;
+      case PROCESS_INSTANCE_BATCH:
+        return index.processInstanceBatch;
       case PROCESS_INSTANCE_CREATION:
         return index.processInstanceCreation;
       case PROCESS_INSTANCE_MODIFICATION:
@@ -153,6 +155,7 @@ public class OpensearchExporterConfiguration {
     public boolean messageSubscription = true;
     public boolean process = true;
     public boolean processInstance = true;
+    public boolean processInstanceBatch = false;
     public boolean processInstanceCreation = true;
     public boolean processInstanceModification = true;
     public boolean processMessageSubscription = true;
@@ -223,6 +226,8 @@ public class OpensearchExporterConfiguration {
           + ", variableDocument="
           + variableDocument
           + ", processInstance="
+          + processInstanceBatch
+          + ", processInstanceBatch="
           + processInstance
           + ", processInstanceCreation="
           + processInstanceCreation

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-batch-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-batch-template.json
@@ -1,0 +1,36 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-batch_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-batch": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "batchElementInstanceKey": {
+              "type": "long"
+            },
+            "index": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -51,6 +51,7 @@ final class TestSupport {
       case JOB -> config.job = value;
       case DEPLOYMENT -> config.deployment = value;
       case PROCESS_INSTANCE -> config.processInstance = value;
+      case PROCESS_INSTANCE_BATCH -> config.processInstanceBatch = value;
       case INCIDENT -> config.incident = value;
       case MESSAGE -> config.message = value;
       case MESSAGE_SUBSCRIPTION -> config.messageSubscription = value;

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+
+public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
+    implements ProcessInstanceBatchRecordValue {
+
+  private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+  private final LongProperty batchElementInstanceKeyProperty =
+      new LongProperty("batchElementInstanceKey");
+
+  /**
+   * The index is used to determine the beginning of the next batch. If the index equals -1 it means
+   * there won't be another batch. For the TERMINATE intent this index will be the element instance
+   * key of the first child instance of the next batch.
+   */
+  private final LongProperty indexProperty = new LongProperty("index", -1L);
+
+  public ProcessInstanceBatchRecord() {
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(batchElementInstanceKeyProperty)
+        .declareProperty(indexProperty);
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBatchRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getBatchElementInstanceKey() {
+    return batchElementInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBatchRecord setBatchElementInstanceKey(final long batchElementInstanceKey) {
+    batchElementInstanceKeyProperty.setValue(batchElementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getIndex() {
+    return indexProperty.getValue();
+  }
+
+  public ProcessInstanceBatchRecord setIndex(final long index) {
+    indexProperty.setValue(index);
+    return this;
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
@@ -1265,6 +1266,45 @@ final class JsonSerializableToJsonTest {
                 "decisionsMetadata": [],
                 "decisionRequirementsMetadata": []
               }
+          }
+          """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////// ProcessInstanceBatchRecord /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ProcessInstanceBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new ProcessInstanceBatchRecord()
+                    .setProcessInstanceKey(123L)
+                    .setBatchElementInstanceKey(456L)
+                    .setIndex(10L),
+        """
+          {
+            "processInstanceKey": 123,
+            "batchElementInstanceKey": 456,
+            "index": 10
+          }
+          """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////// Empty ProcessInstanceBatchRecord ///////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty ProcessInstanceBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new ProcessInstanceBatchRecord()
+                    .setProcessInstanceKey(123L)
+                    .setBatchElementInstanceKey(456L),
+        """
+          {
+            "processInstanceKey": 123,
+            "batchElementInstanceKey": 456,
+            "index": -1
           }
           """
       },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -57,6 +58,7 @@ import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
@@ -194,6 +196,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.COMMAND_DISTRIBUTION,
         new Mapping<>(CommandDistributionRecordValue.class, CommandDistributionIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_BATCH,
+        new Mapping<>(ProcessInstanceBatchRecordValue.class, ProcessInstanceBatchIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -50,7 +50,8 @@ public interface Intent {
           SignalIntent.class,
           SignalSubscriptionIntent.class,
           ResourceDeletionIntent.class,
-          CommandDistributionIntent.class);
+          CommandDistributionIntent.class,
+          ProcessInstanceBatchIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -128,6 +129,8 @@ public interface Intent {
         return ResourceDeletionIntent.from(intent);
       case COMMAND_DISTRIBUTION:
         return CommandDistributionIntent.from(intent);
+      case PROCESS_INSTANCE_BATCH:
+        return ProcessInstanceBatchIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
+  TERMINATE(0);
+
+  private final short value;
+  private final boolean shouldBlacklist;
+
+  ProcessInstanceBatchIntent(final int value) {
+    this(value, true);
+  }
+
+  ProcessInstanceBatchIntent(final int value, final boolean shouldBlacklist) {
+    this.value = (short) value;
+    this.shouldBlacklist = shouldBlacklist;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return TERMINATE;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return shouldBlacklist;
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBatchRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBatchRecordValue.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * Represents a batch action that's performed for a process instance. An example for this is
+ * termination of child instances. Instead of writing a TERMINATE command for all children, this
+ * command is used to batch these commands in smaller chunks.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableProcessInstanceBatchRecordValue.Builder.class)
+public interface ProcessInstanceBatchRecordValue extends RecordValue, ProcessInstanceRelated {
+
+  /**
+   * @return the element instance for which a batch action is being performed. This should be a
+   *     container element (e.g. a subprocess).
+   */
+  long getBatchElementInstanceKey();
+
+  /**
+   * @return an index used to keep track of where we are in our batch process and where to start the
+   *     next batch.
+   */
+  long getIndex();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -48,6 +48,7 @@
       <validValue name="SIGNAL">31</validValue>
       <validValue name="RESOURCE_DELETION">32</validValue>
       <validValue name="COMMAND_DISTRIBUTION">33</validValue>
+      <validValue name="PROCESS_INSTANCE_BATCH">34</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds the `ProcessInstanceBatch` record and intent. This will be used to terminate a process in batches, to prevent running into a `ExceededBatchRecordSizeException` when terminating a process instance with a lot of active element instances.

- Added record
- Added intent
- Extended exporter configuration

Official docs will be extended with the exporter configurations in a later issue.

Implemented using the developers handbook https://github.com/camunda/zeebe/blob/main/docs/developer_handbook.md#how-to-create-a-new-record

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12537 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
