### PR TITLE
Introduce `recordVersion` for records in protocol

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -84,11 +85,12 @@ public final class CheckpointCreateProcessor {
       final ProcessingResultBuilder resultBuilder) {
     resultBuilder.appendRecord(
         command.getKey(),
-        RecordType.EVENT,
-        resultIntent,
-        RejectionType.NULL_VAL,
-        "",
-        checkpointRecord);
+        checkpointRecord,
+        new RecordMetadata()
+            .recordType(RecordType.EVENT)
+            .intent(resultIntent)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason(""));
 
     if (command.hasRequestMetadata()) {
       resultBuilder.withResponse(

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -60,14 +61,16 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
 
     @Override
     public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
-        final long key,
-        final RecordType type,
-        final Intent intent,
-        final RejectionType rejectionType,
-        final String rejectionReason,
-        final RecordValue value) {
+        final long key, final RecordValue value, final RecordMetadata metadata) {
 
-      final var record = new Event(intent, type, rejectionType, rejectionReason, key, value);
+      final var record =
+          new Event(
+              metadata.getIntent(),
+              metadata.getRecordType(),
+              metadata.getRejectionType(),
+              metadata.getRejectionReason(),
+              key,
+              value);
       followupRecords.add(record);
       return Either.right(null);
     }

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -68,6 +68,11 @@ record MockTypedCheckpointRecord(
   }
 
   @Override
+  public int getRecordVersion() {
+    return 1;
+  }
+
+  @Override
   public ValueType getValueType() {
     return ValueType.CHECKPOINT;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
@@ -80,6 +80,11 @@ final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> 
   }
 
   @Override
+  public int getRecordVersion() {
+    return 1;
+  }
+
+  @Override
   public ValueType getValueType() {
     return null;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -37,7 +38,13 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-    resultBuilder().appendRecord(key, RecordType.EVENT, intent, RejectionType.NULL_VAL, "", value);
+    final var metadata =
+        new RecordMetadata()
+            .recordType(RecordType.EVENT)
+            .intent(intent)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason("");
+    resultBuilder().appendRecord(key, value, metadata);
     eventApplier.applyState(key, intent, value);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -27,13 +28,12 @@ final class ResultBuilderBackedRejectionWriter extends AbstractResultBuilderBack
       final TypedRecord<? extends RecordValue> command,
       final RejectionType rejectionType,
       final String reason) {
-    resultBuilder()
-        .appendRecord(
-            command.getKey(),
-            RecordType.COMMAND_REJECTION,
-            command.getIntent(),
-            rejectionType,
-            reason,
-            command.getValue());
+    final var metadata =
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND_REJECTION)
+            .intent(command.getIntent())
+            .rejectionType(rejectionType)
+            .rejectionReason(reason);
+    resultBuilder().appendRecord(command.getKey(), command.getValue(), metadata);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -38,7 +39,12 @@ final class ResultBuilderBackedTypedCommandWriter extends AbstractResultBuilderB
   }
 
   private void appendRecord(final long key, final Intent intent, final RecordValue value) {
-    resultBuilder()
-        .appendRecord(key, RecordType.COMMAND, intent, RejectionType.NULL_VAL, "", value);
+    final var metadata =
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .intent(intent)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason("");
+    resultBuilder().appendRecord(key, value, metadata);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -67,8 +67,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -81,7 +80,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -100,8 +99,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -120,7 +118,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -145,8 +143,7 @@ public class SubscriptionCommandSenderTest {
             eq(ProcessMessageSubscriptionIntent.CORRELATE),
             any());
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -162,8 +159,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -179,7 +175,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -201,8 +197,7 @@ public class SubscriptionCommandSenderTest {
             eq(MessageSubscriptionIntent.DELETE),
             any());
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -221,8 +216,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -241,7 +235,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -266,8 +260,7 @@ public class SubscriptionCommandSenderTest {
             eq(MessageSubscriptionIntent.CREATE),
             any());
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -280,8 +273,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -294,7 +286,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -311,8 +303,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -329,7 +320,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -346,8 +337,7 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder, never())
-        .appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder, never()).appendRecord(anyLong(), any(), any());
   }
 
   @Test
@@ -364,6 +354,6 @@ public class SubscriptionCommandSenderTest {
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
-    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any(), any(), any(), any());
+    verify(mockProcessingResultBuilder).appendRecord(anyLong(), any(), any());
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -114,6 +114,11 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   }
 
   @Override
