### PR TITLE
POC: Create additional CF

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.db.impl.rocksdb;
 
 import java.util.Properties;
+import java.util.Set;
 
 public final class RocksDbConfiguration {
 
@@ -41,6 +42,8 @@ public final class RocksDbConfiguration {
   public static final boolean DEFAULT_SST_PARTITIONING_ENABLED = false;
 
   public static final int DEFAULT_IO_RATE_BYTES_PER_SECOND = 0;
+
+  public Set<String> separateColumnFamiliesPrefix = Set.of("job", "element");
 
   private Properties columnFamilyOptions = new Properties();
   private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;
@@ -153,5 +156,13 @@ public final class RocksDbConfiguration {
   public RocksDbConfiguration setSstPartitioningEnabled(final boolean sstPartitioningEnabled) {
     this.sstPartitioningEnabled = sstPartitioningEnabled;
     return this;
+  }
+
+  public Set<String> getSeparateColumnFamiliesPrefix() {
+    return separateColumnFamiliesPrefix;
+  }
+
+  public void setSeparateColumnFamiliesPrefix(final Set<String> separateColumnFamiliesPrefix) {
+    this.separateColumnFamiliesPrefix = separateColumnFamiliesPrefix;
   }
 }


### PR DESCRIPTION
## Description


We have seen with #12483 that splitting up the key-space into separate SST files (based on logic/virtual CF) brings us an enormous boost in performance. 

The assumption was that separation can also be archived potential with introducing some real column families, without relying on an experimental feature.

This POC allows to configure column family name prefixes, which should be included in a separate real column family. In this POC jobs and element instances are separated from the default. This means we will have three real column families.

Running the JMH benchmark shows us a similar results as with #12483, which means our thesis seems to be correct.

```

Result "io.camunda.zeebe.engine.perf.EnginePerformanceTest.measureProcessExecutionTime":
  681.872 ±(99.9%) 77.924 ops/s [Average]
  (min, avg, max) = (1.763, 681.872, 1123.390), stdev = 329.935
  CI (99.9%): [603.948, 759.796] (assumes normal distribution)


# Run complete. Total time: 00:06:16

Benchmark                                           Mode  Cnt    Score    Error  Units
EnginePerformanceTest.measureProcessExecutionTime  thrpt  200  681.872 ± 77.924  ops/s

Process finished with exit code 0

```

I will run some more Zeebe benchmarks to see the real impact, maxing out performance and large state.

Benchmarks:

 * [Large state](https://grafana.dev.zeebe.io/d/I4lo7_EZk/zeebe?orgId=1&refresh=10s&var-DS_PROMETHEUS=Prometheus&var-cluster=All&var-namespace=zell-db-separate-cf-large-state&var-pod=All&var-partition=All&from=now-30m&to=now)
 * [Normal benchmark](https://grafana.dev.zeebe.io/d/I4lo7_EZk/zeebe?orgId=1&refresh=10s&var-DS_PROMETHEUS=Prometheus&var-cluster=All&var-namespace=zell-db-separate-cf-benchmark&var-pod=All&var-partition=All&from=now-30m&to=now)
 * [Maxing out](https://grafana.dev.zeebe.io/d/I4lo7_EZk/zeebe?orgId=1&refresh=10s&var-DS_PROMETHEUS=Prometheus&var-cluster=All&var-namespace=zell-db-separate-cf-max-out&var-pod=All&var-partition=All&from=now-30m&to=now)
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
