### PR TITLE
[Backport 8.1]: Restore blacklist metric

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/BlacklistMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/BlacklistMetrics.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 
 public final class BlacklistMetrics {
 
-  private static final Counter BLACKLISTED_INSTANCES_COUNTER =
-      Counter.build()
+  private static final Gauge BLACKLISTED_INSTANCES_COUNTER =
+      Gauge.build()
           .namespace("zeebe")
           .name("blacklisted_instances_total")
           .help("Number of blacklisted instances")
@@ -27,5 +27,9 @@ public final class BlacklistMetrics {
 
   public void countBlacklistedInstance() {
     BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).inc();
+  }
+
+  public void setBlacklistInstanceCounter(final int counter) {
+    BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).set(counter);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 
@@ -50,7 +51,10 @@ public final class DbBlackListState implements MutableBlackListState {
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    empty = blackListColumnFamily.isEmpty();
+    final var counter = new AtomicInteger(0);
+    blackListColumnFamily.forEach(ignore -> counter.getAndIncrement());
+    empty = counter.get() == 0;
+    blacklistMetrics.setBlacklistInstanceCounter(counter.get());
   }
 
   private void blacklist(final long key) {


### PR DESCRIPTION
## Description
Backports https://github.com/camunda/zeebe/pull/12606

Merge conflicts because of imports.

## Related issues

closes https://github.com/camunda/zeebe/issues/8263

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
