### PR TITLE
Build journal index on demand

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalIndex.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalIndex.java
@@ -78,4 +78,15 @@ interface JournalIndex {
 
   /** Delete all index mappings */
   void clear();
+
+  /**
+   * Checks if the entry at this index might have been already indexed. Note that the result is
+   * probabilistic. If it returns true, it does not mean the lookup return exact index. If it
+   * returns false, it is likely that calling {@link JournalIndex#index(JournalRecord, int)} with
+   * the entry at this index is useful.
+   *
+   * @param index
+   * @return true if this index likely have been already indexed. false if otherwise.
+   */
+  boolean hasIndexed(long index);
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
@@ -88,8 +88,16 @@ final class SegmentReader implements Iterator<JournalRecord> {
       currentIndex = position.index() - 1;
     }
 
+    // If the returned index is far away from the seekIndex, it is likely that this segment was not
+    // indexed before. So we try to index them during the seek.
+    final boolean shouldIndex = this.index.hasIndexed(index);
+
     while (getNextIndex() < index && hasNext()) {
-      next();
+      final var nextPosition = buffer.position();
+      final var nextEntry = next();
+      if (shouldIndex) {
+        this.index.index(nextEntry, nextPosition);
+      }
     }
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
@@ -90,7 +90,7 @@ final class SegmentReader implements Iterator<JournalRecord> {
 
     // If the returned index is far away from the seekIndex, it is likely that this segment was not
     // indexed before. So we try to index them during the seek.
-    final boolean shouldIndex = this.index.hasIndexed(index);
+    final boolean shouldIndex = !this.index.hasIndexed(index);
 
     while (getNextIndex() < index && hasNext()) {
       final var nextPosition = buffer.position();

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -174,7 +174,7 @@ public final class SegmentedJournal implements Journal {
   public JournalReader openReader() {
     final var stamped = acquireReadlock();
     try {
-      final var reader = new SegmentedJournalReader(this);
+      final var reader = new SegmentedJournalReader(this, journalMetrics);
       readers.add(reader);
       return reader;
     } finally {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
@@ -124,8 +124,7 @@ class SegmentedJournalReader implements JournalReader {
         final var index = journalIndex.lookupAsqn(asqn, indexUpperBound);
 
         // depending on the type of index, it's possible there is no ASQN indexed, in which case
-        // start
-        // from the beginning
+        // start from the beginning
         if (index == null) {
           unsafeSeekToFirst();
         } else {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
@@ -18,12 +18,15 @@ package io.camunda.zeebe.journal.file;
 import io.camunda.zeebe.journal.JournalRecord;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 final class SparseJournalIndex implements JournalIndex {
 
   private final int density;
-  private final TreeMap<Long, Integer> indexToPosition = new TreeMap<>();
-  private final TreeMap<Long, Long> asqnToIndex = new TreeMap<>();
+  private final ConcurrentNavigableMap<Long, Integer> indexToPosition =
+      new ConcurrentSkipListMap<>();
+  private final ConcurrentNavigableMap<Long, Long> asqnToIndex = new ConcurrentSkipListMap<>();
   // This is added to make deleteAfter and deleteUntil easier.
   // TODO: Check if this can be improved. https://github.com/zeebe-io/zeebe/issues/6220
   private final TreeMap<Long, Long> indexToAsqn = new TreeMap<>();

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
@@ -102,4 +102,14 @@ final class SparseJournalIndex implements JournalIndex {
     indexToAsqn.clear();
     asqnToIndex.clear();
   }
+
+  @Override
+  public boolean hasIndexed(final long index) {
+    final var indexInfo = lookup(index);
+    if (indexInfo == null) {
+      return false;
+    } else {
+      return indexInfo.index() > index - density;
+    }
+  }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SparseJournalIndex.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.journal.file;
 
 import io.camunda.zeebe.journal.JournalRecord;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
@@ -29,7 +28,7 @@ final class SparseJournalIndex implements JournalIndex {
   private final ConcurrentNavigableMap<Long, Long> asqnToIndex = new ConcurrentSkipListMap<>();
   // This is added to make deleteAfter and deleteUntil easier.
   // TODO: Check if this can be improved. https://github.com/zeebe-io/zeebe/issues/6220
-  private final TreeMap<Long, Long> indexToAsqn = new TreeMap<>();
+  private final ConcurrentNavigableMap<Long, Long> indexToAsqn = new ConcurrentSkipListMap<>();
 
   SparseJournalIndex(final int density) {
     this.density = density;

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -129,7 +129,7 @@ final class SegmentedJournalWriterTest {
   @Test
   void shouldInvalidateNextEntryAfterAppend() {
     try (final SegmentedJournalReader reader =
-        new SegmentedJournalReader(journalFactory.journal(segments))) {
+        new SegmentedJournalReader(journalFactory.journal(segments), new JournalMetrics("1"))) {
       // when
       writer.append(-1, journalFactory.entry());
 
@@ -155,7 +155,8 @@ final class SegmentedJournalWriterTest {
             followerJournalFactory.metrics());
 
     try (final SegmentedJournalReader reader =
-        new SegmentedJournalReader(followerJournalFactory.journal(followerSegments))) {
+        new SegmentedJournalReader(
+            followerJournalFactory.journal(followerSegments), new JournalMetrics("1"))) {
       // when
       final byte[] serializedRecord = BufferUtil.bufferAsArray(writtenRecord.serializedRecord());
       followerWriter.append(writtenRecord.checksum(), serializedRecord);

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -238,5 +239,30 @@ class SparseJournalIndexTest {
     assertEquals(4, index.lookupAsqn(5, 5));
     assertEquals(4, index.lookupAsqn(Long.MAX_VALUE, 5));
     assertEquals(6, index.lookupAsqn(Long.MAX_VALUE, 6));
+  }
+
+  @Test
+  void shouldReturnAsIndexedWhenWithInDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    index.index(asJournalRecord(5, 1), 2);
+
+    // when - then
+    assertThat(index.hasIndexed(6)).isTrue();
+    assertThat(index.hasIndexed(7)).isTrue();
+    assertThat(index.hasIndexed(8)).isTrue();
+    assertThat(index.hasIndexed(9)).isTrue();
+  }
+
+  @Test
+  void shouldReturnAsNotIndexedWhenOutsideDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    index.index(asJournalRecord(5, 1), 2);
+
+    // when - then
+    assertThat(index.hasIndexed(10)).isFalse();
+    assertThat(index.hasIndexed(11)).isFalse();
+    assertThat(index.hasIndexed(100)).isFalse();
   }
 }


### PR DESCRIPTION
## Description

With PR #12839 , we do not built index of segment entries for existing segments after restart. This can impact seek time, as the seek has to read all entries to reach the desired index. In this PR, we built the index on demand - that is the  first time when a reader seek to an unindexed entry, it index the entries that it read while seeking. If the reader has to seek again, then it can use the index. There are cases where reader has to seek twice such in seekToAsqn, or in rare cases, if the follower fails frequently, leader has to reset the index by seeking. 

Pros:
- Only index if necessary. This operation is cheap as the seek has to read the entries anyway and indexing is cheap. 

Cons:
- First seek can still be slow if the entry is not at the beginning of a segment.
- The index re-built may not be used again, if there is not another seek in the same segment.

Alternative approach:
- Built index in a background thread after startup. However, I'm not sure if the complexity is worth it as the segments will be most likely deleted soon.

## Related issues

closes #12667

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
