### PR TITLE
fix: brokers can list more than 255 backups

### DIFF
--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -110,6 +110,64 @@
           "code": "java.method.removed",
           "old": "method io.camunda.zeebe.protocol.record.value.ImmutableEvaluatedDecisionValue io.camunda.zeebe.protocol.record.value.ImmutableEvaluatedDecisionValue::withDecisionVersion(long)",
           "justification": "This method provided an input argument of the wrong type. The version property is unlikely to surpass MAX_INT. Furthermore, in many cases the JVM automatically converts long to int."
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder.HEADER_SIZE",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder.HEADER_SIZE",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder.HEADER_SIZE",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method short io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder::countMaxValue()",
+          "new": "method int io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder::countMaxValue()",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method short io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder::countMinValue()",
+          "new": "method int io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder::countMinValue()",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method short io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder::countMaxValue()",
+          "new": "method int io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder::countMaxValue()",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method short io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder::countMinValue()",
+          "new": "method int io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder::countMinValue()",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": "class io.camunda.zeebe.protocol.management.GroupSizeEncodingDecoder",
+          "justification": "This is no longer used for listing backups"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": "class io.camunda.zeebe.protocol.management.GroupSizeEncodingEncoder",
+          "justification": "This is no longer used for listing backups"
         }
       ]
     }

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -26,6 +26,15 @@
       <validValue name="COMPLETED">2</validValue>
       <validValue name="FAILED">3</validValue>
     </enum>
+
+    <composite name="largeGroupSizeEncoding">
+      <!-- Similar to groupSizeEncoding in common-types.xml but uses uint16 instead of uint8 to count entries.-->
+      <type name="blockLength" primitiveType="uint16"/>
+      <type name="numInGroup" primitiveType="uint16"/>
+      <type name="numGroups" primitiveType="uint16"/>
+      <type name="numVarDataFields" primitiveType="uint16"/>
+    </composite>
+
   </types>
 
   <sbe:message name="AdminRequest" id="1">
@@ -63,7 +72,7 @@
 
   <sbe:message name="BackupListResponse" id="5">
     <!-- This response contains a subset of fields from BackupStatusResponse  -->
-    <group name="backups" id="1" dimensionType="groupSizeEncoding">
+    <group name="backups" id="1" dimensionType="largeGroupSizeEncoding">
       <field name="backupId" id="1" type="int64"/>
       <field name="status" id="2" type="BackupStatusCode"/>
       <field name="partitionId" id="3" type="uint16"/>


### PR DESCRIPTION
Switches to a new encoding that uses 16 bits instead of 8 to count entries.
Rather than changing the generic `groupSizeEncoding` which is used in other places such as raft configuration entries, this introduces a second `largeGroupSizeEncoding` that is only used for listing backups. This is mostly to ensure backwards compatibility and to save some bits where they are not needed.

This PR does not introduce an artificial limit such as only returning the 100 newest backups. IMO this is something that we should consider separately.

closes #12597