### PR TITLE
fix(broker): reject requests larger than max message size

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -43,11 +44,13 @@ import org.mockito.Mockito;
 public class CommandApiRequestHandlerTest {
   @Rule public final ControlledActorSchedulerRule scheduler = new ControlledActorSchedulerRule();
   final CommandApiRequestHandler handler = new CommandApiRequestHandler();
+  private LogStreamWriter logStreamWriter;
 
   @Before
   public void setup() {
     scheduler.submitActor(handler);
-    handler.addPartition(0, mock(LogStreamWriter.class), new NoopRequestLimiter<>());
+    logStreamWriter = mock(LogStreamWriter.class);
+    handler.addPartition(0, logStreamWriter, new NoopRequestLimiter<>());
     scheduler.workUntilDone();
   }
 
@@ -166,6 +169,28 @@ public class CommandApiRequestHandlerTest {
 
     // then
     verify(logWriter).tryWrite(Mockito.<LogAppendEntry>any());
+  }
+
+  @Test
+  public void shouldRejectRequestIfTooLarge() {
+    when(logStreamWriter.canWriteEvents(anyInt(), anyInt())).thenReturn(false);
+
+    final var request =
+        new BrokerPublishMessageRequest("test", "1").setMessageId("1").setTimeToLive(0);
+    request.serializeValue();
+
+    // when
+    final var responseFuture = handleRequest(request);
+
+    // then
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofMinutes(1))
+        .matches(Either::isLeft)
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode, e -> BufferUtil.bufferAsString(e.getErrorData()))
+        .containsExactly(
+            ErrorCode.INTERNAL_ERROR,
+            "Failed writing request: Request size is above configured maxMessageSize.");
   }
 
   private CompletableFuture<Either<ErrorResponse, ExecuteCommandResponse>> handleRequest(

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -157,6 +157,7 @@ public class CommandApiRequestHandlerTest {
   public void shouldWriteToLog() {
     // given
     final var logWriter = mock(LogStreamWriter.class);
+    when(logWriter.canWriteEvents(anyInt(), anyInt())).thenReturn(true);
     handler.addPartition(0, logWriter, new NoopRequestLimiter<>());
     scheduler.workUntilDone();
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -152,7 +152,8 @@ public final class GrpcErrorMapper {
         builder.setCode(Code.INTERNAL_VALUE);
         message =
             String.format(
-                "Unexpected error occurred between gateway and broker (code: %s)", error.getCode());
+                "Unexpected error occurred between gateway and broker (code: %s) (message: %s)",
+                error.getCode(), error.getMessage());
         break;
     }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateLargeDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateLargeDeploymentTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.springframework.util.unit.DataSize;
+
+public final class CreateLargeDeploymentTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE =
+      new EmbeddedBrokerRule(b -> b.getNetwork().setMaxMessageSize(DataSize.ofMegabytes(1)));
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  // Regression "https://github.com/camunda/zeebe/issues/12591")
+  @Test
+  public void shouldRejectDeployIfResourceIsTooLarge() {
+    // when
+    final var deployLargeProcess =
+        CLIENT_RULE
+            .getClient()
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("processes/too_large_process.bpmn")
+            .send();
+
+    // then
+    assertThatThrownBy(deployLargeProcess::join)
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("Request size is above configured maxMessageSize.");
+
+    // then - can deploy another process
+    final var deployedValidProcess =
+        CLIENT_RULE
+            .getClient()
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("processes/one-task-process.bpmn")
+            .send()
+            .join();
+    assertThat(deployedValidProcess.getProcesses()).hasSize(1);
+  }
+}


### PR DESCRIPTION
## Description

Reject requests larger than max message size in CommandApi. Previously this was written to logstream, and rejected during processing, which is unnecessary. This also caused issues because, the engine could not write rejection record to the logstream.

## Related issues

closes #12591 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
