### PR TITLE
[Backport stable/8.2] fix(journal): avoid gaps in logs due to reset

### DIFF
--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -70,6 +70,18 @@
       <artifactId>jnr-posix</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -90,6 +90,10 @@ final class SegmentedJournalWriter {
   }
 
   void deleteAfter(final long index) {
+    // reset the last flushed index first to avoid corruption on restart in case of partial
+    // truncation (e.g. the node crashed while deleting segments)
+    flusher.setLastFlushedIndex(index);
+
     // Delete all segments with first indexes greater than the given index.
     while (index < currentSegment.index() && currentSegment != segments.getFirstSegment()) {
       segments.removeSegment(currentSegment);
@@ -99,7 +103,6 @@ final class SegmentedJournalWriter {
 
     // Truncate down to the current index, such that the last index is `index`, and the next index
     // `index + 1`
-    flusher.setLastFlushedIndex(index);
     currentWriter.truncate(index);
   }
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.record.SBESerializer;
 import io.camunda.zeebe.journal.util.MockJournalMetastore;
@@ -93,6 +94,11 @@ final class TestJournalFactory {
   }
 
   SegmentsManager segmentsManager(final Path directory, final SegmentLoader loader) {
+    return segmentsManager(directory, loader, metaStore);
+  }
+
+  SegmentsManager segmentsManager(
+      final Path directory, final SegmentLoader loader, final JournalMetaStore metaStore) {
     return new SegmentsManager(
         index,
         maxSegmentSize(),


### PR DESCRIPTION
# Description
Backport of #12868 to `stable/8.2`.

relates to #12754