### PR TITLE
Integrate Snyk into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,10 +549,24 @@ jobs:
         run: ./mvnw -pl benchmarks/project jib:build -P starter
       - name: Build Worker Image
         run: ./mvnw -pl benchmarks/project jib:build -P worker
+  deploy-snyk-projects:
+    name: Deploy Snyk development projects
+    needs: [ test-summary ]
+    if: |
+      github.repository == 'camunda/zeebe' &&
+      (startsWith(github.ref, 'stable/') || github.ref == 'main')
+    concurrency:
+      group: deploy-snyk-projects
+      cancel-in-progress: false
+    uses: ./.github/workflows/snyk.yml
+    with:
+      monitor: true
+      build: true
+    secrets: inherit
   notify-if-failed:
     name: Send slack notification on build failure
     runs-on: ubuntu-latest
-    needs: [ test-summary, deploy-snapshots, deploy-docker-snapshot ]
+    needs: [ test-summary, deploy-snapshots, deploy-docker-snapshot, deploy-snyk-projects ]
     if: failure() && github.repository == 'camunda/zeebe' && github.ref == 'refs/heads/main'
     steps:
       - id: slack-notify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,8 @@ jobs:
     needs: [ test-summary ]
     if: |
       github.repository == 'camunda/zeebe' &&
