### PR TITLE
deps(renovate): enable dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     "main",
     "/^stable\\/8\\..*/"
   ],
-  "dependencyDashboard": false,
+  "dependencyDashboard": true,
   "enabledManagers": [
     "dockerfile"
   ],


### PR DESCRIPTION
## Description

Curious to try + [allows us to trigger a run manually,](https://github.com/renovatebot/config-help/issues/814) at least for testing I would like to enable it temporarily.

relates to #12577