### PR TITLE
feat(engine): support bpmn converging inclusive gateway

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/InclusiveGatewayValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/InclusiveGatewayValidator.java
@@ -32,15 +32,10 @@ public class InclusiveGatewayValidator implements ModelElementValidator<Inclusiv
       final InclusiveGateway element, final ValidationResultCollector validationResultCollector) {
 
     final SequenceFlow defaultFlow = element.getDefault();
-    final int size = element.getIncoming().size();
     if (defaultFlow != null) {
       if (defaultFlow.getSource() != element) {
         validationResultCollector.addError(0, "Default flow must start at gateway");
       }
-    }
-    if (size > 1) {
-      validationResultCollector.addError(
-          0, "Currently the inclusive gateway can only have one incoming sequence flow");
     }
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeGatewayValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeGatewayValidationTest.java
@@ -52,26 +52,6 @@ public class ZeebeGatewayValidationTest extends AbstractZeebeValidationTest {
             .done(),
         singletonList(expect("flow1", "Must have a condition"))
       },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent("start")
-            .inclusiveGateway("fork")
-            .defaultFlow()
-            .sequenceFlowId("flow1")
-            .conditionExpression("= contains(str,\"a\")")
-            .serviceTask("task1", b -> b.zeebeJobType("type1"))
-            .inclusiveGateway("join")
-            .endEvent("end")
-            .moveToNode("fork")
-            .sequenceFlowId("flow2")
-            .conditionExpression("= contains(str,\"b\")")
-            .serviceTask("task2", b -> b.zeebeJobType("type2"))
-            .connectTo("join")
-            .done(),
-        singletonList(
-            expect(
-                "join", "Currently the inclusive gateway can only have one incoming sequence flow"))
-      },
       {"default-flow.bpmn", singletonList(expect("gateway", "Default flow must start at gateway"))},
       {
         "default-flow-inclusive-gateway.bpmn",

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
@@ -40,7 +40,7 @@ public interface BroadcastSignalCommandStep1 {
     BroadcastSignalCommandStep2 variables(InputStream variables);
 
     /**
-     * Set the variables of the message.
+     * Set the variables of the signal.
      *
      * @param variables the variables (JSON) as String
      * @return the builder for this command. Call {@link #send()} to complete the command and send
@@ -49,7 +49,7 @@ public interface BroadcastSignalCommandStep1 {
     BroadcastSignalCommandStep2 variables(String variables);
 
     /**
-     * Set the variables of the message.
+     * Set the variables of the signal.
      *
      * @param variables the variables as map
      * @return the builder for this command. Call {@link #send()} to complete the command and send
@@ -58,7 +58,7 @@ public interface BroadcastSignalCommandStep1 {
     BroadcastSignalCommandStep2 variables(Map<String, Object> variables);
 
     /**
-     * Set the variables of the message.
+     * Set the variables of the signal.
      *
      * @param variables the variables as object
      * @return the builder for this command. Call {@link #send()} to complete the command and send

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public final class BpmnStateBehavior {
@@ -96,6 +97,15 @@ public final class BpmnStateBehavior {
 
   public ElementInstance getFlowScopeInstance(final BpmnElementContext context) {
     return elementInstanceState.getInstance(context.getFlowScopeKey());
+  }
+
+  public List<BpmnElementContext> getChildInstances(final BpmnElementContext context) {
+    return elementInstanceState.getChildren(context.getElementInstanceKey()).stream()
+        .map(
+            childInstance ->
+                context.copy(
+                    childInstance.getKey(), childInstance.getValue(), childInstance.getState()))
+        .collect(Collectors.toList());
   }
 
   public BpmnElementContext getFlowScopeContext(final BpmnElementContext context) {


### PR DESCRIPTION
## Description
This PR adds support for converging/joining inclusive gateway.

## Related issues
closes #10031

## Definition of Done
Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
