### PR TITLE
Inject job streamer in the gateway

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -32,9 +32,8 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
         new EmbeddedGatewayService(
             brokerStartupContext.getBrokerConfiguration(),
             brokerStartupContext.getActorSchedulingService(),
-            clusterServices.getMessagingService(),
-            clusterServices.getMembershipService(),
-            clusterServices.getEventService());
+            clusterServices,
+            concurrencyControl);
 
     final var embeddedGatewayServiceFuture = embeddedGatewayService.start();
     concurrencyControl.runOnCompletion(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -7,40 +7,54 @@
  */
 package io.camunda.zeebe.broker.system;
 
-import io.atomix.cluster.ClusterMembershipService;
-import io.atomix.cluster.messaging.ClusterEventService;
-import io.atomix.cluster.messaging.MessagingService;
+import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.Gateway;
+import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
+import io.camunda.zeebe.gateway.impl.stream.JobStreamClientImpl;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
+import org.agrona.CloseHelper;
 
 public final class EmbeddedGatewayService implements AutoCloseable {
   private final Gateway gateway;
   private final BrokerClientImpl brokerClient;
+  private final JobStreamClient jobStreamClient;
+  private final ConcurrencyControl concurrencyControl;
 
   public EmbeddedGatewayService(
       final BrokerCfg configuration,
       final ActorSchedulingService actorScheduler,
-      final MessagingService messagingService,
-      final ClusterMembershipService membershipService,
-      final ClusterEventService eventService) {
+      final ClusterServices clusterServices,
+      final ConcurrencyControl concurrencyControl) {
+    this.concurrencyControl = concurrencyControl;
     brokerClient =
         new BrokerClientImpl(
             configuration.getGateway().getCluster().getRequestTimeout(),
-            messagingService,
-            membershipService,
-            eventService,
+            clusterServices.getMessagingService(),
+            clusterServices.getMembershipService(),
+            clusterServices.getEventService(),
             actorScheduler);
-    gateway = new Gateway(configuration.getGateway(), brokerClient, actorScheduler);
+    jobStreamClient =
+        new JobStreamClientImpl(actorScheduler, clusterServices.getCommunicationService());
+    gateway =
+        new Gateway(
+            configuration.getGateway(), brokerClient, actorScheduler, jobStreamClient.streamer());
   }
 
   @Override
   public void close() {
-    if (gateway != null) {
-      gateway.stop();
-    }
+    CloseHelper.closeAll(
+        error ->
+            Loggers.GATEWAY_LOGGER.warn(
+                "Error occurred while shutting down embedded gateway", error),
+        gateway,
+        brokerClient,
+        jobStreamClient);
   }
 
   public Gateway get() {
@@ -48,7 +62,16 @@ public final class EmbeddedGatewayService implements AutoCloseable {
   }
 
   public ActorFuture<Gateway> start() {
-    brokerClient.start();
+    jobStreamClient.start();
+
+    // before we can add the job stream client as a topology listener, we need to wait for the
+    // topology to be set up, otherwise the callback may be lost
+    final var brokerClientStart =
+        brokerClient.start().stream().collect(new ActorFutureCollector<>(concurrencyControl));
+    concurrencyControl.runOnCompletion(
+        brokerClientStart,
+        (ok, error) -> brokerClient.getTopologyManager().addTopologyListener(jobStreamClient));
+
     return gateway.start();
   }
 }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -127,6 +127,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-transport</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <exclusions>

--- a/dist/src/main/java/io/camunda/zeebe/gateway/JobStreamComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/JobStreamComponent.java
@@ -11,16 +11,20 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClientImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.util.VisibleForTesting;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
+@VisibleForTesting
 @Component
-final class JobStreamComponent {
+public final class JobStreamComponent {
 
+  @VisibleForTesting
   @Bean(destroyMethod = "close")
   @Autowired
-  JobStreamClient jobStreamClient(final ActorScheduler scheduler, final AtomixCluster cluster) {
+  public JobStreamClient jobStreamClient(
+      final ActorScheduler scheduler, final AtomixCluster cluster) {
     return new JobStreamClientImpl(scheduler, cluster.getCommunicationService());
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/JobStreamComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/JobStreamComponent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway;
+
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
+import io.camunda.zeebe.gateway.impl.stream.JobStreamClientImpl;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+final class JobStreamComponent {
+
+  @Bean(destroyMethod = "close")
+  @Autowired
+  JobStreamClient jobStreamClient(final ActorScheduler scheduler, final AtomixCluster cluster) {
+    return new JobStreamClientImpl(scheduler, cluster.getCommunicationService());
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -101,7 +101,7 @@ public class StandaloneGateway
 
     actorScheduler.start();
     atomixCluster.start();
-    jobStreamClient.start();
+    jobStreamClient.start().join();
 
     // before we can add the job stream client as a topology listener, we need to wait for the
     // topology to be set up, otherwise the callback may be lost

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -12,7 +12,9 @@ import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.shared.Profile;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VersionUtil;
@@ -53,6 +55,7 @@ public class StandaloneGateway
   private final ActorScheduler actorScheduler;
   private final AtomixCluster atomixCluster;
   private final BrokerClient brokerClient;
+  private final JobStreamClient jobStreamClient;
 
   private Gateway gateway;
 
@@ -62,12 +65,14 @@ public class StandaloneGateway
       final SpringGatewayBridge springGatewayBridge,
       final ActorScheduler actorScheduler,
       final AtomixCluster atomixCluster,
-      final BrokerClient brokerClient) {
+      final BrokerClient brokerClient,
+      final JobStreamClient jobStreamClient) {
     this.configuration = configuration;
     this.springGatewayBridge = springGatewayBridge;
     this.actorScheduler = actorScheduler;
     this.atomixCluster = atomixCluster;
     this.brokerClient = brokerClient;
+    this.jobStreamClient = jobStreamClient;
   }
 
   public static void main(final String[] args) {
@@ -94,8 +99,16 @@ public class StandaloneGateway
       LOG.info("Starting standalone gateway with configuration {}", configuration.toJson());
     }
 
-    gateway = new Gateway(configuration, brokerClient, actorScheduler);
+    actorScheduler.start();
+    atomixCluster.start();
+    jobStreamClient.start();
 
+    // before we can add the job stream client as a topology listener, we need to wait for the
+    // topology to be set up, otherwise the callback may be lost
+    brokerClient.start().forEach(ActorFuture::join);
+    brokerClient.getTopologyManager().addTopologyListener(jobStreamClient);
+
+    gateway = new Gateway(configuration, brokerClient, actorScheduler, jobStreamClient.streamer());
     springGatewayBridge.registerBrokerClientSupplier(gateway::getBrokerClient);
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);
     springGatewayBridge.registerClusterStateSupplier(
@@ -104,9 +117,6 @@ public class StandaloneGateway
                 .map(BrokerClient::getTopologyManager)
                 .map(BrokerTopologyManager::getTopology));
 
-    actorScheduler.start();
-    atomixCluster.start();
-    brokerClient.start();
     gateway.start().join(30, TimeUnit.SECONDS);
   }
 

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -9,11 +9,15 @@ package io.camunda.zeebe.gateway;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
+import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
+import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.shared.ActorClockConfiguration;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
@@ -28,6 +32,10 @@ import org.junit.jupiter.api.Test;
 final class StandaloneGatewaySecurityTest {
   private SelfSignedCertificate certificate;
   private StandaloneGateway gateway;
+  private BrokerClient brokerClient;
+  private AtomixCluster atomixCluster;
+  private ActorScheduler actorScheduler;
+  private JobStreamClient jobStreamClient;
 
   @BeforeEach
   void beforeEach() throws Exception {
@@ -36,7 +44,8 @@ final class StandaloneGatewaySecurityTest {
 
   @AfterEach
   public void tearDown() {
-    CloseHelper.quietClose(gateway);
+    CloseHelper.quietCloseAll(
+        gateway, brokerClient, jobStreamClient, actorScheduler, () -> atomixCluster.stop().join());
   }
 
   @Test
@@ -126,15 +135,21 @@ final class StandaloneGatewaySecurityTest {
   }
 
   private StandaloneGateway buildGateway(final GatewayCfg gatewayCfg) {
-    final var atomixCluster = new GatewayClusterConfiguration().atomixCluster(gatewayCfg);
+    atomixCluster = new GatewayClusterConfiguration().atomixCluster(gatewayCfg);
     final ActorSchedulerComponent actorSchedulerComponent =
         new ActorSchedulerComponent(gatewayCfg, new ActorClockConfiguration(false));
-    final var actorScheduler = actorSchedulerComponent.actorScheduler();
+    actorScheduler = actorSchedulerComponent.actorScheduler();
     final BrokerClientComponent brokerClientComponent =
         new BrokerClientComponent(gatewayCfg, atomixCluster, actorScheduler);
-    final var brokerClient = brokerClientComponent.brokerClient();
+    brokerClient = brokerClientComponent.brokerClient();
+    jobStreamClient = new JobStreamComponent().jobStreamClient(actorScheduler, atomixCluster);
 
     return new StandaloneGateway(
-        gatewayCfg, new SpringGatewayBridge(), actorScheduler, atomixCluster, brokerClient);
+        gatewayCfg,
+        new SpringGatewayBridge(),
+        actorScheduler,
+        atomixCluster,
+        brokerClient,
+        jobStreamClient);
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
+import io.camunda.zeebe.gateway.impl.stream.JobActivationProperties;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
@@ -56,6 +57,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
+import io.camunda.zeebe.transport.stream.api.ClientStreamer;
 import io.camunda.zeebe.util.VersionUtil;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -69,11 +71,19 @@ public final class EndpointManager {
   private final ActivateJobsHandler activateJobsHandler;
   private final RequestRetryHandler requestRetryHandler;
 
+  // TODO: actually make use of it
+  @SuppressWarnings({"FieldCanBeLocal", "unused"})
+  private final ClientStreamer<JobActivationProperties> jobStreamer;
+
   public EndpointManager(
-      final BrokerClient brokerClient, final ActivateJobsHandler activateJobsHandler) {
+      final BrokerClient brokerClient,
+      final ActivateJobsHandler activateJobsHandler,
+      final ClientStreamer<JobActivationProperties> jobStreamer) {
     this.brokerClient = brokerClient;
-    topologyManager = brokerClient.getTopologyManager();
     this.activateJobsHandler = activateJobsHandler;
+    this.jobStreamer = jobStreamer;
+
+    topologyManager = brokerClient.getTopologyManager();
     requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
+import io.camunda.zeebe.gateway.impl.stream.JobActivationProperties;
 import io.camunda.zeebe.gateway.interceptors.impl.ContextInjectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.IdentityInterceptor;
@@ -27,6 +28,8 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.transport.stream.api.ClientStreamer;
+import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.Either;
 import io.grpc.BindableService;
 import io.grpc.Server;
@@ -47,7 +50,7 @@ import me.dinowernli.grpc.prometheus.Configuration;
 import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 import org.slf4j.Logger;
 
-public final class Gateway {
+public final class Gateway implements CloseableSilently {
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;
   private static final MonitoringServerInterceptor MONITORING_SERVER_INTERCEPTOR =
       MonitoringServerInterceptor.create(Configuration.allMetrics());
@@ -57,6 +60,7 @@ public final class Gateway {
   private final GatewayCfg gatewayCfg;
   private final ActorSchedulingService actorSchedulingService;
   private final GatewayHealthManager healthManager;
+  private final ClientStreamer<JobActivationProperties> jobStreamer;
 
   private Server server;
   private final BrokerClient brokerClient;
@@ -64,10 +68,12 @@ public final class Gateway {
   public Gateway(
       final GatewayCfg gatewayCfg,
       final BrokerClient brokerClient,
-      final ActorSchedulingService actorSchedulingService) {
+      final ActorSchedulingService actorSchedulingService,
+      final ClientStreamer<JobActivationProperties> jobStreamer) {
     this.gatewayCfg = gatewayCfg;
     this.brokerClient = brokerClient;
     this.actorSchedulingService = actorSchedulingService;
+    this.jobStreamer = jobStreamer;
 
     healthManager = new GatewayHealthManagerImpl();
   }
@@ -113,7 +119,8 @@ public final class Gateway {
 
   private Either<Exception, Server> createAndStartServer(
       final ActivateJobsHandler activateJobsHandler) {
-    final EndpointManager endpointManager = new EndpointManager(brokerClient, activateJobsHandler);
+    final EndpointManager endpointManager =
+        new EndpointManager(brokerClient, activateJobsHandler, jobStreamer);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
 
     try {
@@ -193,6 +200,11 @@ public final class Gateway {
     }
 
     serverBuilder.useTransportSecurity(certificateChainPath, privateKeyPath);
+  }
+
+  @Override
+  public void close() {
+    stop();
   }
 
   private CompletableFuture<ActivateJobsHandler> createAndStartActivateJobsHandler(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
@@ -113,12 +113,15 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
     }
   }
 
-  public void addBrokerIfAbsent(final int nodeId) {
-    if (brokerAddresses.get(nodeId) == null) {
-      brokerAddresses.put(nodeId, "");
-      brokerVersions.put(nodeId, "");
-      brokers.addInt(nodeId);
+  public boolean addBrokerIfAbsent(final int nodeId) {
+    if (brokerAddresses.get(nodeId) != null) {
+      return false;
     }
+
+    brokerAddresses.put(nodeId, "");
+    brokerVersions.put(nodeId, "");
+    brokers.addInt(nodeId);
+    return true;
   }
 
   public void setBrokerAddressIfPresent(final int brokerId, final String address) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManager.java
@@ -7,7 +7,25 @@
  */
 package io.camunda.zeebe.gateway.impl.broker.cluster;
 
+import io.atomix.cluster.MemberId;
+
 public interface BrokerTopologyManager {
 
   BrokerClusterState getTopology();
+
+  /**
+   * Adds the topology listener. For each existing brokers, the listener will be notified via {@link
+   * BrokerTopologyListener#brokerAdded(MemberId)}. After that, the listener gets notified of every
+   * new broker added or removed events.
+   *
+   * @param listener the topology listener
+   */
+  void addTopologyListener(final BrokerTopologyListener listener);
+
+  /**
+   * Removes the given topology listener by identity.
+   *
+   * @param listener the listener to remove
+   */
+  void removeTopologyListener(final BrokerTopologyListener listener);
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobActivationProperties.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobActivationProperties.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.stream;
+
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Collection;
+import org.agrona.DirectBuffer;
+
+/**
+ * {@link JobActivationProperties} represents the minimum set of properties required to activate a
+ * {@link JobRecordValue} in the engine.
+ *
+ * <p>TODO: centralize this and the one found in the engine module
+ */
+public interface JobActivationProperties extends BufferReader, BufferWriter {
+
+  /**
+   * Returns the name of the worker. This is mostly used for debugging purposes.
+   *
+   * @see JobRecordValue#getWorker()
+   */
+  DirectBuffer worker();
+
+  /**
+   * Returns the variables requested by the worker, or an empty collection if all variables are
+   * requested.
+   *
+   * @see JobRecordValue#getVariables()
+   */
+  Collection<DirectBuffer> fetchVariables();
+
+  /**
+   * Returns the activation timeout of the job, i.e. how long before the job is made activate-able
+   * again after activation
+   *
+   * @see JobRecordValue#getDeadline()
+   */
+  long timeout();
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.stream;
+
+import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+
+final class JobClientStreamMetrics implements ClientStreamMetrics {
+  private static final String NAMESPACE = "zeebe_gateway_job_stream";
+
+  private static final Gauge SERVERS =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("servers")
+          .help("The count of known job stream servers/brokers")
+          .register();
+  private static final Gauge CLIENTS =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("clients")
+          .help("The count of known job stream clients")
+          .register();
+  private static final Gauge AGGREGATED_STREAMS =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("streams")
+          .help("Total count of aggregated streams")
+          .register();
+  private static final Histogram AGGREGATED_CLIENTS =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("aggregated_stream_clients")
+          .help("Distribution of client count per aggregated stream")
+          .register();
+  private static final Counter PUSHES =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("push")
+          .help("Count of pushed payloads, tagged by result status (success, failure)")
+          .labelNames("status")
+          .register();
+
+  private final Counter.Child pushSuccessCount;
+  private final Counter.Child pushFailureCount;
+
+  JobClientStreamMetrics() {
+    pushSuccessCount = PUSHES.labels("success");
+    pushFailureCount = PUSHES.labels("failure");
+  }
+
+  @Override
+  public void serverCount(final int count) {
+    SERVERS.set(count);
+  }
+
+  @Override
+  public void clientCount(final int count) {
+    CLIENTS.set(count);
+  }
+
+  @Override
+  public void aggregatedStreamCount(final int count) {
+    AGGREGATED_STREAMS.set(count);
+  }
+
+  @Override
+  public void observeAggregatedClientCount(final int count) {
+    AGGREGATED_CLIENTS.observe(count);
+  }
+
+  @Override
+  public void pushSucceeded() {
+    pushSuccessCount.inc();
+  }
+
+  @Override
+  public void pushFailed() {
+    pushFailureCount.inc();
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClient.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClient.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.stream;
+
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyListener;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.transport.stream.api.ClientStreamer;
+import io.camunda.zeebe.util.CloseableSilently;
+
+/** The main entry point for the client side of job streaming in the gateway. */
+public interface JobStreamClient extends BrokerTopologyListener, CloseableSilently {
+
+  /** Returns the underlying job streamer. */
+  ClientStreamer<JobActivationProperties> streamer();
+
+  /** Asynchronously starts the job stream client. */
+  ActorFuture<Void> start();
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.stream;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.transport.TransportFactory;
+import io.camunda.zeebe.transport.stream.api.ClientStreamService;
+import io.camunda.zeebe.transport.stream.api.ClientStreamer;
+
+/**
+ * A thin adapter around a {@link ClientStreamService} instance specifically for streaming jobs.
+ * It's intended to be the main entry point when setting up the client side of job streaming in the
+ * gateway.
+ *
+ * <p>NOTE: most methods are synchronized to avoid dealing with concurrency issues with
+ * startup/shutdown, and that's not on any hot path. Can be reconsidered if this is not true
+ * anymore, or not the only constraint.
+ */
+public final class JobStreamClientImpl implements JobStreamClient {
+  private final ActorSchedulingService schedulingService;
+  private final ClientStreamService<JobActivationProperties> streamService;
+
+  private boolean started;
+  private ActorFuture<Void> startedFuture;
+
+  public JobStreamClientImpl(
+      final ActorSchedulingService schedulingService,
+      final ClusterCommunicationService clusterCommunicationService) {
+    this.schedulingService = schedulingService;
+    this.streamService =
+        new TransportFactory(schedulingService)
+            .createRemoteStreamClient(clusterCommunicationService, new JobClientStreamMetrics());
+  }
+
+  @Override
+  public synchronized void brokerAdded(final MemberId memberId) {
+    if (!started) {
+      return;
+    }
+
+    streamService.onServerJoined(memberId);
+  }
+
+  @Override
+  public synchronized void brokerRemoved(final MemberId memberId) {
+    if (!started) {
+      return;
+    }
+
+    streamService.onServerRemoved(memberId);
+  }
+
+  @Override
+  public ClientStreamer<JobActivationProperties> streamer() {
+    return streamService.streamer();
+  }
+
+  @Override
+  public synchronized ActorFuture<Void> start() {
+    if (startedFuture == null) {
+      startedFuture = streamService.start(schedulingService);
+      started = true;
+    }
+
+    return startedFuture;
+  }
+
+  @Override
+  public synchronized void close() {
+    if (!started) {
+      return;
+    }
+
+    started = false;
+    streamService.closeAsync().join();
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -70,7 +70,7 @@ class UnavailableBrokersTest {
             cluster.getEventService(),
             actorScheduler);
     jobStreamClient = new JobStreamClientImpl(actorScheduler, cluster.getCommunicationService());
-    jobStreamClient.start();
+    jobStreamClient.start().join();
 
     // before we can add the job stream client as a topology listener, we need to wait for the
     // topology to be set up, otherwise the callback may be lost

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterStateImpl;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyListener;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
-import java.util.HashSet;
-import java.util.Set;
 
 public final class StubbedTopologyManager implements BrokerTopologyManager {
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -11,7 +11,10 @@ import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterStateImpl;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyListener;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import java.util.HashSet;
+import java.util.Set;
 
 public final class StubbedTopologyManager implements BrokerTopologyManager {
 
@@ -35,5 +38,15 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   @Override
   public BrokerClusterState getTopology() {
     return clusterState;
+  }
+
+  @Override
+  public void addTopologyListener(final BrokerTopologyListener listener) {
+    throw new UnsupportedOperationException("Not yet implemented; implement if need be");
+  }
+
+  @Override
+  public void removeTopologyListener(final BrokerTopologyListener listener) {
+    throw new UnsupportedOperationException("Not yet implemented; implement if need be");
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -161,7 +161,7 @@ final class SecurityTest {
             atomix.getEventService(),
             actorScheduler);
     jobStreamClient = new JobStreamClientImpl(actorScheduler, atomix.getCommunicationService());
-    jobStreamClient.start();
+    jobStreamClient.start().join();
 
     // before we can add the job stream client as a topology listener, we need to wait for the
     // topology to be set up, otherwise the callback may be lost

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -65,6 +65,12 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-transport</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-exporter-api</artifactId>
       <scope>test</scope>
     </dependency>

--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -12,8 +12,11 @@ import io.atomix.cluster.messaging.MessagingService;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
+import io.camunda.zeebe.transport.stream.api.ClientStreamService;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
+import io.camunda.zeebe.transport.stream.impl.ClientStreamServiceImpl;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamApiHandler;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamEndpoint;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamRegistry;
@@ -54,5 +57,11 @@ public final class TransportFactory {
         new RemoteStreamerImpl<>(clusterCommunicationService, registry, metrics),
         new RemoteStreamEndpoint<>(
             clusterCommunicationService, new RemoteStreamApiHandler<>(registry, metadataFactory)));
+  }
+
+  public <M extends BufferWriter> ClientStreamService<M> createRemoteStreamClient(
+      final ClusterCommunicationService clusterCommunicationService,
+      final ClientStreamMetrics metrics) {
+    return new ClientStreamServiceImpl<>(clusterCommunicationService, metrics);
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.api;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.AsyncClosable;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+
+/**
+ * Manages an instance of {@link ClientStreamer}. Intended to be the main entry point when setting
+ * up the client side for remote streams, primarily via {@link
+ * io.camunda.zeebe.transport.TransportFactory#createRemoteStreamClient(ClusterCommunicationService,
+ * ClientStreamMetrics)}.
+ *
+ * @param <M> the type of the streaming metadata
+ */
+public interface ClientStreamService<M extends BufferWriter> extends AsyncClosable {
+
+  /**
+   * Starts the service, optionally with the given actor scheduling service. Assumes the scheduling
+   * service is already running.
+   */
+  ActorFuture<Void> start(final ActorSchedulingService schedulingService);
+
+  /**
+   * A callback to be invoked when a new streaming server is added. Implementations should be
+   * idempotent.
+   */
+  void onServerJoined(final MemberId memberId);
+
+  /**
+   * A callback to be invoked when a new streaming server is removed. Implementations should be
+   * idempotent.
+   */
+  void onServerRemoved(final MemberId memberId);
+
+  /** Returns the managed {@link ClientStreamer} associated with this service. */
+  ClientStreamer<M> streamer();
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.transport.stream.api;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 
@@ -17,7 +18,7 @@ import org.agrona.DirectBuffer;
  * <p>When a client stream is added, it opens a stream to all servers. When a server pushes data to
  * this stream, the client receives it via {@link ClientStreamConsumer#push(DirectBuffer)}
  */
-public interface ClientStreamer<M extends BufferWriter> {
+public interface ClientStreamer<M extends BufferWriter> extends CloseableSilently {
 
   /**
    * Registers a client and opens a stream for the given streamType and associated Metadata with all

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 /** Tests end-to-end stream management from client to server */
 class StreamIntegrationTest {
 
-  private ClientStreamService<TestSerializableData> clientStreamer;
+  private ClientStreamServiceImpl<TestSerializableData> clientStreamer;
   private RemoteStreamer<TestSerializableData, TestSerializableData> remoteStreamer;
 
   private final DirectBuffer streamType = BufferUtil.wrapString("foo");
@@ -65,10 +65,10 @@ class StreamIntegrationTest {
     clientStreamer = startClientStreamer(clientService, serverId);
   }
 
-  private ClientStreamService<TestSerializableData> startClientStreamer(
+  private ClientStreamServiceImpl<TestSerializableData> startClientStreamer(
       final TestCommunicationService clientService, final MemberId serverId) {
-    final ClientStreamService<TestSerializableData> clientStreamService =
-        new ClientStreamService<>(clientService);
+    final ClientStreamServiceImpl<TestSerializableData> clientStreamService =
+        new ClientStreamServiceImpl<>(clientService);
     actorScheduler.submitActor(clientStreamService).join();
     closeables.add(clientStreamService);
 


### PR DESCRIPTION
## Description

This PR adds job specific implementations/adapters around the remote streaming client capabilities of the transport module. As an end result, there is a `ClientStreamer<JobActivationProperties>` available to the `EndpointManager`, ready to be used by the ZPA team when implementing the job streaming endpoint.

There aren't really any tests, as there isn't a way to test the integration of all these things yet without the gRPC API. Once that's present, we can add integration tests.

One other caveat is I had to introduce a new `ClientStreamService` interface in the transport to avoid exposing that the streamer implementation is an actor itself. Right now there's only one implementation, but I would like to do a follow up pass after this to clean things up a little. I'm also not super happy with the startup process of having to wait for the broker client's topology manager to start before adding the listener, but that can go in a follow up as well.

Another issue is around the integration tests where we create the gateway. Adding more things to construct a `Gateway` instance meant updating multiple tests. I'd like to also time box some time as a follow up to figure out how we can simplify this, e.g. a gateway analogous rule like `EmbeddedBrokerRule` or something. There's a bunch of duplication around constructing a `Gateway` instance.

@koevskinikola As a caveat, I ended up duplicating the `JobActivationProperties` type in the gateway module as well, since the gateway is not aware of the engine. I think that interface and its implementation should be moved to the `protocol-impl`, but I'll let your team do that to avoid conflicts. When that's done, just remove the duplicate implementation.

## Related issues

closes #12388 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