+  public int getRecordVersion() {
+    return metadata.getRecordVersion();
+  }
+
+  @Override
   public ValueType getValueType() {
     return metadata.getValueType();
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -42,6 +42,9 @@
         "brokerVersion": {
           "type": "keyword"
         },
+        "recordVersion": {
+          "type": "integer"
+        },
         "sequence": {
           "type": "long"
         }

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -42,6 +42,9 @@
         "brokerVersion": {
           "type": "keyword"
         },
+        "recordVersion": {
+          "type": "integer"
+        },
         "sequence": {
           "type": "long"
         }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -30,6 +30,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final RejectionType rejectionType;
   private final String rejectionReason;
   private final String brokerVersion;
+  private final int recordVersion;
 
   public CopiedRecord(
       final T recordValue,
@@ -52,6 +53,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     rejectionReason = metadata.getRejectionReason();
     valueType = metadata.getValueType();
     brokerVersion = metadata.getBrokerVersion().toString();
+    recordVersion = metadata.getRecordVersion();
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -84,6 +86,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     rejectionReason = copiedRecord.rejectionReason;
     valueType = copiedRecord.valueType;
     brokerVersion = copiedRecord.brokerVersion;
+    recordVersion = copiedRecord.recordVersion;
   }
 
   @Override
@@ -134,6 +137,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public String getBrokerVersion() {
     return brokerVersion;
+  }
+
+  @Override
+  public int getRecordVersion() {
+    return recordVersion;
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -87,10 +87,10 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
             .orElse(VersionInfo.UNKNOWN);
 
     final int decodedRecordVersion = decoder.recordVersion();
-    if (decodedRecordVersion > 0) {
-      recordVersion = decodedRecordVersion;
-    } else {
+    if (decodedRecordVersion == RecordMetadataDecoder.recordVersionNullValue()) {
       recordVersion = DEFAULT_RECORD_VERSION;
+    } else {
+      recordVersion = decodedRecordVersion;
     }
 
     final int rejectionReasonLength = decoder.rejectionReasonLength();

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -33,6 +33,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
   private static final VersionInfo CURRENT_BROKER_VERSION =
       VersionInfo.parse(VersionUtil.getVersion());
+  private static final int DEFAULT_RECORD_VERSION = 1;
 
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
@@ -51,6 +52,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   // always the current version by default
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
   private VersionInfo brokerVersion = CURRENT_BROKER_VERSION;
+  private int recordVersion = DEFAULT_RECORD_VERSION;
 
   public RecordMetadata() {
     reset();
@@ -83,6 +85,13 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
                         versionDecoder.minorVersion(),
                         versionDecoder.patchVersion()))
             .orElse(VersionInfo.UNKNOWN);
+
+    final int decodedRecordVersion = decoder.recordVersion();
+    if (decodedRecordVersion > 0) {
+      recordVersion = decodedRecordVersion;
+    } else {
+      recordVersion = DEFAULT_RECORD_VERSION;
+    }
 
     final int rejectionReasonLength = decoder.rejectionReasonLength();
 
@@ -122,7 +131,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         .protocolVersion(protocolVersion)
         .valueType(valueType)
         .intent(intentValue)
-        .rejectionType(rejectionType);
+        .rejectionType(rejectionType)
+        .recordVersion(recordVersion);
 
     encoder
         .brokerVersion()
@@ -227,6 +237,15 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     return brokerVersion;
   }
 
+  public RecordMetadata recordVersion(final int recordVersion) {
+    this.recordVersion = recordVersion;
+    return this;
+  }
+
+  public int getRecordVersion() {
+    return recordVersion;
+  }
+
   public RecordMetadata reset() {
     recordType = RecordType.NULL_VAL;
     requestId = RecordMetadataEncoder.requestIdNullValue();
@@ -238,6 +257,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
     brokerVersion = CURRENT_BROKER_VERSION;
+    recordVersion = DEFAULT_RECORD_VERSION;
     return this;
   }
 
@@ -252,7 +272,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         rejectionType,
         rejectionReason,
         protocolVersion,
-        brokerVersion);
+        brokerVersion,
+        recordVersion);
   }
 
   @Override
