### PR TITLE
Fix flaky `EmbeddedSubProcessTest`

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessConcurrencyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessConcurrencyTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -95,10 +96,15 @@ public class EmbeddedSubProcessConcurrencyTest {
             .withVariable("correlationKey", "correlationKey")
             .create();
 
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("task")
-        .await();
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .describedAs(
+            "The 2 message subscriptions must be created before we publish the "
+                + "messages. As the messages have a TTL of 0 seconds")
+        .describedAs("")
+        .hasSize(2);
 
     // when
     // We need to make sure no records are written in between the publish commands. This could


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The test was flaky because it could occur that the messages got published before the subscription were opened. As the messages have no TTL this means they were not getting correlated, as expected.

Log of a failing run:
```
C DPLY         CREATE            - #01-> -1  -1 - 
E PROC         CREATED           - #02->#01 K01 - process.xml -> "process..process" (version:1)
E DPLY         CREATED           - #03->#01 K02 - process.xml
E DPLY         FULLY_DISTRIBUTED - #04->#01 K02 - 
C CREA         CREATE            - #05-> -1  -1 - new <process "process..process"> with variables: {correlationKey=correlationKey}
E VAR          CREATED           - #06->#05 K04 - correlationKey->"correlationKey" in <process [K03]>
C PI           ACTIVATE          - #07->#05 K03 - PROCESS "process..process" in <process "process..process"[K03]>
E CREA         CREATED           - #08->#05 K05 - new <process "process..process"> with variables: {correlationKey=correlationKey}
E PI           ACTIVATING        - #09->#07 K03 - PROCESS "process..process" in <process "process..process"[K03]>
E PI           ACTIVATED         - #10->#07 K03 - PROCESS "process..process" in <process "process..process"[K03]>
C PI           ACTIVATE          - #11->#07  -1 - START_EVENT "startEv..8897acc" in <process "process..process"[K03]>
E PI           ACTIVATING        - #12->#11 K06 - START_EVENT "startEv..8897acc" in <process "process..process"[K03]>
E PI           ACTIVATED         - #13->#11 K06 - START_EVENT "startEv..8897acc" in <process "process..process"[K03]>
C PI           COMPLETE          - #14->#11 K06 - START_EVENT "startEv..8897acc" in <process "process..process"[K03]>
E PI           COMPLETING        - #15->#14 K06 - START_EVENT "startEv..8897acc" in <process "process..process"[K03]>
E PROC_MSG_SUB CREATING          - #16->#14 K07 - "eventSubProcess" (inter.) correlationKey: correlationKey @[K03] in <process "process..process"[K03]> (no vars)
E PI           COMPLETED         - #17->#14 K06 - START_EVENT "startEv..8897acc" in <process "process..process"[K03]>
E PI           SEQ_FLOW_TAKEN    - #18->#14 K08 - SEQUENCE_FLOW "sequenc..b7cb1a6" in <process "process..process"[K03]>
C PI           ACTIVATE          - #19->#14 K09 - SUB_PROCESS "subProcess" in <process "process..process"[K03]>
E PI           ACTIVATING        - #20->#19 K09 - SUB_PROCESS "subProcess" in <process "process..process"[K03]>
E PI           ACTIVATED         - #21->#19 K09 - SUB_PROCESS "subProcess" in <process "process..process"[K03]>
C PI           ACTIVATE          - #22->#19  -1 - START_EVENT "startEv..8b12a7c" in <process "process..process"[K03]>
E PI           ACTIVATING        - #23->#22 K10 - START_EVENT "startEv..8b12a7c" in <process "process..process"[K03]>
E PI           ACTIVATED         - #24->#22 K10 - START_EVENT "startEv..8b12a7c" in <process "process..process"[K03]>
C PI           COMPLETE          - #25->#22 K10 - START_EVENT "startEv..8b12a7c" in <process "process..process"[K03]>
E PI           COMPLETING        - #26->#25 K10 - START_EVENT "startEv..8b12a7c" in <process "process..process"[K03]>
E PROC_MSG_SUB CREATING          - #27->#25 K11 - "boundary" (inter.) correlationKey: correlationKey @[K09] in <process "process..process"[K03]> (no vars)
E PI           COMPLETED         - #28->#25 K10 - START_EVENT "startEv..8b12a7c" in <process "process..process"[K03]>
E PI           SEQ_FLOW_TAKEN    - #29->#25 K12 - SEQUENCE_FLOW "sequenc..8c72ad0" in <process "process..process"[K03]>
C PI           ACTIVATE          - #30->#25 K13 - SERVICE_TASK "task" in <process "process..process"[K03]>
E PI           ACTIVATING        - #31->#30 K13 - SERVICE_TASK "task" in <process "process..process"[K03]>
E JOB          CREATED           - #32->#30 K14 - K14 "task" @"task"[K13] 3 retries, in <process "process..process"[K03]> (no vars)
E PI           ACTIVATED         - #33->#30 K13 - SERVICE_TASK "task" in <process "process..process"[K03]>
C MSG          PUBLISH           - #34-> -1 K01 - "boundary" correlationKey: correlationKey (no vars)
C MSG          PUBLISH           - #35-> -1 K01 - "eventSubProcess" correlationKey: correlationKey (no vars)
E MSG          PUBLISHED         - #36->#34 K15 - "boundary" correlationKey: correlationKey (no vars)
E MSG          EXPIRED           - #37->#34 K15 - "boundary" correlationKey: correlationKey (no vars)
E MSG          PUBLISHED         - #38->#35 K16 - "eventSubProcess" correlationKey: correlationKey (no vars)
E MSG          EXPIRED           - #39->#35 K16 - "eventSubProcess" correlationKey: correlationKey (no vars)
C MSG_SUB      CREATE            - #40-> -1  -1 - "eventSubProcess" (inter.) correlationKey: correlationKey @[K03] in <process "process..process"[K03]> (no vars)
C MSG_SUB      CREATE            - #41-> -1  -1 - "boundary" (inter.) correlationKey: correlationKey @[K09] in <process "process..process"[K03]> (no vars)
E MSG_SUB      CREATED           - #42->#40 K17 - "eventSubProcess" (inter.) correlationKey: correlationKey @[K03] in <process "process..process"[K03]> (no vars)
C PROC_MSG_SUB CREATE            - #43-> -1  -1 - "eventSubProcess" (inter.) @[K03] in <process ?[K03]> (no vars)
E MSG_SUB      CREATED           - #44->#41 K18 - "boundary" (inter.) correlationKey: correlationKey @[K09] in <process "process..process"[K03]> (no vars)
C PROC_MSG_SUB CREATE            - #45-> -1  -1 - "boundary" (inter.) @[K09] in <process ?[K03]> (no vars)
E PROC_MSG_SUB CREATED           - #46->#43 K07 - "eventSubProcess" (inter.) correlationKey: correlationKey @[K03] in <process "process..process"[K03]> (no vars)
E PROC_MSG_SUB CREATED           - #47->#45 K11 - "boundary" (inter.) correlationKey: correlationKey @[K09] in <process "process..process"[K03]> (no vars)
```

The test isn't really flaky on 8.2+ anymore. This is a result of batch processing that was introduced recently. However, I believe it's still good to fix it on all versions and keep the test aligned across versions.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11844 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
