### PR TITLE
[Backport stable/8.0] feat(cluster): improve error message when bootstrap channel fails

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -720,7 +720,9 @@ public final class NettyMessagingService implements ManagedMessagingService {
                   if (!onConnect.isSuccess()) {
                     future.completeExceptionally(
                         new ConnectException(
-                            String.format("Failed to connect channel for address %s", address)));
+                            String.format(
+                                "Failed to connect channel for address %s (resolved: %s) : %s",
+                                address, address.address(), onConnect.cause())));
                   }
                 })
             .channel();


### PR DESCRIPTION
# Description
Backport of #12781 to `stable/8.0`.

relates to #12760