### PR TITLE
#9970 Followers should return the full partition status for the /partitions actuator.

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/PartitionStatus.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/PartitionStatus.java
@@ -11,102 +11,11 @@ import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 
-public final class PartitionStatus {
-
-  private final Role role;
-  private final String snapshotId;
-  private final Long processedPosition;
-  private final Long processedPositionInSnapshot;
-  private final Phase streamProcessorPhase;
-  private final ExporterPhase exporterPhase;
-  private final Long exportedPosition;
-
-  private PartitionStatus(
-      final Role role,
-      final Long processedPosition,
-      final String snapshotId,
-      final Long processedPositionInSnapshot,
-      final Phase streamProcessorPhase,
-      final ExporterPhase exporterPhase,
-      final Long exportedPosition) {
-    this.role = role;
-    this.processedPosition = processedPosition;
-    this.snapshotId = snapshotId;
-    this.processedPositionInSnapshot = processedPositionInSnapshot;
-    this.streamProcessorPhase = streamProcessorPhase;
-    this.exporterPhase = exporterPhase;
-    this.exportedPosition = exportedPosition;
-  }
-
-  public static PartitionStatus ofLeader(
-      final Long processedPosition,
-      final String snapshotId,
-      final Long processedPositionInSnapshot,
-      final Phase streamProcessorPhase,
-      final ExporterPhase exporterPhase,
-      final long exportedPosition) {
-    return new PartitionStatus(
-        Role.LEADER,
-        processedPosition,
-        snapshotId,
-        processedPositionInSnapshot,
-        streamProcessorPhase,
-        exporterPhase,
-        exportedPosition);
-  }
-
-  public static PartitionStatus ofFollower(
-      final String snapshotId, final Long processedPositionInSnapshot) {
-    return new PartitionStatus(
-        Role.FOLLOWER, null, snapshotId, processedPositionInSnapshot, null, null, null);
-  }
-
-  public Role getRole() {
-    return role;
-  }
-
-  public Long getProcessedPosition() {
-    return processedPosition;
-  }
-
-  public String getSnapshotId() {
-    return snapshotId;
-  }
-
-  public Long getProcessedPositionInSnapshot() {
-    return processedPositionInSnapshot;
-  }
-
-  public Phase getStreamProcessorPhase() {
-    return streamProcessorPhase;
-  }
-
-  public ExporterPhase getExporterPhase() {
-    return exporterPhase;
-  }
-
-  public Long getExportedPosition() {
-    return exportedPosition;
-  }
-
-  @Override
-  public String toString() {
-    return "PartitionStatus{"
-        + "role="
-        + role
-        + ", snapshotId='"
-        + snapshotId
-        + '\''
-        + ", processedPosition="
-        + processedPosition
-        + ", processedPositionInSnapshot="
-        + processedPositionInSnapshot
-        + ", streamProcessorPhase="
-        + streamProcessorPhase
-        + ", exporterPhase="
-        + exporterPhase
-        + ", exportedPosition="
-        + exportedPosition
-        + '}';
-  }
-}
+public record PartitionStatus(
+    Role role,
+    Long processedPosition,
+    String snapshotId,
+    Long processedPositionInSnapshot,
+    Phase streamProcessorPhase,
+    ExporterPhase exporterPhase,
+    Long exportedPosition) {}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -97,9 +97,9 @@ public class BrokerSnapshotTest {
                         adminService
                             .getPartitionStatus()
                             .get(partitionId)
-                            .getProcessedPositionInSnapshot())
+                            .processedPositionInSnapshot())
                     .isNotNull());
     final PartitionStatus partitionStatus = brokerAdminService.getPartitionStatus().get(1);
