### PR TITLE
POC: introduce key formats

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -434,6 +434,11 @@ public final class EngineRule extends ExternalResource {
     public DirectBuffer getDirectBuffer() {
       return genericBuffer;
     }
+
+    @Override
+    public boolean isValid() {
+      return genericBuffer.capacity() > 0;
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/zb-db/src/main/java/io/camunda/zeebe/db/DbKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/DbKey.java
@@ -11,4 +11,16 @@ import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 
 /** The key which is used to store a value. */
-public interface DbKey extends BufferReader, BufferWriter {}
+public interface DbKey extends BufferReader, BufferWriter {
+
+  /**
+   * Implementation of DbKey can define certain key ranges or structure, if this format doesn't
+   * apply to the current key instance, then this method should return false.
+   *
+   * <p>In this case the database can do some shortcuts like not storing the data or returning false
+   * immediately.
+   *
+   * @return true, if applies to a specific key format
+   */
+  boolean isValid();
+}

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbByte.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbByte.java
@@ -43,4 +43,9 @@ public final class DbByte implements DbKey, DbValue {
   public String toString() {
     return "DbByte{" + "value=" + value + '}';
   }
+
+  @Override
+  public boolean isValid() {
+    return value > 0;
+  }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbCompositeKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbCompositeKey.java
@@ -75,4 +75,9 @@ public final class DbCompositeKey<FirstKeyType extends DbKey, SecondKeyType exte
   public String toString() {
     return "DbCompositeKey{" + "first=" + first + ", second=" + second + '}';
   }
+
+  @Override
+  public boolean isValid() {
+    return first.isValid() || second.isValid();
+  }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
@@ -60,6 +60,11 @@ public record DbForeignKey<K extends DbKey>(
     return skip.test(inner);
   }
 
+  @Override
+  public boolean isValid() {
+    return inner.isValid();
+  }
+
   public enum MatchType {
     Full,
     Prefix,

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbInt.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbInt.java
@@ -45,4 +45,9 @@ public final class DbInt implements DbKey, DbValue {
   public String toString() {
     return "DbInt{" + intValue + '}';
   }
+
+  @Override
+  public boolean isValid() {
+    return intValue > 0;
+  }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbLong.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbLong.java
@@ -45,4 +45,9 @@ public final class DbLong implements DbKey, DbValue {
   public String toString() {
     return "DbLong{" + longValue + '}';
   }
+
+  @Override
+  public boolean isValid() {
+    return longValue > 0;
+  }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbString.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbString.java
@@ -61,4 +61,9 @@ public final class DbString implements DbKey, DbValue {
   public DirectBuffer getBuffer() {
     return bytes;
   }
+
+  @Override
+  public boolean isValid() {
+    return bytes.capacity() > 0;
+  }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DbNullKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DbNullKey.java
@@ -24,12 +24,17 @@ final class DbNullKey implements DbKey {
   }
 
   @Override
+  public int getLength() {
+    return 0;
+  }
+
+  @Override
   public void write(final MutableDirectBuffer buffer, final int offset) {
     // do nothing
   }
 
   @Override
-  public int getLength() {
-    return 0;
+  public boolean isValid() {
+    return true;
   }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -74,6 +74,10 @@ class TransactionalColumnFamily<
 
   @Override
   public void insert(final KeyType key, final ValueType value) {
+    if (!key.isValid()) {
+      throw new IllegalStateException("lol");
+    }
+
     ensureInOpenTransaction(
         transaction -> {
           columnFamilyContext.writeKey(key);
@@ -92,6 +96,10 @@ class TransactionalColumnFamily<
 
   @Override
   public void update(final KeyType key, final ValueType value) {
+    if (!key.isValid()) {
+      throw new IllegalStateException("lol");
+    }
+
     ensureInOpenTransaction(
         transaction -> {
           columnFamilyContext.writeKey(key);
@@ -109,6 +117,10 @@ class TransactionalColumnFamily<
 
   @Override
   public void upsert(final KeyType key, final ValueType value) {
+    if (!key.isValid()) {
+      throw new IllegalStateException("lol");
+    }
+
     ensureInOpenTransaction(
         transaction -> {
           columnFamilyContext.writeKey(key);
@@ -125,6 +137,10 @@ class TransactionalColumnFamily<
 
   @Override
   public ValueType get(final KeyType key) {
+    if (!key.isValid()) {
+      return null;
+    }
+
     ensureInOpenTransaction(
         transaction -> {
           columnFamilyContext.writeKey(key);

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -127,6 +127,7 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
     transaction.rollback();
   }
 
+  @Override
   public void close() {
     transaction.close();
   }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -77,6 +77,19 @@ public final class ColumnFamilyTest {
   }
 
   @Test
+  public void shouldReturnNullIfNotValid() {
+    // given
+    key.wrapLong(-1);
+
+    // when
+    final DbLong zbLong = columnFamily.get(key);
+
+    // then
+    assertThat(key.isValid()).isFalse();
+    assertThat(zbLong).isNull();
+  }
+
+  @Test
   public void shouldPutMultipleValues() {
     // given
     upsertKeyValuePair(1213, 255);


### PR DESCRIPTION
## Description

We have some keys where we do unnecessary lookups with non existing or invalid keys like `-1`. If we would define the right format of a key, for example numeric key shouldn't be negative or a string key should be empty. Then we can easily handle this in our ZeebeDB API, simply return null if the key doesn't respect the key format.

This is what this PR tries todo. JMH Benchmark doesn't show any significant improvement, but might be different in our benchmarks.

```

Result "io.camunda.zeebe.engine.perf.EnginePerformanceTest.measureProcessExecutionTime":
  227.234 ±(99.9%) 15.272 ops/s [Average]
  (min, avg, max) = (152.141, 227.234, 1035.326), stdev = 64.663
  CI (99.9%): [211.962, 242.506] (assumes normal distribution)


# Run complete. Total time: 00:05:10

Benchmark                                           Mode  Cnt    Score    Error  Units
EnginePerformanceTest.measureProcessExecutionTime  thrpt  200  227.234 ± 15.272  ops/s

```

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

Related to https://github.com/camunda/zeebe/issues/12035
Related to https://github.com/camunda/zeebe/issues/12039

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
