### PR TITLE
[Backport stable/8.0] Fix flaky `EmbeddedSubProcessTest`

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -623,10 +624,15 @@ public final class EmbeddedSubProcessTest {
             .withVariable("correlationKey", "correlationKey")
             .create();
 
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("task")
-        .await();
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .describedAs(
+            "The 2 message subscriptions must be created before we publish the "
+                + "messages. As the messages have a TTL of 0 seconds")
+        .describedAs("")
+        .hasSize(2);
 
     // when
     // We need to make sure no records are written in between the publish commands. This could


### PR DESCRIPTION
# Description
Backport of #12697 to `stable/8.0`.

relates to #11844