### PR TITLE
Process `ProcessInstanceBatch.TERMINATE` commands

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -51,6 +51,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
         ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.SIGNAL, SignalRecord::new);
     RECORDS_BY_TYPE.put(ValueType.COMMAND_DISTRIBUTION, CommandDistributionRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -730,6 +730,7 @@
         #     process: true
         #     processEvent: false
         #     processInstance: true
+        #     processInstanceBatch: false
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
@@ -799,6 +800,7 @@
         #     process: true
         #     processEvent: false
         #     processInstance: true
+        #     processInstanceBatch: false
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -640,6 +640,7 @@
         #     process: true
         #     processEvent: false
         #     processInstance: true
+        #     processInstanceBatch: false
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
@@ -709,6 +710,7 @@
         #     process: true
         #     processEvent: false
         #     processInstance: true
+        #     processInstanceBatch: false
         #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -46,7 +46,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.COMMAND_DISTRIBUTION);
+      EnumSet.range(ValueType.JOB, ValueType.PROCESS_INSTANCE_BATCH);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/TerminateProcessInstanceBatchProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/TerminateProcessInstanceBatchProcessor.java
@@ -11,7 +11,10 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
@@ -32,5 +35,46 @@ public final class TerminateProcessInstanceBatchProcessor
   }
 
   @Override
-  public void processRecord(final TypedRecord<ProcessInstanceBatchRecord> record) {}
+  public void processRecord(final TypedRecord<ProcessInstanceBatchRecord> record) {
+    final var recordValue = record.getValue();
+
+    elementInstanceState.forEachChild(
+        recordValue.getBatchElementInstanceKey(),
+        recordValue.getIndex(),
+        (childKey, childInstance) -> {
+          if (canWriteCommand(record, childInstance)) {
+            terminateChildInstance(childInstance);
+            return true;
+          } else {
+            final var nextBatchRecord =
+                new ProcessInstanceBatchRecord()
+                    .setProcessInstanceKey(recordValue.getProcessInstanceKey())
+                    .setBatchElementInstanceKey(recordValue.getBatchElementInstanceKey())
+                    .setIndex(childKey);
+            final long key = keyGenerator.nextKey();
+            commandWriter.appendFollowUpCommand(
+                key, ProcessInstanceBatchIntent.TERMINATE, nextBatchRecord);
+            return false;
+          }
+        });
+  }
+
+  private boolean canWriteCommand(
+      final TypedRecord<ProcessInstanceBatchRecord> record, final ElementInstance childInstance) {
+    // We must have space in the batch to write both the TERMINATE command as the potential
+    // follow-up batch command. An excessive 8Kb is added to account for metadata. This is way
+    // more than will be necessary.
+    final var expectedCommandLength =
+        childInstance.getValue().getLength() + record.getLength() + (1024 * 8);
+    return commandWriter.canWriteCommandOfLength(expectedCommandLength);
+  }
+
+  private void terminateChildInstance(final ElementInstance childInstance) {
+    if (childInstance.canTerminate()) {
+      commandWriter.appendFollowUpCommand(
+          childInstance.getKey(),
+          ProcessInstanceIntent.TERMINATE_ELEMENT,
+          childInstance.getValue());
+    }
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/TerminateProcessInstanceBatchProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/TerminateProcessInstanceBatchProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public final class TerminateProcessInstanceBatchProcessor
+    implements TypedRecordProcessor<ProcessInstanceBatchRecord> {
+
+  private final TypedCommandWriter commandWriter;
+  private final KeyGenerator keyGenerator;
+  private final ElementInstanceState elementInstanceState;
+
+  public TerminateProcessInstanceBatchProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ElementInstanceState elementInstanceState) {
+    commandWriter = writers.command();
+    this.keyGenerator = keyGenerator;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceBatchRecord> record) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
@@ -32,6 +32,11 @@ final class ResultBuilderBackedTypedCommandWriter extends AbstractResultBuilderB
     appendRecord(key, intent, value);
   }
 
