### PR TITLE
Allow deploying benchmarks on stable VMs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,6 +30,11 @@ on:
         type: string
         required: false
         default: 'true'
+      stable-vms:
+        description: 'Deploy to non-spot VMs'
+        type: boolean
+        required: false
+        default: false
 
   workflow_call:
     inputs:
@@ -66,6 +71,12 @@ on:
         default: ""
         type: string
         required: false
+      stable-vms:
+        description: 'Deploy to non-spot VMs'
+        type: boolean
+        required: false
+        default: false
+
 jobs:
   build-zeebe-image:
     name: Build Zeebe
@@ -201,4 +212,15 @@ jobs:
           --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
           --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
+          ${{ inputs.stable-vms && '-f benchmarks/setup/default/values-stable.yaml' || '' }}
           ${{ inputs.benchmark-load }}
+      - name: Summarize deployment
+        if: success()
+        run: |
+
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+            ## Benchmark `${{ inputs.name }}` values
+            ```yaml
+              $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            ```
+          EOF

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -217,10 +217,9 @@ jobs:
       - name: Summarize deployment
         if: success()
         run: |
-
           cat >> $GITHUB_STEP_SUMMARY <<EOF
-            ## Benchmark `${{ inputs.name }}` values
-            ```yaml
-              $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
-            ```
+            ## Benchmark \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
           EOF

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,10 +26,10 @@ on:
         type: string
         required: false
       measure:
-        description: 'If enabled, impact of network latency is measured.'
-        type: string
+        description: 'Measure impact of network latency'
+        type: boolean
         required: false
-        default: 'true'
+        default: true
       stable-vms:
         description: 'Deploy to non-spot VMs'
         type: boolean
@@ -62,10 +62,10 @@ on:
         type: string
         required: false
       measure:
-        description: 'If enabled, impact of network latency is measured.'
-        type: string
+        description: 'Measure impact of network latency'
+        type: boolean
         required: false
-        default: 'true'
+        default: true
       publish:
         description: 'Where to publish the results, can be "slack" or "comment"'
         default: ""
@@ -164,7 +164,7 @@ jobs:
       - build-benchmark-images
     uses: zeebe-io/zeebe-performance-test/.github/workflows/measure.yaml@main
     secrets: inherit
-    if: inputs.measure == 'true'
+    if: inputs.measure
     with:
       name: measurement-${{ github.run_id }}
       chaos: network-latency-5

--- a/benchmarks/setup/README.md
+++ b/benchmarks/setup/README.md
@@ -82,6 +82,31 @@ In order to do this easily, just run:
 
 This will switch to the default namespace, delete the given namespace and delete the corresponding folder.
 
+## Running on stable/non-spot VMs
+
+You may sometimes want to run benchmarks on non-spot (or non-preemptible) VMs, for example, if you
+want to test for slow memory leaks.
+
+In order to do this, simply pass the copied `values-stable.yaml` file as an additional argument to
+Helm. For example:
+
+```shell
+helm install myRelease zeebe-benchmark/zeebe-benchmark -f values.yaml -f values-stable.yaml
+```
+
+You can also use the `*-stable` Makefile jobs, namely:
+
+```shell
+# Deploys the Zeebe pods on stable nodes
+make benchmark-stable
+# Spits out the rendered templates targeting stable nodes
+make template-stable
+# Updates a benchmark targeting stable nodes
+make update-stable
+```
+
+The `clean` job works regardless.
+
 ## Benchmarking Camunda Cloud SaaS
 
 _You need a Kubernetes Cluster at your disposal to run the benchmark itself, which then connects to your Camunda Cloud Cluster._

--- a/benchmarks/setup/default/Makefile
+++ b/benchmarks/setup/default/Makefile
@@ -7,15 +7,28 @@ all: benchmark
 benchmark:
 	helm install --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml --skip-crds
 
