### PR TITLE
Refactor gateway ClientStreamConsumer

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
+import java.util.concurrent.CompletableFuture;
 import org.agrona.DirectBuffer;
 
 /**
@@ -16,10 +17,11 @@ import org.agrona.DirectBuffer;
 public interface ClientStreamConsumer {
 
   /**
-   * Consumes the payload received from the server to the client. Implementation of this method can
-   * be asynchronous.
+   * Consumes the payload received from the server to the client. It is recommended to make the
+   * implementation to be asynchronous. Otherwise, it could block the thread of {@link
+   * ClientStreamService} and thus possibly delaying data from other streams being pushed.
    *
    * @param payload the data to be consumed by the client
    */
-  void push(DirectBuffer payload);
+  CompletableFuture<Void> push(DirectBuffer payload);
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
-import io.camunda.zeebe.scheduler.future.ActorFuture;
 import org.agrona.DirectBuffer;
 
 /**
@@ -22,5 +21,5 @@ public interface ClientStreamConsumer {
    *
    * @param payload the data to be consumed by the client
    */
-  ActorFuture<Void> push(DirectBuffer payload);
+  void push(DirectBuffer payload);
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
@@ -124,7 +125,10 @@ final class AggregatedClientStream<M extends BufferWriter> {
     return logicalId;
   }
 