-      (startsWith(github.ref, 'stable/') || github.ref == 'main')
+      github.event_name == 'push' &&
+      (startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
     concurrency:
       group: deploy-snyk-projects
       cancel-in-progress: false

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -64,10 +64,8 @@ jobs:
       - name: Install Snyk CLI
         uses: snyk/actions/setup@master
       - uses: actions/checkout@v3
-        if: inputs.build
       - name: Setup Zeebe
         uses: ./.github/actions/setup-zeebe
-        if: inputs.build
         with:
           maven-cache-key-modifier: snyk
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,169 @@
+# This workflow either scans all distribute-able projects with snyk, or updates the relevant
+# projects on the Snyk servers
+name: Snyk
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The project version; defaults to the version as defined by the root POM
+        required: false
+        type: string
+      target:
+        description: Allows overriding the project target reference directly; defaults to the current branch
+        required: false
+        type: string
+      monitor:
+        description: Upload Snyk snapshot instead of test
+        required: false
+        type: boolean
+        default: false
+      build:
+        description: Enable to also build Zeebe
+        required: false
+        type: boolean
+        default: true
+  workflow_call:
+    secrets:
+      SNYK_TOKEN:
+        required: true
+    inputs:
+      version:
+        description: The project version; defaults to the version as defined by the root POM
+        required: false
+        type: string
+      target:
+        description: Allows overriding the project target reference directly; defaults to the current branch
+        required: false
+        type: string
+      monitor:
+        description: Upload Snyk snapshot instead of test
+        required: false
+        type: boolean
+        default: false
+      build:
+        description: Enable to also build Zeebe
+        required: false
+        type: boolean
+        default: true
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  scan:
+    name: Snyk Scan
+    # Run on self-hosted to make building Zeebe much faster
+    runs-on: [ self-hosted, linux, amd64, "16" ]
+    permissions:
+      security-events: write # required to upload SARIF files
+    steps:
+      - name: Install Snyk CLI
+        uses: snyk/actions/setup@master
+      - uses: actions/checkout@v3
+        if: inputs.build
+      - name: Setup Zeebe
+        uses: ./.github/actions/setup-zeebe
+        if: inputs.build
+        with:
+          maven-cache-key-modifier: snyk
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      # We need to build the Docker image (and thus the distribution) to scan it
+      - name: Build Zeebe Distribution
+        uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        if: inputs.build
+      - name: Build Docker Image
+        uses: ./.github/actions/build-docker
+        id: build-docker
+        if: inputs.build
+        with:
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      # Prepares the bash environment for the step which will actually run Snyk, to avoid mixing too
+      # much the GitHub Action contexts/syntax and bash itself.
+      - name: Build Snyk Environment
+        id: info
+        run: |
+          set -x
+
+          export TARGET=$([[ ! -z '${{ inputs.target }}' ]] && echo '${{ inputs.target }}' || echo "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}")
+          export VERSION=$([[ ! -z '${{ inputs.version }}' ]] && echo '${{ inputs.version }}' || ./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec 2>/dev/null)
+          export VERSION_TAG=$([[ "${VERSION}" == *-SNAPSHOT ]] && echo 'development' || echo "${VERSION}")
+          export LIFECYCLE=$([[ "${VERSION}" == *-SNAPSHOT ]] && echo 'development' || echo 'production')
+
+          echo "SNYK_ARGS=" \
+            "--show-vulnerable-paths=all" \
+            "--severity-threshold=high" \
+            "--org=team-zeebe" \
+            "--project-lifecycle=${LIFECYCLE}" \
+            "--project-tags=version=${VERSION_TAG}" \
+            "--target-reference=${TARGET}" >> $GITHUB_ENV
+          echo "TARGET=${TARGET}" >> $GITHUB_ENV
+          echo "SNYK_COMMAND=${{ (inputs.monitor && 'monitor') || 'test' }}" >> $GITHUB_ENV
+          echo "SARIF=${{ (inputs.monitor && 'false') || 'true' }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${{ steps.build-docker.outputs.image }}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+      - name: Run Snyk
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        # The script is set up to scan all distributable artifacts: the projects listed in the bom,
+        # the Go client, and the official Docker image.
+        # If we add things to the BOM, for example, we should also add them here to the
+        # JAVA_PROJECTS variable.
+        run: |
+          # To avoid exiting on the first failure, we instead flip this to 1 as soon as one of the
+          # command fails, and return this at the end; anything non 0 will cause the step to fail
+          exitCode=0
+          JAVA_PROJECTS=(bom bpmn-model clients/java exporter-api gateway-protocol-impl protocol)
+
+          # Remember that when called from a sub-shell, the environment/globals are different
+          function output() {
+            local sarif="$1"
+            local name="$2"
+            [ "${sarif}" == 'true' ] && echo "--sarif-file-output=sarif-results/${name}.sarif"
+          }
+
+          # Print out command if debug logging is enabled
+          set -x
+
+          # Project names contain the target branch, setting the target reference is not yet supported
+          # for containers. So projects are named using this pattern: `zeebe(BRANCH):path/to/buildFile`
+          #
+          # Since the snyk CLI here pass the command as a string, any parenthesis will break the eval
+          # call. As such, we need to double escape the `--project-name` in single quotes
+          PROJECT_NAME="zeebe(${TARGET}):clients/go/go.mod"
+          snyk "${SNYK_COMMAND}" --file=clients/go/go.mod "'--project-name=${PROJECT_NAME}'" ${SNYK_ARGS} "$(output "${SARIF}" 'go')" || exitCode=1
+
+          for project in "${JAVA_PROJECTS[@]}"; do
+            PROJECT_NAME="zeebe(${TARGET}):${project}/pom.xml"
+            snyk "${SNYK_COMMAND}" --file=${project}/pom.xml "'--project-name=${PROJECT_NAME}'" ${SNYK_ARGS} "$(output "${SARIF}" "${project/\//-}")" || exitCode=1
+          done
+
+          # The `container` command does not yet support setting a target reference, as this is a beta
+          # feature at the moment. It's added here anyway for now, and hopefully support will come soon.
+          PROJECT_NAME="zeebe(${TARGET}):Dockerfile"
+          snyk container "${SNYK_COMMAND}" "${DOCKER_IMAGE}" --file=Dockerfile "'--project-name=${PROJECT_NAME}'" ${SNYK_ARGS} "$(output "${SARIF}" 'docker')" || exitCode=1
+          exit "${exitCode}"
+      # This makes the result of our test available in GitHub Code Scanning (look for the Snyk tools)
+      # You can filter by your PR ID, by branch, etc.
+      # This step is only executed if we're testing, as otherwise no SARIF files are emitted
+      - name: Upload Snyk results to GitHub Code Scanning
+        if: ${{ ! inputs.monitor }}
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: sarif-results/
+      - name: Code Scanning summary
+        if: ${{ ! inputs.monitor }}
+        run: |
+          export PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+            ## Result Links
+            - [Code scanning (PR)](https://github.com/camunda/zeebe/security/code-scanning?query=pr:${PR_NUMBER}+tool:"Snyk+Container","Snyk+Open+Source"+is:open)
+            - [Code scanning (branch)](https://github.com/camunda/zeebe/security/code-scanning?query=branch:${{ github.ref_name }}+tool:"Snyk+Container","Snyk+Open+Source"+is:open)
+            - [Snyk projects](https://app.snyk.io/org/team-zeebe/projects)
+          EOF

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,3 @@
+# snyk CLI configuration file
+# Full documentation here: https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/the-.snyk-file
+ignore: {}

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -70,6 +70,7 @@
         <artifactId>zeebe-client-java</artifactId>
         <version>${project.version}</version>
       </dependency>
+
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-exporter-api</artifactId>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -58,6 +58,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

This PR adds a new workflow which integrates Snyk with our project. The workflow is executed during CI on every push to `main` or any of the stable branches. It can also be called manually via `workflow_dispatch`.

The workflow can run in two modes: monitor, and test.

> **Note**
> Snyk has two mode of operations. The `test` command will scan the given projects and output a summary of vulnerabilities. The `monitor` command will simply detect the dependencies/vulnerabilities, and upload the snapshot to the Snyk servers. In other words, use `test` to actively report issues with the local code/container image, and `monitor` on every release to update the state of distributed artifacts. Snyk will then notify us of new vulnerabilities based on the uploaded snapshots.

The workflow will test all the distributable artifacts of Zeebe:

- The clients (Go, Java, zbctl)
- All modules listed in our Maven BOM
- The official Docker image, which includes:
  - Scanning the base image
  - Scanning the distribution (i.e. dist module)
  - Scanning zbctl

The workflow fails if it detects [any licenses which violate the organization's license policy](https://docs.snyk.io/scan-application-code/snyk-open-source/licenses), and if it detects any vulnerabilities with a severity of `high` or greater.

If testing, the results are emitted as SARIF files, and uploaded to GitHub Code Scanning. The job summary of the workflow contains links to check them directly. For simplicity, both the PR based link and branch based links are added, regardless of whether the scan occurs during a PR or push.

When monitoring, no SARIF files are emitted.

Currently, the workflow is hooked into our CI workflow to monitor the development head of each supported versions (e.g. `stable/8.2`, `stable/8.1`, etc.), and the latest development head (main).

A final note: the workflow runs on self-hosted, n2-standard-16 instances. This is to speed up building the project (required to scan the Docker image), as running on `ubuntu-latest` is noticeably slower. However, to save cost, we could run on `ubuntu-latest`. Let me know what you think.

## Related issues

related to #9245

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
