### PR TITLE
[Backport stable/8.1] fix(journal): avoid gaps in logs due to reset

### DIFF
--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -70,6 +70,18 @@
       <artifactId>jnr-posix</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -93,7 +93,8 @@ class SegmentedJournalWriter {
       currentWriter = currentSegment.writer();
     }
 
-    // Truncate the current index.
+    // Truncate down to the current index, such that the last index is `index`, and the next index
+    // `index + 1`
     currentWriter.truncate(index);
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -204,16 +205,26 @@ final class SegmentsManager implements AutoCloseable {
    * @return the first segment
    */
   Segment resetSegments(final long index) {
-    for (final Segment segment : segments.values()) {
-      segment.delete();
-      journalMetrics.decSegmentCount();
-    }
-    segments.clear();
-
+    // reset the last flushed index before deleting data to avoid data corruption on start up in
+    // case of node crash
     // setting the last flushed index to a semantic-null value will let us know on start up that
     // there is "nothing" written, even if we cannot read the descriptor (e.g. if we crash after
     // creating the segment but before writing its descriptor)
     metaStore.resetLastFlushedIndex();
+
+    // delete the segments in reverse order, such that if the operation is interrupted (e.g. crash)
+    // in the middle, there are no gaps in the log (or between the log and snapshot)
+    final Iterator<Segment> it = segments.descendingMap().values().iterator();
+    while (it.hasNext()) {
+      // we explicitly do not want to close the segment, as we may be only soft deleting it here to
+      // allow readers to finish what they're doing and avoid a race condition with unmapping the
+      // underlying buffer
+      //noinspection resource
+      final var segment = it.next();
+      segment.delete();
+      it.remove();
+      journalMetrics.decSegmentCount();
+    }
 
     final SegmentDescriptor descriptor =
         SegmentDescriptor.builder()

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -13,14 +13,20 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.journal.CorruptedJournalException;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.agrona.CloseHelper;
+import org.agrona.collections.ArrayUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 class SegmentsManagerTest {
   private static final String JOURNAL_NAME = "journal";
@@ -251,6 +257,56 @@ class SegmentsManagerTest {
     assertThat(invalidSegmentWasCreated).hasRootCause(expectedRootCause);
     segments = journalFactory.segmentsManager(directory);
     assertThatNoException().isThrownBy(() -> segments.open());
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/12754")
+  void shouldDeleteSegmentsInReverseOrderOnReset() {
+    // given
+    final var loader = Mockito.spy(journalFactory.segmentLoader());
+    final var metaStore = Mockito.spy(journalFactory.metaStore());
+    try (final var journal = openJournal()) {
+      journal.append(1, journalFactory.entry()).index();
+      journal.append(2, journalFactory.entry()).index();
+      journal.append(3, journalFactory.entry()).index();
+    }
+
+    // spy on all created segments, so we can assert the order in which they're deleted
+    //noinspection resource
+    Mockito.doAnswer(call -> Mockito.spy(call.callRealMethod()))
+        .when(loader)
+        .loadExistingSegment(Mockito.any(), Mockito.anyLong(), Mockito.any());
+
+    // when
+    segments = journalFactory.segmentsManager(directory, loader, metaStore);
+    try (final var journal = journalFactory.journal(segments)) {
+      // grab all segments and copy them to avoid the map getting cleared
+      final var loadedSegments = getJournalSegments(segments);
+      journal.reset(10);
+
+      // then - assert we reset first, then delete the segments in reversed order
+      final var mocks = ArrayUtil.add(loadedSegments.toArray(), metaStore);
+      final var inOrder = Mockito.inOrder(mocks);
+
+      inOrder.verify(metaStore).resetLastFlushedIndex();
+      loadedSegments.forEach(s -> inOrder.verify(s).delete());
+      inOrder.verifyNoMoreInteractions();
+    }
+  }
+
+  private List<Segment> getJournalSegments(final SegmentsManager segmentsManager) {
+    final var segments = new ArrayList<Segment>();
+    final long firstIndex =
+        Optional.ofNullable(segmentsManager.getFirstSegment()).map(Segment::index).orElse(0L);
+    var segment = segmentsManager.getLastSegment();
+    long nextSegmentIndex = (segment == null ? -1 : segment.index() - 1);
+
+    while (segment != null && nextSegmentIndex > firstIndex) {
+      segments.add(segment);
+      nextSegmentIndex = segment.index() - 1;
+      segment = segmentsManager.getSegment(nextSegmentIndex);
+    }
+
+    return segments;
   }
 
   private SegmentedJournal openJournal() {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.record.SBESerializer;
@@ -93,6 +94,11 @@ final class TestJournalFactory {
   }
 
   SegmentsManager segmentsManager(final Path directory, final SegmentLoader loader) {
+    return segmentsManager(directory, loader, metaStore);
+  }
+
+  SegmentsManager segmentsManager(
+      final Path directory, final SegmentLoader loader, final JournalMetaStore metaStore) {
     return new SegmentsManager(
         index, maxSegmentSize(), directory.resolve("data").toFile(), "journal", loader, metaStore);
   }


### PR DESCRIPTION
## Description

Avoid gaps in the log when resetting the log by deleting the segments in reverse order. This may cause data loss, but that's acceptable in the context of a reset operation. Deleting segments in reverse order will ensure we have no gaps between the remaining snapshot and segments should the operation fail midway.

Note that this does not make persisting a new snapshot/reseting the log atomic unfortunately.

Unfortunately tests were also not ideal, and require heavy use of mocks. It's also not possible to write integration test without major refactoring. As this is a quick fix, the hope is that the proper solution to make the Raft install operation atomic will redeem this.

(cherry picked from commit 6d6f47b57907abbe138f67ed48712b0051906071)

## Related issues

backports #12868 