### PR TITLE
fix: do not retake backup if it already exists

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupAlreadyExistsException.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupAlreadyExistsException.java
@@ -8,11 +8,11 @@
 package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupIdentifier;
-import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
 
 class BackupAlreadyExistsException extends RuntimeException {
 
-  BackupAlreadyExistsException(final BackupIdentifier id, final BackupStatus status) {
+  BackupAlreadyExistsException(final BackupIdentifier id, final BackupStatusCode status) {
     super("Backup with id %s already exists, status of the backup is %s".formatted(id, status));
   }
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -15,6 +15,8 @@ import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -44,16 +46,22 @@ final class BackupServiceImpl {
 
     backupsInProgress.add(inProgressBackup);
 
-    final var checkCurrentBackup = backupStore.getStatus(inProgressBackup.id());
+    final var checkCurrentBackup =
+        backupStore.list(
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(),
+                Optional.of(inProgressBackup.id().partitionId()),
+                Optional.of(inProgressBackup.checkpointId())));
 
     final ActorFuture<Void> backupSaved = concurrencyControl.createFuture();
 
     checkCurrentBackup.whenCompleteAsync(
-        (status, error) -> {
+        (availableBackups, error) -> {
           if (error != null) {
             backupSaved.completeExceptionally(error);
           } else {
-            takeBackupIfDoesNotExist(status, inProgressBackup, concurrencyControl, backupSaved);
+            takeBackupIfDoesNotExist(
+                availableBackups, inProgressBackup, concurrencyControl, backupSaved);
           }
         },
         concurrencyControl::run);
@@ -63,12 +71,17 @@ final class BackupServiceImpl {
   }
 
   private void takeBackupIfDoesNotExist(
-      final BackupStatus status,
+      final Collection<BackupStatus> availableBackups,
       final InProgressBackup inProgressBackup,
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<Void> backupSaved) {
 
-    switch (status.statusCode()) {
+    final BackupStatusCode existingBackupStatus =
+        availableBackups.isEmpty()
+            ? BackupStatusCode.DOES_NOT_EXIST
+            : Collections.max(availableBackups, Comparator.comparing(BackupStatus::statusCode))
+                .statusCode();
+    switch (existingBackupStatus) {
       case COMPLETED -> {
         LOG.debug("Backup {} is already completed, will not take a new one", inProgressBackup.id());
         backupSaved.complete(null);
@@ -77,9 +90,9 @@ final class BackupServiceImpl {
         LOG.error(
             "Backup {} already exists with status {}, will not take a new one",
             inProgressBackup.id(),
-            status);
+            existingBackupStatus);
         backupSaved.completeExceptionally(
-            new BackupAlreadyExistsException(inProgressBackup.id(), status));
+            new BackupAlreadyExistsException(inProgressBackup.id(), existingBackupStatus));
       }
       default -> {
         final ActorFuture<Void> snapshotFound = concurrencyControl.createFuture();

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -79,8 +78,7 @@ final class BackupServiceImpl {
     final BackupStatusCode existingBackupStatus =
         availableBackups.isEmpty()
             ? BackupStatusCode.DOES_NOT_EXIST
-            : Collections.max(availableBackups, Comparator.comparing(BackupStatus::statusCode))
-                .statusCode();
+            : Collections.max(availableBackups, BackupStatusCode.BY_STATUS).statusCode();
     switch (existingBackupStatus) {
       case COMPLETED -> {
         LOG.debug("Backup {} is already completed, will not take a new one", inProgressBackup.id());


### PR DESCRIPTION
## Description

In this PR, we check if the backup exists for that partition by listing using the wildcard. This returns the backups taken by other nodes as well. The backup is taken only if no backup exists for that partition with the same checkpointId. Previiously, we were checking using the full backupId which included the nodeId, so it can only find the backup taken by the same node. This is not ideal, because it can result in duplicate unnecessary backups, for example after restoring from a backup.

## Related issues

closes #12623 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
