### PR TITLE
Add specific error codes for logstream write failure

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
@@ -83,22 +83,14 @@ final class RemoteJobStreamErrorHandler implements RemoteStreamErrorHandler<Acti
       final LogStreamWriter writer,
       final TaskResult result) {
     final var writeResult = writer.tryWrite(result.getRecordBatch().entries());
-    if (writeResult.isRight()) {
-      if (writeResult.get() == 0) {
-        NO_ACTION_LOGGER.warn(
-            """
-           Failed to push job {} on partition {}, but the error handler did not return anything;
-           the job will be activated again when it times out""",
-            job.jobKey(),
-            partitionId);
-      }
-    } else {
+    if (writeResult.isLeft()) {
       FAILED_WRITER_LOGGER.warn(
           """
-          Failed to handle failed job push {} on partition {};
-          job will remain activated until it times out""",
+          Failed to handle failed job push {} on partition {}. Write to logstream failed with {};
+          job will remain activated until it times out. """,
           job.jobKey(),
-          partitionId);
+          partitionId,
+          writeResult.getLeft());
     }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -134,7 +134,7 @@ public final class ErrorResponseWriter implements BufferWriter {
                       + " leader for this partition.")
                   .formatted(partitionId));
       case FULL -> raiseInternalError("because the writer is full.", partitionId);
-      case INVALID_ENTRY -> raiseInternalError("due to invalid entry.", partitionId);
+      case INVALID_ARGUMENT -> raiseInternalError("due to invalid entry.", partitionId);
     };
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -133,13 +133,12 @@ public final class ErrorResponseWriter implements BufferWriter {
                       + " but the writer is closed. Most likely, this node is not the"
                       + " leader for this partition.")
                   .formatted(partitionId));
-      case FULL -> logInternalError("because the writer is full.", partitionId);
-      case INVALID_ENTRY -> logInternalError("due to invalid entry.", partitionId);
-      case UNKNOWN -> logInternalError("due to unknown reason.", partitionId);
+      case FULL -> raiseInternalError("because the writer is full.", partitionId);
+      case INVALID_ENTRY -> raiseInternalError("due to invalid entry.", partitionId);
     };
   }
 
-  private ErrorResponseWriter logInternalError(final String reason, final int partitionId) {
+  private ErrorResponseWriter raiseInternalError(final String reason, final int partitionId) {
     final String message =
         "Failed to write client request to partition '%d', %s".formatted(partitionId, reason);
     LOG.debug(message);

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -115,7 +115,7 @@ public final class BackupApiRequestHandler
     final var checkpointRecord = new CheckpointRecord().setCheckpointId(requestReader.backupId());
     final var written = logStreamWriter.tryWrite(LogAppendEntry.of(metadata, checkpointRecord));
 
-    if (written > 0) {
+    if (written.isRight()) {
       // Response will be sent by the processor
       return Either.right(responseWriter.noResponse());
     } else {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -119,7 +119,7 @@ public final class BackupApiRequestHandler
       // Response will be sent by the processor
       return Either.right(responseWriter.noResponse());
     } else {
-      return Either.left(errorWriter.internalError("Failed to write command to logstream."));
+      return Either.left(errorWriter.mapWriteError(partitionId, written.getLeft()));
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -150,9 +150,10 @@ final class CommandApiRequestHandler
     }
 
     if (logStreamWriter.canWriteEvents(1, appendEntry.getLength())) {
-      return logStreamWriter.tryWrite(appendEntry) >= 0
-          ? Either.right(true)
-          : Either.left("Failed to write request to logstream");
+      return logStreamWriter
+          .tryWrite(appendEntry)
+          .map(ignore -> true)
+          .mapLeft(error -> "Failed to write request to logstream");
     } else {
       return Either.left("Request size is above configured maxMessageSize.");
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -89,7 +89,7 @@ final class InterPartitionCommandReceiverImpl {
             .intent(CheckpointIntent.CREATE)
             .valueType(ValueType.CHECKPOINT);
     final var checkpointRecord = new CheckpointRecord().setCheckpointId(decoded.checkpointId);
-    return logStreamWriter.tryWrite(LogAppendEntry.of(metadata, checkpointRecord)) >= 0;
+    return logStreamWriter.tryWrite(LogAppendEntry.of(metadata, checkpointRecord)).isRight();
   }
 
   private boolean writeCommand(final DecodedMessage decoded) {
@@ -99,7 +99,7 @@ final class InterPartitionCommandReceiverImpl {
             .map(key -> LogAppendEntry.of(key, decoded.metadata(), decoded.command()))
             .orElseGet(() -> LogAppendEntry.of(decoded.metadata(), decoded.command()));
 
-    return logStreamWriter.tryWrite(appendEntry) >= 0;
+    return logStreamWriter.tryWrite(appendEntry).isRight();
   }
 
   void setDiskSpaceAvailable(final boolean available) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
 import org.agrona.MutableDirectBuffer;
@@ -44,7 +45,7 @@ final class RemoteJobStreamErrorHandlerTest {
     final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler);
     final var job = new TestActivatedJob(Protocol.encodePartitionId(1, 1), new JobRecord());
     final var error = new RuntimeException("Failure");
-    handler.addWriter(1, (entries, ignored) -> 1);
+    handler.addWriter(1, (entries, ignored) -> Either.right(1L));
 
     // when
     handler.handleError(error, job);
@@ -62,7 +63,7 @@ final class RemoteJobStreamErrorHandlerTest {
     // given
     final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler);
     final var job = new TestActivatedJob(1, new JobRecord());
-    handler.addWriter(1, (entries, ignored) -> 1);
+    handler.addWriter(1, (entries, ignored) -> Either.right(1L));
 
     // when
     handler.removeWriter(1);
@@ -82,7 +83,7 @@ final class RemoteJobStreamErrorHandlerTest {
         1,
         (entries, ignored) -> {
           writtenEntries.addAll(entries);
-          return 1;
+          return Either.right(1L);
         });
 
     // when

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -217,8 +217,7 @@ public class CommandApiRequestHandlerTest {
         .extracting(Either::getLeft)
         .extracting(ErrorResponse::getErrorCode, e -> BufferUtil.bufferAsString(e.getErrorData()))
         .containsExactly(
-            ErrorCode.INTERNAL_ERROR,
-            "Failed writing request: Request size is above configured maxMessageSize.");
+            ErrorCode.MALFORMED_REQUEST, "Request size is above configured maxMessageSize.");
   }
 
   private CompletableFuture<Either<ErrorResponse, ExecuteCommandResponse>> handleRequest(

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -141,7 +141,7 @@ final class InterPartitionCommandCheckpointTest {
   void shouldNotWriteCommandIfCheckpointCreateFailed() {
     // given
     when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any()))
-        .thenReturn(Either.left(WriteFailure.UNKNOWN), Either.right(1L));
+        .thenReturn(Either.left(WriteFailure.FULL), Either.right(1L));
     receiver.setCheckpointId(5);
     sender.setCheckpointId(17);
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -21,6 +21,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.util.Either;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -58,7 +60,7 @@ final class InterPartitionCommandCheckpointTest {
   @Test
   void shouldHandleMissingCheckpoints() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(1L);
+    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -72,7 +74,7 @@ final class InterPartitionCommandCheckpointTest {
   @Test
   void shouldCreateFirstCheckpoint() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(1L);
+    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
     sender.setCheckpointId(1);
 
     // when
@@ -89,7 +91,7 @@ final class InterPartitionCommandCheckpointTest {
   @Test
   void shouldUpdateExistingCheckpoint() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(1L);
+    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
     receiver.setCheckpointId(5);
     sender.setCheckpointId(17);
 
@@ -106,7 +108,7 @@ final class InterPartitionCommandCheckpointTest {
   @Test
   void shouldNotRecreateExistingCheckpoint() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(1L);
+    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
     receiver.setCheckpointId(5);
     sender.setCheckpointId(5);
 
@@ -122,7 +124,7 @@ final class InterPartitionCommandCheckpointTest {
   @Test
   void shouldNotOverwriteNewerCheckpoint() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(1L);
+    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
     receiver.setCheckpointId(6);
     sender.setCheckpointId(5);
 
@@ -138,7 +140,8 @@ final class InterPartitionCommandCheckpointTest {
   @Test
   void shouldNotWriteCommandIfCheckpointCreateFailed() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(-1L, 1L);
+    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any()))
+        .thenReturn(Either.left(WriteFailure.UNKNOWN), Either.right(1L));
     receiver.setCheckpointId(5);
     sender.setCheckpointId(17);
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import io.atomix.cluster.MemberId;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.util.Either;
 import org.agrona.ExpandableArrayBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -53,8 +55,7 @@ final class InterPartitionCommandReceiverTest {
             MessageSubscriptionIntent.CORRELATE,
             new MessageSubscriptionRecord().setProcessInstanceKey(1).setElementInstanceKey(1));
 
-    final var logStreamWriter =
-        mock(LogStreamWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
+    final LogStreamWriter logStreamWriter = getLogStreamWriter();
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
@@ -62,6 +63,13 @@ final class InterPartitionCommandReceiverTest {
 
     // then - sent message can be written to log stream
     verify(logStreamWriter).tryWrite(Mockito.<LogAppendEntry>any());
+  }
+
+  private static LogStreamWriter getLogStreamWriter() {
+    final var logStreamWriter =
+        mock(LogStreamWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
+    when(logStreamWriter.tryWrite(any(LogAppendEntry.class))).thenReturn(Either.right(1L));
+    return logStreamWriter;
   }
 
   @Test
@@ -78,8 +86,7 @@ final class InterPartitionCommandReceiverTest {
             MessageSubscriptionIntent.CORRELATE,
             new MessageSubscriptionRecord().setProcessInstanceKey(1).setElementInstanceKey(1));
 
-    final var logStreamWriter =
-        mock(LogStreamWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
+    final LogStreamWriter logStreamWriter = getLogStreamWriter();
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
@@ -107,8 +114,7 @@ final class InterPartitionCommandReceiverTest {
             intent,
             new MessageSubscriptionRecord().setProcessInstanceKey(1).setElementInstanceKey(1));
 
-    final var logStreamWriter =
-        mock(LogStreamWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
+    final LogStreamWriter logStreamWriter = getLogStreamWriter();
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
@@ -145,8 +151,7 @@ final class InterPartitionCommandReceiverTest {
             MessageSubscriptionIntent.CORRELATE,
             recordValue);
 
-    final var logStreamWriter =
-        mock(LogStreamWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
+    final LogStreamWriter logStreamWriter = getLogStreamWriter();
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
@@ -176,8 +181,7 @@ final class InterPartitionCommandReceiverTest {
             recordKey,
             new MessageSubscriptionRecord().setProcessInstanceKey(1).setElementInstanceKey(1));
 
-    final var logStreamWriter =
-        mock(LogStreamWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
+    final LogStreamWriter logStreamWriter = getLogStreamWriter();
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
     final var entryCaptor = ArgumentCaptor.forClass(LogAppendEntry.class);
 
@@ -203,8 +207,7 @@ final class InterPartitionCommandReceiverTest {
             MessageSubscriptionIntent.CORRELATE,
             new MessageSubscriptionRecord().setProcessInstanceKey(1).setElementInstanceKey(1));
 
-    final var logStreamWriter =
-        mock(LogStreamWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
+    final LogStreamWriter logStreamWriter = getLogStreamWriter();
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
     final var entryCaptor = ArgumentCaptor.forClass(LogAppendEntry.class);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -133,7 +133,7 @@ public class StreamProcessingComposite {
 
   public long writeBatch(final RecordToWrite... recordsToWrite) {
     final var writer = streams.newLogStreamWriter(getLogName(partitionId));
-    return writeActor.submit(() -> writer.tryWrite(Arrays.asList(recordsToWrite))).join();
+    return writeActor.submit(() -> writer.tryWrite(Arrays.asList(recordsToWrite)).get()).join();
   }
 
   public long writeCommandOnPartition(

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.stream.impl.TypedEventRegistry;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -391,7 +392,8 @@ public final class TestStreams {
           .pollInSameThread()
           .pollDelay(Duration.ZERO)
           .pollInterval(Duration.ofMillis(50))
-          .until(() -> writer.tryWrite(entry, sourceRecordPosition), p -> p >= 0);
+          .until(() -> writer.tryWrite(entry, sourceRecordPosition), Either::isRight)
+          .get();
     }
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -129,20 +129,19 @@ public final class GrpcErrorMapper {
     String message = error.getMessage();
 
     switch (error.getCode()) {
-      case PROCESS_NOT_FOUND:
-        builder.setCode(Code.NOT_FOUND_VALUE);
-        break;
-      case RESOURCE_EXHAUSTED:
+      case PROCESS_NOT_FOUND -> builder.setCode(Code.NOT_FOUND_VALUE);
+      case RESOURCE_EXHAUSTED -> {
         builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE);
         logger.trace("Target broker is currently overloaded: {}", error, rootError);
-        break;
-      case PARTITION_LEADER_MISMATCH:
+      }
+      case PARTITION_LEADER_MISMATCH -> {
         // return UNAVAILABLE to indicate to the user that retrying might solve the issue, as this
         // is usually a transient issue
         logger.trace("Target broker was not the leader of the partition: {}", error, rootError);
         builder.setCode(Code.UNAVAILABLE_VALUE);
-        break;
-      default:
+      }
+      case MALFORMED_REQUEST -> builder.setCode(Code.INVALID_ARGUMENT_VALUE);
+      default -> {
         // all the following are for cases where retrying (with the same gateway) is not expected
         // to solve anything
         logger.error(
@@ -154,7 +153,7 @@ public final class GrpcErrorMapper {
             String.format(
                 "Unexpected error occurred between gateway and broker (code: %s) (message: %s)",
                 error.getCode(), error.getMessage());
-        break;
+      }
     }
 
     return builder.setMessage(message).build();

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -74,12 +74,12 @@ final class Sequencer implements LogStreamWriter, Closeable {
     for (final var entry : appendEntries) {
       if (!isEntryValid(entry)) {
         LOG.warn("Reject write of invalid entry {}", entry);
-        return Either.left(WriteFailure.INVALID_ENTRY);
+        return Either.left(WriteFailure.INVALID_ARGUMENT);
       }
     }
     final var batchSize = appendEntries.size();
     if (batchSize == 0) {
-      return Either.right(0L);
+      return Either.left(WriteFailure.INVALID_ARGUMENT);
     }
 
     final long currentPosition;

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
@@ -71,6 +71,6 @@ public interface LogStreamWriter {
   enum WriteFailure {
     CLOSED,
     FULL,
-    INVALID_ENTRY
+    INVALID_ARGUMENT
   }
 }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
@@ -71,7 +71,6 @@ public interface LogStreamWriter {
   enum WriteFailure {
     CLOSED,
     FULL,
-    INVALID_ENTRY,
-    UNKNOWN
+    INVALID_ENTRY
   }
 }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.logstreams.log;
 
 import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;
+import io.camunda.zeebe.util.Either;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,12 +34,13 @@ public interface LogStreamWriter {
    * @return the event position, a negative value if fails to write the event, or 0 if the value is
    *     empty
    */
-  default long tryWrite(final LogAppendEntry appendEntry) {
+  default Either<WriteFailure, Long> tryWrite(final LogAppendEntry appendEntry) {
     return tryWrite(appendEntry, LogEntryDescriptor.KEY_NULL_VALUE);
   }
 
   /** {@inheritDoc} */
-  default long tryWrite(final LogAppendEntry appendEntry, final long sourcePosition) {
+  default Either<WriteFailure, Long> tryWrite(
+      final LogAppendEntry appendEntry, final long sourcePosition) {
     return tryWrite(Collections.singletonList(appendEntry), sourcePosition);
   }
 
@@ -50,7 +52,7 @@ public interface LogStreamWriter {
    * @return the last (i.e. highest) event position, a negative value if fails to write the events,
    *     or 0 if the batch is empty
    */
-  default long tryWrite(final List<LogAppendEntry> appendEntries) {
+  default Either<WriteFailure, Long> tryWrite(final List<LogAppendEntry> appendEntries) {
     return tryWrite(appendEntries, LogEntryDescriptor.KEY_NULL_VALUE);
   }
 
@@ -63,5 +65,13 @@ public interface LogStreamWriter {
    * @return the last (i.e. highest) event position, a negative value if fails to write the events,
    *     or 0 if the batch is empty
    */
-  long tryWrite(final List<LogAppendEntry> appendEntries, final long sourcePosition);
+  Either<WriteFailure, Long> tryWrite(
+      final List<LogAppendEntry> appendEntries, final long sourcePosition);
+
+  enum WriteFailure {
+    CLOSED,
+    FULL,
+    INVALID_ENTRY,
+    UNKNOWN
+  }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -71,7 +71,7 @@ final class LogStorageAppenderTest {
     final var latch = new CountDownLatch(1);
     final var entry = TestEntry.ofDefaults();
     // when
-    final var position = sequencer.tryWrite(entry);
+    final var position = sequencer.tryWrite(entry).get();
     logStorage.setPositionListener(i -> latch.countDown());
     scheduler.submitActor(appender).join();
 
@@ -90,7 +90,7 @@ final class LogStorageAppenderTest {
     final var latch = new CountDownLatch(1);
 
     // when
-    final var highestPosition = sequencer.tryWrite(entries);
+    final var highestPosition = sequencer.tryWrite(entries).get();
     final var lowestPosition = highestPosition - 1;
     logStorage.setPositionListener(i -> latch.countDown());
     scheduler.submitActor(appender).join();

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
@@ -51,8 +51,8 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldReadEventsInBatch() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofKey(1L), 1L);
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofKey(2L), 1L);
+    final long eventPosition1 = writer.tryWrite(TestEntry.ofKey(1L), 1L).get();
+    final long eventPosition2 = writer.tryWrite(TestEntry.ofKey(2L), 1L).get();
 
     // then
     assertThat(batchReader.hasNext()).isTrue();
@@ -77,8 +77,8 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldReadNextBatch() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofKey(1L));
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofKey(2L));
+    final long eventPosition1 = writer.tryWrite(TestEntry.ofKey(1L)).get();
+    final long eventPosition2 = writer.tryWrite(TestEntry.ofKey(2L)).get();
 
     // then
     assertThat(batchReader.hasNext()).isTrue();
@@ -105,8 +105,8 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldReadEventsWithoutSourceEventPosition() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults());
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults());
+    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
 
     // then
     assertThat(batchReader.hasNext()).isTrue();
@@ -126,9 +126,9 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldNotIncludeEventsWithoutSourceEventPosition() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults());
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults());
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults());
+    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults()).get();
 
     // then
     assertThat(batchReader.hasNext()).isTrue();
@@ -155,9 +155,9 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldMoveBatchToHead() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L);
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults(), 1L);
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L);
+    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L).get();
+    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults(), 1L).get();
+    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L).get();
 
     assertThat(batchReader.hasNext()).isTrue();
 
@@ -185,9 +185,9 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSkipEventsInBatch() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L);
+    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L).get();
     writer.tryWrite(TestEntry.ofDefaults(), 1L);
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L);
+    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L).get();
 
     assertThat(batchReader.hasNext()).isTrue();
 
@@ -206,7 +206,7 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSeekToHeadIfNegative() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults());
+    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
     writer.tryWrite(TestEntry.ofDefaults());
 
     // when
@@ -225,8 +225,8 @@ public class LogStreamBatchReaderTest {
   public void shouldSeekToNextBatch() {
     // given
     writer.tryWrite(TestEntry.ofDefaults());
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults());
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults());
+    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults()).get();
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition2);
@@ -243,9 +243,9 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSeekToNextEventWithinBatch() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L);
+    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L).get();
     writer.tryWrite(TestEntry.ofDefaults(), 1L);
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L);
+    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L).get();
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition1);
@@ -263,7 +263,7 @@ public class LogStreamBatchReaderTest {
   public void shouldSeekToTailIfLastEvent() {
     // given
     writer.tryWrite(TestEntry.ofDefaults());
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults());
+    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition2);
@@ -276,7 +276,7 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSeekToNotExistingPosition() {
     // given
-    final var eventPosition = writer.tryWrite(TestEntry.ofDefaults());
+    final var eventPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition + 1);

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderTest.java
@@ -77,7 +77,7 @@ public final class LogStreamReaderTest {
   public void shouldHaveNext() {
     // given
     final var entry = TestEntry.ofKey(5);
-    final long position = writer.tryWrite(entry);
+    final long position = writer.tryWrite(entry).get();
 
     // then
     assertThat(reader.hasNext()).isTrue();
@@ -98,7 +98,7 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldReturnPositionOfCurrentLoggedEvent() {
     // given
-    final long position = writer.tryWrite(TestEntry.ofDefaults());
+    final long position = writer.tryWrite(TestEntry.ofDefaults()).get();
     reader.seekToFirstEvent();
 
     // then
@@ -119,7 +119,7 @@ public final class LogStreamReaderTest {
     // given
     reader.close();
     final var entry = TestEntry.ofKey(5);
-    final long position = writer.tryWrite(entry);
+    final long position = writer.tryWrite(entry).get();
     reader = readerRule.resetReader();
 
     // then
@@ -133,7 +133,7 @@ public final class LogStreamReaderTest {
     // given
     writer.tryWrite(TestEntry.ofDefaults());
     final var entry = TestEntry.ofKey(5);
-    final long secondPos = writer.tryWrite(entry);
+    final long secondPos = writer.tryWrite(entry).get();
 
     // when
     reader = logStreamRule.newLogStreamReader();
@@ -170,7 +170,7 @@ public final class LogStreamReaderTest {
     final long seekedPosition = reader.seekToEnd();
 
     // when
-    final long newLastPosition = writer.tryWrite(TestEntry.ofDefaults());
+    final long newLastPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
 
     // then
     assertThat(lastEventPosition).isEqualTo(seekedPosition);
@@ -254,7 +254,7 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldSeekToFirstEvent() {
     // given
-    final long firstPosition = writer.tryWrite(TestEntry.ofDefaults());
+    final long firstPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
     writeEvents(2);
 
     // when
@@ -268,7 +268,7 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldSeekToFirstPositionWhenPositionBeforeFirstEvent() {
     // given
-    final long firstPosition = writer.tryWrite(TestEntry.ofDefaults());
+    final long firstPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
     writeEvents(2);
 
     // when
@@ -347,7 +347,7 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldSeekToFirstEventWhenNextIsNegative() {
     // given
-    final long firstEventPosition = writer.tryWrite(TestEntry.ofDefaults());
+    final long firstEventPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
     writeEvents(10);
     reader.seekToEnd();
 
@@ -363,7 +363,7 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldPeekFirstEvent() {
     // given
-    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults());
+    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
     writer.tryWrite(TestEntry.ofDefaults());
 
     assertThat(reader.hasNext()).isTrue();
@@ -378,8 +378,8 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldPeekNextEvent() {
     // given
-    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults());
-    final var eventPosition2 = writer.tryWrite(TestEntry.ofDefaults());
+    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final var eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().getPosition()).isEqualTo(eventPosition1);
@@ -394,8 +394,8 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldPeekAndReadNextEvent() {
     // given
-    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults());
-    final var eventPosition2 = writer.tryWrite(TestEntry.ofDefaults());
+    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final var eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
 
     assertThat(reader.hasNext()).isTrue();
 
@@ -427,6 +427,6 @@ public final class LogStreamReaderTest {
             .mapToObj(TestEntry::ofKey)
             .collect(Collectors.toList());
 
-    return writer.tryWrite(entries);
+    return writer.tryWrite(entries).get();
   }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
@@ -67,7 +67,7 @@ public final class LogStreamTest {
     writer.tryWrite(TestEntry.ofDefaults());
     writer.tryWrite(TestEntry.ofDefaults());
     writer.tryWrite(TestEntry.ofDefaults());
-    final long positionBeforeClose = writer.tryWrite(TestEntry.ofDefaults());
+    final long positionBeforeClose = writer.tryWrite(TestEntry.ofDefaults()).get();
     Awaitility.await("until everything is written")
         .until(logStream::getLastWrittenPosition, position -> position >= positionBeforeClose);
 
@@ -75,7 +75,7 @@ public final class LogStreamTest {
     logStream.close();
     logStreamRule.createLogStream();
     final var newWriter = logStreamRule.getLogStream().newLogStreamWriter();
-    final long positionAfterReOpen = newWriter.tryWrite(TestEntry.ofDefaults());
+    final long positionAfterReOpen = newWriter.tryWrite(TestEntry.ofDefaults()).get();
 
     // then
     assertThat(positionAfterReOpen).isGreaterThan(positionBeforeClose);

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.logstreams.util.LogStreamReaderRule;
 import io.camunda.zeebe.logstreams.util.LogStreamRule;
 import io.camunda.zeebe.logstreams.util.SynchronousLogStream;
@@ -49,12 +50,12 @@ public final class LogStreamWriterTest {
   }
 
   @Test
-  public void shouldNotFailToWriteBatchWithoutEvents() {
+  public void shouldFailToWriteBatchWithoutEvents() {
     // when
-    final long pos = writer.tryWrite(List.of()).get();
+    final var result = writer.tryWrite(List.of());
 
     // then
-    assertThat(pos).isEqualTo(0);
+    EitherAssert.assertThat(result).isLeft().left().isEqualTo(WriteFailure.INVALID_ARGUMENT);
   }
 
   @Test

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -143,6 +143,9 @@ public class ProcessingScheduleServiceImpl
           writeRetryStrategy.runWithRetry(
               () -> {
                 LOG.trace("Write scheduled TaskResult to dispatcher!");
+                if (recordBatch.isEmpty()) {
+                  return true;
+                }
                 return logStreamWriter.tryWrite(recordBatch.entries()).isRight();
               },
               abortCondition);

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -143,7 +143,7 @@ public class ProcessingScheduleServiceImpl
           writeRetryStrategy.runWithRetry(
               () -> {
                 LOG.trace("Write scheduled TaskResult to dispatcher!");
-                return logStreamWriter.tryWrite(recordBatch.entries()) >= 0;
+                return logStreamWriter.tryWrite(recordBatch.entries()).isRight();
               },
               abortCondition);
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -455,11 +455,12 @@ public final class ProcessingStateMachine {
     final ActorFuture<Boolean> retryFuture =
         writeRetryStrategy.runWithRetry(
             () -> {
-              final long position = logStreamWriter.tryWrite(pendingWrites, sourceRecordPosition);
-              if (position > 0) {
-                writtenPosition = position;
+              final var writeResult = logStreamWriter.tryWrite(pendingWrites, sourceRecordPosition);
+              if (writeResult.isRight()) {
+                writtenPosition = writeResult.get();
+                return writtenPosition >= 0;
               }
-              return position >= 0;
+              return false;
             },
             abortCondition);
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -455,12 +455,16 @@ public final class ProcessingStateMachine {
     final ActorFuture<Boolean> retryFuture =
         writeRetryStrategy.runWithRetry(
             () -> {
+              if (pendingWrites.isEmpty()) {
+                return true;
+              }
               final var writeResult = logStreamWriter.tryWrite(pendingWrites, sourceRecordPosition);
               if (writeResult.isRight()) {
                 writtenPosition = writeResult.get();
-                return writtenPosition >= 0;
+                return true;
+              } else {
+                return false;
               }
-              return false;
             },
             abortCondition);
 

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -379,7 +379,7 @@ class ProcessingScheduleServiceTest {
     public Either<WriteFailure, Long> tryWrite(
         final List<LogAppendEntry> appendEntries, final long sourcePosition) {
       if (!acceptWrites.get().getAsBoolean()) {
-        return Either.left(WriteFailure.UNKNOWN);
+        return Either.left(WriteFailure.FULL);
       }
 
       entries.addAll(appendEntries);

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.impl.records.RecordBatch;
 import io.camunda.zeebe.stream.util.Records;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -375,13 +376,14 @@ class ProcessingScheduleServiceTest {
     }
 
     @Override
-    public long tryWrite(final List<LogAppendEntry> appendEntries, final long sourcePosition) {
+    public Either<WriteFailure, Long> tryWrite(
+        final List<LogAppendEntry> appendEntries, final long sourcePosition) {
       if (!acceptWrites.get().getAsBoolean()) {
-        return -1;
+        return Either.left(WriteFailure.UNKNOWN);
       }
 
       entries.addAll(appendEntries);
-      return entries.size();
+      return Either.right((long) entries.size());
     }
   }
 }

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -312,7 +312,7 @@ public final class StreamPlatform {
   }
 
   public long writeBatch(final RecordToWrite... recordsToWrite) {
-    return logContext.setupWriter().tryWrite(Arrays.asList(recordsToWrite));
+    return logContext.setupWriter().tryWrite(Arrays.asList(recordsToWrite)).get();
   }
 
   public void closeStreamProcessor() throws Exception {


### PR DESCRIPTION
## Description

LogstreamWriter#tryWrite returns specific error codes. If the sequencer is full, then the CommandApi can return a partition-leader-mismatch error code so that the gateway can retry the request. Other errors are mapped to internal error and logged at debug level. 

## Related issues

closes #12780 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
