### PR TITLE
Remove scanning of segment on startup

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -147,31 +147,6 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldAppendPersistedRaftEntry(@TempDir final File directory) {
-    // given
-    final RaftLogEntry entry = new RaftLogEntry(1, firstApplicationEntry);
-    final var persistedRaftRecord = raftlog.append(entry).getPersistedRaftRecord();
-    final var raftlogFollower =
-        RaftLog.builder()
-            .withDirectory(directory)
-            .withName("test-follower")
-            .withMetaStore(new InMemory())
-            .build();
-
-    // when
-    final var appended = raftlogFollower.append(persistedRaftRecord);
-
-    // then
-    assertThat(raftlogFollower.getLastEntry()).isEqualTo(appended);
-    assertThat(appended.index()).isEqualTo(1);
-    assertThat(appended.entry()).isEqualTo(firstApplicationEntry);
-    assertThat(appended.getPersistedRaftRecord().asqn())
-        .isEqualTo(firstApplicationEntry.lowestPosition());
-
-    raftlogFollower.close();
-  }
-
-  @Test
   void shouldAppendReplicatableJournalRecord(@TempDir final File directory) {
     // given
     final RaftLogEntry entry = new RaftLogEntry(1, firstApplicationEntry);

--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -82,6 +82,11 @@
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -283,4 +283,12 @@ final class Segment implements AutoCloseable, FlushableSegment {
     descriptor.setLastPosition(writer.getLastEntryPosition());
     descriptor.updateIfCurrentVersion(buffer);
   }
+
+  void resetLastEntryInDescriptor() {
+    descriptor.setLastIndex(0);
+    descriptor.setLastPosition(0);
+    descriptor.updateIfCurrentVersion(buffer);
+    // flush immediately to prevent inconsistencies between descriptor and actual last written entry
+    buffer.force(0, descriptor.length());
+  }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -277,4 +277,10 @@ final class Segment implements AutoCloseable, FlushableSegment {
     }
     markedForDeletion = true;
   }
+
+  void updateDescriptor() {
+    descriptor.setLastIndex(writer.getLastIndex());
+    descriptor.setLastPosition(writer.getLastEntryPosition());
+    descriptor.updateIfCurrentVersion(buffer);
+  }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -366,6 +366,10 @@ final class SegmentDescriptor {
     // will overwrite the first entry.
   }
 