+  @Override
+  public boolean canWriteCommandOfLength(final int commandLength) {
+    return resultBuilder().canWriteEventOfLength(commandLength);
+  }
+
   private void appendRecord(final long key, final Intent intent, final RecordValue value) {
     resultBuilder()
         .appendRecord(key, RecordType.COMMAND, intent, RejectionType.NULL_VAL, "", value);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
@@ -33,4 +33,10 @@ public interface TypedCommandWriter {
    *     RecordBatch
    */
   void appendFollowUpCommand(long key, Intent intent, RecordValue value);
+
+  /**
+   * @param commandLength the length of the command that will be written
+   * @return true if a command of the given length can be written
+   */
+  boolean canWriteCommandOfLength(final int commandLength);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.engine.state.instance.AwaitProcessInstanceResultMetadata;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import java.util.List;
+import java.util.function.BiFunction;
 import org.agrona.DirectBuffer;
 
 public interface ElementInstanceState {
@@ -17,6 +18,22 @@ public interface ElementInstanceState {
   ElementInstance getInstance(long key);
 
   List<ElementInstance> getChildren(long parentKey);
+
+  /**
+   * Applies the provided visitor to each child element of the given parent. The visitor can
+   * indicate via the return value, whether the iteration should continue or not. This means if the
+   * visitor returns false the iteration will stop.
+   *
+   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exists,
+   * the first key-value-pair will contain the equal key as {@code startAtKey}. If the key doesn't
+   * exist it will start after.
+   *
+   * @param parentKey the key of the parent element instance
+   * @param startAtKey the element instance key of child the iteration should start at
+   * @param visitor the visitor which is applied for each child
+   */
+  void forEachChild(
+      long parentKey, long startAtKey, BiFunction<Long, ElementInstance, Boolean> visitor);
 
   AwaitProcessInstanceResultMetadata getAwaitResultRequestMetadata(long processInstanceKey);
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -231,6 +231,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.processInstance) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE);
       }
+      if (index.processInstanceBatch) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH);
+      }
       if (index.processInstanceCreation) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
       }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -82,6 +82,8 @@ public class ElasticsearchExporterConfiguration {
         return index.variableDocument;
       case PROCESS_INSTANCE:
         return index.processInstance;
+      case PROCESS_INSTANCE_BATCH:
+        return index.processInstanceBatch;
       case PROCESS_INSTANCE_CREATION:
         return index.processInstanceCreation;
       case PROCESS_INSTANCE_MODIFICATION:
@@ -157,6 +159,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean messageSubscription = true;
     public boolean process = true;
     public boolean processInstance = true;
+    public boolean processInstanceBatch = false;
     public boolean processInstanceCreation = true;
     public boolean processInstanceModification = true;
     public boolean processMessageSubscription = true;
@@ -232,6 +235,8 @@ public class ElasticsearchExporterConfiguration {
           + process
           + ", processInstance="
           + processInstance
+          + ", processInstanceBatch="
+          + processInstanceBatch
           + ", processInstanceCreation="
           + processInstanceCreation
           + ", processInstanceModification="

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-batch-template.json
@@ -1,0 +1,36 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-batch_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-batch": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "batchElementInstanceKey": {
+              "type": "long"
+            },
+            "index": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -52,6 +52,7 @@ final class TestSupport {
       case JOB -> config.job = value;
       case DEPLOYMENT -> config.deployment = value;
       case PROCESS_INSTANCE -> config.processInstance = value;
+      case PROCESS_INSTANCE_BATCH -> config.processInstanceBatch = value;
       case INCIDENT -> config.incident = value;
       case MESSAGE -> config.message = value;
       case MESSAGE_SUBSCRIPTION -> config.messageSubscription = value;

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -225,6 +225,9 @@ public class OpensearchExporter implements Exporter {
       if (index.processInstance) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE);
       }
+      if (index.processInstanceBatch) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH);
+      }
       if (index.processInstanceCreation) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
       }

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -78,6 +78,8 @@ public class OpensearchExporterConfiguration {
         return index.variableDocument;
       case PROCESS_INSTANCE:
         return index.processInstance;
+      case PROCESS_INSTANCE_BATCH:
+        return index.processInstanceBatch;
       case PROCESS_INSTANCE_CREATION:
         return index.processInstanceCreation;
       case PROCESS_INSTANCE_MODIFICATION:
@@ -153,6 +155,7 @@ public class OpensearchExporterConfiguration {
     public boolean messageSubscription = true;
     public boolean process = true;
     public boolean processInstance = true;
+    public boolean processInstanceBatch = false;
     public boolean processInstanceCreation = true;
     public boolean processInstanceModification = true;
     public boolean processMessageSubscription = true;
@@ -223,6 +226,8 @@ public class OpensearchExporterConfiguration {
           + ", variableDocument="
           + variableDocument
           + ", processInstance="
+          + processInstanceBatch
+          + ", processInstanceBatch="
           + processInstance
           + ", processInstanceCreation="
           + processInstanceCreation

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-batch-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-batch-template.json
@@ -1,0 +1,36 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-batch_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-batch": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "batchElementInstanceKey": {
+              "type": "long"
+            },
+            "index": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -51,6 +51,7 @@ final class TestSupport {
       case JOB -> config.job = value;
       case DEPLOYMENT -> config.deployment = value;
       case PROCESS_INSTANCE -> config.processInstance = value;
+      case PROCESS_INSTANCE_BATCH -> config.processInstanceBatch = value;
       case INCIDENT -> config.incident = value;
       case MESSAGE -> config.message = value;
       case MESSAGE_SUBSCRIPTION -> config.messageSubscription = value;

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+
+public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
+    implements ProcessInstanceBatchRecordValue {
+
+  private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+  private final LongProperty batchElementInstanceKeyProperty =
+      new LongProperty("batchElementInstanceKey");
+
+  /**
+   * The index is used to determine the beginning of the next batch. If the index equals -1 it means
+   * there won't be another batch. For the TERMINATE intent this index will be the element instance
+   * key of the first child instance of the next batch.
+   */
+  private final LongProperty indexProperty = new LongProperty("index", -1L);
+
+  public ProcessInstanceBatchRecord() {
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(batchElementInstanceKeyProperty)
+        .declareProperty(indexProperty);
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBatchRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getBatchElementInstanceKey() {
+    return batchElementInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBatchRecord setBatchElementInstanceKey(final long batchElementInstanceKey) {
+    batchElementInstanceKeyProperty.setValue(batchElementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getIndex() {
+    return indexProperty.getValue();
+  }
+
+  public ProcessInstanceBatchRecord setIndex(final long index) {
+    indexProperty.setValue(index);
+    return this;
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
@@ -1265,6 +1266,45 @@ final class JsonSerializableToJsonTest {
                 "decisionsMetadata": [],
                 "decisionRequirementsMetadata": []
               }
+          }
+          """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////// ProcessInstanceBatchRecord /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ProcessInstanceBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new ProcessInstanceBatchRecord()
+                    .setProcessInstanceKey(123L)
+                    .setBatchElementInstanceKey(456L)
+                    .setIndex(10L),
+        """
+          {
+            "processInstanceKey": 123,
+            "batchElementInstanceKey": 456,
+            "index": 10
+          }
+          """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////// Empty ProcessInstanceBatchRecord ///////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty ProcessInstanceBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new ProcessInstanceBatchRecord()
+                    .setProcessInstanceKey(123L)
+                    .setBatchElementInstanceKey(456L),
+        """
+          {
+            "processInstanceKey": 123,
+            "batchElementInstanceKey": 456,
+            "index": -1
           }
           """
       },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -57,6 +58,7 @@ import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
@@ -194,6 +196,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.COMMAND_DISTRIBUTION,
         new Mapping<>(CommandDistributionRecordValue.class, CommandDistributionIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_BATCH,
+        new Mapping<>(ProcessInstanceBatchRecordValue.class, ProcessInstanceBatchIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -50,7 +50,8 @@ public interface Intent {
           SignalIntent.class,
           SignalSubscriptionIntent.class,
           ResourceDeletionIntent.class,
-          CommandDistributionIntent.class);
+          CommandDistributionIntent.class,
+          ProcessInstanceBatchIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -128,6 +129,8 @@ public interface Intent {
         return ResourceDeletionIntent.from(intent);
       case COMMAND_DISTRIBUTION:
         return CommandDistributionIntent.from(intent);
+      case PROCESS_INSTANCE_BATCH:
+        return ProcessInstanceBatchIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
+  TERMINATE(0);
+
+  private final short value;
+  private final boolean shouldBlacklist;
+
+  ProcessInstanceBatchIntent(final int value) {
+    this(value, true);
+  }
+
+  ProcessInstanceBatchIntent(final int value, final boolean shouldBlacklist) {
+    this.value = (short) value;
+    this.shouldBlacklist = shouldBlacklist;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return TERMINATE;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return shouldBlacklist;
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBatchRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBatchRecordValue.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * Represents a batch action that's performed for a process instance. An example for this is
+ * termination of child instances. Instead of writing a TERMINATE command for all children, this
+ * command is used to batch these commands in smaller chunks.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableProcessInstanceBatchRecordValue.Builder.class)
+public interface ProcessInstanceBatchRecordValue extends RecordValue, ProcessInstanceRelated {
+
+  /**
+   * @return the element instance for which a batch action is being performed. This should be a
+   *     container element (e.g. a subprocess).
+   */
+  long getBatchElementInstanceKey();
+
+  /**
+   * @return an index used to keep track of where we are in our batch process and where to start the
+   *     next batch.
+   */
+  long getIndex();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -48,6 +48,7 @@
       <validValue name="SIGNAL">31</validValue>
       <validValue name="RESOURCE_DELETION">32</validValue>
       <validValue name="COMMAND_DISTRIBUTION">33</validValue>
+      <validValue name="PROCESS_INSTANCE_BATCH">34</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubs
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -78,6 +79,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.ESCALATION, EscalationRecord.class);
     registry.put(ValueType.SIGNAL_SUBSCRIPTION, SignalSubscriptionRecord.class);
     registry.put(ValueType.SIGNAL, SignalRecord.class);
+    registry.put(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -118,6 +118,26 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
   void whileEqualPrefix(DbKey keyPrefix, KeyValuePairVisitor<KeyType, ValueType> visitor);
 
   /**
+   * Visits the key-value pairs, which are stored in the column family and which have the same
+   * common prefix. The ordering depends on the key. The visitor can indicate via the return value,
+   * whether the iteration should continue or * not. This means if the visitor returns false the
+   * iteration will stop.
+   *
+   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exists,
+   * the first key-value-pair will contain the equal key as {@code startAtKey}. If the key doesn't
+   * exist it will start after.
+   *
+   * <p>Similar to {@link #whileEqualPrefix(DbKey, BiConsumer) and {@link
+   * #whileTrue(KeyValuePairVisitor)}}.
+   *
+   * @param keyPrefix the prefix which should have the keys in common
+   * @param startAtKey indicates on which key the iteration should start
+   * @param visitor the visitor which visits the key-value pairs
+   */
+  void whileEqualPrefix(
+      DbKey keyPrefix, KeyType startAtKey, KeyValuePairVisitor<KeyType, ValueType> visitor);
+
+  /**
    * Deletes the key-value pair with the given key if it exists in the column family
    *
    * @throws IllegalStateException if the key does not exist

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -199,6 +199,14 @@ class TransactionalColumnFamily<
   }
 
   @Override
+  public void whileEqualPrefix(
+      final DbKey keyPrefix,
+      final KeyType startAtKey,
+      final KeyValuePairVisitor<KeyType, ValueType> visitor) {
+    ensureInOpenTransaction(transaction -> forEachInPrefix(startAtKey, keyPrefix, visitor));
+  }
+
+  @Override
   public void deleteExisting(final KeyType key) {
     ensureInOpenTransaction(
         transaction -> {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I recommend reviewing this per commit.

This PR introduces the `TerminateProcessInstanceBatchProcessor`. This will be used to take care of terminating child element instances in batches. The implementation of this processor required a couple of things:

1. We needed a way to iterate over a ColumnFamily with a prefix, starting at a specific suffix. For this I have added a new method to the `ColumnFamily` interface. This method is very similar to the `whileTrue` method which also takes a `startAtKey`. The only difference is that the new method passes the prefix, whereas the `whileTrue` method always passes a `DbNullKey' as prefix.
2. We needed a way to verify if we can write a command of a specific length. This will be used by the processor to determine if writing `TERMINATE` command for the next child will result in an `ExceededBatchRecordSizeException` or not. If it is we should not write this command.
3. We needed a method on the `ElementInstanceState` to allow us to perform an action for each the children of a specific element instance.
4. Finally, we need the processor itself. The processor will use all of the above to send as many `TERMINATE` commands as will fit in the batch. When it doesn't fit anymore it sends a follow-up batch command. This is repeated until TERMINATE commands are send for all children.


As the processor is not used yet there are no tests to verify if it works. These will be implemented when we actually start using the processor in #12538.

## Related issues

<!-- Which issues are closed by this PR or are related -->

blocked by #12542
closes #12539 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
