### PR TITLE
fix(engine): catch-all error events with empty errorCode

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ErrorTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ErrorTransformer.java
@@ -27,19 +27,14 @@ public class ErrorTransformer implements ModelElementTransformer<Error> {
 
     final var error = new ExecutableError(element.getId());
     final var expressionLanguage = context.getExpressionLanguage();
+    final var errorCode = Optional.ofNullable(element.getErrorCode()).orElse("");
+    final Expression errorCodeExpression = expressionLanguage.parseExpression(errorCode);
 
-    // ignore error events that are not references by the process
-    Optional.ofNullable(element.getErrorCode())
-        .ifPresent(
-            errorCode -> {
-              final Expression errorCodeExpression = expressionLanguage.parseExpression(errorCode);
+    error.setErrorCodeExpression(errorCodeExpression);
+    if (errorCodeExpression.isStatic()) {
+      error.setErrorCode(BufferUtil.wrapString(errorCode));
+    }
 
-              error.setErrorCodeExpression(errorCodeExpression);
-              if (errorCodeExpression.isStatic()) {
-                error.setErrorCode(BufferUtil.wrapString(element.getErrorCode()));
-              }
-
-              context.addError(error);
-            });
+    context.addError(error);
   }
 }


### PR DESCRIPTION
## Description

If 'errorCode' is omitted, an empty error without errorCode will be created to facilitate finding catch-all error events.

## Related issues
closes #12837

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
