### PR TITLE
a send task or message throw events can reference publish message

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -223,6 +223,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeLoopCharacteristicsI
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeOutputImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebePropertiesImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebePropertyImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebePublishMessageImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeScriptImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeSubscriptionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskDefinitionImpl;
@@ -653,6 +654,7 @@ public class Bpmn {
     ZeebePropertyImpl.registerType(bpmnModelBuilder);
     ZeebePropertiesImpl.registerType(bpmnModelBuilder);
     ZeebeScriptImpl.registerType(bpmnModelBuilder);
+    ZeebePublishMessageImpl.registerType(bpmnModelBuilder);
   }
 
   /**

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractSendTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractSendTaskBuilder.java
@@ -17,9 +17,11 @@
 package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.zeebe.PublishMessageBuilder;
 import io.camunda.zeebe.model.bpmn.instance.Message;
 import io.camunda.zeebe.model.bpmn.instance.Operation;
 import io.camunda.zeebe.model.bpmn.instance.SendTask;
+import java.util.function.Consumer;
 
 /**
  * @author Sebastian Menski
@@ -64,6 +66,13 @@ public abstract class AbstractSendTaskBuilder<B extends AbstractSendTaskBuilder<
   public B message(final String messageName) {
     final Message message = findMessageForName(messageName);
     return message(message);
+  }
+
+  public B message(final Consumer<PublishMessageBuilder> consumer) {
+    final PublishMessageBuilder builder =
+        new PublishMessageBuilder(modelInstance, element, element::setMessage);
+    consumer.accept(builder);
+    return myself;
   }
 
   /**

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
@@ -17,12 +17,14 @@
 package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.zeebe.PublishMessageBuilder;
 import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ThrowEvent;
+import java.util.function.Consumer;
 
 /**
  * @author Sebastian Menski
@@ -52,6 +54,17 @@ public abstract class AbstractThrowEventBuilder<
     final MessageEventDefinition messageEventDefinition = createMessageEventDefinition(messageName);
     element.getEventDefinitions().add(messageEventDefinition);
 
+    return myself;
+  }
+
+  public B message(final Consumer<PublishMessageBuilder> consumer) {
+    final MessageEventDefinition messageEventDefinition = createEmptyMessageEventDefinition();
+    final PublishMessageBuilder builder =
+        new PublishMessageBuilder(
+            modelInstance, messageEventDefinition, messageEventDefinition::setMessage);
+
+    consumer.accept(builder);
+    element.getEventDefinitions().add(messageEventDefinition);
     return myself;
   }
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/zeebe/PublishMessageBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/zeebe/PublishMessageBuilder.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder.zeebe;
+
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.Message;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import java.util.function.Consumer;
+
+public class PublishMessageBuilder
+    extends AbstractBaseElementBuilder<PublishMessageBuilder, BaseElement> {
+  public final Consumer<Message> consumer;
+
+  public PublishMessageBuilder(
+      final BpmnModelInstance modelInstance,
+      final BaseElement element,
+      final Consumer<Message> consumer) {
+    super(modelInstance, element, PublishMessageBuilder.class);
+    this.consumer = consumer;
+  }
+
+  public PublishMessageBuilder name(final String name) {
+    consumer.accept(findMessageForName(name));
+    return this;
+  }
+
+  public PublishMessageBuilder nameExpression(final String nameExpression) {
+    return name(asZeebeExpression(nameExpression));
+  }
+
+  /**
+   * Sets a static id of the message.
+   *
+   * @param messageId the id of the message
+   * @return the builder object
+   */
+  public PublishMessageBuilder zeebeMessageId(final String messageId) {
+    final ZeebePublishMessage publishMessage =
+        getCreateSingleExtensionElement(ZeebePublishMessage.class);
+    publishMessage.setMessageId(messageId);
+
+    return myself;
+  }
+
+  /**
+   * Sets a dynamic id of the message. The id is retrieved from the given expression.
+   *
+   * @param messageIdExpression the expression for the id of the message
+   * @return the builder object
+   */
+  public PublishMessageBuilder zeebeMessageIdExpression(final String messageIdExpression) {
+    return zeebeMessageId(asZeebeExpression(messageIdExpression));
+  }
+
+  /**
+   * Sets a static correlation key of the message.
+   *
+   * @param correlationKey the correlation key of the message
+   * @return the builder object
+   */
+  public PublishMessageBuilder zeebeCorrelationKey(String correlationKey) {
+    final ZeebePublishMessage publishMessage =
+        getCreateSingleExtensionElement(ZeebePublishMessage.class);
+    publishMessage.setCorrelationKey(correlationKey);
+
+    return myself;
+  }
+
+  /**
+   * Sets a dynamic correlation key of the message. The correlation key is retrieved from the given
+   * expression.
+   *
+   * @param correlationKeyExpression the expression for the correlation key of the message
+   * @return the builder object
+   */
+  public PublishMessageBuilder zeebeCorrelationKeyExpression(
+      final String correlationKeyExpression) {
+    return zeebeCorrelationKey(asZeebeExpression(correlationKeyExpression));
+  }
+
+  /**
+   * Sets a static time to live of the message.
+   *
+   * @param timeToLive the correlation key of the message
+   * @return the builder object
+   */
+  public PublishMessageBuilder zeebeTimeToLive(String timeToLive) {
+    final ZeebePublishMessage publishMessage =
+        getCreateSingleExtensionElement(ZeebePublishMessage.class);
+    publishMessage.setTimeToLive(timeToLive);
+
+    return myself;
+  }
+
+  /**
+   * Sets a dynamic time to live of the message. The time to live is retrieved from the given
+   * expression.
+   *
+   * @param timeToLiveExpression the expression for the time to live of the message
+   * @return the builder object
+   */
+  public PublishMessageBuilder zeebeTimeToLiveExpression(final String timeToLiveExpression) {
+    return zeebeTimeToLive(asZeebeExpression(timeToLiveExpression));
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -28,6 +28,8 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_TARGET = "target";
 
   public static final String ATTRIBUTE_CORRELATION_KEY = "correlationKey";
+  public static final String ATTRIBUTE_MESSAGE_ID = "messageId";
+  public static final String ATTRIBUTE_MESSAGE_TIME_TO_LIVE = "timeToLive";
 
   public static final String ATTRIBUTE_INPUT_COLLECTION = "inputCollection";
   public static final String ATTRIBUTE_INPUT_ELEMENT = "inputElement";
@@ -59,6 +61,7 @@ public class ZeebeConstants {
 
   public static final String ELEMENT_SCRIPT = "script";
   public static final String ELEMENT_SUBSCRIPTION = "subscription";
+  public static final String ELEMENT_PUBLISH_MESSAGE = "publishMessage";
 
   public static final String ELEMENT_TASK_DEFINITION = "taskDefinition";
   public static final String ELEMENT_TASK_HEADERS = "taskHeaders";

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebePublishMessageImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebePublishMessageImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebePublishMessageImpl extends BpmnModelElementInstanceImpl
+    implements ZeebePublishMessage {
+
+  private static Attribute<String> messageIdAttribute;
+  private static Attribute<String> correlationKeyAttribute;
+  private static Attribute<String> timeToLiveAttribute;
+
+  public ZeebePublishMessageImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebePublishMessage.class, ZeebeConstants.ELEMENT_PUBLISH_MESSAGE)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebePublishMessageImpl::new);
+
+    correlationKeyAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_CORRELATION_KEY)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    messageIdAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_MESSAGE_ID)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    timeToLiveAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_MESSAGE_TIME_TO_LIVE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    typeBuilder.build();
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return correlationKeyAttribute.getValue(this);
+  }
+
+  @Override
+  public void setCorrelationKey(final String correlationKey) {
+    correlationKeyAttribute.setValue(this, correlationKey);
+  }
+
+  @Override
+  public String getMessageId() {
+    return messageIdAttribute.getValue(this);
+  }
+
+  @Override
+  public void setMessageId(final String messageId) {
+    messageIdAttribute.setValue(this, messageId);
+  }
+
+  @Override
+  public String getTimeToLive() {
+    return timeToLiveAttribute.getValue(this);
+  }
+
+  @Override
+  public void setTimeToLive(final String timeToLive) {
+    timeToLiveAttribute.setValue(this, timeToLive);
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebePublishMessage.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebePublishMessage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+public interface ZeebePublishMessage extends BpmnModelElementInstance {
+
+  /**
+   * @return the correlation key of the message
+   */
+  String getCorrelationKey();
+
+  /**
+   * Sets the correlation key of the message.
+   *
+   * @param correlationKey the correlation key of the message
+   */
+  void setCorrelationKey(String correlationKey);
+
+  /**
+   * @return the id of the message
+   */
+  String getMessageId();
+
+  /**
+   * Sets the id of the message.
+   *
+   * @param messageId the id of the message
+   */
+  void setMessageId(String messageId);
+
+  /**
+   * @return the time to live of the message
+   */
+  String getTimeToLive();
+
+  /**
+   * Sets the time to live of the message.
+   *
+   * @param timeToLive the time to live of the message
+   */
+  void setTimeToLive(final String timeToLive);
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageThrowEventValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageThrowEventValidator.java
@@ -15,20 +15,20 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
+import io.camunda.zeebe.model.bpmn.impl.QueryImpl;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ThrowEvent;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import java.util.Collection;
+import java.util.Collections;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
 public class MessageThrowEventValidator implements ModelElementValidator<ThrowEvent> {
-
-  private final ExtensionElementsValidator<ThrowEvent, ZeebeTaskDefinition>
-      extensionElementsValidator =
-          ExtensionElementsValidator.verifyThat(ThrowEvent.class)
-              .hasSingleExtensionElement(
-                  ZeebeTaskDefinition.class, ZeebeConstants.ELEMENT_TASK_DEFINITION);
 
   @Override
   public Class<ThrowEvent> getElementType() {
@@ -40,13 +40,52 @@ public class MessageThrowEventValidator implements ModelElementValidator<ThrowEv
       final ThrowEvent element, final ValidationResultCollector validationResultCollector) {
 
     if (isMessageThrowEvent(element)) {
-      // a message throw event must have a task definition
-      extensionElementsValidator.validate(element, validationResultCollector);
+      final MessageEventDefinition messageEventDefinition = getEventDefinition(element);
+      final Collection<ZeebePublishMessage> publishMessageExtensions =
+          getExtensionElementsByType(
+              messageEventDefinition.getExtensionElements(), ZeebePublishMessage.class);
+
+      final Collection<ZeebeTaskDefinition> taskDefinitionExtensions =
+          getExtensionElementsByType(element.getExtensionElements(), ZeebeTaskDefinition.class);
+
+      // a message throw event must have either one task definition or publish message
+      if (!hasExactlyOneExtension(publishMessageExtensions, taskDefinitionExtensions)) {
+        validationResultCollector.addError(
+            0,
+            String.format(
+                "Must have either one 'zeebe:%s' or one 'zeebe:%s' extension element",
+                ZeebeConstants.ELEMENT_PUBLISH_MESSAGE, ZeebeConstants.ELEMENT_TASK_DEFINITION));
+      } else {
+        if (taskDefinitionExtensions.isEmpty() && messageEventDefinition.getMessage() == null) {
+          validationResultCollector.addError(0, "Must reference a message");
+        }
+      }
     }
   }
 
   private boolean isMessageThrowEvent(final ThrowEvent element) {
     return element.getEventDefinitions().stream()
         .anyMatch(MessageEventDefinition.class::isInstance);
+  }
+
+  private MessageEventDefinition getEventDefinition(final ThrowEvent event) {
+    return new QueryImpl<>(event.getEventDefinitions())
+        .filterByType(MessageEventDefinition.class)
+        .singleResult();
+  }
+
+  public <T extends BpmnModelElementInstance> Collection<T> getExtensionElementsByType(
+      final ExtensionElements extensionElements, Class<T> type) {
+    if (extensionElements == null) {
+      return Collections.emptyList();
+    }
+    return extensionElements.getChildElementsByType(type);
+  }
+
+  private boolean hasExactlyOneExtension(
+      final Collection<ZeebePublishMessage> publishMessageExtensions,
+      final Collection<ZeebeTaskDefinition> taskDefinitionExtensions) {
+    return publishMessageExtensions.size() == 1 && taskDefinitionExtensions.isEmpty()
+        || publishMessageExtensions.isEmpty() && taskDefinitionExtensions.size() == 1;
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SendTaskValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SendTaskValidator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import java.util.Collection;
+import java.util.Collections;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public final class SendTaskValidator implements ModelElementValidator<SendTask> {
+
+  @Override
+  public Class<SendTask> getElementType() {
+    return SendTask.class;
+  }
+
+  @Override
+  public void validate(
+      final SendTask element, final ValidationResultCollector validationResultCollector) {
+    final ExtensionElements extensionElements = element.getExtensionElements();
+
+    final Collection<ZeebePublishMessage> publishMessageExtensions =
+        getExtensionElementsByType(extensionElements, ZeebePublishMessage.class);
+    final Collection<ZeebeTaskDefinition> taskDefinitionExtensions =
+        getExtensionElementsByType(extensionElements, ZeebeTaskDefinition.class);
+
+    if (!hasExactlyOneExtension(publishMessageExtensions, taskDefinitionExtensions)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Must have either one 'zeebe:%s' or one 'zeebe:%s' extension element",
+              ZeebeConstants.ELEMENT_PUBLISH_MESSAGE, ZeebeConstants.ELEMENT_TASK_DEFINITION));
+    }
+
+    if (!publishMessageExtensions.isEmpty() && element.getMessage() == null) {
+      validationResultCollector.addError(0, "Must reference a message");
+    }
+  }
+
+  public <T extends BpmnModelElementInstance> Collection<T> getExtensionElementsByType(
+      final ExtensionElements extensionElements, Class<T> type) {
+    if (extensionElements == null) {
+      return Collections.emptyList();
+    }
+    return extensionElements.getChildElementsByType(type);
+  }
+
+  private boolean hasExactlyOneExtension(
+      final Collection<ZeebePublishMessage> publishMessageExtensions,
+      final Collection<ZeebeTaskDefinition> taskDefinitionExtensions) {
+    return publishMessageExtensions.size() == 1 && taskDefinitionExtensions.isEmpty()
+        || publishMessageExtensions.isEmpty() && taskDefinitionExtensions.size() == 1;
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -18,12 +18,12 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
-import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
@@ -67,10 +67,6 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new ScriptTaskValidation());
     validators.add(new SequenceFlowValidator());
     validators.add(
-        ExtensionElementsValidator.verifyThat(SendTask.class)
-            .hasSingleExtensionElement(
-                ZeebeTaskDefinition.class, ZeebeConstants.ELEMENT_TASK_DEFINITION));
-    validators.add(
         ExtensionElementsValidator.verifyThat(ServiceTask.class)
             .hasSingleExtensionElement(
                 ZeebeTaskDefinition.class, ZeebeConstants.ELEMENT_TASK_DEFINITION));
@@ -113,6 +109,11 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new LinkEventDefinitionValidator());
     validators.add(new EscalationEventDefinitionValidator());
     validators.add(new EscalationValidator());
+    validators.add(new SendTaskValidator());
+    validators.add(
+        ZeebeElementValidator.verifyThat(ZeebePublishMessage.class)
+            .hasNonEmptyAttribute(
+                ZeebePublishMessage::getCorrelationKey, ZeebeConstants.ATTRIBUTE_CORRELATION_KEY));
 
     VALIDATORS = Collections.unmodifiableList(validators);
   }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/EndEventBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/EndEventBuilderTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.impl.QueryImpl;
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import org.junit.jupiter.api.Test;
+
+public class EndEventBuilderTest {
+
+  @Test
+  void shouldSetMessageId() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("message")
+            .message(b -> b.name("message").zeebeMessageId("message-id-1"))
+            .done();
+
+    // then
+    final EndEvent event = instance.getModelElementById("message");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getMessageId)
+        .containsExactly("message-id-1");
+  }
+
+  @Test
+  void shouldSetMessageIdExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("message")
+            .message(b -> b.name("message").zeebeMessageIdExpression("messageIdExpr"))
+            .done();
+
+    // then
+    final EndEvent event = instance.getModelElementById("message");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getMessageId)
+        .containsExactly("=messageIdExpr");
+  }
+
+  @Test
+  void shouldSetCorrelationKey() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("message")
+            .message(b -> b.name("message").zeebeCorrelationKey("correlation-key-1"))
+            .done();
+
+    // then
+    final EndEvent event = instance.getModelElementById("message");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getCorrelationKey)
+        .containsExactly("correlation-key-1");
+  }
+
+  @Test
+  void shouldSetCorrelationKeyExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("message")
+            .message(b -> b.name("message").zeebeCorrelationKeyExpression("correlationKeyExpr"))
+            .done();
+
+    // then
+    final EndEvent event = instance.getModelElementById("message");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getCorrelationKey)
+        .containsExactly("=correlationKeyExpr");
+  }
+
+  @Test
+  void shouldSetTimeToLive() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("message")
+            .message(b -> b.name("message").zeebeTimeToLive("PT10S"))
+            .done();
+
+    // then
+    final EndEvent event = instance.getModelElementById("message");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getTimeToLive)
+        .containsExactly("PT10S");
+  }
+
+  @Test
+  void shouldSetTimeToLiveExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("message")
+            .message(b -> b.name("message").zeebeTimeToLiveExpression("timeToLiveExpr"))
+            .done();
+
+    // then
+    final EndEvent event = instance.getModelElementById("message");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getTimeToLive)
+        .containsExactly("=timeToLiveExpr");
+  }
+
+  @Test
+  void shouldSetMessageIdAndCorrelationKeyAndTimeToLive() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("message")
+            .message(
+                m ->
+                    m.zeebeMessageId("message-id")
+                        .zeebeCorrelationKey("correlation-key")
+                        .zeebeTimeToLive("PT10S"))
+            .done();
+
+    // then
+    final EndEvent event = instance.getModelElementById("message");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(
+            ZeebePublishMessage::getMessageId,
+            ZeebePublishMessage::getCorrelationKey,
+            ZeebePublishMessage::getTimeToLive)
+        .containsExactly(tuple("message-id", "correlation-key", "PT10S"));
+  }
+
+  private MessageEventDefinition getEventDefinition(final EndEvent event) {
+    return new QueryImpl<>(event.getEventDefinitions())
+        .filterByType(MessageEventDefinition.class)
+        .singleResult();
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/IntermediateThrowEventBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/IntermediateThrowEventBuilderTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.impl.QueryImpl;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
+import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import org.junit.jupiter.api.Test;
+
+public class IntermediateThrowEventBuilderTest {
+
+  @Test
+  void shouldSetMessageId() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent("throw")
+            .message(b -> b.name("message").zeebeMessageId("message-id-1"))
+            .done();
+
+    // then
+    final IntermediateThrowEvent event = instance.getModelElementById("throw");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getMessageId)
+        .containsExactly("message-id-1");
+  }
+
+  @Test
+  void shouldSetMessageIdExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent("throw")
+            .message(b -> b.name("message").zeebeMessageIdExpression("messageIdExpr"))
+            .done();
+
+    // then
+    final IntermediateThrowEvent event = instance.getModelElementById("throw");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getMessageId)
+        .containsExactly("=messageIdExpr");
+  }
+
+  @Test
+  void shouldSetCorrelationKey() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent("throw")
+            .message(b -> b.name("message").zeebeCorrelationKey("correlation-key-1"))
+            .done();
+
+    // then
+    final IntermediateThrowEvent event = instance.getModelElementById("throw");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getCorrelationKey)
+        .containsExactly("correlation-key-1");
+  }
+
+  @Test
+  void shouldSetCorrelationKeyExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent("throw")
+            .message(b -> b.name("message").zeebeCorrelationKeyExpression("correlationKeyExpr"))
+            .done();
+
+    // then
+    final IntermediateThrowEvent event = instance.getModelElementById("throw");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getCorrelationKey)
+        .containsExactly("=correlationKeyExpr");
+  }
+
+  @Test
+  void shouldSetTimeToLive() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent("throw")
+            .message(b -> b.name("message").zeebeTimeToLive("PT10S"))
+            .done();
+
+    // then
+    final IntermediateThrowEvent event = instance.getModelElementById("throw");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getTimeToLive)
+        .containsExactly("PT10S");
+  }
+
+  @Test
+  void shouldSetTimeToLiveExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent("throw")
+            .message(b -> b.name("message").zeebeTimeToLiveExpression("timeToLiveExpr"))
+            .done();
+
+    // then
+    final IntermediateThrowEvent event = instance.getModelElementById("throw");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getTimeToLive)
+        .containsExactly("=timeToLiveExpr");
+  }
+
+  @Test
+  void shouldSetMessageIdAndCorrelationKeyAndTimeToLive() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent("throw")
+            .message(
+                b ->
+                    b.name("message")
+                        .zeebeMessageId("message-id")
+                        .zeebeCorrelationKey("correlation-key")
+                        .zeebeTimeToLive("PT10S"))
+            .done();
+
+    // then
+    final IntermediateThrowEvent event = instance.getModelElementById("throw");
+    final MessageEventDefinition messageEventDefinition = getEventDefinition(event);
+    final ExtensionElements extensionElements =
+        (ExtensionElements)
+            messageEventDefinition.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(
+            ZeebePublishMessage::getMessageId,
+            ZeebePublishMessage::getCorrelationKey,
+            ZeebePublishMessage::getTimeToLive)
+        .containsExactly(tuple("message-id", "correlation-key", "PT10S"));
+  }
+
+  private MessageEventDefinition getEventDefinition(final IntermediateThrowEvent event) {
+    return new QueryImpl<>(event.getEventDefinitions())
+        .filterByType(MessageEventDefinition.class)
+        .singleResult();
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/SendTaskBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/SendTaskBuilderTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.jupiter.api.Test;
+
+public class SendTaskBuilderTest {
+
+  @Test
+  void shouldSetMessageId() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(b -> b.name("message").zeebeMessageId("message-id-1"))
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getMessageId)
+        .containsExactly("message-id-1");
+  }
+
+  @Test
+  void shouldSetMessageIdExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(b -> b.name("message").zeebeMessageIdExpression("messageIdExpr"))
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getMessageId)
+        .containsExactly("=messageIdExpr");
+  }
+
+  @Test
+  void shouldSetCorrelationKey() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(b -> b.name("message").zeebeCorrelationKey("correlation-key-1"))
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getCorrelationKey)
+        .containsExactly("correlation-key-1");
+  }
+
+  @Test
+  void shouldSetCorrelationKeyExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(b -> b.name("message").zeebeCorrelationKeyExpression("correlationKeyExpr"))
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getCorrelationKey)
+        .containsExactly("=correlationKeyExpr");
+  }
+
+  @Test
+  void shouldSetTimeToLive() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(b -> b.name("message").zeebeTimeToLive("PT10S"))
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getTimeToLive)
+        .containsExactly("PT10S");
+  }
+
+  @Test
+  void shouldSetTimeToLiveExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(b -> b.name("message").zeebeTimeToLiveExpression("timeToLiveExpr"))
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(ZeebePublishMessage::getTimeToLive)
+        .containsExactly("=timeToLiveExpr");
+  }
+
+  @Test
+  void shouldSetMessageNameAndMessageIdAndCorrelationKeyAndTimeToLive() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(
+                b ->
+                    b.name("message")
+                        .zeebeMessageId("message-id")
+                        .zeebeCorrelationKey("correlation-key")
+                        .zeebeTimeToLive("PT10S"))
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+
+    assertThat(extensionElements.getChildElementsByType(ZeebePublishMessage.class))
+        .hasSize(1)
+        .extracting(
+            ZeebePublishMessage::getMessageId,
+            ZeebePublishMessage::getCorrelationKey,
+            ZeebePublishMessage::getTimeToLive)
+        .containsExactly(tuple("message-id", "correlation-key", "PT10S"));
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
@@ -106,6 +106,11 @@ class ZeebeEndEventValidationTest {
         new EndEventTypeBuilder(
             MessageEventDefinition.class,
             endEvent -> endEvent.message("message-name").zeebeJobType("job-type")),
+        new EndEventTypeBuilder(
+            MessageEventDefinition.class,
+            endEvent ->
+                endEvent.message(
+                    b -> b.name("message-name").zeebeCorrelationKey("correlationKey"))),
         new EndEventTypeBuilder(TerminateEventDefinition.class, EndEventBuilder::terminate));
   }
 

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobWorkerElementValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobWorkerElementValidationTest.java
@@ -76,13 +76,16 @@ public class ZeebeJobWorkerElementValidationTest {
 
   @ParameterizedTest
   @MethodSource("jobWorkerElementBuilderProvider")
-  @DisplayName("element without job type")
-  void missingJobType(final JobWorkerElementBuilder elementBuilder) {
-
+  @DisplayName("element without job type or publish message")
+  void missingJobTypeOrPublishMessage(final JobWorkerElementBuilder elementBuilder) {
+    String message =
+        "Must have either one 'zeebe:publishMessage' or one 'zeebe:taskDefinition' extension element";
+    if ("serviceTask".equals(elementBuilder.elementType)) {
+      message = "Must have exactly one 'zeebe:taskDefinition' extension element";
+    }
     final BpmnModelInstance process = processWithJobWorkerElement(elementBuilder, element -> {});
 
-    ProcessValidationUtil.assertThatProcessHasViolations(
-        process, expect("task", "Must have exactly one 'zeebe:taskDefinition' extension element"));
+    ProcessValidationUtil.assertThatProcessHasViolations(process, expect("task", message));
   }
 
   @ParameterizedTest

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeSendTaskValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeSendTaskValidationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.zeebe.PublishMessageBuilder;
+import io.camunda.zeebe.model.bpmn.instance.Message;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class ZeebeSendTaskValidationTest {
+
+  @Test
+  void noMessageRef() {
+    // when
+    final BpmnModelInstance process = process(b -> b.zeebeCorrelationKey("corrleationKey"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(SendTask.class, "Must reference a message"));
+  }
+
+  @Test
+  void emptyMessageName() {
+    // when
+    final BpmnModelInstance process =
+        process(b -> b.name("").zeebeCorrelationKey("corrleationKey"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(Message.class, "Name must be present and not empty"));
+  }
+
+  @Test
+  void emptyCorrleationKey() {
+    // when
+    final BpmnModelInstance process = process(b -> b.name("message-name").zeebeCorrelationKey(""));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebePublishMessage.class, "Attribute 'correlationKey' must be present and not empty"));
+  }
+
+  @Test
+  void noPublishMessageAndTaskDefinitionExtension() {
+    // when
+    final BpmnModelInstance process = process(b -> {});
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        ExpectedValidationResult.expect(
+            SendTask.class,
+            "Must have either one 'zeebe:publishMessage' or one 'zeebe:taskDefinition' extension element"));
+  }
+
+  @Test
+  void emptyJobType() {
+    // when
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("jobType"))
+            .zeebeJobType("")
+            .done();
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(ZeebeTaskDefinition.class, "Attribute 'type' must be present and not empty"));
+  }
+
+  @Test
+  void bothPublishMessageAndTaskDefinitionExtension() {
+    // when
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("jobType"))
+            .message(b -> b.name("message-name").zeebeCorrelationKey("corrleation-key"))
+            .done();
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        ExpectedValidationResult.expect(
+            SendTask.class,
+            "Must have either one 'zeebe:publishMessage' or one 'zeebe:taskDefinition' extension element"));
+  }
+
+  private BpmnModelInstance process(final Consumer<PublishMessageBuilder> consumer) {
+    return Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .sendTask("task")
+        .message(consumer)
+        .done();
+  }
+}


### PR DESCRIPTION
## Description

* add the new Zeebe extension element `publishMessage` with the attributes
    * `messageId`
    *  `correlationKey`
    *  `timeToLive`
* extend the builder of send tasks and throw events to define the publish message

## Related issues
closes #12878

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