+  long lastIndex() {
+    return lastIndex;
+  }
+
   /** Segment descriptor builder. */
   static final class Builder {
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -346,6 +346,26 @@ final class SegmentDescriptor {
         + '}';
   }
 
+  int lastEntryPosition() {
+    return lastPosition;
+  }
+
+  void setLastPosition(final int lastPosition) {
+    this.lastPosition = lastPosition;
+  }
+
+  void setLastIndex(final long lastIndex) {
+    this.lastIndex = lastIndex;
+  }
+
+  void updateIfCurrentVersion(final ByteBuffer buffer) {
+    if (version >= 3) {
+      copyTo(buffer);
+    }
+    // Do not overwrite the descriptor for older versions. The new version has a higher length and
+    // will overwrite the first entry.
+  }
+
   /** Segment descriptor builder. */
   static final class Builder {
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -65,14 +65,11 @@ final class SegmentDescriptor {
   private int lastPosition;
   private int encodedLength;
   private long checksum;
-
   private final DescriptorMetadataEncoder metadataEncoder = new DescriptorMetadataEncoder();
   private final DescriptorMetadataDecoder metadataDecoder = new DescriptorMetadataDecoder();
-
   private final SegmentDescriptorDecoder segmentDescriptorDecoder = new SegmentDescriptorDecoder();
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
   private final MutableDirectBuffer directBuffer = new UnsafeBuffer();
-
   private final SegmentDescriptorEncoder segmentDescriptorEncoder = new SegmentDescriptorEncoder();
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final ChecksumGenerator checksumGen = new ChecksumGenerator();
@@ -81,7 +78,7 @@ final class SegmentDescriptor {
     directBuffer.wrap(buffer);
 
     version = directBuffer.getByte(0);
-    if (version >= 2) {
+    if (version > NO_META_VERSION) {
       readV2Descriptor(directBuffer);
     } else if (version == NO_META_VERSION) {
       readV1Descriptor(directBuffer);
@@ -361,7 +358,7 @@ final class SegmentDescriptor {
   }
 
   void updateIfCurrentVersion(final ByteBuffer buffer) {
-    if (version >= 3) {
+    if (version >= CUR_VERSION) {
       copyTo(buffer);
     }
     // Do not overwrite the descriptor for older versions. The new version has a higher length and

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -165,8 +165,8 @@ final class SegmentDescriptor {
     id = segmentDescriptorDecoder.id();
     index = segmentDescriptorDecoder.index();
     maxSegmentSize = segmentDescriptorDecoder.maxSegmentSize();
-    lastIndex = version >= 3 ? segmentDescriptorDecoder.lastIndex() : 0;
-    lastPosition = version >= 3 ? segmentDescriptorDecoder.lastPosition() : 0;
+    lastIndex = Math.max(0, segmentDescriptorDecoder.lastIndex());
+    lastPosition = Math.max(0, (int) segmentDescriptorDecoder.lastPosition());
     encodedLength =
         offset + headerDecoder.encodedLength() + segmentDescriptorDecoder.encodedLength();
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -24,6 +24,8 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The segment descriptor stores the metadata of a single segment {@link Segment} of a {@link
@@ -44,7 +46,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  * segment.
  */
 final class SegmentDescriptor {
-
+  private static final Logger LOG = LoggerFactory.getLogger(SegmentDescriptor.class);
   private static final int VERSION_LENGTH = Byte.BYTES;
   // current descriptor version containing: header, metadata, header and descriptor. descriptor
   // contains lastIndex and lastPosition. Version 2 does not contain lastIndex and lastPosition.
@@ -360,9 +362,15 @@ final class SegmentDescriptor {
   void updateIfCurrentVersion(final ByteBuffer buffer) {
     if (version >= CUR_VERSION) {
       copyTo(buffer);
+    } else {
+      // Do not overwrite the descriptor for older versions. The new version has a higher length and
+      // will overwrite the first entry.
+      LOG.trace(
+          "Segment descriptor version is {}, which is lower than current version {}."
+              + "Skipping update to the descriptor.",
+          version,
+          CUR_VERSION);
     }
-    // Do not overwrite the descriptor for older versions. The new version has a higher length and
-    // will overwrite the first entry.
   }
 
   long lastIndex() {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -47,7 +47,7 @@ final class SegmentDescriptor {
 
   private static final int VERSION_LENGTH = Byte.BYTES;
   // current descriptor version containing: header, metadata, header and descriptor. descriptor
-  // contains lastIndex and lastPosition.
+  // contains lastIndex and lastPosition. Version 2 does not contain lastIndex and lastPosition.
   private static final byte CUR_VERSION = 3;
   // previous descriptor version containing: header and descriptor
   private static final byte NO_META_VERSION = 1;
@@ -59,7 +59,9 @@ final class SegmentDescriptor {
   private long id;
   private long index;
   private int maxSegmentSize;
+  // index of the last entry in this segment. Can be 0 if not set, even if an entry exists.
   private long lastIndex;
+  // position of the last entry in this segment. Can be 0 if not set, even if an entry exists.
   private int lastPosition;
   private int encodedLength;
   private long checksum;
@@ -346,7 +348,7 @@ final class SegmentDescriptor {
         + '}';
   }
 
-  int lastEntryPosition() {
+  int lastPosition() {
     return lastPosition;
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -80,12 +80,12 @@ final class SegmentDescriptor {
     directBuffer.wrap(buffer);
 
     version = directBuffer.getByte(0);
-    if (version > NO_META_VERSION) {
+    if (version > NO_META_VERSION && version <= CUR_VERSION) {
       readV2Descriptor(directBuffer);
     } else if (version == NO_META_VERSION) {
       readV1Descriptor(directBuffer);
     } else {
-      throw new CorruptedJournalException(
+      throw new UnknownVersionException(
           String.format(
               "Expected version to be one [%d %d] but read %d instead.",
               NO_META_VERSION, CUR_VERSION, version));
@@ -229,7 +229,7 @@ final class SegmentDescriptor {
 
   /** The number of bytes required to read and write a descriptor of a given version. */
   static int getEncodingLengthForVersion(final byte version) {
-    if (version == 0 || version > VERSION_LENGTHS.length) {
+    if (version <= 0 || version > VERSION_LENGTHS.length) {
       throw new UnknownVersionException(
           String.format(
               "Expected version byte to be one [%d %d] but got %d instead.",

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -75,7 +75,7 @@ final class SegmentWriter {
     writeBuffer.wrap(buffer);
     firstAsqn = lastWrittenAsqn + 1;
     lastAsqn = lastWrittenAsqn;
-    lastEntryPosition = segment.descriptor().lastEntryPosition();
+    lastEntryPosition = segment.descriptor().lastPosition();
     this.metrics = metrics;
     if (lastEntryPosition > 0) {
       // jump to last entry

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -78,9 +78,15 @@ final class SegmentWriter {
     lastEntryPosition = segment.descriptor().lastPosition();
     this.metrics = metrics;
     if (lastEntryPosition > 0) {
+      LOG.trace(
+          "Found lastEntryPosition {} and lastIndex {} in descriptor.",
+          lastEntryPosition,
+          segment.descriptor().lastIndex());
       // jump to last entry
       jumpToLastEntry(lastEntryPosition, segment.descriptor().lastIndex());
     } else {
+      LOG.trace(
+          "Found not info about last entry in descriptor. Scanning the segment to reset the writer.");
       // iterate over all entries
       reset(0, false);
     }
@@ -284,6 +290,11 @@ final class SegmentWriter {
       - the last entry read does not have the expected index
        To simplify handling of such cases, reset the writer by scanning the whole segment.
        */
+      LOG.trace(
+          "Failed to read last entry from the given lastEntryPosition {}."
+              + "Scanning the segment to reset the writer.",
+          lastPosition,
+          e);
       reset(0, false);
     }
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -123,6 +123,7 @@ final class SegmentedJournalWriter {
   }
 
   private void createNewSegment() {
+    currentSegment.updateDescriptor();
     currentSegment = segments.getNextSegment();
     currentWriter = currentSegment.writer();
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -110,6 +110,9 @@ final class SegmentedJournalWriter {
       currentWriter = currentSegment.writer();
     }
 
+    // Reset last entry position in descriptor to 0, to ensure that after a restart it is not using
+    // the old truncated entry.
+    currentSegment.resetLastEntryInDescriptor();
     // Truncate down to the current index, such that the last index is `index`, and the next index
     // `index + 1`
     currentWriter.truncate(index);

--- a/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordSerializer.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordSerializer.java
@@ -42,6 +42,14 @@ public interface JournalRecordSerializer {
       MutableDirectBuffer writeBuffer,
       int offset);
 
+  Either<BufferOverflowException, Integer> writeDataAtVersion(
+      int version,
+      final long index,
+      final long asqn,
+      BufferWriter recordDataWriter,
+      MutableDirectBuffer writeBuffer,
+      int offset);
+
   /**
    * Writes a {@link RecordMetadata} to the buffer.
    *

--- a/journal/src/main/java/io/camunda/zeebe/journal/record/SBESerializer.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/record/SBESerializer.java
@@ -38,6 +38,18 @@ public final class SBESerializer implements JournalRecordSerializer {
       final BufferWriter recordDataWriter,
       final MutableDirectBuffer writeBuffer,
       final int offset) {
+    return writeDataAtVersion(
+        recordEncoder.sbeSchemaVersion(), index, asqn, recordDataWriter, writeBuffer, offset);
+  }
+
+  @Override
+  public Either<BufferOverflowException, Integer> writeDataAtVersion(
+      final int version,
+      final long index,
+      final long asqn,
+      final BufferWriter recordDataWriter,
+      final MutableDirectBuffer writeBuffer,
+      final int offset) {
     final int entryLength = recordDataWriter.getLength();
     final int serializedLength = getSerializedLength(entryLength);
     if (offset + serializedLength > writeBuffer.capacity()) {
@@ -49,7 +61,7 @@ public final class SBESerializer implements JournalRecordSerializer {
         .blockLength(recordEncoder.sbeBlockLength())
         .templateId(recordEncoder.sbeTemplateId())
         .schemaId(recordEncoder.sbeSchemaId())
-        .version(recordEncoder.sbeSchemaVersion());
+        .version(version);
 
     recordEncoder.wrap(writeBuffer, offset + headerEncoder.encodedLength());
 

--- a/journal/src/main/resources/journal-schema.xml
+++ b/journal/src/main/resources/journal-schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  package="io.camunda.zeebe.journal.file" id="7" version="1"
+  package="io.camunda.zeebe.journal.file" id="7" version="2"
   semanticVersion="${project.version}" description="Zeebe Journal Record Schema"
   byteOrder="littleEndian">
 
@@ -30,6 +30,8 @@
     <field name="id" id="1" type="int64"/>
     <field name="index" id="2" type="int64"/>
     <field name="maxSegmentSize" id="3" type="int32"/>
+    <field name="lastIndex" id="4" type="int64" sinceVersion="2"/>
+    <field name="lastPosition" id="5" type="int32" sinceVersion="2"/>
   </sbe:message>
 
   <sbe:message name="DescriptorMetadata" id="4" >

--- a/journal/src/main/resources/journal-schema.xml
+++ b/journal/src/main/resources/journal-schema.xml
@@ -30,8 +30,8 @@
     <field name="id" id="1" type="int64"/>
     <field name="index" id="2" type="int64"/>
     <field name="maxSegmentSize" id="3" type="int32"/>
-    <field name="lastIndex" id="4" type="int64" sinceVersion="2"/>
-    <field name="lastPosition" id="5" type="int32" sinceVersion="2"/>
+    <field name="lastIndex" id="4" type="uint64" sinceVersion="2"/>
+    <field name="lastPosition" id="5" type="uint32" sinceVersion="2"/>
   </sbe:message>
 
   <sbe:message name="DescriptorMetadata" id="4" >

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -157,7 +157,7 @@ class SegmentDescriptorTest {
         .isEqualTo(SegmentDescriptor.getEncodingLengthForVersion((byte) (2)));
   }
 
-  private static void writeDescriptorV2(
+  private void writeDescriptorV2(
       final SegmentDescriptor descriptor,
       final UnsafeBuffer directBuffer,
       final ByteBuffer buffer) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -151,10 +151,10 @@ class SegmentDescriptorTest {
     assertThat(descriptorRead.id()).isEqualTo(2);
     assertThat(descriptorRead.index()).isEqualTo(100);
     assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
-    assertThat(descriptorRead.lastIndex()).isZero();
-    assertThat(descriptorRead.lastPosition()).isZero();
     assertThat(descriptorRead.length())
         .isEqualTo(SegmentDescriptor.getEncodingLengthForVersion((byte) (2)));
+    assertThat(descriptorRead.lastIndex()).isZero();
+    assertThat(descriptorRead.lastPosition()).isZero();
   }
 
   private void writeDescriptorV2(

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -32,6 +32,8 @@ class SegmentDescriptorTest {
     // given
     SegmentDescriptor descriptor =
         SegmentDescriptor.builder().withId(2).withIndex(100).withMaxSegmentSize(1024).build();
+    descriptor.setLastPosition(100);
+    descriptor.setLastIndex(10);
     final ByteBuffer buffer = ByteBuffer.allocate(SegmentDescriptor.getEncodingLength());
     descriptor = descriptor.copyTo(buffer);
 
@@ -43,6 +45,8 @@ class SegmentDescriptorTest {
     assertThat(descriptorRead.id()).isEqualTo(2);
     assertThat(descriptorRead.index()).isEqualTo(100);
     assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
+    assertThat(descriptorRead.lastIndex()).isEqualTo(10);
+    assertThat(descriptorRead.lastEntryPosition()).isEqualTo(100);
     assertThat(descriptorRead.length()).isEqualTo(SegmentDescriptor.getEncodingLength());
   }
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.journal.CorruptedJournalException;
+import io.camunda.zeebe.journal.util.ChecksumGenerator;
 import java.nio.ByteBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -30,12 +31,12 @@ class SegmentDescriptorTest {
   @Test
   void shouldWriteAndReadDescriptor() {
     // given
-    SegmentDescriptor descriptor =
+    final SegmentDescriptor descriptor =
         SegmentDescriptor.builder().withId(2).withIndex(100).withMaxSegmentSize(1024).build();
     descriptor.setLastPosition(100);
     descriptor.setLastIndex(10);
     final ByteBuffer buffer = ByteBuffer.allocate(SegmentDescriptor.getEncodingLength());
-    descriptor = descriptor.copyTo(buffer);
+    descriptor.copyTo(buffer);
 
     // when
     final SegmentDescriptor descriptorRead = new SegmentDescriptor(buffer);
@@ -99,5 +100,102 @@ class SegmentDescriptorTest {
     // then
     assertThatThrownBy(() -> new SegmentDescriptor(buffer))
         .isInstanceOf(CorruptedJournalException.class);
+  }
+
+  @Test
+  void shouldReadV2Message() {
+    // given
+    final SegmentDescriptor descriptor =
+        SegmentDescriptor.builder().withId(2).withIndex(100).withMaxSegmentSize(1024).build();
+
+    final ByteBuffer buffer = ByteBuffer.allocate(SegmentDescriptor.getEncodingLength());
+    final UnsafeBuffer directBuffer = new UnsafeBuffer();
+    directBuffer.wrap(buffer);
+    writeDescriptorV2(descriptor, directBuffer, buffer);
+
+    // when
+    final SegmentDescriptor descriptorRead = new SegmentDescriptor(buffer);
+
+    // then
+    assertThat(descriptorRead).isEqualTo(descriptor);
+    assertThat(descriptorRead.id()).isEqualTo(2);
+    assertThat(descriptorRead.index()).isEqualTo(100);
+    assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
+    assertThat(descriptorRead.lastIndex()).isZero();
+    assertThat(descriptorRead.lastEntryPosition()).isZero();
+    assertThat(descriptorRead.length())
+        .isEqualTo(SegmentDescriptor.getEncodingLengthForVersion((byte) (2)));
+  }
+
+  @Test
+  void shouldNotOverwriteV2Descriptor() {
+    // given
+    final SegmentDescriptor descriptor =
+        SegmentDescriptor.builder().withId(2).withIndex(100).withMaxSegmentSize(1024).build();
+
+    final ByteBuffer buffer = ByteBuffer.allocate(SegmentDescriptor.getEncodingLength());
+    final UnsafeBuffer directBuffer = new UnsafeBuffer();
+    directBuffer.wrap(buffer);
+    writeDescriptorV2(descriptor, directBuffer, buffer);
+
+    // when
+    final SegmentDescriptor descriptorToUpdate = new SegmentDescriptor(buffer);
+    descriptorToUpdate.setLastIndex(100);
+    descriptorToUpdate.setLastPosition(100);
+    descriptorToUpdate.updateIfCurrentVersion(buffer);
+
+    final SegmentDescriptor descriptorRead = new SegmentDescriptor(buffer);
+
+    // then
+    assertThat(descriptorRead).isEqualTo(descriptor);
+    assertThat(descriptorRead.id()).isEqualTo(2);
+    assertThat(descriptorRead.index()).isEqualTo(100);
+    assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
+    assertThat(descriptorRead.lastIndex()).isZero();
+    assertThat(descriptorRead.lastEntryPosition()).isZero();
+    assertThat(descriptorRead.length())
+        .isEqualTo(SegmentDescriptor.getEncodingLengthForVersion((byte) (2)));
+  }
+
+  private static void writeDescriptorV2(
+      final SegmentDescriptor descriptor,
+      final UnsafeBuffer directBuffer,
+      final ByteBuffer buffer) {
+
+    final byte version = 2;
+    directBuffer.putByte(0, version);
+
+    // descriptor header
+    final int VERSION_LENGTH = Byte.BYTES;
+    final int descHeaderOffset =
+        VERSION_LENGTH
+            + MessageHeaderEncoder.ENCODED_LENGTH
+            + DescriptorMetadataEncoder.BLOCK_LENGTH;
+
+    final SegmentDescriptorEncoder segmentDescriptorEncoder = new SegmentDescriptorEncoder();
+    final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+
+    headerEncoder
+        .wrap(directBuffer, descHeaderOffset)
+        .blockLength(20)
+        .templateId(SegmentDescriptorEncoder.TEMPLATE_ID)
+        .schemaId(SegmentDescriptorEncoder.SCHEMA_ID)
+        .version(1);
+
+    segmentDescriptorEncoder.wrap(
+        directBuffer, descHeaderOffset + MessageHeaderEncoder.ENCODED_LENGTH);
+    segmentDescriptorEncoder
+        .id(descriptor.id())
+        .index(descriptor.index())
+        .maxSegmentSize(descriptor.maxSegmentSize());
+
+    final long checksum =
+        new ChecksumGenerator()
+            .compute(buffer, descHeaderOffset, headerEncoder.encodedLength() + 20);
+    final DescriptorMetadataEncoder metadataEncoder = new DescriptorMetadataEncoder();
+
+    metadataEncoder
+        .wrapAndApplyHeader(directBuffer, VERSION_LENGTH, headerEncoder)
+        .checksum(checksum);
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -47,7 +47,7 @@ class SegmentDescriptorTest {
     assertThat(descriptorRead.index()).isEqualTo(100);
     assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
     assertThat(descriptorRead.lastIndex()).isEqualTo(10);
-    assertThat(descriptorRead.lastEntryPosition()).isEqualTo(100);
+    assertThat(descriptorRead.lastPosition()).isEqualTo(100);
     assertThat(descriptorRead.length()).isEqualTo(SegmentDescriptor.getEncodingLength());
   }
 
@@ -122,7 +122,7 @@ class SegmentDescriptorTest {
     assertThat(descriptorRead.index()).isEqualTo(100);
     assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
     assertThat(descriptorRead.lastIndex()).isZero();
-    assertThat(descriptorRead.lastEntryPosition()).isZero();
+    assertThat(descriptorRead.lastPosition()).isZero();
     assertThat(descriptorRead.length())
         .isEqualTo(SegmentDescriptor.getEncodingLengthForVersion((byte) (2)));
   }
@@ -152,7 +152,7 @@ class SegmentDescriptorTest {
     assertThat(descriptorRead.index()).isEqualTo(100);
     assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
     assertThat(descriptorRead.lastIndex()).isZero();
-    assertThat(descriptorRead.lastEntryPosition()).isZero();
+    assertThat(descriptorRead.lastPosition()).isZero();
     assertThat(descriptorRead.length())
         .isEqualTo(SegmentDescriptor.getEncodingLengthForVersion((byte) (2)));
   }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -166,9 +166,9 @@ class SegmentDescriptorTest {
     directBuffer.putByte(0, version);
 
     // descriptor header
-    final int VERSION_LENGTH = Byte.BYTES;
+    final int versionLength = Byte.BYTES;
     final int descHeaderOffset =
-        VERSION_LENGTH
+        versionLength
             + MessageHeaderEncoder.ENCODED_LENGTH
             + DescriptorMetadataEncoder.BLOCK_LENGTH;
 
@@ -195,7 +195,7 @@ class SegmentDescriptorTest {
     final DescriptorMetadataEncoder metadataEncoder = new DescriptorMetadataEncoder();
 
     metadataEncoder
-        .wrapAndApplyHeader(directBuffer, VERSION_LENGTH, headerEncoder)
+        .wrapAndApplyHeader(directBuffer, versionLength, headerEncoder)
         .checksum(checksum);
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -25,6 +25,8 @@ import java.nio.ByteBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class SegmentDescriptorTest {
 
@@ -51,14 +53,16 @@ class SegmentDescriptorTest {
     assertThat(descriptorRead.length()).isEqualTo(SegmentDescriptor.getEncodingLength());
   }
 
-  @Test
-  void shouldValidateDescriptorHeader() {
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 0, 100})
+  void shouldValidateDescriptorHeader(final int invalidVersion) {
     // given
     final ByteBuffer buffer = ByteBuffer.allocate(SegmentDescriptor.getEncodingLength());
+    buffer.put(0, (byte) invalidVersion);
 
     // when/then
     assertThatThrownBy(() -> new SegmentDescriptor(buffer))
-        .isInstanceOf(CorruptedJournalException.class);
+        .isInstanceOf(UnknownVersionException.class);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -256,6 +256,29 @@ class SegmentedJournalTest {
   }
 
   @Test
+  void shouldReadTruncatedSegmentCorrectlyAfterRestart() {
+    final int entryPerSegment = 5;
+    journal = openJournal(entryPerSegment);
+    for (int i = 0; i < entryPerSegment * 2; i++) {
+      journal.append(i + 1, journalFactory.entry()).index();
+    }
+
+    final long truncateIndex = 3;
+    journal.deleteAfter(truncateIndex);
+
+    // when
+    journal.close();
+    journal = openJournal(entryPerSegment);
+    final var reader = journal.openReader();
+    journal.append(10, journalFactory.entry());
+
+    // then
+    assertThat(reader.seek(truncateIndex)).isEqualTo(truncateIndex);
+    assertThat(reader.next().index()).isEqualTo(truncateIndex);
+    assertThat(journal.getLastIndex()).isEqualTo(truncateIndex + 1);
+  }
+
+  @Test
   void shouldCompactUpToStartOfSegment() {
     final int entryPerSegment = 2;
     journal = openJournal(entryPerSegment);


### PR DESCRIPTION
## Description

To reduce the startup time, this PR removes scanning of the segments on startup. Instead metadata about last entry is persisted in the descriptor. On startup, segment writer can jump to the last entry without scanning the whole segment. 

`SegmentDescriptor` now contains two more fields:
- index of the last entry
- position of the last entry
This is used by `SegmentWriter` to jump to the last entry, if present. If these meta data is not present, it switches to scanning the whole segment.

`lastIndex` and `lastPosition` in the descriptor is only updated once when the writer moves from the segment to the next. This is done so to keep it simple. It is difficult to keep update the descriptor and the last entry in sync, as it involves when the blocks are flushed. As a result, the last segment will not have these metadata in the descriptor. So after a restart, the writer has to scan the last segment. This is ok because it is just one segment, and it will be useful to built the index in that segment.

There are some potential inconsistency between updating the descriptor and the actual last entry.
1. The descriptor is updated and flushed to disk. The last entry is not flushed to disk. On startup, when the writer jump to the lastPosition, it may not find the entry and could detect it as corruption. When this happens, we scan the whole segment to reset the writer.
2. The descriptor is not updated or flushed to disk. The last entry is flushed to disk. This is ok. If the last index and position is 0, the writer scans the segment to reset. If the last index and position is not 0, but if it points to an incorrect entry, it would detect it as corruption and switch to scanning. 
3. Segment 1 updates last index and position, write to descriptor, and move to Segment 2.  Then the journal is truncated to an index in Segment 1. Segment 2 is deleted. The entry representing last index and position in the descriptor is also deleted. This could lead to inconsistency after restart, because the writer might jump to the last entry and may not detect it as deleted or corrupted. To prevent this, before truncation we update the descriptor and flush to disk immediately.

Another caveat is that, if the descriptor was written using the old version, we should never overwrite it. This is because the descriptor length changes and this could overflow into the first entry and overwrite it. 

Note:- In this PR, after restart the index of existing segments are never re-built. This will be done in a follow up PR. 

## Related issues

related #12667 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
