### PR TITLE
Terminate children using the new `ProcessInstanceBatch` command

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public final class BpmnStateBehavior {
@@ -97,15 +96,6 @@ public final class BpmnStateBehavior {
 
   public ElementInstance getFlowScopeInstance(final BpmnElementContext context) {
     return elementInstanceState.getInstance(context.getFlowScopeKey());
-  }
-
-  public List<BpmnElementContext> getChildInstances(final BpmnElementContext context) {
-    return elementInstanceState.getChildren(context.getElementInstanceKey()).stream()
-        .map(
-            childInstance ->
-                context.copy(
-                    childInstance.getKey(), childInstance.getValue(), childInstance.getState()))
-        .collect(Collectors.toList());
   }
 
   public BpmnElementContext getFlowScopeContext(final BpmnElementContext context) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -256,6 +257,7 @@ public final class BoundaryEventTest {
             tuple(ValueType.PROCESS_EVENT, ProcessEventIntent.TRIGGERING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchIntent.TERMINATE),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.JOB, JobIntent.CANCELED),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
@@ -584,9 +584,10 @@ public final class ProcessInstanceCommandRejectionTest {
                 .endEvent()
                 .done());
 
-    final var timerCreated =
-        RecordingExporter.timerRecords(TimerIntent.CREATED)
+    final var serviceTaskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
+            .withElementId("a")
             .getFirst();
 
     final var jobCreated =
@@ -596,7 +597,8 @@ public final class ProcessInstanceCommandRejectionTest {
 
     // when
     engine.writeRecords(
-        cancelProcessInstanceCommand(processInstanceKey), triggerTimerCommand(timerCreated));
+        terminateElementCommand(serviceTaskActivated),
+        terminateElementCommand(serviceTaskActivated));
 
     // then
     final var rejectedCommand =
@@ -630,6 +632,12 @@ public final class ProcessInstanceCommandRejectionTest {
 
   private RecordToWrite triggerTimerCommand(final Record<TimerRecordValue> timer) {
     return RecordToWrite.command().timer(TimerIntent.TRIGGER, timer.getValue()).key(timer.getKey());
+  }
+
+  private RecordToWrite terminateElementCommand(final Record<ProcessInstanceRecordValue> record) {
+    return RecordToWrite.command()
+        .processInstance(ProcessInstanceIntent.TERMINATE_ELEMENT, record.getValue())
+        .key(record.getKey());
   }
 
   private void assertThatCommandIsRejected(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CancelProcessInstanceInBatchesTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CancelProcessInstanceInBatchesTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.springframework.util.unit.DataSize;
+
+public final class CancelProcessInstanceInBatchesTest {
+
+  private static final int AMOUNT_OF_ELEMENT_INSTANCES = 100;
+  private static final int MAX_MESSAGE_SIZE_KB = 32;
+  private static final EmbeddedBrokerRule BROKER_RULE =
+      new EmbeddedBrokerRule(
+          cfg -> {
+            cfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(MAX_MESSAGE_SIZE_KB));
+            cfg.getGateway()
+                .getNetwork()
+                .setMaxMessageSize(DataSize.ofKilobytes(MAX_MESSAGE_SIZE_KB));
+            // Note: this is a bout the batch for writing to the logstream, not the terminate batch
+            cfg.getProcessing().setMaxCommandsInBatch(1);
+          });
+  private static final GrpcClientRule CLIENT_RULE =
+      new GrpcClientRule(
+          BROKER_RULE,
+          zeebeClientBuilder -> zeebeClientBuilder.maxMessageSize(MAX_MESSAGE_SIZE_KB * ONE_KB));
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldCancelInstanceWithMoreChildrenThanTheBatchSizeCanHandle() {
+    // given
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess("PROCESS")
+            .startEvent()
+            .zeebeOutputExpression("0", "count")
+            .exclusiveGateway("joining")
+            .parallelGateway("split")
+            .userTask("userTask")
+            .endEvent()
+            .moveToLastGateway()
+            .exclusiveGateway("forking")
+            .sequenceFlowId("sequenceToEnd")
+            .conditionExpression("count > " + (AMOUNT_OF_ELEMENT_INSTANCES - 2))
+            .endEvent("endEvent")
+            .moveToLastExclusiveGateway()
+            .defaultFlow()
+            .scriptTask(
+                "increment", task -> task.zeebeExpression("count + 1").zeebeResultVariable("count"))
+            .connectTo("joining")
+            .done());
+
+    // when
+    final ProcessInstanceEvent processInstance = startProcessInstance();
+    cancelProcessInstance(processInstance);
+
+    // then
+    hasTerminatedProcessInstance(processInstance);
+    hasTerminatedAllUserTasks(processInstance);
+    hasTerminatedInMultipleBatches(processInstance, processInstance.getProcessInstanceKey());
+  }
+
+  @Test
+  public void shouldCancelSubprocessWithMoreNestedChildrenThanTheBatchSizeCanHandle() {
+    // given
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess("PROCESS")
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                sp ->
+                    sp.embeddedSubProcess()
+                        .startEvent()
+                        .zeebeOutputExpression("0", "count")
+                        .exclusiveGateway("joining")
+                        .parallelGateway("split")
+                        .userTask("userTask")
+                        .endEvent()
+                        .moveToLastGateway()
+                        .exclusiveGateway("forking")
+                        .sequenceFlowId("sequenceToEnd")
+                        .conditionExpression("count > " + (AMOUNT_OF_ELEMENT_INSTANCES - 2))
+                        .endEvent("endEvent")
+                        .moveToLastExclusiveGateway()
+                        .defaultFlow()
+                        .scriptTask(
+                            "increment",
+                            task -> task.zeebeExpression("count + 1").zeebeResultVariable("count"))
+                        .connectTo("joining"))
+            .endEvent()
+            .done());
+
+    // when
+    final ProcessInstanceEvent processInstance = startProcessInstance();
+    final var subProcess =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+            .withElementId("subprocess")
+            .getFirst();
+    cancelProcessInstance(processInstance);
+
+    // then
+    hasTerminatedProcessInstance(processInstance);
+    hasTerminatedAllUserTasks(processInstance);
+    hasTerminatedInMultipleBatches(processInstance, subProcess.getKey());
+  }
+
+  private ProcessInstanceEvent startProcessInstance() {
+    final var processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId("PROCESS")
+            .latestVersion()
+            .send()
+            .join();
+    return processInstance;
+  }
+
+  private void cancelProcessInstance(final ProcessInstanceEvent processInstance) {
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+        .withElementId("endEvent")
+        .limit(1)
+        .await();
+
+    CLIENT_RULE
+        .getClient()
+        .newCancelInstanceCommand(processInstance.getProcessInstanceKey())
+        .send();
+  }
+
+  private void hasTerminatedProcessInstance(final ProcessInstanceEvent processInstance) {
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .withElementType(BpmnElementType.PROCESS)
+                .limitToProcessInstanceTerminated()
+                .exists())
+        .describedAs("Has terminated process instance")
+        .isTrue();
+  }
+
+  private void hasTerminatedAllUserTasks(final ProcessInstanceEvent processInstance) {
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .withElementId("userTask")
+                .limit(AMOUNT_OF_ELEMENT_INSTANCES))
+        .describedAs("Has terminated all " + AMOUNT_OF_ELEMENT_INSTANCES + " user tasks")
+        .hasSize(AMOUNT_OF_ELEMENT_INSTANCES);
+  }
+
+  private void hasTerminatedInMultipleBatches(
+      final ProcessInstanceEvent processInstance, final long batchElementInstanceKey) {
+    assertThat(
+            RecordingExporter.processInstanceBatchRecords()
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .withBatchElementInstanceKey(batchElementInstanceKey)
+                .limit(2))
+        .describedAs("Has terminated in multiple batches")
+        .hasSize(2);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceBatchRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceBatchRecordStream.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+import java.util.stream.Stream;
+
+public class ProcessInstanceBatchRecordStream
+    extends ExporterRecordStream<
+        ProcessInstanceBatchRecordValue, ProcessInstanceBatchRecordStream> {
+
+  public ProcessInstanceBatchRecordStream(
+      final Stream<Record<ProcessInstanceBatchRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ProcessInstanceBatchRecordStream supply(
+      final Stream<Record<ProcessInstanceBatchRecordValue>> wrappedStream) {
+    return new ProcessInstanceBatchRecordStream(wrappedStream);
+  }
+
+  public ProcessInstanceBatchRecordStream withProcessInstanceKey(final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+
+  public ProcessInstanceBatchRecordStream withBatchElementInstanceKey(
+      final long batchElementInstanceKey) {
+    return valueFilter(v -> v.getBatchElementInstanceKey() == batchElementInstanceKey);
+  }
+
+  public ProcessInstanceBatchRecordStream withIndex(final long index) {
+    return valueFilter(v -> v.getIndex() == index);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
@@ -234,6 +235,11 @@ public final class RecordingExporter implements Exporter {
   public static ProcessInstanceRecordStream processInstanceRecords(
       final ProcessInstanceIntent intent) {
     return processInstanceRecords().withIntent(intent);
+  }
+
+  public static ProcessInstanceBatchRecordStream processInstanceBatchRecords() {
+    return new ProcessInstanceBatchRecordStream(
+        records(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchRecordValue.class));
   }
 
   public static TimerRecordStream timerRecords() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR switches the termination of child instances to use the new `ProcessInstanceBatch` command.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12538 
closes #11355 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
