### PR TITLE
[Backport stable/8.2] build: remove unnecessary commit for old go compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,10 +186,6 @@ jobs:
             exit 0
           fi
 
-          pushd clients/go
-          git commit -am "build(project): update go versions"
-          popd
-
           ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${RELEASE_VERSION}"
           FILE=$(./mvnw -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"


### PR DESCRIPTION
# Description
Backport of #12724 to `stable/8.2`.

relates to 