### PR TITLE
test(engine): ensure that only event appliers are modifying state

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/StateModificationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/StateModificationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * This architecture test ensures that only event appliers mutate state. This enforces the event
+ * sourcing pattern, where all state changes are made by applying events.
+ *
+ * @see <a
+ *     href=https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md>ZEP004</a>
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.engine",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class StateModificationTest {
+
+  /**
+   * Describes all methods that directly mutate state. This is all methods in the mutable package,
+   * except getters for other state classes and the key generator. These don't mutate state
+   * directly, and are only there to provide access other related state classes.
+   */
+  private static final DescribedPredicate<JavaMethod> DIRECTLY_MUTATE_STATE =
+      new DescribedPredicate<>("directly mutate state") {
+        @Override
+        public boolean test(JavaMethod input) {
+          return input
+                  .getOwner()
+                  .getPackageName()
+                  .startsWith("io.camunda.zeebe.engine.state.mutable")
+              // Except getters for other state classes and the key generator
+              && !(input.getName().startsWith("get") && input.getName().endsWith("State"))
+              && !input.getName().equals("getKeyGenerator");
+        }
+      };
+
+  /**
+   * Describes methods allowed to mutate state. This is mainly appliers, but we also allow
+   * transitive usage from other methods in the mutable package. Additionally, we allow migration
+   * classes to mutate state, as they are only used during migration and not during normal
+   * processing.
+   */
+  private static final DescribedPredicate<JavaMethod> ARE_ALLOWED_TO_MUTATE_STATE =
+      new DescribedPredicate<>("are allowed to mutate state") {
+        @Override
+        public boolean test(JavaMethod input) {
+          final var pkg = input.getOwner().getPackageName();
+          return pkg.startsWith("io.camunda.zeebe.engine.state.appliers")
+              // or transitive usage in the mutable package
+              || pkg.startsWith("io.camunda.zeebe.engine.state.mutable")
+              // or migration classes which we can ignore as a special case
+              || pkg.startsWith("io.camunda.zeebe.engine.state.migration");
+        }
+      };
+
+  @ArchTest()
+  public static final ArchRule ONLY_ALLOWED_STATE_MODIFICATIONS =
+      methods()
+          .that(DIRECTLY_MUTATE_STATE)
+          .should()
+          .onlyBeCalled()
+          .byMethodsThat(ARE_ALLOWED_TO_MUTATE_STATE);
+}


### PR DESCRIPTION
This adds an ArchUnit test to ensure that only event appliers modify state. This enforces the rules set in [ZEP004](https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.)

As of now, this test is failing!

```
java.lang.AssertionError: Architecture Violation [Priority: MEDIUM] - Rule 'methods that directly mutate state should only be called by methods that are allowed to mutate state' was violated (7 times):
Method <io.camunda.zeebe.engine.processing.message.PendingMessageSubscriptionChecker.run()> calls method <io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState.visitSubscriptionBefore(long, io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState$MessageSubscriptionVisitor)> in (PendingMessageSubscriptionChecker.java:32)
Method <io.camunda.zeebe.engine.processing.message.PendingMessageSubscriptionChecker.sendCommand(io.camunda.zeebe.engine.state.message.MessageSubscription)> calls method <io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState.updateCommandSentTime(io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord, long)> in (PendingMessageSubscriptionChecker.java:50)
Method <io.camunda.zeebe.engine.processing.message.PendingProcessMessageSubscriptionChecker.checkPendingSubscriptions()> calls method <io.camunda.zeebe.engine.state.mutable.MutablePendingProcessMessageSubscriptionState.visitSubscriptionBefore(long, io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState$ProcessMessageSubscriptionVisitor)> in (PendingProcessMessageSubscriptionChecker.java:79)
Method <io.camunda.zeebe.engine.processing.message.PendingProcessMessageSubscriptionChecker.sendPendingCommand(io.camunda.zeebe.engine.state.message.ProcessMessageSubscription)> calls method <io.camunda.zeebe.engine.state.mutable.MutablePendingProcessMessageSubscriptionState.updateSentTime(io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord, long)> in (PendingProcessMessageSubscriptionChecker.java:93)
Method <io.camunda.zeebe.engine.processing.processinstance.CreateProcessInstanceWithResultProcessor$CommandControlWithAwaitResult.accept(io.camunda.zeebe.protocol.record.intent.Intent, io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord)> calls method <io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState.setAwaitResultRequestMetadata(long, io.camunda.zeebe.engine.state.instance.AwaitProcessInstanceResultMetadata)> in (CreateProcessInstanceWithResultProcessor.java:88)
Method <io.camunda.zeebe.engine.state.instance.DbElementInstanceState.createInstance(io.camunda.zeebe.engine.state.instance.ElementInstance)> calls method <io.camunda.zeebe.engine.state.mutable.MutableVariableState.createScope(long, long)> in (DbElementInstanceState.java:176)
Method <io.camunda.zeebe.engine.state.instance.DbElementInstanceState.removeInstance(long)> calls method <io.camunda.zeebe.engine.state.mutable.MutableVariableState.removeScope(long)> in (DbElementInstanceState.java:152)
```

:lady_beetle: The first issues are from `PendingMessageSubscriptionChecker` and `PendingProcessMessageSubscriptionChecker` and are known issues related to https://github.com/camunda/zeebe/issues/12798

:lady_beetle: Then there is `CreateProcessInstanceWithResultProcessor` which does indeed mutate state even though it is a processor, not an event applier!
https://github.com/camunda/zeebe/blob/9eac8c32c3bbe8aa0002eaf816de1e495a88b5c9/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithResultProcessor.java#L88-L89

 :question: And then there is `DbElementInstanceState` which directly calls into `MutableVariableState` which is a bit unusual but probably not a bug?

