### PR TITLE
Allow configuring request timeout for InstallRequest

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 public class RaftPartitionConfig {
 
   private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
+  private static final Duration DEFAULT_SNAPSHOT_REQUEST_TIMEOUT = Duration.ofMillis(2500);
   private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
   private static final boolean DEFAULT_PRIORITY_ELECTION = true;
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
@@ -37,6 +38,7 @@ public class RaftPartitionConfig {
   private int maxAppendBatchSize = 32 * 1024;
   private boolean priorityElectionEnabled = DEFAULT_PRIORITY_ELECTION;
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  private Duration snapshotRequestTimeout = DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private PartitionDistributor partitionDistributor = DEFAULT_PARTITION_DISTRIBUTOR;
@@ -119,6 +121,19 @@ public class RaftPartitionConfig {
     this.requestTimeout = requestTimeout;
   }
 
+  public Duration getSnapshotRequestTimeout() {
+    return snapshotRequestTimeout;
+  }
+
+  /**
+   * Sets the timeout for every snapshot request sent by raft leaders to the followers.
+   *
+   * @param snapshotRequestTimeout the request timeout
+   */
+  public void setSnapshotRequestTimeout(final Duration snapshotRequestTimeout) {
+    this.snapshotRequestTimeout = snapshotRequestTimeout;
+  }
+
   public int getMinStepDownFailureCount() {
     return minStepDownFailureCount;
   }
@@ -183,6 +198,8 @@ public class RaftPartitionConfig {
         + priorityElectionEnabled
         + ", requestTimeout="
         + requestTimeout
+        + ", snapshotRequestTimeout="
+        + snapshotRequestTimeout
         + ", minStepDownFailureCount="
         + minStepDownFailureCount
         + ", maxQuorumResponseTimeout="

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -416,6 +416,17 @@ public final class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
+     * Sets the snapshot request timeout for all messages sent between raft replicas.
+     *
+     * @param snapshotRequestTimeout the timeout
+     * @return the Raft Partition group builder
+     */
+    public Builder withSnapshotRequestTimeout(final Duration snapshotRequestTimeout) {
+      config.getPartitionConfig().setSnapshotRequestTimeout(snapshotRequestTimeout);
+      return this;
+    }
+
+    /**
      * If the leader is not able to reach the quorum, the leader may step down. This is triggered
      * after minStepDownFailureCount number of requests fails to get a response from the quorum of
      * followers as well as if the last response was received before maxQuorumResponseTime.

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -69,7 +69,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
   private final Set<FailureListener> deferredFailureListeners = new CopyOnWriteArraySet<>();
   private final PartitionMetadata partitionMetadata;
   private final Duration requestTimeout;
-
+  private final Duration snapshotRequestTimeout;
   private RaftServer server;
   private ReceivableSnapshotStore persistedSnapshotStore;
 
@@ -91,6 +91,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
             LoggerContext.builder(RaftPartitionServer.class).addValue(partition.name()).build());
     this.partitionMetadata = partitionMetadata;
     requestTimeout = config.getPartitionConfig().getRequestTimeout();
+    snapshotRequestTimeout = config.getPartitionConfig().getSnapshotRequestTimeout();
   }
 
   @Override
@@ -336,7 +337,8 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
         partition.name(),
         Serializer.using(RaftNamespaces.RAFT_PROTOCOL),
         clusterCommunicator,
-        requestTimeout);
+        requestTimeout,
+        snapshotRequestTimeout);
   }
 
   public CompletableFuture<Void> stepDown() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -82,6 +82,7 @@ public final class RaftPartitionGroupFactory {
             .withElectionTimeout(clusterCfg.getElectionTimeout())
             .withHeartbeatInterval(clusterCfg.getHeartbeatInterval())
             .withRequestTimeout(experimentalCfg.getRaft().getRequestTimeout())
+            .withSnapshotRequestTimeout(experimentalCfg.getRaft().getSnapshotRequestTimeout())
             .withMaxQuorumResponseTimeout(experimentalCfg.getRaft().getMaxQuorumResponseTimeout())
             .withMinStepDownFailureCount(experimentalCfg.getRaft().getMinStepDownFailureCount())
             .withPreferSnapshotReplicationThreshold(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 
 public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
+  public static final Duration DEFAULT_SNAPSHOT_REQUEST_TIMEOUT = Duration.ofMillis(2500);
   // Requests should time out faster than the election timeout to ensure that a single missed
   // heartbeat does not cause immediate re-election.
   private static final Duration DEFAULT_REQUEST_TIMEOUT = DEFAULT_ELECTION_TIMEOUT;
@@ -20,8 +21,8 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final int DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD = 100;
   private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
-
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  private Duration snapshotRequestTimeout = DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
@@ -34,6 +35,14 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public void setRequestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
+  }
+
+  public Duration getSnapshotRequestTimeout() {
+    return snapshotRequestTimeout;
+  }
+
+  public void setSnapshotRequestTimeout(final Duration snapshotRequestTimeout) {
+    this.snapshotRequestTimeout = snapshotRequestTimeout;
   }
 
   public Duration getMaxQuorumResponseTimeout() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -67,6 +67,19 @@ final class RaftPartitionGroupFactoryTest {
   }
 
   @Test
+  void shouldSetRaftSnapshotRequestTimeout() {
+    // given
+    final Duration expected = Duration.ofSeconds(15);
+    brokerCfg.getExperimental().getRaft().setSnapshotRequestTimeout(expected);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getSnapshotRequestTimeout()).isEqualTo(expected);
+  }
+
+  @Test
   void shouldSetRaftMaxQuorumResponseTimeout() {
     // given
     final Duration expected = Duration.ofSeconds(13);

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -898,7 +898,13 @@
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
+        # When modifying the values for requestTimeout, it might also be useful to update snapshotTimeout.
         # requestTimeout: 2500ms
+
+        # Sets the timeout for all snapshot requests sent by raft leaders to the followers.
+        # If the network latency between brokers is high, it would help to set a higher timeout here.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_SNAPSHOTREQUESTTIMEOUT.
+        # snapshotRequestTimeout: 2500ms
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -808,7 +808,13 @@
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
+        # When modifying the values for requestTimeout, it might also be useful to update snapshotTimeout.
         # requestTimeout: 2500ms
+
+        # Sets the timeout for all snapshot requests sent by raft leaders to the followers.
+        # If the network latency between brokers is high, it would help to set a higher timeout here.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_SNAPSHOTREQUESTTIMEOUT.
+        # snapshotRequestTimeout: 2500ms
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures


### PR DESCRIPTION
## Description

Allows configuring request timeout for install requests. The default value was set as 10 seconds.

To test the configuration a benchmark was created with the default install request timeout of 500ms and request timeout of 2500ms.
After the creation, it was observed that the benchmark was stable in the Grafana dashboards.
Following this, a latency of 500ms was introduced on the brokers which caused only the install requests timeout to fail, as observed in the Response Failure Count panel in Grafana.

![Screenshot 2023-05-30 at 15 07 41](https://github.com/camunda/zeebe/assets/132340590/1d40a49d-c648-4a1f-89b5-a15451e38056)

The same Chaos mesh run on a different benchmark without these timeout changes did not reproduce these install request timeout exceptions.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12793

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
