### PR TITLE
Use prod credentials for Testbench

### DIFF
--- a/.github/workflows/testbench.yaml
+++ b/.github/workflows/testbench.yaml
@@ -88,5 +88,5 @@ jobs:
           IMAGE: ${{ steps.build-docker.outputs.image }}
           ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
           ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
-          ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.ultrawombat.com/oauth/token'
-          ZEEBE_CLIENT_ID: 'S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo'
+          ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.camunda.io/oauth/token'
+          ZEEBE_CLIENT_ID: 'Jg9caDRuAWHchvM7JiaVlndL-qVFfp~0'


### PR DESCRIPTION
## Description

Testbench has been migrated to prod, use correct credentials for testbench.