### PR TITLE
[Backport stable/8.2] Restore blacklist metric

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/BlacklistMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/BlacklistMetrics.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 
 public final class BlacklistMetrics {
 
-  private static final Counter BLACKLISTED_INSTANCES_COUNTER =
-      Counter.build()
+  private static final Gauge BLACKLISTED_INSTANCES_COUNTER =
+      Gauge.build()
           .namespace("zeebe")
           .name("blacklisted_instances_total")
           .help("Number of blacklisted instances")
@@ -27,5 +27,9 @@ public final class BlacklistMetrics {
 
   public void countBlacklistedInstance() {
     BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).inc();
+  }
+
+  public void setBlacklistInstanceCounter(final int counter) {
+    BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).set(counter);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 
@@ -50,7 +51,10 @@ public final class DbBlackListState implements MutableBlackListState {
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    empty = blackListColumnFamily.isEmpty();
+    final var counter = new AtomicInteger(0);
+    blackListColumnFamily.forEach(ignore -> counter.getAndIncrement());
+    empty = counter.get() == 0;
+    blacklistMetrics.setBlacklistInstanceCounter(counter.get());
   }
 
   private void blacklist(final long key) {


### PR DESCRIPTION
# Description
Backport of #12606 to `stable/8.2`.

relates to camunda/zeebe#8263