@@ -272,7 +293,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && recordType == that.recordType
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
-        && brokerVersion.equals(that.brokerVersion);
+        && brokerVersion.equals(that.brokerVersion)
+        && recordVersion == that.recordVersion;
   }
 
   @Override

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -130,6 +130,7 @@ final class JsonSerializableToJsonTest {
                   .intent(intent)
                   .protocolVersion(protocolVersion)
                   .brokerVersion(brokerVersion)
+                  .recordVersion(10)
                   .valueType(valueType)
                   .recordType(recordType)
                   .rejectionReason(rejectionReason)
@@ -167,7 +168,7 @@ final class JsonSerializableToJsonTest {
               return new CopiedRecord<>(
                   record, recordMetadata, key, 0, position, sourcePosition, timestamp);
             },
-        "{'valueType':'DEPLOYMENT','key':1234,'position':4321,'timestamp':2191,'recordType':'COMMAND','intent':'CREATE','partitionId':0,'rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','brokerVersion':'1.2.3','sourceRecordPosition':231,'value':{'processesMetadata':[{'version':12,'bpmnProcessId':'testProcess','resourceName':'resource','checksum':'Y2hlY2tzdW0=','processDefinitionKey':123, 'duplicate':false}],'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}],'decisionsMetadata':[],'decisionRequirementsMetadata':[]}}"
+        "{'valueType':'DEPLOYMENT','key':1234,'position':4321,'timestamp':2191,'recordType':'COMMAND','intent':'CREATE','partitionId':0,'rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','brokerVersion':'1.2.3','recordVersion':10,'sourceRecordPosition':231,'value':{'processesMetadata':[{'version':12,'bpmnProcessId':'testProcess','resourceName':'resource','checksum':'Y2hlY2tzdW0=','processDefinitionKey':123, 'duplicate':false}],'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}],'decisionsMetadata':[],'decisionRequirementsMetadata':[]}}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       //////////////////////////////////// DeploymentRecord ///////////////////////////////////////

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -171,6 +171,46 @@ final class JsonSerializableToJsonTest {
         "{'valueType':'DEPLOYMENT','key':1234,'position':4321,'timestamp':2191,'recordType':'COMMAND','intent':'CREATE','partitionId':0,'rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','brokerVersion':'1.2.3','recordVersion':10,'sourceRecordPosition':231,'value':{'processesMetadata':[{'version':12,'bpmnProcessId':'testProcess','resourceName':'resource','checksum':'Y2hlY2tzdW0=','processDefinitionKey':123, 'duplicate':false}],'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}],'decisionsMetadata':[],'decisionRequirementsMetadata':[]}}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
+      /////////////////////////////////////// Empty Record ////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      new Object[] {
+        "Empty Record",
+        (Supplier<JsonSerializable>)
+            () -> {
+              final var record = new DeploymentRecord();
+              final var metadata = new RecordMetadata().brokerVersion(new VersionInfo(0, 0, 0));
+              final int key = -1;
+              final int partitionId = -1;
+              final int position = -1;
+              final int sourcePosition = -1;
+              final int timestamp = -1;
+              return new CopiedRecord<>(
+                  record, metadata, key, partitionId, position, sourcePosition, timestamp);
+            },
+        """
+      {
+          "key": -1,
+          "position": -1,
+          "sourceRecordPosition": -1,
+          "partitionId": -1,
+          "timestamp": -1,
+          "recordType": "NULL_VAL",
+          "valueType": "NULL_VAL",
+          "intent": null,
+          "rejectionType": "NULL_VAL",
+          "rejectionReason": "",
+          "brokerVersion": "0.0.0",
+          "recordVersion": 1,
+          "value": {
+              "resources": [],
+              "decisionRequirementsMetadata": [],
+              "processesMetadata": [],
+              "decisionsMetadata": []
+          }
+      }
+      """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
       //////////////////////////////////// DeploymentRecord ///////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       new Object[] {

--- a/protocol/ignored-changes.json
+++ b/protocol/ignored-changes.json
@@ -1,0 +1,28 @@
+[
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.RecordMetadataDecoder.BLOCK_LENGTH",
+          "newValue": "32",
+          "justification": "The recordVersion property is added as an optional property where it gets version `1` if the property isn't set on records appended in old Zeebe versions. This is a backward compatible change and therefore acceptable."
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.RecordMetadataEncoder.BLOCK_LENGTH",
+          "newValue": "32",
+          "justification": "The recordVersion property is added as an optional property where it gets version `1` if the property isn't set on records appended in old Zeebe versions. This is a backward compatible change and therefore acceptable."
+        }
+      ]
+    }
+  }
+]
+
+
+
+

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -168,6 +168,20 @@
           "code": "java.class.removed",
           "old": "class io.camunda.zeebe.protocol.management.GroupSizeEncodingEncoder",
           "justification": "This is no longer used for listing backups"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.RecordMetadataDecoder.BLOCK_LENGTH",
+          "newValue": "32",
+          "justification": "The recordVersion property is added as an optional property where it gets version `1` if the property isn't set on records appended in old Zeebe versions. This is a backward compatible change and therefore acceptable."
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.RecordMetadataEncoder.BLOCK_LENGTH",
+          "newValue": "32",
+          "justification": "The recordVersion property is added as an optional property where it gets version `1` if the property isn't set on records appended in old Zeebe versions. This is a backward compatible change and therefore acceptable."
         }
       ]
     }

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -168,20 +168,6 @@
           "code": "java.class.removed",
           "old": "class io.camunda.zeebe.protocol.management.GroupSizeEncodingEncoder",
           "justification": "This is no longer used for listing backups"
-        },
-        {
-          "ignore": true,
-          "code": "java.field.constantValueChanged",
-          "old": "field io.camunda.zeebe.protocol.record.RecordMetadataDecoder.BLOCK_LENGTH",
-          "newValue": "32",
-          "justification": "The recordVersion property is added as an optional property where it gets version `1` if the property isn't set on records appended in old Zeebe versions. This is a backward compatible change and therefore acceptable."
-        },
-        {
-          "ignore": true,
-          "code": "java.field.constantValueChanged",
-          "old": "field io.camunda.zeebe.protocol.record.RecordMetadataEncoder.BLOCK_LENGTH",
-          "newValue": "32",
-          "justification": "The recordVersion property is added as an optional property where it gets version `1` if the property isn't set on records appended in old Zeebe versions. This is a backward compatible change and therefore acceptable."
         }
       ]
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -88,6 +88,18 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
   String getBrokerVersion();
 
   /**
+   * A record version is an integer starting from 1. The version of a record is defined when it is
+   * written. It allows different versions of the same record to be processed or applied
+   * differently.
+   *
+   * <p>For example, it allows us to apply an older event in the same way as when it was originally
+   * written, while allowing newer events to be applied differently.
+   *
+   * @return the version of the record when written
+   */
+  int getRecordVersion();
+
+  /**
    * @return the type of the record (e.g. job, process, process instance, etc.)
    */
   ValueType getValueType();

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -137,10 +137,10 @@
     <field name="protocolVersion" id="4" type="uint16"/>
     <field name="valueType" id="5" type="ValueType"/>
     <field name="intent" id="6" type="uint8"/>
