### PR TITLE
Restore blacklist metric

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/BlacklistMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/BlacklistMetrics.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 
 public final class BlacklistMetrics {
 
-  private static final Counter BLACKLISTED_INSTANCES_COUNTER =
-      Counter.build()
+  private static final Gauge BLACKLISTED_INSTANCES_COUNTER =
+      Gauge.build()
           .namespace("zeebe")
           .name("blacklisted_instances_total")
           .help("Number of blacklisted instances")
@@ -27,5 +27,9 @@ public final class BlacklistMetrics {
 
   public void countBlacklistedInstance() {
     BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).inc();
+  }
+
+  public void setBlacklistInstanceCounter(final int counter) {
+    BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).set(counter);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 
@@ -50,7 +51,10 @@ public final class DbBlackListState implements MutableBlackListState {
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    empty = blackListColumnFamily.isEmpty();
+    final var counter = new AtomicInteger(0);
+    blackListColumnFamily.forEach(ignore -> counter.getAndIncrement());
+    empty = counter.get() == 0;
+    blacklistMetrics.setBlacklistInstanceCounter(counter.get());
   }
 
   private void blacklist(final long key) {


### PR DESCRIPTION
## Description
On restart/recovery we need to restore the blacklist metric in order to report it always. Otherwise, we will have gaps in the reports and it is not reliable, due to restarts and resetting of counters.

Change counter to gauge, such that it can be reset/set to a specific value based on the state.

See related comment https://github.com/camunda/zeebe/issues/8263#issuecomment-1144811212

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/8263

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_
