### PR TITLE
Support versioned event appliers

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -79,7 +79,7 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getKeyGenerator());
     final var scheduledTaskDbState = new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
 
-    eventApplier = new EventAppliers(processingState);
+    eventApplier = new EventAppliers().registerEventAppliers(processingState);
 
     writers = new Writers(resultBuilderMutex, eventApplier);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -107,7 +107,8 @@ public class Engine implements RecordProcessor {
 
   @Override
   public void replay(final TypedRecord event) {
-    eventApplier.applyState(event.getKey(), event.getIntent(), event.getValue());
+    eventApplier.applyState(
+        event.getKey(), event.getIntent(), event.getValue(), event.getRecordVersion());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -38,10 +38,17 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
+    appendFollowUpEvent(key, intent, value, RecordMetadata.DEFAULT_RECORD_VERSION);
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key, final Intent intent, final RecordValue value, final int recordVersion) {
     final var metadata =
         new RecordMetadata()
             .recordType(RecordType.EVENT)
             .intent(intent)
+            .recordVersion(recordVersion)
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("");
     resultBuilder().appendRecord(key, value, metadata);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -52,7 +52,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("");
     resultBuilder().appendRecord(key, value, metadata);
-    eventApplier.applyState(key, intent, value);
+    eventApplier.applyState(key, intent, value, recordVersion);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -14,7 +14,10 @@ import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 public interface TypedEventWriter {
 
   /**
-   * Append a follow up event to the result builder
+   * Append a follow up event to the result builder.
+   *
+   * <p>If multiple versions of a record exists, consider using {@link #appendFollowUpEvent(long,
+   * Intent, RecordValue, int)} instead.
    *
    * @param key the key of the event
    * @param intent the intent of the event
@@ -22,6 +25,23 @@ public interface TypedEventWriter {
    * @throws ExceededBatchRecordSizeException if the appended event doesn't fit into the RecordBatch
    */
   void appendFollowUpEvent(long key, Intent intent, RecordValue value);
+
+  /**
+   * Append a specific version of a follow up event to the result builder.
+   *
+   * <p>Different versions of event records may be applied by different {@link
+   * io.camunda.zeebe.engine.state.EventApplier EventApplier}s, leading to differing state changes.
+   * This allows fixing bugs in event appliers because every event applier must produce the same
+   * state changes for an event both when writing it and when replaying it, even on newer versions
+   * of Zeebe.
+   *
+   * @param key the key of the event
+   * @param intent the intent of the event
+   * @param value the record of the event
+   * @param recordVersion the version of the record of the event
+   * @throws ExceededBatchRecordSizeException if the appended event doesn't fit into the RecordBatch
+   */
+  void appendFollowUpEvent(long key, Intent intent, RecordValue value, int recordVersion);
 
   /**
    * Use this to know whether you can write an event of this length.

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
@@ -19,6 +19,7 @@ public interface EventApplier {
    * @param key the key of the event
    * @param intent the intent of the event
    * @param recordValue the value of the event
+   * @param recordVersion the record version of the event
    */
-  void applyState(long key, Intent intent, RecordValue recordValue);
+  void applyState(long key, Intent intent, RecordValue recordValue, final int recordVersion);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -51,7 +51,7 @@ public final class EventAppliers implements EventApplier {
 
   private final Map<IntentAndVersion, TypedEventApplier> mapping = new HashMap<>();
 
-  public EventAppliers(final MutableProcessingState state) {
+  public EventAppliers registerEventAppliers(final MutableProcessingState state) {
     registerProcessInstanceEventAppliers(state);
     registerProcessInstanceCreationAppliers(state);
     registerProcessInstanceModificationAppliers(state);
@@ -78,6 +78,7 @@ public final class EventAppliers implements EventApplier {
     registerSignalSubscriptionAppliers(state);
 
     registerCommandDistributionAppliers(state);
+    return this;
   }
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -297,7 +297,7 @@ public final class EventAppliers implements EventApplier {
     register(intent, RecordMetadata.DEFAULT_RECORD_VERSION, applier);
   }
 
-  private <I extends Intent> void register(
+  <I extends Intent> void register(
       final I intent, final int version, final TypedEventApplier<I, ?> applier) {
     mapping.put(new IntentAndVersion(intent, version), applier);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
@@ -48,7 +49,7 @@ public final class EventAppliers implements EventApplier {
   private static final Function<Intent, TypedEventApplier<?, ?>> UNIMPLEMENTED_EVENT_APPLIER =
       intent -> (key, value) -> {};
 
-  private final Map<Intent, TypedEventApplier> mapping = new HashMap<>();
+  private final Map<IntentAndVersion, TypedEventApplier> mapping = new HashMap<>();
 
   public EventAppliers(final MutableProcessingState state) {
     registerProcessInstanceEventAppliers(state);
@@ -293,13 +294,22 @@ public final class EventAppliers implements EventApplier {
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {
-    mapping.put(intent, applier);
+    register(intent, RecordMetadata.DEFAULT_RECORD_VERSION, applier);
+  }
+
+  private <I extends Intent> void register(
+      final I intent, final int version, final TypedEventApplier<I, ?> applier) {
+    mapping.put(new IntentAndVersion(intent, version), applier);
   }
 
   @Override
-  public void applyState(final long key, final Intent intent, final RecordValue value) {
+  public void applyState(
+      final long key, final Intent intent, final RecordValue value, final int recordVersion) {
     final var eventApplier =
-        mapping.getOrDefault(intent, UNIMPLEMENTED_EVENT_APPLIER.apply(intent));
+        mapping.getOrDefault(
+            new IntentAndVersion(intent, recordVersion), UNIMPLEMENTED_EVENT_APPLIER.apply(intent));
     eventApplier.applyState(key, value);
   }
+
+  record IntentAndVersion(Intent intent, int version) {}
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -56,7 +56,8 @@ public final class MessageStreamProcessorTest {
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
     final var mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
     final var writers =
-        new Writers(() -> mockProcessingResultBuilder, (key, intent, recordValue) -> {});
+        new Writers(
+            () -> mockProcessingResultBuilder, (key, intent, recordValue, recordVersion) -> {});
     spySubscriptionCommandSender =
         spy(new SubscriptionCommandSender(1, mockInterpartitionCommandSender));
     spySubscriptionCommandSender.setWriters(writers);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -53,7 +53,8 @@ public class SubscriptionCommandSenderTest {
         new SubscriptionCommandSender(SAME_PARTITION, mockInterPartitionCommandSender);
     mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
     final var writers =
-        new Writers(() -> mockProcessingResultBuilder, (key, intent, recordValue) -> {});
+        new Writers(
+            () -> mockProcessingResultBuilder, (key, intent, recordValue, recordVersion) -> {});
     subscriptionCommandSender.setWriters(writers);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.variable;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
 import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 
@@ -34,7 +35,13 @@ public final class EventApplyingStateWriter implements StateWriter {
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-    eventWriter.appendFollowUpEvent(key, intent, value);
+    appendFollowUpEvent(key, intent, value, RecordMetadata.DEFAULT_RECORD_VERSION);
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key, final Intent intent, final RecordValue value, final int recordVersion) {
+    eventWriter.appendFollowUpEvent(key, intent, value, recordVersion);
     eventApplier.applyState(key, intent, value);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
@@ -42,7 +42,7 @@ public final class EventApplyingStateWriter implements StateWriter {
   public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
     eventWriter.appendFollowUpEvent(key, intent, value, recordVersion);
-    eventApplier.applyState(key, intent, value);
+    eventApplier.applyState(key, intent, value, recordVersion);
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -42,8 +42,9 @@ final class VariableBehaviorTest {
 
   @BeforeEach
   void beforeEach() {
-    final var stateWriter =
-        new EventApplyingStateWriter(eventWriter, new EventAppliers(processingState));
+    final var eventAppliers = new EventAppliers();
+    eventAppliers.registerEventAppliers(processingState);
+    final var stateWriter = new EventApplyingStateWriter(eventWriter, eventAppliers);
 
     state = processingState.getVariableState();
     behavior = new VariableBehavior(state, stateWriter, processingState.getKeyGenerator());

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -11,8 +11,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,12 +20,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(ProcessingStateExtension.class)
 @ExtendWith(MockitoExtension.class)
 public class EventAppliersTest {
-
-  /** Injected by {@link ProcessingStateExtension}. */
-  private MutableProcessingState state;
 
   private EventAppliers eventAppliers;
 
@@ -36,7 +30,7 @@ public class EventAppliersTest {
 
   @BeforeEach
   void setup() {
-    eventAppliers = new EventAppliers(state);
+    eventAppliers = new EventAppliers();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(ProcessingStateExtension.class)
+@ExtendWith(MockitoExtension.class)
+public class EventAppliersTest {
+
+  /** Injected by {@link ProcessingStateExtension}. */
+  private MutableProcessingState state;
+
+  private EventAppliers eventAppliers;
+
+  @Mock private TypedEventApplier<Intent, ? extends RecordValue> mockedApplier;
+  @Mock private TypedEventApplier<Intent, ? extends RecordValue> anotherMockedApplier;
+
+  @BeforeEach
+  void setup() {
+    eventAppliers = new EventAppliers(state);
+  }
+
+  @Test
+  void shouldApplyStateUsingRegisteredApplier() {
+    // given
+    eventAppliers.register(Intent.UNKNOWN, 1, mockedApplier);
+
+    // when
+    eventAppliers.applyState(1, Intent.UNKNOWN, null, 1);
+
+    // then
+    Mockito.verify(mockedApplier).applyState(anyLong(), any());
+  }
+
+  @Test
+  void shouldNotApplyStateUsingUnregisteredApplier() {
+    // given no registered appliers
+
+    // when
+    eventAppliers.applyState(1, Intent.UNKNOWN, null, 1);
+
+    // then
+    Mockito.verify(mockedApplier, Mockito.never()).applyState(anyLong(), any());
+  }
+
+  @Test
+  void shouldNotApplyStateUsingRegisteredApplierForOlderVersion() {
+    // given
+    eventAppliers.register(Intent.UNKNOWN, 1, mockedApplier);
+
+    // when
+    eventAppliers.applyState(1, Intent.UNKNOWN, null, 2);
+
+    // then
+    Mockito.verify(mockedApplier, Mockito.never()).applyState(anyLong(), any());
+  }
+
+  @Test
+  void shouldApplyStateUsingRegisteredApplierForSpecificVersion() {
+    // given
+    eventAppliers.register(Intent.UNKNOWN, 1, mockedApplier);
+    eventAppliers.register(Intent.UNKNOWN, 2, anotherMockedApplier);
+
+    // when
+    eventAppliers.applyState(1, Intent.UNKNOWN, null, 2);
+
+    // then
+    Mockito.verify(mockedApplier, Mockito.never()).applyState(anyLong(), any());
+    Mockito.verify(anotherMockedApplier).applyState(anyLong(), any());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.List;
@@ -28,7 +29,13 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-    events.add(new RecordedEvent<>(key, intent, value));
+    appendFollowUpEvent(key, intent, value, RecordMetadata.DEFAULT_RECORD_VERSION);
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key, final Intent intent, final RecordValue value, final int recordVersion) {
+    events.add(new RecordedEvent<>(key, intent, value, recordVersion));
   }
 
   @Override
@@ -41,16 +48,28 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
     public final long key;
     public final Intent intent;
     public final T value;
+    private final int recordVersion;
 
-    public RecordedEvent(final long key, final Intent intent, final T value) {
+    public RecordedEvent(
+        final long key, final Intent intent, final T value, final int recordVersion) {
       this.key = key;
       this.intent = intent;
       this.value = (T) Records.cloneValue(value);
+      this.recordVersion = recordVersion;
     }
 
     @Override
     public String toString() {
-      return "RecordedEvent{" + "key=" + key + ", intent=" + intent + ", value=" + value + '}';
+      return "RecordedEvent{"
+          + "key="
+          + key
+          + ", intent="
+          + intent
+          + ", value="
+          + value
+          + ", recordVersion="
+          + recordVersion
+          + '}';
     }
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -87,7 +87,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
             .orElse(VersionInfo.UNKNOWN);
 
     final int decodedRecordVersion = decoder.recordVersion();
-    if (decodedRecordVersion == RecordMetadataDecoder.recordVersionNullValue()) {
+    if (decodedRecordVersion == 0
+        || decodedRecordVersion == RecordMetadataDecoder.recordVersionNullValue()) {
       recordVersion = DEFAULT_RECORD_VERSION;
     } else {
       recordVersion = decodedRecordVersion;

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -30,10 +30,10 @@ import org.agrona.concurrent.UnsafeBuffer;
 public final class RecordMetadata implements BufferWriter, BufferReader {
   public static final int BLOCK_LENGTH =
       MessageHeaderEncoder.ENCODED_LENGTH + RecordMetadataEncoder.BLOCK_LENGTH;
+  public static final int DEFAULT_RECORD_VERSION = 1;
 
   private static final VersionInfo CURRENT_BROKER_VERSION =
       VersionInfo.parse(VersionUtil.getVersion());
-  private static final int DEFAULT_RECORD_VERSION = 1;
 
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds the ability to register event appliers for the combination of intent and record version. Events are applied by the state writer using the record version that is chosen when the event is appended. And events that were appended are applied using their record version when replayed.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12764 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