-    <!-- populated when RecordType is COMMAND_REJECTION -->
-    <field name="rejectionType" id="7" type="RejectionType"/>
     <field name="brokerVersion" id="9" type="Version" sinceVersion="2" presence="optional"/>
     <field name="recordVersion" id="10" type="uint16" sinceVersion="3" presence="optional"/>
+    <!-- populated when RecordType is COMMAND_REJECTION -->
+    <field name="rejectionType" id="7" type="RejectionType"/>
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
   </sbe:message>

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -140,6 +140,7 @@
     <!-- populated when RecordType is COMMAND_REJECTION -->
     <field name="rejectionType" id="7" type="RejectionType"/>
     <field name="brokerVersion" id="9" type="Version" sinceVersion="2" presence="optional"/>
+    <field name="recordVersion" id="10" type="uint16" sinceVersion="3" presence="optional"/>
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
   </sbe:message>

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.api;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -27,15 +28,9 @@ public interface ProcessingResultBuilder {
    *     RecordBatch
    */
   default ProcessingResultBuilder appendRecord(
-      final long key,
-      final RecordType type,
-      final Intent intent,
-      final RejectionType rejectionType,
-      final String rejectionReason,
-      final RecordValue value)
+      final long key, final RecordValue value, final RecordMetadata metadata)
       throws RuntimeException {
-    final var either =
-        appendRecordReturnEither(key, type, intent, rejectionType, rejectionReason, value);
+    final var either = appendRecordReturnEither(key, value, metadata);
 
     if (either.isLeft()) {
       // This is how we handled too big record batches as well, except that this is now a
@@ -56,12 +51,7 @@ public interface ProcessingResultBuilder {
    * @return returns either a failure or itself for chaining
    */
   Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
-      final long key,
-      final RecordType type,
-      final Intent intent,
-      final RejectionType rejectionType,
-      final String rejectionReason,
-      final RecordValue value);
+      final long key, final RecordValue value, final RecordMetadata metadata);
 
   /**
    * Sets the response for the result; will be overwritten if called more than once

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/MutableRecordBatch.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/MutableRecordBatch.java
@@ -7,10 +7,7 @@
  */
 package io.camunda.zeebe.stream.api.records;
 
-import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 
@@ -24,25 +21,16 @@ public interface MutableRecordBatch extends ImmutableRecordBatch {
    * Allows to add a new Record to the batch
    *
    * @param key the key of the record
+   * @param metadata the record's metadata
    * @param sourceIndex the position/index in the current batch which caused that entry; should be
    *     set to -1 if no entry caused it
-   * @param recordType the type of the record, part of the record metadata, must be set
-   * @param intent the intent of the record, part of the record metadata, must be set
-   * @param rejectionType the rejection type, part of the record metadata, can be set to a
-   *     NULL_VALUE
-   * @param rejectionReason the rejection reason, part of the record metadata, can be empty
-   * @param valueType the value type, part of the record metadata, must be set
    * @param valueWriter the actual record value
    * @return either a failure if record can't be added to the batch or null on success
    */
   Either<RuntimeException, Void> appendRecord(
       final long key,
+      final RecordMetadata metadata,
       final int sourceIndex,
-      final RecordType recordType,
-      final Intent intent,
-      final RejectionType rejectionType,
-      final String rejectionReason,
-      final ValueType valueType,
       final BufferWriter valueWriter);
 
   /**

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -85,9 +86,14 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
       final String rejectionReason,
       final long requestId,
       final int requestStreamId) {
-    final var entry =
-        RecordBatchEntry.createEntry(
-            key, -1, recordType, intent, rejectionType, rejectionReason, valueType, value);
+    final var metadata =
+        new RecordMetadata()
+            .recordType(recordType)
+            .intent(intent)
+            .rejectionType(rejectionType)
+            .rejectionReason(rejectionReason)
+            .valueType(valueType);
+    final var entry = RecordBatchEntry.createEntry(key, metadata, -1, value);
     processingResponse = new ProcessingResponseImpl(entry, requestId, requestStreamId);
     return this;
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -45,12 +45,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
 
   @Override
   public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
-      final long key,
-      final RecordType type,
-      final Intent intent,
-      final RejectionType rejectionType,
-      final String rejectionReason,
-      final RecordValue value) {
+      final long key, final RecordValue value, final RecordMetadata metadata) {
 
     final ValueType valueType = TypedEventRegistry.TYPE_REGISTRY.get(value.getClass());
     if (valueType == null) {
@@ -59,14 +54,9 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
     }
 
     if (value instanceof UnifiedRecordValue unifiedRecordValue) {
-      final var metadata =
-          new RecordMetadata()
-              .recordType(type)
-              .intent(intent)
-              .rejectionType(rejectionType)
-              .rejectionReason(rejectionReason)
-              .valueType(valueType);
-      final var either = mutableRecordBatch.appendRecord(key, metadata, -1, unifiedRecordValue);
+      final var metadataWithValueType = metadata.valueType(valueType);
+      final var either =
+          mutableRecordBatch.appendRecord(key, metadataWithValueType, -1, unifiedRecordValue);
       if (either.isLeft()) {
         return Either.left(either.getLeft());
       }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -59,9 +59,14 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
     }
 
     if (value instanceof UnifiedRecordValue unifiedRecordValue) {
-      final var either =
-          mutableRecordBatch.appendRecord(
-              key, -1, type, intent, rejectionType, rejectionReason, valueType, unifiedRecordValue);
+      final var metadata =
+          new RecordMetadata()
+              .recordType(type)
+              .intent(intent)
+              .rejectionType(rejectionType)
+              .rejectionReason(rejectionReason)
+              .valueType(valueType);
+      final var either = mutableRecordBatch.appendRecord(key, metadata, -1, unifiedRecordValue);
       if (either.isLeft()) {
         return Either.left(either.getLeft());
       }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -41,9 +42,14 @@ public final class BufferedTaskResultBuilder implements TaskResultBuilder {
       throw new IllegalStateException("Missing value type mapping for record: " + value.getClass());
     }
 
-    final var either =
-        mutableRecordBatch.appendRecord(
-            key, -1, RecordType.COMMAND, intent, RejectionType.NULL_VAL, "", valueType, value);
+    final var metadata =
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .intent(intent)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason("")
+            .valueType(valueType);
+    final var either = mutableRecordBatch.appendRecord(key, metadata, -1, value);
 
     return either.isRight();
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatch.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatch.java
@@ -9,10 +9,6 @@ package io.camunda.zeebe.stream.impl.records;
 
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
-import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.ImmutableRecordBatch;
 import io.camunda.zeebe.stream.api.records.MutableRecordBatch;
@@ -43,20 +39,9 @@ public final class RecordBatch implements MutableRecordBatch {
   @Override
   public Either<RuntimeException, Void> appendRecord(
       final long key,
+      final RecordMetadata metadata,
       final int sourceIndex,
-      final RecordType recordType,
-      final Intent intent,
-      final RejectionType rejectionType,
-      final String rejectionReason,
-      final ValueType valueType,
       final BufferWriter valueWriter) {
-    final var metadata =
-        new RecordMetadata()
-            .recordType(recordType)
-            .intent(intent)
-            .rejectionType(rejectionType)
-            .rejectionReason(rejectionReason)
-            .valueType(valueType);
     final var recordBatchEntry =
         RecordBatchEntry.createEntry(key, metadata, sourceIndex, valueWriter);
     final var entryLength = recordBatchEntry.getLength();

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatch.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/RecordBatch.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl.records;
 
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -49,16 +50,15 @@ public final class RecordBatch implements MutableRecordBatch {
       final String rejectionReason,
       final ValueType valueType,
       final BufferWriter valueWriter) {
+    final var metadata =
+        new RecordMetadata()
+            .recordType(recordType)
+            .intent(intent)
+            .rejectionType(rejectionType)
+            .rejectionReason(rejectionReason)
+            .valueType(valueType);
     final var recordBatchEntry =
-        RecordBatchEntry.createEntry(
-            key,
-            sourceIndex,
-            recordType,
-            intent,
-            rejectionType,
-            rejectionReason,
-            valueType,
-            valueWriter);
+        RecordBatchEntry.createEntry(key, metadata, sourceIndex, valueWriter);
     final var entryLength = recordBatchEntry.getLength();
 
     if (!recordBatchSizePredicate.test(recordBatchEntries.size() + 1, batchSize + entryLength)) {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -83,6 +83,11 @@ public final class TypedRecordImpl implements TypedRecord {
   }
 
   @Override
+  public int getRecordVersion() {
+    return metadata.getRecordVersion();
+  }
+
+  @Override
   public ValueType getValueType() {
     return metadata.getValueType();
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -78,6 +78,11 @@ public class UnwrittenRecord implements TypedRecord {
   }
 
   @Override
+  public int getRecordVersion() {
+    return metadata.getRecordVersion();
+  }
+
+  @Override
   public ValueType getValueType() {
     return metadata.getValueType();
   }

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -24,6 +24,19 @@ import org.junit.jupiter.api.Test;
 
 class RecordBatchTest {
 
+  private static final RecordType RECORD_TYPE = RecordType.COMMAND;
+  private static final ProcessInstanceIntent INTENT = ProcessInstanceIntent.ACTIVATE_ELEMENT;
+  private static final RejectionType REJECTION_TYPE = RejectionType.ALREADY_EXISTS;
+  private static final String REJECTION_REASON = "broken somehow";
+  private static final ValueType VALUE_TYPE = ValueType.PROCESS_INSTANCE;
+  private static final RecordMetadata RECORD_METADATA =
+      new RecordMetadata()
+          .recordType(RECORD_TYPE)
+          .intent(INTENT)
+          .rejectionType(REJECTION_TYPE)
+          .rejectionReason(REJECTION_REASON)
+          .valueType(VALUE_TYPE);
+
   @Test
   void shouldAppendToRecordBatch() {
     // given
@@ -31,15 +44,7 @@ class RecordBatchTest {
     final var processInstanceRecord = Records.processInstance(1);
 
     // when
-    recordBatch.appendRecord(
-        1,
-        -1,
-        RecordType.COMMAND,
-        ProcessInstanceIntent.ACTIVATE_ELEMENT,
-        RejectionType.ALREADY_EXISTS,
-        "broken somehow",
-        ValueType.PROCESS_INSTANCE,
-        processInstanceRecord);
+    recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // then
     final var batchSize = recordBatch.getBatchSize();
@@ -50,23 +55,23 @@ class RecordBatchTest {
     assertThat(recordBatch)
         .map(RecordBatchEntry::recordMetadata)
         .map(RecordMetadata::getIntent)
-        .containsOnly(ProcessInstanceIntent.ACTIVATE_ELEMENT);
+        .containsOnly(INTENT);
     assertThat(recordBatch)
         .map(RecordBatchEntry::recordMetadata)
         .map(RecordMetadata::getRecordType)
-        .containsOnly(RecordType.COMMAND);
+        .containsOnly(RECORD_TYPE);
     assertThat(recordBatch)
         .map(RecordBatchEntry::recordMetadata)
         .map(RecordMetadata::getRejectionType)
-        .containsOnly(RejectionType.ALREADY_EXISTS);
+        .containsOnly(REJECTION_TYPE);
     assertThat(recordBatch)
         .map(RecordBatchEntry::recordMetadata)
         .map(RecordMetadata::getValueType)
-        .containsOnly(ValueType.PROCESS_INSTANCE);
+        .containsOnly(VALUE_TYPE);
     assertThat(recordBatch)
         .map(RecordBatchEntry::recordMetadata)
         .map(RecordMetadata::getRejectionReason)
-        .containsOnly("broken somehow");
+        .containsOnly(REJECTION_REASON);
     assertThat(recordBatch).map(RecordBatchEntry::recordValue).containsOnly(processInstanceRecord);
   }
 
@@ -88,15 +93,7 @@ class RecordBatchTest {
     final var processInstanceRecord = Records.processInstance(1);
 
     // when
-    recordBatch.appendRecord(
-        1,
-        -1,
-        RecordType.COMMAND,
-        ProcessInstanceIntent.ACTIVATE_ELEMENT,
-        RejectionType.ALREADY_EXISTS,
-        "broken somehow",
-        ValueType.PROCESS_INSTANCE,
-        processInstanceRecord);
+    recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // then
     assertThat(recordBatch.getBatchSize()).isEqualTo(batchSize.get());
@@ -120,26 +117,10 @@ class RecordBatchTest {
         };
     final var recordBatch = new RecordBatch(batchSizePredicate);
     final var processInstanceRecord = Records.processInstance(1);
-    recordBatch.appendRecord(
-        1,
-        -1,
-        RecordType.COMMAND,
-        ProcessInstanceIntent.ACTIVATE_ELEMENT,
-        RejectionType.ALREADY_EXISTS,
-        "broken somehow",
-        ValueType.PROCESS_INSTANCE,
-        processInstanceRecord);
+    recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // when
-    recordBatch.appendRecord(
-        1,
-        -1,
-        RecordType.COMMAND,
-        ProcessInstanceIntent.ACTIVATE_ELEMENT,
-        RejectionType.ALREADY_EXISTS,
-        "broken somehow",
-        ValueType.PROCESS_INSTANCE,
-        processInstanceRecord);
+    recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // then
     assertThat(recordBatch.getBatchSize()).isEqualTo(batchSize.get());
@@ -154,16 +135,7 @@ class RecordBatchTest {
     final var processInstanceRecord = Records.processInstance(1);
 
     // when
-    final var either =
-        recordBatch.appendRecord(
-            1,
-            -1,
-            RecordType.COMMAND,
-            ProcessInstanceIntent.ACTIVATE_ELEMENT,
-            RejectionType.ALREADY_EXISTS,
-            "broken somehow",
-            ValueType.PROCESS_INSTANCE,
-            processInstanceRecord);
+    final var either = recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // then
     assertThat(either.isLeft()).isTrue();
@@ -178,27 +150,10 @@ class RecordBatchTest {
     final var recordBatch = new RecordBatch((count, size) -> count < 2);
     final var processInstanceRecord = Records.processInstance(1);
 
-    recordBatch.appendRecord(
-        1,
-        -1,
-        RecordType.COMMAND,
-        ProcessInstanceIntent.ACTIVATE_ELEMENT,
-        RejectionType.ALREADY_EXISTS,
-        "broken somehow",
-        ValueType.PROCESS_INSTANCE,
-        processInstanceRecord);
+    recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // when
-    final var either =
-        recordBatch.appendRecord(
-            1,
-            -1,
-            RecordType.COMMAND,
-            ProcessInstanceIntent.ACTIVATE_ELEMENT,
-            RejectionType.ALREADY_EXISTS,
-            "broken somehow",
-            ValueType.PROCESS_INSTANCE,
-            processInstanceRecord);
+    final var either = recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // then
     assertThat(either.isLeft()).isTrue();
@@ -237,15 +192,7 @@ class RecordBatchTest {
     final var recordBatch = new RecordBatch((count, size) -> size < 300);
     final var processInstanceRecord = Records.processInstance(1);
 
-    recordBatch.appendRecord(
-        1,
-        -1,
-        RecordType.COMMAND,
-        ProcessInstanceIntent.ACTIVATE_ELEMENT,
-        RejectionType.ALREADY_EXISTS,
-        "broken somehow",
-        ValueType.PROCESS_INSTANCE,
-        processInstanceRecord);
+    recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // when
     final var canAppend = recordBatch.canAppendRecordOfLength(recordBatch.getBatchSize());
@@ -260,15 +207,7 @@ class RecordBatchTest {
     final var recordBatch = new RecordBatch((count, size) -> count < 2);
     final var processInstanceRecord = Records.processInstance(1);
 
-    recordBatch.appendRecord(
-        1,
-        -1,
-        RecordType.COMMAND,
-        ProcessInstanceIntent.ACTIVATE_ELEMENT,
-        RejectionType.ALREADY_EXISTS,
-        "broken somehow",
-        ValueType.PROCESS_INSTANCE,
-        processInstanceRecord);
+    recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // when
     final var canAppend = recordBatch.canAppendRecordOfLength(recordBatch.getBatchSize());

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 275]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 277]");
   }
 
   @Test

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -279,18 +279,20 @@ public final class StreamProcessorTest {
               final var resultBuilder = resultBuilderCaptor.getValue();
               resultBuilder.appendRecordReturnEither(
                   1,
-                  RecordType.EVENT,
-                  ACTIVATE_ELEMENT,
-                  RejectionType.NULL_VAL,
-                  "",
-                  Records.processInstance(1));
+                  Records.processInstance(1),
+                  new RecordMetadata()
+                      .recordType(RecordType.EVENT)
+                      .intent(ACTIVATE_ELEMENT)
+                      .rejectionType(RejectionType.NULL_VAL)
+                      .rejectionReason(""));
               resultBuilder.appendRecordReturnEither(
                   2,
-                  RecordType.COMMAND,
-                  ACTIVATE_ELEMENT,
-                  RejectionType.NULL_VAL,
-                  "",
-                  Records.processInstance(1));
+                  Records.processInstance(1),
+                  new RecordMetadata()
+                      .recordType(RecordType.COMMAND)
+                      .intent(ACTIVATE_ELEMENT)
+                      .rejectionType(RejectionType.NULL_VAL)
+                      .rejectionReason(""));
               return resultBuilder.build();
             })
         .thenAnswer(
@@ -298,11 +300,12 @@ public final class StreamProcessorTest {
               final var resultBuilder = resultBuilderCaptor.getValue();
               resultBuilder.appendRecordReturnEither(
                   3,
-                  RecordType.EVENT,
-                  ACTIVATE_ELEMENT,
-                  RejectionType.NULL_VAL,
-                  "",
-                  Records.processInstance(1));
+                  Records.processInstance(1),
+                  new RecordMetadata()
+                      .recordType(RecordType.EVENT)
+                      .intent(ACTIVATE_ELEMENT)
+                      .rejectionType(RejectionType.NULL_VAL)
+                      .rejectionReason(""));
               return resultBuilder.build();
             });
 
@@ -344,18 +347,20 @@ public final class StreamProcessorTest {
     final var resultBuilder = new BufferedProcessingResultBuilder((c, v) -> true);
     resultBuilder.appendRecordReturnEither(
         1,
-        RecordType.EVENT,
-        ACTIVATE_ELEMENT,
-        RejectionType.NULL_VAL,
-        "",
-        Records.processInstance(1));
+        Records.processInstance(1),
+        new RecordMetadata()
+            .recordType(RecordType.EVENT)
+            .intent(ACTIVATE_ELEMENT)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason(""));
     resultBuilder.appendRecordReturnEither(
         2,
-        RecordType.COMMAND,
-        COMPLETE_ELEMENT,
-        RejectionType.NULL_VAL,
-        "",
-        Records.processInstance(1));
+        Records.processInstance(1),
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .intent(COMPLETE_ELEMENT)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason(""));
 
     when(defaultRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
 
@@ -843,11 +848,12 @@ public final class StreamProcessorTest {
             12)
         .appendRecord(
             4,
-            RecordType.COMMAND,
-            ELEMENT_ACTIVATING,
-            RejectionType.NULL_VAL,
-            "",
-            Records.processInstance(1));
+            Records.processInstance(1),
+            new RecordMetadata()
+                .recordType(RecordType.COMMAND)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""));
     final var secondResultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     secondResultBuilder.withResponse(
         RecordType.EVENT,
@@ -899,33 +905,36 @@ public final class StreamProcessorTest {
                         12)
                     .appendRecord(
                         4,
-                        RecordType.COMMAND,
-                        ELEMENT_ACTIVATING,
-                        RejectionType.NULL_VAL,
-                        "",
-                        Records.processInstance(1))
+                        Records.processInstance(1),
+                        new RecordMetadata()
+                            .recordType(RecordType.COMMAND)
+                            .intent(ELEMENT_ACTIVATING)
+                            .rejectionType(RejectionType.NULL_VAL)
+                            .rejectionReason(""))
                     .build())
         .thenAnswer(
             invocation ->
                 ((ProcessingResultBuilder) invocation.getArgument(1))
                     .appendRecord(
                         5,
-                        RecordType.COMMAND,
-                        ELEMENT_ACTIVATING,
-                        RejectionType.NULL_VAL,
-                        "",
-                        Records.processInstance(2))
+                        Records.processInstance(2),
+                        new RecordMetadata()
+                            .recordType(RecordType.COMMAND)
+                            .intent(ELEMENT_ACTIVATING)
+                            .rejectionType(RejectionType.NULL_VAL)
+                            .rejectionReason(""))
                     .build())
         .thenAnswer(
             invocation ->
                 ((ProcessingResultBuilder) invocation.getArgument(1))
                     .appendRecord(
                         6,
-                        RecordType.EVENT,
-                        ELEMENT_ACTIVATING,
-                        RejectionType.NULL_VAL,
-                        "",
-                        Records.processInstance(2))
+                        Records.processInstance(2),
+                        new RecordMetadata()
+                            .recordType(RecordType.EVENT)
+                            .intent(ELEMENT_ACTIVATING)
+                            .rejectionType(RejectionType.NULL_VAL)
+                            .rejectionReason(""))
                     .build());
 
     streamPlatform.startStreamProcessor();
@@ -999,11 +1008,12 @@ public final class StreamProcessorTest {
             12)
         .appendRecord(
             4,
-            RecordType.COMMAND,
-            ELEMENT_ACTIVATING,
-            RejectionType.NULL_VAL,
-            "",
-            Records.processInstance(1));
+            Records.processInstance(1),
+            new RecordMetadata()
+                .recordType(RecordType.COMMAND)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""));
 
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     when(defaultMockedRecordProcessor.process(any(), any()))
@@ -1068,11 +1078,12 @@ public final class StreamProcessorTest {
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder.appendRecordReturnEither(
         1,
-        RecordType.COMMAND_REJECTION,
-        ACTIVATE_ELEMENT,
-        RejectionType.NULL_VAL,
-        "",
-        Records.processInstance(1));
+        Records.processInstance(1),
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND_REJECTION)
+            .intent(ACTIVATE_ELEMENT)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason(""));
     when(defaultMockedRecordProcessor.onProcessingError(any(), any(), any()))
         .thenReturn(resultBuilder.build());
 
@@ -1169,11 +1180,12 @@ public final class StreamProcessorTest {
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder.appendRecordReturnEither(
         1,
-        RecordType.EVENT,
-        ELEMENT_ACTIVATING,
-        RejectionType.NULL_VAL,
-        "",
-        Records.processInstance(1));
+        Records.processInstance(1),
+        new RecordMetadata()
+            .recordType(RecordType.EVENT)
+            .intent(ELEMENT_ACTIVATING)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason(""));
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
     streamPlatform.startStreamProcessor();
 

--- a/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -105,6 +105,11 @@ public final class RecordingExporterTest {
     }
 
     @Override
+    public int getRecordVersion() {
+      return 1;
+    }
+
+    @Override
     public ValueType getValueType() {
       return VALUE_TYPE;
     }


### PR DESCRIPTION
> **Warning**
> This pull request touches code maintained by @camunda/zeebe-distributed-platform (`stream-processor`, and `backup` scopes), @camunda/zeebe-process-automation (`engine`, `exporters` scopes), and code that is shared between the two (`protocol`, `protocol-impl`, `test-util`, and commits without a scope). It should be reviewed by both teams.

## Description

<!-- Please explain the changes you made here. -->

This introduces a new property to records: `recordVersion`. This is an integer starting at `1` that can be incremented when we want to write a new version of a record. It also allows writing specific versions of records in case that is needed (required for #11661). The property is stored as record metadata.

Record versions are necessary to implement:
- #12764 

An attempt was made to use the existing `brokerVersion` to implement it in #11970 but this is hard to maintain (see https://github.com/camunda/zeebe/pull/11970#issuecomment-1544447868). It is never really clear what the next broker version will be while working on it. So it's hard to refer to it. Instead, it's much easier to have a counter that can be incremented for new versions.

The record version property is optional, and when missing the value `1` will be assumed. So all records that were written before this property existed, will be assumed to have version `1`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

part of #12764 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [x] [Operate](https://github.com/camunda/operate/issues)
- [x] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [x] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
