### PR TITLE
deps(renovate): disable patch updates 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommitTypeAll(deps)"
   ],
   "baseBranches": [
     "main",
@@ -24,9 +25,6 @@
     }
   ],
   "dockerfile": {
-    "semanticCommits": "enabled",
-    "semanticCommitType": "deps",
-    "semanticCommitScope": "docker",
     "ignorePaths": [
       "benchmarks/**",
       "clients/go/vendor/**"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,12 +14,13 @@
   ],
   "packageRules": [
     {
-      "matchBaseBranches": [
-        "/^stable\\/.*/"
+      "matchManagers": [
+        "dockerfile"
       ],
       "matchUpdateTypes": [
         "major",
-        "minor"
+        "minor",
+        "patch"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Description

Since we merged https://github.com/camunda/zeebe/pull/12586 actually patch updates to the tag we use popped up. This change also excludes patch updates but should still allow digest updates if I understood https://docs.renovatebot.com/configuration-options/#matchupdatetypes correctly.

I also noticed the semantic commit settings didn't apply https://github.com/camunda/zeebe/pull/12587 and added commitType config as of https://docs.renovatebot.com/semantic-commits/ 🤞 .