### PR TITLE
Retry pushing to similar remote streams

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -178,8 +178,6 @@ final class AggregatedClientStream<M extends BufferWriter> {
     }
   }
 
-  record LogicalId<M>(DirectBuffer streamType, M metadata) {}
-
   private enum State {
     INITIAL,
     OPEN,

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedRemoteStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedRemoteStream.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.atomix.cluster.MemberId;
+import java.util.List;
+import java.util.UUID;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * Keep tracks of {@link StreamConsumer}s which are logically similar.
+ *
+ * @param <M> type of the properties
+ */
+record AggregatedRemoteStream<M>(LogicalId<M> logicalId, List<StreamConsumer<M>> streamConsumers) {
+
+  void addConsumer(final StreamConsumer<M> consumer) {
+    streamConsumers.add(consumer);
+  }
+
+  void removeConsumer(final StreamConsumer<M> consumer) {
+    streamConsumers.remove(consumer);
+  }
+
+  /**
+   * A stream consumer uniquely identified by the id, with its properties and streamType.
+   *
+   * @param id unique id
+   * @param properties properties of the stream
+   * @param streamType type of the stream
+   * @param <M> type of the properties
+   */
+  record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
+
+  /**
+   * Uniquely identifies a stream
+   *
+   * @param streamId
+   * @param receiver
+   */
+  record StreamId(UUID streamId, MemberId receiver) {}
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedRemoteStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedRemoteStream.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.transport.stream.impl;
 import io.atomix.cluster.MemberId;
 import java.util.List;
 import java.util.UUID;
-import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * Keep tracks of {@link StreamConsumer}s which are logically similar.
@@ -31,11 +30,10 @@ record AggregatedRemoteStream<M>(LogicalId<M> logicalId, List<StreamConsumer<M>>
    * A stream consumer uniquely identified by the id, with its properties and streamType.
    *
    * @param id unique id
-   * @param properties properties of the stream
-   * @param streamType type of the stream
+   * @param logicalId logical id
    * @param <M> type of the properties
    */
-  record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
+  record StreamConsumer<M>(StreamId id, LogicalId<M> logicalId) {}
 
   /**
    * Uniquely identifies a stream

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.transport.stream.impl;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
 import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
-import io.camunda.zeebe.transport.stream.impl.AggregatedClientStream.LogicalId;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ImmutableStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ImmutableStreamRegistry.java
@@ -24,6 +24,16 @@ interface ImmutableStreamRegistry<M> {
    */
   Set<StreamConsumer<M>> get(final UnsafeBuffer streamType);
 
+  Set<StreamConsumer<M>> getStreamsByLogicalId(UnsafeBuffer streamType, M properties);
+
+  /**
+   * Uniquely identifies a stream
+   *
+   * @param streamId
+   * @param receiver
+   */
+  record StreamId(UUID streamId, MemberId receiver) {}
+
   /**
    * A stream consumer uniquely identified by the id, with its properties and streamType.
    *
@@ -33,12 +43,4 @@ interface ImmutableStreamRegistry<M> {
    * @param <M> type of the properties
    */
   record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
-
-  /**
-   * Uniquely identifies a stream
-   *
-   * @param streamId
-   * @param receiver
-   */
-  record StreamId(UUID streamId, MemberId receiver) {}
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ImmutableStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ImmutableStreamRegistry.java
@@ -44,6 +44,11 @@ interface ImmutableStreamRegistry<M> {
    */
   record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
 
+  /**
+   * Keep tracks of {@link StreamConsumer}s which are logically similar.
+   *
+   * @param <M> type of the properties
+   */
   class AggregatedRemoteStream<M> {
     private final LogicalId<M> logicalId;
     private final List<StreamConsumer<M>> streamConsumers = new ArrayList<>();

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ImmutableStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ImmutableStreamRegistry.java
@@ -7,11 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import io.atomix.cluster.MemberId;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import org.agrona.concurrent.UnsafeBuffer;
 
 interface ImmutableStreamRegistry<M> {
@@ -25,52 +21,4 @@ interface ImmutableStreamRegistry<M> {
    * @return set of streams for the given type
    */
   Set<AggregatedRemoteStream<M>> get(final UnsafeBuffer streamType);
-
-  /**
-   * Uniquely identifies a stream
-   *
-   * @param streamId
-   * @param receiver
-   */
-  record StreamId(UUID streamId, MemberId receiver) {}
-
-  /**
-   * A stream consumer uniquely identified by the id, with its properties and streamType.
-   *
-   * @param id unique id
-   * @param properties properties of the stream
-   * @param streamType type of the stream
-   * @param <M> type of the properties
-   */
-  record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
-
-  /**
-   * Keep tracks of {@link StreamConsumer}s which are logically similar.
-   *
-   * @param <M> type of the properties
-   */
-  class AggregatedRemoteStream<M> {
-    private final LogicalId<M> logicalId;
-    private final List<StreamConsumer<M>> streamConsumers = new ArrayList<>();
-
-    AggregatedRemoteStream(final LogicalId<M> logicalId) {
-      this.logicalId = logicalId;
-    }
-
-    void addConsumer(final StreamConsumer<M> consumer) {
-      streamConsumers.add(consumer);
-    }
-
-    void removeConsumer(final StreamConsumer<M> consumer) {
-      streamConsumers.remove(consumer);
-    }
-
-    public List<StreamConsumer<M>> getStreamConsumers() {
-      return streamConsumers;
-    }
-
-    public LogicalId<M> getLogicalId() {
-      return logicalId;
-    }
-  }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ImmutableStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ImmutableStreamRegistry.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -22,9 +24,7 @@ interface ImmutableStreamRegistry<M> {
    * @param streamType type of the stream
    * @return set of streams for the given type
    */
-  Set<StreamConsumer<M>> get(final UnsafeBuffer streamType);
-
-  Set<StreamConsumer<M>> getStreamsByLogicalId(UnsafeBuffer streamType, M properties);
+  Set<AggregatedRemoteStream<M>> get(final UnsafeBuffer streamType);
 
   /**
    * Uniquely identifies a stream
@@ -43,4 +43,29 @@ interface ImmutableStreamRegistry<M> {
    * @param <M> type of the properties
    */
   record StreamConsumer<M>(StreamId id, M properties, UnsafeBuffer streamType) {}
+
+  class AggregatedRemoteStream<M> {
+    private final LogicalId<M> logicalId;
+    private final List<StreamConsumer<M>> streamConsumers = new ArrayList<>();
+
+    AggregatedRemoteStream(final LogicalId<M> logicalId) {
+      this.logicalId = logicalId;
+    }
+
+    void addConsumer(final StreamConsumer<M> consumer) {
+      streamConsumers.add(consumer);
+    }
+
+    void removeConsumer(final StreamConsumer<M> consumer) {
+      streamConsumers.remove(consumer);
+    }
+
+    public List<StreamConsumer<M>> getStreamConsumers() {
+      return streamConsumers;
+    }
+
+    public LogicalId<M> getLogicalId() {
+      return logicalId;
+    }
+  }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/LogicalId.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/LogicalId.java
@@ -7,10 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
-import java.util.Set;
+import org.agrona.DirectBuffer;
 
-@FunctionalInterface
-interface RemoteStreamPicker<M> {
-  AggregatedRemoteStream<M> pickStream(final Set<AggregatedRemoteStream<M>> consumers);
-}
+record LogicalId<M>(DirectBuffer streamType, M metadata) {}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/LogicalId.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/LogicalId.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * A logical id that identifies a stream. Multiple streams can have same logical id. A payload
@@ -17,4 +17,4 @@ import org.agrona.DirectBuffer;
  * @param metadata metadata of the stream
  * @param <M> type of metadata
  */
-record LogicalId<M>(DirectBuffer streamType, M metadata) {}
+record LogicalId<M>(UnsafeBuffer streamType, M metadata) {}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/LogicalId.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/LogicalId.java
@@ -9,4 +9,12 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import org.agrona.DirectBuffer;
 
+/**
+ * A logical id that identifies a stream. Multiple streams can have same logical id. A payload
+ * generated for a stream should be accepted by another stream with same logical id.
+ *
+ * @param streamType type of the stream
+ * @param metadata metadata of the stream
+ * @param <M> type of metadata
+ */
 record LogicalId<M>(DirectBuffer streamType, M metadata) {}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RandomStreamPicker.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RandomStreamPicker.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RandomStreamPicker.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RandomStreamPicker.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
+import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -15,7 +15,7 @@ import java.util.concurrent.ThreadLocalRandom;
 final class RandomStreamPicker<M> implements RemoteStreamPicker<M> {
 
   @Override
-  public StreamConsumer<M> pickStream(final Set<StreamConsumer<M>> consumers) {
+  public AggregatedRemoteStream<M> pickStream(final Set<AggregatedRemoteStream<M>> consumers) {
     final var targets = new ArrayList<>(consumers);
     final var index = ThreadLocalRandom.current().nextInt(consumers.size());
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImpl.java
@@ -8,8 +8,7 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.camunda.zeebe.transport.stream.api.RemoteStream;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamConsumer;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.ArrayList;
@@ -40,14 +39,14 @@ public class RemoteStreamImpl<M extends BufferReader, P extends BufferWriter>
 
   @Override
   public M metadata() {
-    return stream.getLogicalId().metadata();
+    return stream.logicalId().metadata();
   }
 
   @Override
   public void push(final P payload, final ErrorHandler<P> errorHandler) {
     executor.execute(
         () -> {
-          final List<StreamConsumer<M>> streamConsumers = stream.getStreamConsumers();
+          final List<StreamConsumer<M>> streamConsumers = stream.streamConsumers();
           final var randomClient =
               streamConsumers.get(ThreadLocalRandom.current().nextInt(streamConsumers.size()));
           streamer.pushAsync(

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPicker.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPicker.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
 import java.util.Set;
 
 @FunctionalInterface

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusher.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusher.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.transport.stream.impl;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.RemoteStream.ErrorHandler;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Objects;

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistry.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamConsumer;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -73,7 +76,7 @@ public class RemoteStreamRegistry<M> implements ImmutableStreamRegistry<M> {
     logicalIdToConsumers.computeIfAbsent(
         logicalId,
         id -> {
-          final var aggregatedStream = new AggregatedRemoteStream<>(logicalId);
+          final var aggregatedStream = new AggregatedRemoteStream<>(logicalId, new ArrayList<>());
           typeToConsumers.get(streamType).add(aggregatedStream);
           return aggregatedStream;
         });
@@ -100,7 +103,7 @@ public class RemoteStreamRegistry<M> implements ImmutableStreamRegistry<M> {
           logicalId,
           (id, aggregatedStream) -> {
             aggregatedStream.removeConsumer(consumer);
-            if (aggregatedStream.getStreamConsumers().isEmpty()) {
+            if (aggregatedStream.streamConsumers().isEmpty()) {
               typeToConsumers.get(consumer.streamType()).remove(aggregatedStream);
               return null;
             } else {

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistry.java
@@ -81,7 +81,7 @@ public class RemoteStreamRegistry<M> implements ImmutableStreamRegistry<M> {
           return aggregatedStream;
         });
 
-    final var streamConsumer = new StreamConsumer<>(uniqueId, properties, streamType);
+    final var streamConsumer = new StreamConsumer<>(uniqueId, logicalId);
     logicalIdToConsumers.get(logicalId).addConsumer(streamConsumer);
 
     idToConsumer.put(uniqueId, streamConsumer);
@@ -98,13 +98,12 @@ public class RemoteStreamRegistry<M> implements ImmutableStreamRegistry<M> {
     final var uniqueId = new StreamId(streamId, receiver);
     final var consumer = idToConsumer.remove(uniqueId);
     if (consumer != null) {
-      final var logicalId = new LogicalId<>(consumer.streamType(), consumer.properties());
       logicalIdToConsumers.computeIfPresent(
-          logicalId,
+          consumer.logicalId(),
           (id, aggregatedStream) -> {
             aggregatedStream.removeConsumer(consumer);
             if (aggregatedStream.streamConsumers().isEmpty()) {
-              typeToConsumers.get(consumer.streamType()).remove(aggregatedStream);
+              typeToConsumers.get(consumer.logicalId().streamType()).remove(aggregatedStream);
               return null;
             } else {
               return aggregatedStream;

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -64,10 +64,8 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
 
     final var target = streamPicker.pickStream(consumers);
 
-    final var targetSet = registry.getStreamsByLogicalId(streamTypeBuffer, target.properties());
-
     final RemoteStreamImpl<M, P> gatewayStream =
-        new RemoteStreamImpl<>(target, targetSet, target.properties(), remoteStreamPusher);
+        new RemoteStreamImpl<>(target, remoteStreamPusher, actor::run);
     return Optional.of(gatewayStream);
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -42,6 +42,7 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
   private final ClusterCommunicationService transport;
   private final ImmutableStreamRegistry<M> registry;
   private final RemoteStreamMetrics metrics;
+  private final RemoteStreamPusher<P> remoteStreamPusher;
 
   public RemoteStreamerImpl(
       final ClusterCommunicationService transport,
@@ -50,20 +51,23 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
     this.transport = Objects.requireNonNull(transport, "must specify a network transport");
     this.registry = Objects.requireNonNull(registry, "must specify a job stream registry");
     this.metrics = metrics;
+    remoteStreamPusher = new RemoteStreamPusher<>(this::send, actor::run, metrics);
   }
 
   @Override
   public Optional<RemoteStream<M, P>> streamFor(final DirectBuffer streamType) {
-    final var consumers = registry.get(new UnsafeBuffer(streamType));
+    final UnsafeBuffer streamTypeBuffer = new UnsafeBuffer(streamType);
+    final var consumers = registry.get(streamTypeBuffer);
     if (consumers.isEmpty()) {
       return Optional.empty();
     }
 
     final var target = streamPicker.pickStream(consumers);
+
+    final var targetSet = registry.getStreamsByLogicalId(streamTypeBuffer, target.properties());
+
     final RemoteStreamImpl<M, P> gatewayStream =
-        new RemoteStreamImpl<>(
-            target.properties(),
-            new RemoteStreamPusher<>(target.id(), this::send, actor::run, metrics));
+        new RemoteStreamImpl<>(target, targetSet, target.properties(), remoteStreamPusher);
     return Optional.of(gatewayStream);
   }
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
@@ -20,14 +20,14 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
 class AggregatedClientStreamTest {
   private static final ClientStreamConsumer CLIENT_STREAM_CONSUMER =
       p -> CompletableActorFuture.completed(null);
 
-  private final DirectBuffer streamType = BufferUtil.wrapString("foo");
+  private final UnsafeBuffer streamType = new UnsafeBuffer(BufferUtil.wrapString("foo"));
   private final TestSerializableData metadata = new TestSerializableData(1234);
   private final TestClientStreamMetrics metrics = new TestClientStreamMetrics();
   final AggregatedClientStream<TestSerializableData> stream =

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
-import io.camunda.zeebe.transport.stream.impl.AggregatedClientStream.LogicalId;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.util.ArrayList;

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
-import io.camunda.zeebe.transport.stream.impl.AggregatedClientStream.LogicalId;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +39,8 @@ class ClientStreamRequestManagerTest {
 
   private final AggregatedClientStream<BufferWriter> clientStream =
       new AggregatedClientStream<>(
-          UUID.randomUUID(), new LogicalId<>(BufferUtil.wrapString("foo"), new TestMetadata()));
+          UUID.randomUUID(),
+          new LogicalId<>(new UnsafeBuffer(BufferUtil.wrapString("foo")), new TestMetadata()));
 
   @BeforeEach
   void setup() {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
@@ -108,10 +108,10 @@ final class RemoteStreamApiHandlerTest {
     final var consumers = registry.get(streamType);
     assertThat(consumers).hasSize(1);
     final var stream = consumers.stream().findFirst().orElseThrow();
-    assertThat(stream.getLogicalId())
+    assertThat(stream.logicalId())
         .extracting(LogicalId::streamType, c -> c.metadata().version)
         .containsExactly(streamType, 1);
-    assertThat(stream.getStreamConsumers())
+    assertThat(stream.streamConsumers())
         .hasSize(1)
         .first()
         .extracting(c -> c.id().streamId(), c -> c.id().receiver())

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
@@ -12,8 +12,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
 import io.camunda.zeebe.transport.stream.impl.messages.AddStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.RemoveStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.UUIDEncoder;
@@ -108,11 +106,16 @@ final class RemoteStreamApiHandlerTest {
 
     // then
     final var consumers = registry.get(streamType);
-    assertThat(consumers)
+    assertThat(consumers).hasSize(1);
+    final var stream = consumers.stream().findFirst().orElseThrow();
+    assertThat(stream.getLogicalId())
+        .extracting(LogicalId::streamType, c -> c.metadata().version)
+        .containsExactly(streamType, 1);
+    assertThat(stream.getStreamConsumers())
         .hasSize(1)
         .first()
-        .extracting(StreamConsumer::streamType, StreamConsumer::id, c -> c.properties().version)
-        .containsExactly(streamType, new StreamId(streamId, sender), 1);
+        .extracting(c -> c.id().streamId(), c -> c.id().receiver())
+        .containsExactly(streamId, sender);
   }
 
   @Test

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
@@ -11,9 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamConsumer;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamPusher.Transport;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -31,7 +30,7 @@ class RemoteStreamImplTest {
   private final TestSerializableData properties = new TestSerializableData(1);
   private final TestSerializableData payload = new TestSerializableData(1234);
   private final AggregatedRemoteStream<TestSerializableData> aggregatedStream =
-      new AggregatedRemoteStream<>(new LogicalId<>(streamType, properties));
+      new AggregatedRemoteStream<>(new LogicalId<>(streamType, properties), new ArrayList<>());
 
   private final FailingTransport transport = new FailingTransport();
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
+import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
+import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.transport.stream.impl.RemoteStreamPusher.Transport;
+import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+class RemoteStreamImplTest {
+
+  private final UnsafeBuffer streamType = new UnsafeBuffer(BufferUtil.wrapString("foo"));
+  private final TestSerializableData properties = new TestSerializableData(1);
+  private final TestSerializableData payload = new TestSerializableData(1234);
+  private final AggregatedRemoteStream<TestSerializableData> aggregatedStream =
+      new AggregatedRemoteStream<>(new LogicalId<>(streamType, properties));
+
+  private final FailingTransport transport = new FailingTransport();
+
+  private final Executor executor = Runnable::run;
+  private final RemoteStreamPusher<TestSerializableData> pusher =
+      new RemoteStreamPusher<>(transport, executor, RemoteStreamMetrics.noop());
+
+  private final RemoteStreamImpl<TestSerializableData, TestSerializableData> remoteStream =
+      new RemoteStreamImpl<>(aggregatedStream, pusher, executor);
+
+  @Test
+  void shouldRetryWithAllAvailableRemoteStreams() {
+    // given
+    final UUID stream1 = UUID.randomUUID();
+    aggregatedStream.addConsumer(
+        new StreamConsumer<>(new StreamId(stream1, MemberId.anonymous()), properties, streamType));
+    final UUID stream2 = UUID.randomUUID();
+    aggregatedStream.addConsumer(
+        new StreamConsumer<>(new StreamId(stream2, MemberId.anonymous()), properties, streamType));
+    final UUID stream3 = UUID.randomUUID();
+    aggregatedStream.addConsumer(
+        new StreamConsumer<>(new StreamId(stream3, MemberId.anonymous()), properties, streamType));
+
+    // when
+    remoteStream.push(payload, (e, p) -> {});
+
+    // then
+    assertThat(transport.attemptedStreams).containsExactlyInAnyOrder(stream1, stream2, stream3);
+  }
+
+  @Test
+  void shouldStopRetryWhenPushSucceeds() {
+    // given
+    final UUID stream1 = UUID.randomUUID();
+    aggregatedStream.addConsumer(
+        new StreamConsumer<>(new StreamId(stream1, MemberId.anonymous()), properties, streamType));
+    final UUID stream2 = UUID.randomUUID();
+    aggregatedStream.addConsumer(
+        new StreamConsumer<>(new StreamId(stream2, MemberId.anonymous()), properties, streamType));
+    final UUID stream3 = UUID.randomUUID();
+    aggregatedStream.addConsumer(
+        new StreamConsumer<>(new StreamId(stream3, MemberId.anonymous()), properties, streamType));
+
+    // when
+    transport.succeedAfterAttempts(1);
+    remoteStream.push(payload, (e, p) -> {});
+
+    // then
+    assertThat(transport.attemptedStreams).hasSize(2);
+  }
+
+  private static class FailingTransport implements Transport {
+
+    private final List<UUID> attemptedStreams = new ArrayList<>();
+
+    private int succeedAfterAttempt = Integer.MAX_VALUE;
+    private int attempt = 0;
+
+    void succeedAfterAttempts(final int attempt) {
+      succeedAfterAttempt = attempt;
+    }
+
+    @Override
+    public CompletableFuture<Void> send(final PushStreamRequest request, final MemberId receiver)
+        throws Exception {
+      attemptedStreams.add(request.streamId());
+      attempt++;
+      if (attempt <= succeedAfterAttempt) {
+        return CompletableFuture.failedFuture(new RuntimeException("force fail"));
+      }
+      return CompletableFuture.completedFuture(null);
+    }
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.transport.stream.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
 import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
 import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.RemoteStream.ErrorHandler;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamPusher.Transport;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.util.buffer.BufferWriter;

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
@@ -30,7 +30,7 @@ final class RemoteStreamPusherTest {
   private final TestTransport transport = new TestTransport();
   private final Executor executor = Runnable::run;
   private final RemoteStreamPusher<Payload> pusher =
-      new RemoteStreamPusher<>(streamId, transport, executor, RemoteStreamMetrics.noop());
+      new RemoteStreamPusher<>(transport, executor, RemoteStreamMetrics.noop());
 
   @Test
   void shouldPushPayload() {
@@ -39,7 +39,7 @@ final class RemoteStreamPusherTest {
     final var errorHandler = new TestErrorHandler();
 
     // when
-    pusher.pushAsync(payload, errorHandler);
+    pusher.pushAsync(payload, errorHandler, streamId);
 
     // then
     final var sentRequest = transport.message;
@@ -59,7 +59,7 @@ final class RemoteStreamPusherTest {
     transport.synchronousException = failure;
 
     // when
-    pusher.pushAsync(payload, errorHandler);
+    pusher.pushAsync(payload, errorHandler, streamId);
 
     // then
     assertThat(errorHandler.errors)
@@ -78,7 +78,7 @@ final class RemoteStreamPusherTest {
     transport.response = CompletableFuture.failedFuture(failure);
 
     // when
-    pusher.pushAsync(payload, errorHandler);
+    pusher.pushAsync(payload, errorHandler, streamId);
 
     // then
     assertThat(errorHandler.errors)
@@ -94,7 +94,7 @@ final class RemoteStreamPusherTest {
     final var errorHandler = new TestErrorHandler();
 
     // when - then
-    assertThatCode(() -> pusher.pushAsync(null, errorHandler))
+    assertThatCode(() -> pusher.pushAsync(null, errorHandler, streamId))
         .isInstanceOf(NullPointerException.class);
   }
 
@@ -104,7 +104,8 @@ final class RemoteStreamPusherTest {
     final var payload = new Payload(1);
 
     // when - then
-    assertThatCode(() -> pusher.pushAsync(payload, null)).isInstanceOf(NullPointerException.class);
+    assertThatCode(() -> pusher.pushAsync(payload, null, streamId))
+        .isInstanceOf(NullPointerException.class);
   }
 
   private record Payload(int version) implements BufferWriter {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
@@ -11,9 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamConsumer;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.UUID;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -42,14 +41,14 @@ final class RemoteStreamRegistryTest {
 
     final AggregatedRemoteStream<Integer> streamFoo =
         streamRegistry.get(typeFoo).stream().findFirst().orElseThrow();
-    assertThat(streamFoo.getLogicalId()).isEqualTo(new LogicalId<>(typeFoo, 1));
-    assertThat(streamFoo.getStreamConsumers())
+    assertThat(streamFoo.logicalId()).isEqualTo(new LogicalId<>(typeFoo, 1));
+    assertThat(streamFoo.streamConsumers())
         .containsExactly(new StreamConsumer<>(new StreamId(id1, gateway), 1, typeFoo));
 
     final AggregatedRemoteStream<Integer> streamBar =
         streamRegistry.get(typeBar).stream().findFirst().orElseThrow();
-    assertThat(streamBar.getLogicalId()).isEqualTo(new LogicalId<>(typeBar, 2));
-    assertThat(streamBar.getStreamConsumers())
+    assertThat(streamBar.logicalId()).isEqualTo(new LogicalId<>(typeBar, 2));
+    assertThat(streamBar.streamConsumers())
         .containsExactly(new StreamConsumer<>(new StreamId(id2, gateway), 2, typeBar));
   }
 
@@ -68,8 +67,8 @@ final class RemoteStreamRegistryTest {
 
     final AggregatedRemoteStream<Integer> streamFoo =
         streamRegistry.get(typeFoo).stream().findFirst().orElseThrow();
-    assertThat(streamFoo.getLogicalId()).isEqualTo(new LogicalId<>(typeFoo, properties));
-    assertThat(streamFoo.getStreamConsumers())
+    assertThat(streamFoo.logicalId()).isEqualTo(new LogicalId<>(typeFoo, properties));
+    assertThat(streamFoo.streamConsumers())
         .containsExactly(
             new StreamConsumer<>(new StreamId(id1, gateway), properties, typeFoo),
             new StreamConsumer<>(new StreamId(id2, gateway), properties, typeFoo));
@@ -88,7 +87,7 @@ final class RemoteStreamRegistryTest {
     // then
     final AggregatedRemoteStream<Integer> aggregatedRemoteStream =
         streamRegistry.get(typeFoo).stream().findFirst().orElseThrow();
-    assertThat(aggregatedRemoteStream.getStreamConsumers())
+    assertThat(aggregatedRemoteStream.streamConsumers())
         .containsExactly(new StreamConsumer<>(new StreamId(id, otherGateway), 1, typeFoo));
   }
 
@@ -118,7 +117,7 @@ final class RemoteStreamRegistryTest {
     // then
     final AggregatedRemoteStream<Integer> aggregatedRemoteStream =
         streamRegistry.get(typeFoo).stream().findFirst().orElseThrow();
-    assertThat(aggregatedRemoteStream.getStreamConsumers())
+    assertThat(aggregatedRemoteStream.streamConsumers())
         .containsExactly(new StreamConsumer<>(new StreamId(id, gateway), 1, typeFoo));
   }
 
@@ -137,7 +136,7 @@ final class RemoteStreamRegistryTest {
     assertThat(streamRegistry.get(typeFoo)).isEmpty();
     final AggregatedRemoteStream<Integer> aggregatedRemoteStream =
         streamRegistry.get(typeBar).stream().findFirst().orElseThrow();
-    assertThat(aggregatedRemoteStream.getStreamConsumers())
+    assertThat(aggregatedRemoteStream.streamConsumers())
         .containsExactly(new StreamConsumer<>(new StreamId(idOther, otherGateway), 3, typeBar));
   }
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
@@ -43,13 +43,13 @@ final class RemoteStreamRegistryTest {
         streamRegistry.get(typeFoo).stream().findFirst().orElseThrow();
     assertThat(streamFoo.logicalId()).isEqualTo(new LogicalId<>(typeFoo, 1));
     assertThat(streamFoo.streamConsumers())
-        .containsExactly(new StreamConsumer<>(new StreamId(id1, gateway), 1, typeFoo));
+        .containsExactly(new StreamConsumer<>(new StreamId(id1, gateway), streamFoo.logicalId()));
 
     final AggregatedRemoteStream<Integer> streamBar =
         streamRegistry.get(typeBar).stream().findFirst().orElseThrow();
     assertThat(streamBar.logicalId()).isEqualTo(new LogicalId<>(typeBar, 2));
     assertThat(streamBar.streamConsumers())
-        .containsExactly(new StreamConsumer<>(new StreamId(id2, gateway), 2, typeBar));
+        .containsExactly(new StreamConsumer<>(new StreamId(id2, gateway), streamBar.logicalId()));
   }
 
   @Test
@@ -70,8 +70,8 @@ final class RemoteStreamRegistryTest {
     assertThat(streamFoo.logicalId()).isEqualTo(new LogicalId<>(typeFoo, properties));
     assertThat(streamFoo.streamConsumers())
         .containsExactly(
-            new StreamConsumer<>(new StreamId(id1, gateway), properties, typeFoo),
-            new StreamConsumer<>(new StreamId(id2, gateway), properties, typeFoo));
+            new StreamConsumer<>(new StreamId(id1, gateway), streamFoo.logicalId()),
+            new StreamConsumer<>(new StreamId(id2, gateway), streamFoo.logicalId()));
   }
 
   @Test
@@ -88,7 +88,8 @@ final class RemoteStreamRegistryTest {
     final AggregatedRemoteStream<Integer> aggregatedRemoteStream =
         streamRegistry.get(typeFoo).stream().findFirst().orElseThrow();
     assertThat(aggregatedRemoteStream.streamConsumers())
-        .containsExactly(new StreamConsumer<>(new StreamId(id, otherGateway), 1, typeFoo));
+        .containsExactly(
+            new StreamConsumer<>(new StreamId(id, otherGateway), new LogicalId<>(typeFoo, 1)));
   }
 
   @Test
@@ -118,7 +119,8 @@ final class RemoteStreamRegistryTest {
     final AggregatedRemoteStream<Integer> aggregatedRemoteStream =
         streamRegistry.get(typeFoo).stream().findFirst().orElseThrow();
     assertThat(aggregatedRemoteStream.streamConsumers())
-        .containsExactly(new StreamConsumer<>(new StreamId(id, gateway), 1, typeFoo));
+        .containsExactly(
+            new StreamConsumer<>(new StreamId(id, gateway), new LogicalId<>(typeFoo, 1)));
   }
 
   @Test
@@ -137,7 +139,8 @@ final class RemoteStreamRegistryTest {
     final AggregatedRemoteStream<Integer> aggregatedRemoteStream =
         streamRegistry.get(typeBar).stream().findFirst().orElseThrow();
     assertThat(aggregatedRemoteStream.streamConsumers())
-        .containsExactly(new StreamConsumer<>(new StreamId(idOther, otherGateway), 3, typeBar));
+        .containsExactly(
+            new StreamConsumer<>(new StreamId(idOther, otherGateway), new LogicalId<>(typeBar, 3)));
   }
 
   @Test

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
@@ -10,8 +10,8 @@ package io.camunda.zeebe.transport.stream.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
+import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.AggregatedRemoteStream;
 import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
 import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
 import io.camunda.zeebe.util.buffer.BufferUtil;

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamRegistryTest.java
@@ -54,6 +54,28 @@ final class RemoteStreamRegistryTest {
   }
 
   @Test
+  void shouldAggregateMultipleStreamsWithSameProperties() {
+    // given
+    final UUID id1 = UUID.randomUUID();
+    final UUID id2 = UUID.randomUUID();
+    final int properties = 1;
+
+    // when
+    streamRegistry.add(typeFoo, id1, gateway, properties);
+    streamRegistry.add(typeFoo, id2, gateway, properties);
+
+    // then
+
+    final AggregatedRemoteStream<Integer> streamFoo =
+        streamRegistry.get(typeFoo).stream().findFirst().orElseThrow();
+    assertThat(streamFoo.getLogicalId()).isEqualTo(new LogicalId<>(typeFoo, properties));
+    assertThat(streamFoo.getStreamConsumers())
+        .containsExactly(
+            new StreamConsumer<>(new StreamId(id1, gateway), properties, typeFoo),
+            new StreamConsumer<>(new StreamId(id2, gateway), properties, typeFoo));
+  }
+
+  @Test
   void shouldRemoveClientStream() {
     // given
     final UUID id = UUID.randomUUID();

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -13,7 +13,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
+import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferReader;

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -13,7 +13,6 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
-import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamConsumer;
 import io.camunda.zeebe.transport.stream.impl.ImmutableStreamRegistry.StreamId;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -124,6 +125,14 @@ final class RemoteStreamerTest {
     @Override
     public Set<StreamConsumer<TestMetadata>> get(final UnsafeBuffer streamType) {
       return consumers.getOrDefault(streamType, Collections.emptySet());
+    }
+
+    @Override
+    public Set<StreamConsumer<TestMetadata>> getStreamsByLogicalId(
+        final UnsafeBuffer streamType, final TestMetadata properties) {
+      return get(streamType).stream()
+          .filter(s -> s.properties().equals(properties))
+          .collect(Collectors.toSet());
     }
   }
 


### PR DESCRIPTION
## Description

Remote StreamConsumers with similar logical ids are tracked in an `AggregatedRemoteStream`. To find a stream to push the job, we first randomly picks an AggregatedRemoteStream, then randomly picks a StreamConsumer from it. If pushing to the chosed StreamConsumer fails, then it is retried with other consumers in the AggregatedRemoteStream, in a random sequence.

## Related issues

closes #12386 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