+# To deploy the Zeebe pods on stable nodes, use this job
+.PHONY: benchmark-stable
+benchmark:
+	helm install --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml -f values-stable.yaml --skip-crds
+
 # Generates templates from the zeebe helm charts, useful to make some more specific changes which are not doable by the values file.
 # To apply the templates use k apply -f zeebe-benchmark/templates/
 .PHONY: template
 template:
 	helm template $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml --skip-crds --output-dir .
 
+.PHONY: template-stable
+benchmark:
+	helm template $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml -f values-stable.yaml --skip-crds --output-dir .
+
 .PHONY: update
 update:
-	helm upgrade --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml
+	helm upgrade --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark --reuse-values -f values.yaml
+
+.PHONY: update-stable
+update:
+	helm upgrade --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark --reuse-values -f values.yaml -f values-stable.yaml
 
 .PHONY: clean
 clean:

--- a/benchmarks/setup/default/values-stable.yaml
+++ b/benchmarks/setup/default/values-stable.yaml
@@ -14,15 +14,16 @@ camunda-platform:
 
   zeebe-gateway:
     # Prefer scheduling on any non-spot VM
+    # GKE does not let us add the cloud.google.com/gke-spot label manually, so when an instance is
+    # not a spot VM, that node label simply is not present. When it is a spot VM, then the value is
+    # set to true.
     affinity:
-      podAffinity:
+      nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: cloud.google.com/gke-spot
-                  operator: In
-                  values: [ 'false' ]
-            topologyKey: "kubernetes.io/hostname"
+          nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-spot
+                operator: DoesNotExist
 
     # Ignore the stable VM node taints
     tolerations:

--- a/benchmarks/setup/default/values-stable.yaml
+++ b/benchmarks/setup/default/values-stable.yaml
@@ -1,0 +1,32 @@
+# Additional values file to run Zeebe on stable VMs
+camunda-platform:
+  zeebe:
+    # Require n2-standard-2 to ensure the broker is the only application running on its node
+    nodeSelector:
+      cloud.google.com/gke-nodepool: n2-standard-2-stable
+
+    # Ignore the stable VM node taints
+    tolerations:
+      - key: cloud.google.com/gke-spot
+        operator: Equal
+        effect: NoSchedule
+        value: 'false'
+
+  zeebe-gateway:
+    # Prefer scheduling on any non-spot VM
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: cloud.google.com/gke-spot
+                  operator: In
+                  values: [ 'false' ]
+            topologyKey: "kubernetes.io/hostname"
+
+    # Ignore the stable VM node taints
+    tolerations:
+      - key: cloud.google.com/gke-spot
+        operator: Equal
+        effect: NoSchedule
+        value: 'false'


### PR DESCRIPTION
## Description

This PR modifies the benchmark setup and GitHub action to allow deploying benchmarks on stable VMs in the GKE cluster `zeebe-cluster`. This is part of an effort to merge our GKE clusters to reduce maintenance effort.

To run benchmarks on stable VMs, we need to specify a few things:

1. Zeebe brokers and gateways must have a toleration for the non-spot taint.
2. Zeebe brokers target a new node pool made of non-spot VMs.
3. Zeebe gateways specify an affinity for non-spot VMs.

Initially I wanted to implement this as a flag in the benchmark chart, but unfortunately since we need conditionally change the values pass to the dependency chart, this is not possible. Helm does not allow templating in the values file, so we cannot do something like `camunda-platform.zeebe.nodeSelector."cloud.google.com\/gke-nodepool": n2-standard-2-{{ .Values.stable-vms }}`. We really need to specify different values during install/update.

One additional caveat is the measurements do not deploy to stable nodes. If we want this, we would need to also add a checkout step to fetch the additional values file. I don't know if I can inject that to a reusable workflow - if it's possible, happy to do so.

The PR also adds a few additional things:

- The measure input is now a boolean flag - this means it's a checkbox in the form, which is nicer than writing true/false.
- There's now a job summary at the end of deployment which will print out the user supplied values, which is useful when debugging. Caveat is don't put anything secret in there :)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
