### PR TITLE
POC: Enhance CF prefix check

### DIFF
--- a/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
@@ -216,14 +216,28 @@ public final class BufferUtil {
       final int prefixOffset,
       final int prefixLength,
       final byte[] content,
-      int contentOffset,
+      final int contentOffset,
       final int contentLength) {
     if (contentLength < prefixLength) {
       return false;
     }
 
-    for (int i = prefixOffset; i < prefixLength; i++, contentOffset++) {
-      if (content[contentOffset] != prefix[i]) {
+    // we know that prefix length is either equal or smaller then content length
+    //
+
+    // prefix look normally like this: [0, 0, 0, 0, 0, 0, 0, 21] length = 8
+    // content like this: [0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 12] length = 12
+
+    // right now we check at the begin, which means we have to iterate several zero values which
+    // are always equal
+    // would be much fast if we iterate from the back
+
+    // prefix start at prefixOffSet + (prefix-length - 1)
+    // content start at contentOffSet + (prefix-length -1)
+
+    var offset = prefixLength - 1;
+    for (; offset >= 0; offset--) {
+      if (content[contentOffset + offset] != prefix[prefixOffset + offset]) {
         return false;
       }
     }


### PR DESCRIPTION
## Description

_Idea:_ 

We know that the prefixes normally look like this: `[0, 0, 0, 0, 0, 0, 0, 21] length = 8`
the keys we check them against look mostly like this: `[0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 12] length = 12`

Right now we check the prefixes via iterating from the beginning, which means we have to iterate over several zero values which could be improved if we start from the back. Right now this will only improve the case when the prefix is different. This was what I first tried.

Later I thought in order to improve this for all cases, I could check the column family byte directly (currently we have less than 128 column families), this means we can just check the last byte of the long (we write them in ByteOrder.BIG_ENDIAN). If this is equal the entry is a valid entry for the CF otherwise not.

Furthermore, sometimes we don't provide any prefix this means we can check whether the length of the prefix is zero so we don't check the key further. If the prefix key is larger then zero we can check the key (starting after the CF prefix).


The JMH benchmark results were interesting since they show a much lower error rate (variance) than the other test runs. 

```
Result "io.camunda.zeebe.engine.perf.EnginePerformanceTest.measureProcessExecutionTime":
  223.584 ±(99.9%) 2.052 ops/s [Average]
  (min, avg, max) = (196.934, 223.584, 238.563), stdev = 8.686
  CI (99.9%): [221.533, 225.636] (assumes normal distribution)

Benchmark                                           Mode  Cnt    Score   Error  Units
EnginePerformanceTest.measureProcessExecutionTime  thrpt  200  223.584 ± 2.052  ops/s
```

I want to start a benchmark by maxing out performance to see whether we see any difference.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/zeebe/issues/12241

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
