### PR TITLE
ci(go): use go-apidiff github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,9 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: joelanford/go-apidiff@main
+        with:
+          # bors-ng fails to set ${GITHUB_BASE_REF} to the target PR branch which breaks go-apidiff
+          base-ref: origin/stable/8.2
   java-checks:
     name: Java checks
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,14 +254,6 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
-      # Once we have breaking changes, this will break since no workaround atm.
-      # Give the official gorelease a try to do this
-      - name: Check backwards compatibility
-        working-directory: clients/go/
-        run: |
-          go install github.com/joelanford/go-apidiff@latest
-          LATEST_TAG_REF=$(git rev-list --tags --max-count=1)
-          go-apidiff --repo-path=../../ $LATEST_TAG_REF
       - uses: ./.github/actions/build-docker
         id: build-docker
         with:
@@ -328,6 +320,20 @@ jobs:
           # fixed to avoid triggering false positive; see https://github.com/golangci/golangci-lint-action/issues/535
           version: v1.52.2
           working-directory: clients/go
+  go-apidiff:
+    name: Go Backward Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 #we need to fetch stable/* branches in order to be run compatibility checks
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          java: false
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: joelanford/go-apidiff@main
   java-checks:
     name: Java checks
     runs-on: ubuntu-latest
@@ -406,6 +412,7 @@ jobs:
       - codeql
       - java-checks
       - go-lint
+      - go-apidiff
       - docker-checks
     steps:
       - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,8 +338,7 @@ jobs:
       # Fetching a shallow copy of the ${GITHUB_BASE_REF} branch to check the compatibility against
       - name: Fetching Base Branch
         run: |
-          git config --add remote.origin.fetch +refs/heads/${{ env.GO_CLIENT_BASE_REF }}:refs/remotes/origin/${{ env.GO_CLIENT_BASE_REF }}
-          git fetch --depth=1
+          git fetch --depth=1 origin ${{ env.GO_CLIENT_BASE_REF }}
       - uses: joelanford/go-apidiff@main
         with:
           base-ref:  origin/${{ env.GO_CLIENT_BASE_REF }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,20 +323,26 @@ jobs:
   go-apidiff:
     name: Go Backward Compatibility
     runs-on: ubuntu-latest
+    env:
+      # bors-ng fails to set ${GITHUB_BASE_REF} to the target PR branch which breaks go-apidiff
+      # so we use this fixed value as a workaround
+      GO_CLIENT_BASE_REF: stable/8.2
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 #we need to fetch stable/* branches in order to be run compatibility checks
       - uses: ./.github/actions/setup-zeebe
         with:
           java: false
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      # Fetching a shallow copy of the ${GITHUB_BASE_REF} branch to check the compatibility against
+      - name: Fetching Base Branch
+        run: |
+          git config --add remote.origin.fetch +refs/heads/${{ env.GO_CLIENT_BASE_REF }}:refs/remotes/origin/${{ env.GO_CLIENT_BASE_REF }}
+          git fetch --depth=1
       - uses: joelanford/go-apidiff@main
         with:
-          # bors-ng fails to set ${GITHUB_BASE_REF} to the target PR branch which breaks go-apidiff
-          base-ref: origin/stable/8.2
+          base-ref:  origin/${{ env.GO_CLIENT_BASE_REF }}
   java-checks:
     name: Java checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
use `go-apidiff` github action instead of `gocompat`
- since `gocompat` is not maintained anymore
- `go-apidiff` uses golang builtin apidiff
- it has a github action



<!-- Please explain the changes you made here. -->

## Related issues
https://github.com/camunda/zeebe/issues/12649
closes: https://github.com/camunda/zeebe/issues/12860

