### PR TITLE
[stable/8.1] build(docker): pin complete docker image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # Override this based on the architecture; this is currently pointing to amd64
-ARG BASE_SHA="22f133769ce2b956d150ab749cd4630b3e7fbac2b37049911aa0973a1283047c"
+ARG BASE_DIGEST="sha256:22f133769ce2b956d150ab749cd4630b3e7fbac2b37049911aa0973a1283047c"
 
 # set to "build" to build zeebe from scratch instead of using a distball
 ARG DIST="distball"
@@ -35,16 +35,16 @@ FROM ${DIST} as dist
 
 # Building application image
 # hadolint ignore=DL3006
-FROM eclipse-temurin:17-jre-focal@sha256:${BASE_SHA} as app
+FROM eclipse-temurin:17-jre-focal@${BASE_DIGEST} as app
 
 # leave unset to use the default value at the top of the file
-ARG BASE_SHA
+ARG BASE_DIGEST
 ARG VERSION=""
 ARG DATE=""
 ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.digest="${BASE_SHA}"
+LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:17-jre-focal"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="zeebe@camunda.com"

--- a/docker/test/docker-labels.golden.json
+++ b/docker/test/docker-labels.golden.json
@@ -5,7 +5,7 @@
   "io.openshift.non-scalable": "false",
   "io.openshift.tags": "bpmn,orchestration,workflow",
   "org.opencontainers.image.authors": "zeebe@camunda.com",
-  "org.opencontainers.image.base.digest": "22f133769ce2b956d150ab749cd4630b3e7fbac2b37049911aa0973a1283047c",
+  "org.opencontainers.image.base.digest": $DIGEST,
   "org.opencontainers.image.base.name": "docker.io/library/eclipse-temurin:17-jre-focal",
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",

--- a/docker/test/verify.sh
+++ b/docker/test/verify.sh
@@ -47,6 +47,16 @@ if ! imageInfo="$(docker inspect "${imageName}")"; then
   exit 1
 fi
 
+DIGEST_REGEX="BASE_DIGEST=\"(sha256\:[a-f0-9\:]+)\""
+DOCKERFILE=$(<"${BASH_SOURCE%/*}/../../Dockerfile")
+if [[ $DOCKERFILE =~ $DIGEST_REGEX ]]; then
+    DIGEST="${BASH_REMATCH[1]}"
+    echo "Digest found: $DIGEST"
+else
+    echo >&2 "Docker image digest can not be found in the Dockerfile"
+    exit 1
+fi
+
 # Extract the actual labels from the info - make sure to sort keys so we always have the same
 # ordering for maps to compare things properly
 actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels')
@@ -65,6 +75,7 @@ expectedLabels=$(
     --arg VERSION "${VERSION}" \
     --arg REVISION "${REVISION}" \
     --arg DATE "${DATE}" \
+    --arg DIGEST "${DIGEST}" \
     "$(cat "${labelsGoldenFile}")"
 )
 


### PR DESCRIPTION
## Description

The previous value lacked the algorithm, this broke automated updates of the digest by renovate. On `main` & `stable/8.2` we already include the algorithm in the variable, so this PR aligns the 8.1 stable branch on that.

By that chance I also backported the dynamic digest value in the golden file we already have on 8.2 and main. This will also allow renovate updates to go through smoothly, as the golden file needs no manual update.

## Related issues

relates #12577