### PR TITLE
[Backport stable/8.0] Remove JDK 8 specific build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,50 +223,6 @@ jobs:
       - name: Run Go tests
         working-directory: clients/go
         run: go test -mod=vendor -v ./...
-  java-client:
-    name: Java client tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v3
-      # First package the complete application
-      - uses: ./.github/actions/setup-zeebe
-        with:
-          go: false
-          maven-cache: 'true'
-          maven-cache-key-modifier: java-client
-      - uses: ./.github/actions/build-zeebe
-        with:
-          go: false
-          maven-extra-args: -am -pl clients/java -T1C
-      # This is a workaround for java 8, which does not support the --add-exports options
-      - run: rm .mvn/jvm.config
-      # Then run client tests with JDK 8
-      - uses: actions/setup-java@v3.5.1
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-          cache: maven
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
-      - name: Maven Test Build
-        run: >
-          mvn -B --no-snapshot-updates
-          -P disableCheckstyle,extract-flaky-tests
-          -D skipChecks -D skipITs
-          -D surefire.rerunFailingTestsCount=3
-          -pl clients/java
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Duplicate Test Check
-        uses: ./.github/actions/check-duplicate-tests
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: failure()
-        with:
-          name: Java 8 Client
   codeql:
     name: CodeQL
     runs-on: [ self-hosted, linux, "16" ]
@@ -359,7 +315,6 @@ jobs:
       - smoke-tests
       - property-tests
       - go-client
-      - java-client
       - codeql
       - java-checks
       - go-lint
@@ -378,7 +333,6 @@ jobs:
       - smoke-tests
       - property-tests
       - go-client
-      - java-client
     if: always()
     steps:
       - name: Upload

--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -153,6 +153,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- Dependencies needed for the integration tests only. See https://github.com/camunda/zeebe/issues/8609 -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,8 +70,7 @@
     <version.opentest4j>1.2.0</version.opentest4j>
     <version.log4j>2.17.2</version.log4j>
     <version.minlog>1.3.1</version.minlog>
-    <version.mockito>4.4.0</version.mockito>
-    <version.mockito-jupiter>4.4.0</version.mockito-jupiter>
+    <version.mockito>5.3.1</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.3</version.msgpack>
     <version.netty>4.1.93.Final</version.netty>
@@ -519,16 +518,10 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
+        <artifactId>mockito-bom</artifactId>
         <version>${version.mockito}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-junit-jupiter</artifactId>
-        <version>${version.mockito-jupiter}</version>
-        <scope>test</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

This PR backports removing the JDK 8 build, and upgrading Mockito to 5.

## Related issues

backport #12533

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