-    return FileBasedSnapshotId.ofFileName(partitionStatus.getSnapshotId()).get();
+    return FileBasedSnapshotId.ofFileName(partitionStatus.snapshotId()).get();
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -109,8 +109,7 @@ final class ClusteredSnapshotTest {
         .until(
             () -> {
               final var partitionStatus = adminService.getPartitionStatus().get(1);
-              return partitionStatus.getExportedPosition()
-                  >= partitionStatus.getProcessedPosition();
+              return partitionStatus.exportedPosition() >= partitionStatus.processedPosition();
             });
 
     snapshotTrigger.accept(clusteringRule);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -886,7 +886,7 @@ public class ClusteringRule extends ExternalResource {
     final var partitionStatus = partitions.get(partitionId);
 
     return Optional.ofNullable(partitionStatus)
-        .map(PartitionStatus::getSnapshotId)
+        .map(PartitionStatus::snapshotId)
         .flatMap(FileBasedSnapshotId::ofFileName);
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceMonitoringFailOverTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceMonitoringFailOverTest.java
@@ -92,7 +92,7 @@ public class DiskSpaceMonitoringFailOverTest {
                     .getBrokerAdminService()
                     .getPartitionStatus()
                     .get(1)
-                    .getStreamProcessorPhase(),
+                    .streamProcessorPhase(),
             p -> p == Phase.PAUSED);
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
@@ -72,18 +72,18 @@ public class BrokerAdminServiceClusterTest {
     // then
     followerStatus.forEach(
         partitionStatus -> {
-          assertThat(partitionStatus.getRole()).isEqualTo(Role.FOLLOWER);
-          assertThat(partitionStatus.getProcessedPosition()).isNull();
-          assertThat(partitionStatus.getSnapshotId()).isNull();
-          assertThat(partitionStatus.getProcessedPositionInSnapshot()).isNull();
-          assertThat(partitionStatus.getStreamProcessorPhase()).isNull();
+          assertThat(partitionStatus.role()).isEqualTo(Role.FOLLOWER);
+          assertThat(partitionStatus.processedPosition()).isEqualTo(-1L);
+          assertThat(partitionStatus.snapshotId()).isNull();
+          assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
+          assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.REPLAY);
         });
 
-    assertThat(leaderStatus.getRole()).isEqualTo(Role.LEADER);
-    assertThat(leaderStatus.getProcessedPosition()).isEqualTo(-1);
-    assertThat(leaderStatus.getSnapshotId()).isNull();
-    assertThat(leaderStatus.getProcessedPositionInSnapshot()).isNull();
-    assertThat(leaderStatus.getStreamProcessorPhase()).isEqualTo(Phase.PROCESSING);
+    assertThat(leaderStatus.role()).isEqualTo(Role.LEADER);
+    assertThat(leaderStatus.processedPosition()).isEqualTo(-1);
+    assertThat(leaderStatus.snapshotId()).isNull();
+    assertThat(leaderStatus.processedPositionInSnapshot()).isNull();
+    assertThat(leaderStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);
   }
 
   @Test
@@ -129,7 +129,7 @@ public class BrokerAdminServiceClusterTest {
         .values()
         .forEach(
             status ->
-                assertThat(status.getProcessedPositionInSnapshot())
+                assertThat(status.processedPositionInSnapshot())
                     .describedAs(status.toString())
                     .isNotNull());
   }
@@ -143,6 +143,6 @@ public class BrokerAdminServiceClusterTest {
                     .getPartitionStatus()
                     .forEach(
                         (p, status) ->
-                            assertThat(status.getStreamProcessorPhase()).isEqualTo(expected)));
+                            assertThat(status.streamProcessorPhase()).isEqualTo(expected)));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
@@ -206,7 +206,7 @@ public class BrokerAdminServiceTest {
                     .getPartitionStatus()
                     .forEach(
                         (p, status) ->
-                            assertThat(status.getStreamProcessorPhase()).isEqualTo(expected)));
+                            assertThat(status.streamProcessorPhase()).isEqualTo(expected)));
   }
 
   private void assertExporterPhase(
@@ -217,7 +217,7 @@ public class BrokerAdminServiceTest {
                 brokerAdminService
                     .getPartitionStatus()
                     .forEach(
-                        (p, status) -> assertThat(status.getExporterPhase()).isEqualTo(expected)));
+                        (p, status) -> assertThat(status.exporterPhase()).isEqualTo(expected)));
   }
 
   private void assertProcessedPositionIsInSnapshot(final BrokerAdminService brokerAdminService) {
@@ -228,8 +228,8 @@ public class BrokerAdminServiceTest {
                     .getPartitionStatus()
                     .forEach(
                         (p, status) ->
-                            assertThat(status.getProcessedPosition())
-                                .isEqualTo(status.getProcessedPositionInSnapshot())));
+                            assertThat(status.processedPosition())
+                                .isEqualTo(status.processedPositionInSnapshot())));
   }
 
   private void waitForSnapshotAtBroker(final BrokerAdminService adminService) {
@@ -240,6 +240,6 @@ public class BrokerAdminServiceTest {
                     .getPartitionStatus()
                     .values()
                     .forEach(
-                        status -> assertThat(status.getProcessedPositionInSnapshot()).isNotNull()));
+                        status -> assertThat(status.processedPositionInSnapshot()).isNotNull()));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
@@ -34,12 +34,12 @@ public class BrokerAdminServiceWithOutExporterTest {
     // when there are no exporters configured
     // then
     final var partitionStatus = leaderAdminService.getPartitionStatus().get(1);
-    assertThat(partitionStatus.getRole()).isEqualTo(Role.LEADER);
-    assertThat(partitionStatus.getProcessedPosition()).isEqualTo(-1);
-    assertThat(partitionStatus.getSnapshotId()).isNull();
-    assertThat(partitionStatus.getProcessedPositionInSnapshot()).isNull();
-    assertThat(partitionStatus.getStreamProcessorPhase()).isEqualTo(Phase.PROCESSING);
-    assertThat(partitionStatus.getExporterPhase()).isEqualTo(ExporterPhase.CLOSED);
-    assertThat(partitionStatus.getExportedPosition()).isEqualTo(-1);
+    assertThat(partitionStatus.role()).isEqualTo(Role.LEADER);
+    assertThat(partitionStatus.processedPosition()).isEqualTo(-1);
+    assertThat(partitionStatus.snapshotId()).isNull();
+    assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
+    assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);
+    assertThat(partitionStatus.exporterPhase()).isEqualTo(ExporterPhase.CLOSED);
+    assertThat(partitionStatus.exportedPosition()).isEqualTo(-1);
   }
 }


### PR DESCRIPTION
## Description

In BrokerAdminServiceImpl we no longer distinguish between leaders and followers when requesting the partition status.

closes #9970

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

- BrokerAdminServiceImpl treats followers and leaders the same when its requested the partition status.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->


Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
