### PR TITLE
Job Yield Processor is implemented to be used for Job Push fallback

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -47,6 +47,15 @@ public class BpmnJobActivationBehavior {
 
   public void publishWork(final JobRecord jobRecord) {
     final String jobType = jobRecord.getType();
+    notifyJobAvailable(jobType);
+  }
+
+  public void notifyJobAvailable(final JobRecord jobRecord) {
+    final String jobType = jobRecord.getType();
+    notifyJobAvailable(jobType);
+  }
+
+  private void notifyJobAvailable(final String jobType) {
     sideEffectWriter.appendSideEffect(
         () -> {
           jobStreamer.notifyWorkAvailable(jobType);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -50,7 +50,7 @@ public class BpmnJobActivationBehavior {
     notifyJobAvailable(jobType);
   }
 
-  public void notifyJobAvailable(final JobRecord jobRecord) {
+  public void notifyJobAvailableAsSideEffect(final JobRecord jobRecord) {
     final String jobType = jobRecord.getType();
     notifyJobAvailable(jobType);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -56,6 +56,10 @@ public final class JobEventProcessors {
                 bpmnBehaviors))
         .onCommand(
             ValueType.JOB,
+            JobIntent.YIELD,
+            new JobYieldProcessor(processingState, bpmnBehaviors, writers))
+        .onCommand(
+            ValueType.JOB,
             JobIntent.THROW_ERROR,
             new JobThrowErrorProcessor(
                 processingState,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public final class JobYieldProcessor implements TypedRecordProcessor<JobRecord> {
+
+  public static final String NOT_ACTIVATED_JOB_MESSAGE =
+      "Expected to time out activated job with key '%d', but %s";
+  private final JobState jobState;
+  private final BpmnJobActivationBehavior jobActivationBehavior;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+
+  public JobYieldProcessor(
+      final ProcessingState state, final BpmnBehaviors bpmnBehaviors, final Writers writers) {
+    jobState = state.getJobState();
+    jobActivationBehavior = bpmnBehaviors.jobActivationBehavior();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<JobRecord> record) {
+    final long key = record.getKey();
+    final JobState.State state = jobState.getState(key);
+    if (state == State.ACTIVATED) {
+      final JobRecord yieldedJob = jobState.getJob(key);
+
+      stateWriter.appendFollowUpEvent(key, JobIntent.YIELDED, yieldedJob);
+      jobActivationBehavior.notifyJobAvailable(yieldedJob);
+    } else {
+      final String textState;
+
+      switch (state) {
+        case ACTIVATABLE:
+          textState = "it must be activated first";
+          break;
+        case FAILED:
+          textState = "it is marked as failed";
+          break;
+        default:
+          textState = "no such job was found";
+          break;
+      }
+
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.NOT_FOUND,
+          String.format(NOT_ACTIVATED_JOB_MESSAGE, key, textState));
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -166,6 +166,7 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.CREATED, new JobCreatedApplier(state));
     register(JobIntent.ERROR_THROWN, new JobErrorThrownApplier(state));
     register(JobIntent.FAILED, new JobFailedApplier(state));
+    register(JobIntent.YIELDED, new JobYieldedApplier(state));
     register(JobIntent.RETRIES_UPDATED, new JobRetriesUpdatedApplier(state));
     register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
     register(JobIntent.RECURRED_AFTER_BACKOFF, new JobRecurredApplier(state));

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobYieldedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobYieldedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+public final class JobYieldedApplier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+
+  JobYieldedApplier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.yield(key, value);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -195,6 +195,11 @@ public final class DbJobState implements JobState, MutableJobState {
   }
 
   @Override
+  public void yield(final long key, final JobRecord updatedValue) {
+    updateJob(key, updatedValue, State.ACTIVATABLE);
+  }
+
+  @Override
   public void resolve(final long key, final JobRecord updatedValue) {
     updateJob(key, updatedValue, State.ACTIVATABLE);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -32,6 +32,8 @@ public interface MutableJobState extends JobState {
 
   void fail(long key, JobRecord updatedValue);
 
+  void yield(long key, JobRecord updatedValue);
+
   void resolve(long key, JobRecord updatedValue);
 
   JobRecord updateJobRetries(long jobKey, int retries);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/YieldJobTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/YieldJobTest.java
@@ -47,7 +47,12 @@ public final class YieldJobTest {
 
     // when
     final Record<JobRecordValue> yieldRecord =
-        ENGINE.job().withKey(jobKey).ofInstance(job.getProcessInstanceKey()).yield();
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withType(jobType)
+            .ofInstance(job.getProcessInstanceKey())
+            .yield();
 
     // then
     Assertions.assertThat(yieldRecord).hasRecordType(RecordType.EVENT).hasIntent(JobIntent.YIELDED);
@@ -74,6 +79,11 @@ public final class YieldJobTest {
             .yield();
 
     // then
-    Assertions.assertThat(yieldRecord).hasRejectionType(RejectionType.NOT_FOUND);
+    Assertions.assertThat(yieldRecord)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                "Expected to yield activated job with key '%d', but it is marked as failed",
+                jobKey));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/YieldJobTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/YieldJobTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class YieldJobTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+  private static String jobType;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Before
+  public void setup() {
+    jobType = Strings.newRandomValidBpmnId();
+  }
+
+  @Test
+  public void shouldYield() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord = ENGINE.jobs().withType(jobType).activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    final Record<JobRecordValue> yieldRecord =
+        ENGINE.job().withKey(jobKey).ofInstance(job.getProcessInstanceKey()).yield();
+
+    // then
+    Assertions.assertThat(yieldRecord).hasRecordType(RecordType.EVENT).hasIntent(JobIntent.YIELDED);
+    Assertions.assertThat(yieldRecord.getValue()).hasWorker(job.getWorker()).hasType(job.getType());
+  }
+
+  @Test
+  public void shouldRejectYieldIfJobNotActivated() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord = ENGINE.jobs().withType(jobType).activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    ENGINE.job().withKey(jobKey).fail();
+
+    // when
+    final Record<JobRecordValue> yieldRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .ofInstance(job.getProcessInstanceKey())
+            .expectRejection()
+            .yield();
+
+    // then
+    Assertions.assertThat(yieldRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -136,6 +136,13 @@ public final class JobClient {
     return expectation.apply(position);
   }
 
+  public Record<JobRecordValue> yield() {
+    final long jobKey = findJobKey();
+    final long position = environmentRule.writeCommand(jobKey, JobIntent.YIELD, jobRecord);
+
+    return expectation.apply(position);
+  }
+
   public Record<JobRecordValue> updateRetries() {
     final long jobKey = findJobKey();
     final long position = environmentRule.writeCommand(jobKey, JobIntent.UPDATE_RETRIES, jobRecord);

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -42,6 +42,7 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   ERROR_THROWN((short) 12),
   RECUR_AFTER_BACKOFF((short) 13),
   RECURRED_AFTER_BACKOFF((short) 14),
+
   YIELD((short) 15),
   YIELDED((short) 16);
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -41,7 +41,9 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   THROW_ERROR((short) 11, false),
   ERROR_THROWN((short) 12),
   RECUR_AFTER_BACKOFF((short) 13),
-  RECURRED_AFTER_BACKOFF((short) 14);
+  RECURRED_AFTER_BACKOFF((short) 14),
+  YIELD((short) 15),
+  YIELDED((short) 16);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -91,6 +93,10 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
         return RECUR_AFTER_BACKOFF;
       case 14:
         return RECURRED_AFTER_BACKOFF;
+      case 15:
+        return YIELD;
+      case 16:
+        return YIELDED;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description
A job pushed to the JobStreamer API may fail while sending it over to the client due to client failure. This should be handled in a way that we should make job available for long polling (make activatable) again.

**First Commit**

* BpmnJobActivationBehavior is refactored to have a method for appending long polling as a side effect
* New JobIntent "YIELD" is created
* JobIntent.YIELD is handled in JobYieldProcessor
* JobYieldProcessor is registered in JobEventProcessors
* New JobIntent "YIELDED" is created
* JobIntent.YIELDED is handled in JobYieldedApplier
* JobYieldedApplier is registered in EventAppliers
* "yield()" method is added to DbJobState to make job ACTIVATABLE in the state

**Second Commit**
* "yield()" method is added to JobClient for testing
* JobYieldProcessor tests are added to YieldJobTest

**Note**: the duplication of job command preconditions will be refactored in a separate PR.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12085 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