-  void push(final DirectBuffer buffer, final ActorFuture<Void> future) {
+  void push(
+      final DirectBuffer buffer,
+      final ActorFuture<Void> future,
+      final ConcurrencyControl executor) {
     final var streams = clientStreams.values();
     if (streams.isEmpty()) {
       throw new NoSuchStreamException();
@@ -133,7 +137,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
     final var targets = new ArrayList<>(streams);
     final var index = ThreadLocalRandom.current().nextInt(streams.size());
 
-    tryPush(targets, index, 1, buffer, future);
+    tryPush(targets, index, 1, buffer, future, executor);
   }
 
   private void tryPush(
@@ -141,14 +145,14 @@ final class AggregatedClientStream<M extends BufferWriter> {
       final int index,
       final int currentCount,
       final DirectBuffer buffer,
-      final ActorFuture<Void> future) {
+      final ActorFuture<Void> future,
+      final ConcurrencyControl executor) {
     // Try with clients in a round-robin starting from the randomly picked startIndex
     final var clientStream = targets.get(index);
 
     LOGGER.trace("Pushing data from stream [{}] to client [{}]", streamId, clientStream.streamId());
     clientStream
-        .clientStreamConsumer()
-        .push(buffer)
+        .push(buffer, executor)
         .onComplete(
             (ok, pushFailed) -> {
               if (pushFailed == null) {
@@ -165,7 +169,13 @@ final class AggregatedClientStream<M extends BufferWriter> {
                       "Failed to push data to client [{}], retrying with next client.",
                       clientStream.streamId(),
                       pushFailed);
-                  tryPush(targets, (index + 1) % targets.size(), currentCount + 1, buffer, future);
+                  tryPush(
+                      targets,
+                      (index + 1) % targets.size(),
+                      currentCount + 1,
+                      buffer,
+                      future,
+                      executor);
                 }
               }
             });

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStream.java
@@ -24,14 +24,7 @@ record ClientStream<M extends BufferWriter>(
   ActorFuture<Void> push(final DirectBuffer payload, final ConcurrencyControl executor) {
     final ActorFuture<Void> result = executor.createFuture();
     try {
-      clientStreamConsumer
-          .push(payload)
-          .thenAccept(ignore -> result.complete(null))
-          .exceptionally(
-              error -> {
-                result.completeExceptionally(error);
-                return null;
-              });
+      clientStreamConsumer.push(payload).whenComplete(result);
     } catch (final Exception e) {
       result.completeExceptionally(e);
     }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
@@ -95,7 +96,9 @@ final class ClientStreamManager<M extends BufferWriter> {
   }
 
   public void onPayloadReceived(
-      final PushStreamRequest pushStreamRequest, final ActorFuture<Void> responseFuture) {
+      final PushStreamRequest pushStreamRequest,
+      final ActorFuture<Void> responseFuture,
+      final ConcurrencyControl executor) {
     final var streamId = pushStreamRequest.streamId();
     final var payload = pushStreamRequest.payload();
 
@@ -112,7 +115,7 @@ final class ClientStreamManager<M extends BufferWriter> {
     clientStream.ifPresentOrElse(
         stream -> {
           try {
-            stream.push(payload, responseFuture);
+            stream.push(payload, responseFuture, executor);
           } catch (final Exception e) {
             responseFuture.completeExceptionally(e);
           }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -67,7 +67,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
               () -> {
                 try {
                   final ActorFuture<Void> payloadPushed = new CompletableActorFuture<>();
-                  clientStreamManager.onPayloadReceived(request, payloadPushed);
+                  clientStreamManager.onPayloadReceived(request, payloadPushed, actor);
                   payloadPushed.onComplete(
                       (ok, error) -> {
                         if (error == null) {
@@ -108,10 +108,12 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
     return schedulingService.submitActor(this);
   }
 
+  @Override
   public void onServerJoined(final MemberId memberId) {
     actor.run(() -> clientStreamManager.onServerJoined(memberId));
   }
 
+  @Override
   public void onServerRemoved(final MemberId memberId) {
     actor.run(() -> clientStreamManager.onServerRemoved(memberId));
   }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
@@ -19,6 +18,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 class AggregatedClientStreamTest {
   private static final ClientStreamConsumer CLIENT_STREAM_CONSUMER =
-      p -> CompletableActorFuture.completed(null);
+      p -> CompletableFuture.completedFuture(null);
 
   private final UnsafeBuffer streamType = new UnsafeBuffer(BufferUtil.wrapString("foo"));
   private final TestSerializableData metadata = new TestSerializableData(1234);
@@ -64,7 +64,12 @@ class AggregatedClientStreamTest {
 
     final AtomicBoolean pushSucceeded = new AtomicBoolean(false);
     final ClientStreamIdImpl streamId = getNextStreamId();
-    addClient(streamId, p -> pushSucceeded.set(true));
+    addClient(
+        streamId,
+        p -> {
+          pushSucceeded.set(true);
+          return CompletableFuture.completedFuture(null);
+        });
 
     // when
     final TestActorFuture<Void> future = new TestActorFuture<>();

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistryTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistryTest.java
@@ -9,15 +9,15 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.concurrent.CompletableFuture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class ClientStreamRegistryTest {
   private static final ClientStreamConsumer CLIENT_STREAM_CONSUMER =
-      p -> CompletableActorFuture.completed(null);
+      p -> CompletableFuture.completedFuture(null);
 
   private final TestClientStreamMetrics metrics = new TestClientStreamMetrics();
   private final ClientStreamRegistry<TestSerializableData> registry =

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -138,7 +138,6 @@ class StreamIntegrationTest {
               payload.wrap(p, 0, p.capacity());
               payloads.get().add(payload.data());
               latch.countDown();
-              return TestActorFuture.completedFuture(null);
             })
         .join();
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
-import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
@@ -23,6 +22,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
@@ -138,6 +138,7 @@ class StreamIntegrationTest {
               payload.wrap(p, 0, p.capacity());
               payloads.get().add(payload.data());
               latch.countDown();
+              return CompletableFuture.completedFuture(null);
             })
         .join();
 
@@ -159,7 +160,9 @@ class StreamIntegrationTest {
     final AtomicReference<Throwable> error = new AtomicReference<>();
     final CountDownLatch latch = new CountDownLatch(1);
     final var clientStreamId =
-        clientStreamer.add(streamType, metadata, p -> TestActorFuture.completedFuture(null)).join();
+        clientStreamer
+            .add(streamType, metadata, p -> CompletableFuture.completedFuture(null))
+            .join();
     Awaitility.await().until(() -> remoteStreamer.streamFor(streamType).isPresent());
     final var serverStream = remoteStreamer.streamFor(streamType).orElseThrow();
     errorHandler =


### PR DESCRIPTION
## Description

Remove dependency to ActorFuture. Instead use CompletableFuture. This is done so that the consumers of this API do not need to know about Actors or actor scheduler. 

We assume the implementation of `ClientStreamConsumer#push` is asynchronous. But we don't enforce it. This should be taken care of in https://github.com/camunda/zeebe/issues/12389

