### PR TITLE
[Backport stable/8.2] fix: brokers can list more than 255 backups

### DIFF
--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -41,6 +41,64 @@
           "justification": "Ignore changes to the project version, as it changes on every release",
           "code": "java.field.constantValueChanged",
           "fieldName": "SEMANTIC_VERSION"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder.HEADER_SIZE",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder.HEADER_SIZE",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder.HEADER_SIZE",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method short io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder::countMaxValue()",
+          "new": "method int io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder::countMaxValue()",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method short io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder::countMinValue()",
+          "new": "method int io.camunda.zeebe.protocol.management.BackupListResponseDecoder.BackupsDecoder::countMinValue()",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method short io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder::countMaxValue()",
+          "new": "method int io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder::countMaxValue()",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method short io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder::countMinValue()",
+          "new": "method int io.camunda.zeebe.protocol.management.BackupListResponseEncoder.BackupsEncoder::countMinValue()",
+          "justification": "Only used for listing backups, this is an acceptable breaking change."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": "class io.camunda.zeebe.protocol.management.GroupSizeEncodingDecoder",
+          "justification": "This is no longer used for listing backups"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": "class io.camunda.zeebe.protocol.management.GroupSizeEncodingEncoder",
+          "justification": "This is no longer used for listing backups"
         }
       ]
     }

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -26,6 +26,15 @@
       <validValue name="COMPLETED">2</validValue>
       <validValue name="FAILED">3</validValue>
     </enum>
+
+    <composite name="largeGroupSizeEncoding">
+      <!-- Similar to groupSizeEncoding in common-types.xml but uses uint16 instead of uint8 to count entries.-->
+      <type name="blockLength" primitiveType="uint16"/>
+      <type name="numInGroup" primitiveType="uint16"/>
+      <type name="numGroups" primitiveType="uint16"/>
+      <type name="numVarDataFields" primitiveType="uint16"/>
+    </composite>
+
   </types>
 
   <sbe:message name="AdminRequest" id="1">
@@ -63,7 +72,7 @@
 
   <sbe:message name="BackupListResponse" id="5">
     <!-- This response contains a subset of fields from BackupStatusResponse  -->
-    <group name="backups" id="1" dimensionType="groupSizeEncoding">
+    <group name="backups" id="1" dimensionType="largeGroupSizeEncoding">
       <field name="backupId" id="1" type="int64"/>
       <field name="status" id="2" type="BackupStatusCode"/>
       <field name="partitionId" id="3" type="uint16"/>


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/12621 to fix revapi merge conflicts.