### PR TITLE
Stateless job stream error handler

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Loggers.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Loggers.java
@@ -27,6 +27,8 @@ public final class Loggers {
   public static final Logger DELETION_SERVICE =
       LoggerFactory.getLogger("io.camunda.zeebe.broker.logstreams.delete");
   public static final Logger RAFT = LoggerFactory.getLogger("io.camunda.zeebe.broker.raft");
+  public static final Logger JOB_STREAM =
+      LoggerFactory.getLogger("io.camunda.zeebe.broker.jobStream");
 
   public static Logger getExporterLogger(final String exporterId) {
     final String loggerName = String.format("io.camunda.zeebe.broker.exporter.%s", exporterId);

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamErrorHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamErrorHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.ActivatedJob;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+
+/**
+ * The {@link JobStreamErrorHandler} allows specifying logic which should be executed whenever the
+ * broker fails to push a job to one of the open streams.
+ *
+ * <p>Implementations can then produce followup records to be appended to the log in order to
+ * perform any actions (e.g. yield the job).
+ */
+@FunctionalInterface
+public interface JobStreamErrorHandler {
+
+  /**
+   * Called when a previously activated job, which was supposed to be pushed, cannot be pushed due
+   * to some error.
+   *
+   * <p>Implementations should use the given {@link TaskResultBuilder} to append followup commands
+   * to the same partition as the job's.
+   *
+   * @param job the activated job which should have been pushed
+   * @param error the last error which caused the failure
+   * @param resultBuilder the result builder on which you can add followup commands to be processed
+   */
+  void handleError(
+      final ActivatedJob job, final Throwable error, final TaskResultBuilder resultBuilder);
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamService.java
@@ -12,22 +12,29 @@ import io.camunda.zeebe.engine.processing.streamprocessor.JobActivationPropertie
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 public record JobStreamService(
     RemoteStreamService<JobActivationProperties, ActivatedJob> remoteStreamService,
-    JobStreamer jobStreamer) {
+    JobStreamer jobStreamer,
+    RemoteJobStreamErrorHandlerService errorHandlerService) {
 
   public JobStreamService(
       final RemoteStreamService<JobActivationProperties, ActivatedJob> remoteStreamService,
-      final JobStreamer jobStreamer) {
+      final JobStreamer jobStreamer,
+      final RemoteJobStreamErrorHandlerService errorHandlerService) {
     this.remoteStreamService =
         Objects.requireNonNull(remoteStreamService, "must provide a stream remoteStreamService");
     this.jobStreamer = Objects.requireNonNull(jobStreamer, "must provide a job streamer");
+    this.errorHandlerService =
+        Objects.requireNonNull(errorHandlerService, "must provide an error handler service");
   }
 
-  public ActorFuture<Void> closeAsync(final ConcurrencyControl executor) {
-    return remoteStreamService.closeAsync(executor);
+  public ActorFuture<?> closeAsync(final ConcurrencyControl executor) {
+    return Stream.of(remoteStreamService.closeAsync(executor), errorHandlerService.closeAsync())
+        .collect(new ActorFutureCollector<>(executor));
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStream.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStream.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.jobstream;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.ActivatedJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobActivationProperties;
-import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.ErrorHandler;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
 import io.camunda.zeebe.transport.stream.api.RemoteStream;
 
@@ -27,7 +26,7 @@ final class RemoteJobStream implements JobStream {
   }
 
   @Override
-  public void push(final ActivatedJob job, final ErrorHandler errorHandler) {
-    remoteStream.push(job, errorHandler::handleError);
+  public void push(final ActivatedJob job) {
+    remoteStream.push(job);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
@@ -111,7 +111,7 @@ final class RemoteJobStreamErrorHandler implements RemoteStreamErrorHandler<Acti
     } else if (position < 0) {
       FAILED_WRITER_LOGGER.warn(
           """
-          Failed to handled failed job push {} on partition {};
+          Failed to handle failed job push {} on partition {};
           job will remain activated until it times out""",
           job.jobKey(),
           partitionId);

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
+import io.camunda.zeebe.engine.processing.streamprocessor.ActivatedJob;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import io.camunda.zeebe.stream.impl.BufferedTaskResultBuilder;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.time.Duration;
+import org.agrona.collections.Int2ObjectHashMap;
+import org.slf4j.Logger;
+
+/**
+ * A {@link RemoteStreamErrorHandler} for {@link ActivatedJob} payloads, which will write any
+ * followup commands produced by the given {@link JobStreamErrorHandler} delegate. The followup
+ * commands are written on the same partition as the job's.
+ *
+ * <p>In order to obtain partition writers, this implementation is then also a {@link
+ * PartitionListener} which must be added to the {@link
+ * BrokerStartupContext#getPartitionListeners()} during the broker's startup process.
+ *
+ * <p>It's possible that a job was pushed when this node was leader for its partition, but that the
+ * error handling occurs after an election change, at which point the job will remain activated
+ * until it times out.
+ */
+final class RemoteJobStreamErrorHandler implements RemoteStreamErrorHandler<ActivatedJob> {
+  private static final Logger LOGGER = Loggers.JOB_STREAM;
+  private static final Logger NO_WRITER_LOGGER = new ThrottledLogger(LOGGER, Duration.ofSeconds(1));
+  private static final Logger NO_ACTION_LOGGER = new ThrottledLogger(LOGGER, Duration.ofSeconds(1));
+  private static final Logger FAILED_WRITER_LOGGER =
+      new ThrottledLogger(LOGGER, Duration.ofSeconds(1));
+
+  private final JobStreamErrorHandler errorHandler;
+  private final ConcurrencyControl executor;
+
+  private final Int2ObjectHashMap<LogStreamWriter> partitionWriters = new Int2ObjectHashMap<>();
+
+  RemoteJobStreamErrorHandler(
+      final JobStreamErrorHandler errorHandler, final ConcurrencyControl executor) {
+    this.errorHandler = errorHandler;
+    this.executor = executor;
+  }
+
+  @Override
+  public void handleError(final Throwable error, final ActivatedJob job) {
+    final var partitionId = Protocol.decodePartitionId(job.jobKey());
+    final var writer = partitionWriters.get(partitionId);
+    if (writer == null) {
+      NO_WRITER_LOGGER.warn(
+          """
+          Cannot handle failed job push on partition {} there is no writer registered;
+          this can occur during an election""",
+          partitionId);
+      return;
+    }
+
+    final var resultBuilder = new BufferedTaskResultBuilder(writer::canWriteEvents);
+    errorHandler.handleError(job, error, resultBuilder);
+
+    final var result = resultBuilder.build();
+    writeEntries(partitionId, job, writer, result);
+  }
+
+  void addWriter(
+      final int partitionId,
+      final ActorFuture<LogStreamWriter> writerFuture,
+      final ActorFuture<Void> onComplete) {
+    executor.runOnCompletion(
+        writerFuture,
+        (writer, error) -> {
+          if (error != null) {
+            onComplete.completeExceptionally(error);
+            return;
+          }
+
+          partitionWriters.put(partitionId, writer);
+          onComplete.complete(null);
+        });
+  }
+
+  void removeWriter(final int partitionId) {
+    partitionWriters.remove(partitionId);
+  }
+
+  private void writeEntries(
+      final int partitionId,
+      final ActivatedJob job,
+      final LogStreamWriter writer,
+      final TaskResult result) {
+    final var position = writer.tryWrite(result.getRecordBatch().entries());
+    if (position == 0) {
+      NO_ACTION_LOGGER.warn(
+          """
+           Failed to push job {} on partition {}, but the error handler did not return anything;
+           the job will be activated again when it times out""",
+          job.jobKey(),
+          partitionId);
+    } else if (position < 0) {
+      FAILED_WRITER_LOGGER.warn(
+          """
+          Failed to handled failed job push {} on partition {};
+          job will remain activated until it times out""",
+          job.jobKey(),
+          partitionId);
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import static io.camunda.zeebe.scheduler.Actor.buildActorName;
+
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.engine.processing.streamprocessor.ActivatedJob;
+import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
+import java.util.Objects;
+
+/**
+ * An empty actor which is used as the execution context for the {@link
+ * RemoteJobStreamErrorHandler}. We split this off from the handler itself to simplify testing and
+ * not rely on a complete actor scheduler.
+ */
+public final class RemoteJobStreamErrorHandlerService extends Actor
+    implements PartitionListener, RemoteStreamErrorHandler<ActivatedJob> {
+  private final RemoteJobStreamErrorHandler delegate;
+  private final String name;
+
+  public RemoteJobStreamErrorHandlerService(
+      final JobStreamErrorHandler errorHandler, final int nodeId) {
+    delegate = new RemoteJobStreamErrorHandler(errorHandler, this);
+    name = buildActorName(nodeId, "RemoteJobStreamErrorHandler");
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
+    return actor.call(() -> delegate.removeWriter(partitionId));
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingLeader(
+      final int partitionId,
+      final long term,
+      final LogStream logStream,
+      final QueryService queryService) {
+    final var result = new CompletableActorFuture<Void>();
+    final var onLogStreamWriter =
+        Objects.requireNonNull(logStream, "must specify a log stream").newLogStreamWriter();
+    actor.call(() -> delegate.addWriter(partitionId, onLogStreamWriter, result));
+    return result;
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return actor.call(() -> delegate.removeWriter(partitionId));
+  }
+
+  @Override
+  public void handleError(final Throwable error, final ActivatedJob job) {
+    actor.run(() -> delegate.handleError(error, job));
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
@@ -28,7 +28,7 @@ final class RemoteJobStreamErrorHandlerTest {
   @Test
   void shouldNotCallDelegateHandlerIfNoWriter() {
     // given
-    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler, executor);
+    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler);
     final var job = new TestActivatedJob(1, new JobRecord());
 
     // when
@@ -41,11 +41,10 @@ final class RemoteJobStreamErrorHandlerTest {
   @Test
   void shouldDelegateToJobHandler() {
     // given
-    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler, executor);
+    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler);
     final var job = new TestActivatedJob(Protocol.encodePartitionId(1, 1), new JobRecord());
     final var error = new RuntimeException("Failure");
-    handler.addWriter(
-        1, executor.completedFuture((entries, ignored) -> 1), executor.createFuture());
+    handler.addWriter(1, (entries, ignored) -> 1);
 
     // when
     handler.handleError(error, job);
@@ -61,10 +60,9 @@ final class RemoteJobStreamErrorHandlerTest {
   @Test
   void shouldRemoveWriter() {
     // given
-    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler, executor);
+    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler);
     final var job = new TestActivatedJob(1, new JobRecord());
-    handler.addWriter(
-        1, executor.completedFuture((entries, ignored) -> 1), executor.createFuture());
+    handler.addWriter(1, (entries, ignored) -> 1);
 
     // when
     handler.removeWriter(1);
@@ -77,17 +75,15 @@ final class RemoteJobStreamErrorHandlerTest {
   @Test
   void shouldWriteResultingEntries() {
     // given
-    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler, executor);
+    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler);
     final var job = new TestActivatedJob(Protocol.encodePartitionId(1, 1), new JobRecord());
     final var writtenEntries = new ArrayList<LogAppendEntry>();
     handler.addWriter(
         1,
-        executor.completedFuture(
-            (entries, ignored) -> {
-              writtenEntries.addAll(entries);
-              return 1;
-            }),
-        executor.createFuture());
+        (entries, ignored) -> {
+          writtenEntries.addAll(entries);
+          return 1;
+        });
 
     // when
     handler.handleError(new RuntimeException("failure"), job);

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.ActivatedJob;
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.MutableDirectBuffer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class RemoteJobStreamErrorHandlerTest {
+
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final TestErrorHandler jobErrorHandler = new TestErrorHandler();
+
+  @Test
+  void shouldNotCallDelegateHandlerIfNoWriter() {
+    // given
+    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler, executor);
+    final var job = new TestActivatedJob(1, new JobRecord());
+
+    // when
+    handler.handleError(new RuntimeException("Failure"), job);
+
+    // then
+    Assertions.assertThat(jobErrorHandler.errors()).isEmpty();
+  }
+
+  @Test
+  void shouldDelegateToJobHandler() {
+    // given
+    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler, executor);
+    final var job = new TestActivatedJob(Protocol.encodePartitionId(1, 1), new JobRecord());
+    final var error = new RuntimeException("Failure");
+    handler.addWriter(
+        1, executor.completedFuture((entries, ignored) -> 1), executor.createFuture());
+
+    // when
+    handler.handleError(error, job);
+
+    // then
+    Assertions.assertThat(jobErrorHandler.errors())
+        .hasSize(1)
+        .first()
+        .extracting(TestErrorHandler.Error::error, TestErrorHandler.Error::job)
+        .containsExactly(error, job);
+  }
+
+  @Test
+  void shouldRemoveWriter() {
+    // given
+    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler, executor);
+    final var job = new TestActivatedJob(1, new JobRecord());
+    handler.addWriter(
+        1, executor.completedFuture((entries, ignored) -> 1), executor.createFuture());
+
+    // when
+    handler.removeWriter(1);
+    handler.handleError(new RuntimeException("Failure"), job);
+
+    // then
+    Assertions.assertThat(jobErrorHandler.errors()).isEmpty();
+  }
+
+  @Test
+  void shouldWriteResultingEntries() {
+    // given
+    final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler, executor);
+    final var job = new TestActivatedJob(Protocol.encodePartitionId(1, 1), new JobRecord());
+    final var writtenEntries = new ArrayList<LogAppendEntry>();
+    handler.addWriter(
+        1,
+        executor.completedFuture(
+            (entries, ignored) -> {
+              writtenEntries.addAll(entries);
+              return 1;
+            }),
+        executor.createFuture());
+
+    // when
+    handler.handleError(new RuntimeException("failure"), job);
+
+    // then
+    Assertions.assertThat(jobErrorHandler.errors()).hasSize(1);
+    Assertions.assertThat(writtenEntries)
+        .hasSize(1)
+        .first()
+        .extracting(LogAppendEntry::key, LogAppendEntry::recordValue)
+        .containsExactly(1L, job.record());
+  }
+
+  // TODO: use actual one if possible
+  private record TestActivatedJob(long jobKey, JobRecord record) implements ActivatedJob {
+
+    @Override
+    public int getLength() {
+      return 0;
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {}
+  }
+
+  private record TestErrorHandler(List<TestErrorHandler.Error> errors)
+      implements JobStreamErrorHandler {
+
+    private TestErrorHandler() {
+      this(new ArrayList<>());
+    }
+
+    @Override
+    public void handleError(
+        final ActivatedJob job, final Throwable error, final TaskResultBuilder resultBuilder) {
+      resultBuilder.appendCommandRecord(1, JobIntent.FAIL, job.record());
+      errors.add(new TestErrorHandler.Error(job, error));
+    }
+
+    private record Error(ActivatedJob job, Throwable error) {}
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/JobStreamer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/JobStreamer.java
@@ -51,13 +51,7 @@ public interface JobStreamer {
      * handler does not close over any shared state.
      *
      * @param payload the data to push to the remote gateway
-     * @param errorHandler logic to execute if the data could not be pushed to the underlying stream
      */
-    void push(final ActivatedJob payload, ErrorHandler errorHandler);
-  }
-
-  /** Logic which is executed when the job cannot be pushed downstream. */
-  interface ErrorHandler {
-    void handleError(final Throwable error, ActivatedJob job);
+    void push(final ActivatedJob payload);
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
@@ -23,11 +23,11 @@ import io.camunda.zeebe.stream.impl.records.RecordBatch;
  * task execution the {@link #build()} will turn the result into a immutable {@link TaskResult},
  * which allows to process the result further.
  */
-final class BufferedTaskResultBuilder implements TaskResultBuilder {
+public final class BufferedTaskResultBuilder implements TaskResultBuilder {
 
   private final MutableRecordBatch mutableRecordBatch;
 
-  BufferedTaskResultBuilder(final RecordBatchSizePredicate predicate) {
+  public BufferedTaskResultBuilder(final RecordBatchSizePredicate predicate) {
     mutableRecordBatch = new RecordBatch(predicate);
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.ClientStreamService;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.impl.ClientStreamServiceImpl;
@@ -51,10 +52,11 @@ public final class TransportFactory {
       RemoteStreamService<M, P> createRemoteStreamServer(
           final ClusterCommunicationService clusterCommunicationService,
           final Supplier<M> metadataFactory,
+          final RemoteStreamErrorHandler<P> errorHandler,
           final RemoteStreamMetrics metrics) {
     final RemoteStreamRegistry<M> registry = new RemoteStreamRegistry<>(metrics);
     return new RemoteStreamServiceImpl<>(
-        new RemoteStreamerImpl<>(clusterCommunicationService, registry, metrics),
+        new RemoteStreamerImpl<>(clusterCommunicationService, registry, errorHandler, metrics),
         new RemoteStreamEndpoint<>(
             clusterCommunicationService, new RemoteStreamApiHandler<>(registry, metadataFactory)));
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStream.java
@@ -17,10 +17,8 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
  * <p>NOTE: it's up to consumers of this API to interpret the metadata {@link #metadata()} and its
  * relation to the payload.
  *
- * <p>NOTE: implementations of the {@link RemoteStream#push(Object, ErrorHandler)} method are likely
- * asynchronous. As such, errors handled via the {@link ErrorHandler} may be executed after the
- * initial call. Callers should be careful with the state they close on in the implementations of
- * their {@link ErrorHandler}.
+ * <p>NOTE: implementations of the {@link RemoteStream#push(BufferWriter)}, so the payload should be
+ * immutable.
  *
  * @param <M> associated metadata with the stream
  * @param <P> the payload type that can be pushed to the stream
@@ -35,17 +33,6 @@ public interface RemoteStream<M extends BufferReader, P extends BufferWriter> {
    * does not close over any shared state.
    *
    * @param payload the data to push to the remote gateway
-   * @param errorHandler logic to execute if the data could not be pushed to the underlying stream
    */
-  void push(final P payload, ErrorHandler<P> errorHandler);
-
-  /**
-   * Allows consumers of this API to specify error handling logic when a payload cannot be pushed
-   * out.
-   *
-   * @param <P> the payload type
-   */
-  interface ErrorHandler<P extends BufferWriter> {
-    void handleError(final Throwable error, P data);
-  }
+  void push(final P payload);
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamErrorHandler.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamErrorHandler.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.api;
+
+/**
+ * Allows consumers of this API to specify error handling logic when a payload cannot be pushed out.
+ *
+ * @param <P> the payload type
+ */
+@FunctionalInterface
+public interface RemoteStreamErrorHandler<P> {
+
+  /**
+   * This method is called whenever pushing the given {@code data} to a stream has failed.
+   *
+   * @param error the associated failure
+   * @param data the data we attempted to push
+   */
+  void handleError(final Throwable error, P data);
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.transport.stream.api.RemoteStream;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
@@ -31,8 +32,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  *
  * <p>NOTE: any payload pushed is sent via the stream from {@link #streamFor(DirectBuffer)} will be
  * asynchronous, so the payload should be immutable, and the errors reported to the given {@link
- * io.camunda.zeebe.transport.stream.api.RemoteStream.ErrorHandler} may be reported on different
- * threads.
+ * RemoteStreamErrorHandler} may be reported on different threads.
  */
 public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWriter> extends Actor
     implements RemoteStreamer<M, P> {
@@ -41,16 +41,18 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
   private final RemoteStreamPicker<M> streamPicker = new RandomStreamPicker<>();
   private final ClusterCommunicationService transport;
   private final ImmutableStreamRegistry<M> registry;
-  private final RemoteStreamMetrics metrics;
   private final RemoteStreamPusher<P> remoteStreamPusher;
+  private final RemoteStreamErrorHandler<P> errorHandler;
 
   public RemoteStreamerImpl(
       final ClusterCommunicationService transport,
       final ImmutableStreamRegistry<M> registry,
+      final RemoteStreamErrorHandler<P> errorHandler,
       final RemoteStreamMetrics metrics) {
     this.transport = Objects.requireNonNull(transport, "must specify a network transport");
     this.registry = Objects.requireNonNull(registry, "must specify a job stream registry");
-    this.metrics = metrics;
+    this.errorHandler = Objects.requireNonNull(errorHandler, "must specify an error handler");
+
     remoteStreamPusher = new RemoteStreamPusher<>(this::send, actor::run, metrics);
   }
 
@@ -65,7 +67,7 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
     final var target = streamPicker.pickStream(consumers);
 
     final RemoteStreamImpl<M, P> gatewayStream =
-        new RemoteStreamImpl<>(target, remoteStreamPusher, actor::run);
+        new RemoteStreamImpl<>(target, remoteStreamPusher, errorHandler, actor::run);
     return Optional.of(gatewayStream);
   }
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
@@ -40,7 +40,7 @@ class RemoteStreamImplTest {
       new RemoteStreamPusher<>(transport, executor, RemoteStreamMetrics.noop());
 
   private final RemoteStreamImpl<TestSerializableData, TestSerializableData> remoteStream =
-      new RemoteStreamImpl<>(aggregatedStream, pusher, executor);
+      new RemoteStreamImpl<>(aggregatedStream, pusher, (e, d) -> {}, executor);
 
   @BeforeEach
   void setup() {
@@ -63,7 +63,7 @@ class RemoteStreamImplTest {
         aggregatedStream.streamConsumers().stream().map(s -> s.id().streamId()).toList();
 
     // when
-    remoteStream.push(payload, (e, p) -> {});
+    remoteStream.push(payload);
 
     // then
     assertThat(transport.attemptedStreams).containsExactlyInAnyOrderElementsOf(streams);
@@ -75,7 +75,7 @@ class RemoteStreamImplTest {
     transport.succeedAfterAttempts(1);
 
     // when
-    remoteStream.push(payload, (e, p) -> {});
+    remoteStream.push(payload);
 
     // then
     assertThat(transport.attemptedStreams).hasSize(2);

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.transport.stream.api.RemoteStream.ErrorHandler;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamPusher.Transport;
@@ -121,7 +121,7 @@ final class RemoteStreamPusherTest {
     }
   }
 
-  private record TestErrorHandler(List<Error> errors) implements ErrorHandler<Payload> {
+  private record TestErrorHandler(List<Error> errors) implements RemoteStreamErrorHandler<Payload> {
 
     private TestErrorHandler() {
       this(new ArrayList<>());

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -38,7 +38,8 @@ final class RemoteStreamerTest {
       new RemoteStreamRegistry<>(RemoteStreamMetrics.noop());
 
   private final RemoteStreamerImpl<TestMetadata, TestPayload> streamer =
-      new RemoteStreamerImpl<>(communicationService, registry, RemoteStreamMetrics.noop());
+      new RemoteStreamerImpl<>(
+          communicationService, registry, (e, d) -> {}, RemoteStreamMetrics.noop());
 
   @RegisterExtension
   private final ControlledActorSchedulerExtension scheduler =
@@ -85,7 +86,7 @@ final class RemoteStreamerTest {
 
     // when
     final var stream = streamer.streamFor(type).orElseThrow();
-    stream.push(payload, (job, error) -> {});
+    stream.push(payload);
     scheduler.workUntilDone();
 
     // then

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
@@ -36,14 +37,15 @@ import org.junit.jupiter.api.Test;
 /** Tests end-to-end stream management from client to server */
 class StreamIntegrationTest {
 
+  private final List<AutoCloseable> closeables = new ArrayList<>();
+
   private ClientStreamServiceImpl<TestSerializableData> clientStreamer;
   private RemoteStreamer<TestSerializableData, TestSerializableData> remoteStreamer;
 
   private final DirectBuffer streamType = BufferUtil.wrapString("foo");
   private final TestSerializableData metadata = new TestSerializableData(1);
   private ActorScheduler actorScheduler;
-
-  private final List<AutoCloseable> closeables = new ArrayList<>();
+  private RemoteStreamErrorHandler<TestSerializableData> errorHandler = (e, d) -> {};
 
   @BeforeEach
   void setup() {
@@ -101,7 +103,10 @@ class StreamIntegrationTest {
                   remoteStreamService =
                       new TransportFactory(actorScheduler)
                           .createRemoteStreamServer(
-                              serverService, TestSerializableData::new, RemoteStreamMetrics.noop());
+                              serverService,
+                              TestSerializableData::new,
+                              (e, d) -> errorHandler.handleError(e, d),
+                              RemoteStreamMetrics.noop());
               closeables.add(
                   () -> testActor.call(() -> remoteStreamService.closeAsync(testActor)).join());
               return remoteStreamService.start(actorScheduler, testActor);
@@ -150,23 +155,23 @@ class StreamIntegrationTest {
   @Test
   void shouldReturnErrorWhenClientStreamIsClosed() throws InterruptedException {
     // given
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    final CountDownLatch latch = new CountDownLatch(1);
     final var clientStreamId =
         clientStreamer.add(streamType, metadata, p -> TestActorFuture.completedFuture(null)).join();
     Awaitility.await().until(() -> remoteStreamer.streamFor(streamType).isPresent());
     final var serverStream = remoteStreamer.streamFor(streamType).orElseThrow();
+    errorHandler =
+        (e, p) -> {
+          error.set(e);
+          latch.countDown();
+        };
 
     // when
     clientStreamer.remove(clientStreamId);
 
-    final AtomicReference<Throwable> error = new AtomicReference<>();
-    final CountDownLatch latch = new CountDownLatch(1);
     // Use serverStream obtained before stream is removed
-    serverStream.push(
-        new TestSerializableData(100),
-        (e, p) -> {
-          error.set(e);
-          latch.countDown();
-        });
+    serverStream.push(new TestSerializableData(100));
 
     // then
     latch.await();
@@ -174,7 +179,7 @@ class StreamIntegrationTest {
   }
 
   private void pushPayload(final TestSerializableData data) {
-    remoteStreamer.streamFor(streamType).orElseThrow().push(data, (p, e) -> {});
+    remoteStreamer.streamFor(streamType).orElseThrow().push(data);
   }
 
   private static final class TestActor extends Actor {}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -105,6 +105,8 @@ class StreamIntegrationTest {
                           .createRemoteStreamServer(
                               serverService,
                               TestSerializableData::new,
+                              // reference the errorHandler indirectly to allow changing its value
+                              // during tests
                               (e, d) -> errorHandler.handleError(e, d),
                               RemoteStreamMetrics.noop());
               closeables.add(


### PR DESCRIPTION
## Description

This PR modifies the current error handling API for the job streams, and moves it to a stateless handler created during startup. It introduces a new interface, `JobStreamErrorHandler`, which the ZPA team should implement, create in `JobStreamServiceStep`, and provide to our own `RemoteJobStreamErrorHandler`.

The new interface provides them with the error, the job, and a `TaskResultBuilder` they can use to append followup commands (e.g. job yield), using APIs they're familiar with.

One downside is we now use stream processor classes directly in the broker, outside of a stream processing context. This creates coupling between "unrelated" contexts, making changing stream processing classes more complicated as they may now impact non-processing contexts. I'm open to alternatives while providing the same nice UX to the ZPA team.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
