### PR TITLE
ci(release): add optional slackId to identity update workflow

### DIFF
--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -10,6 +10,10 @@ on:
         description: 'The branch to update the identity version on, typically a release branch like release-8.3.15'
         type: string
         required: true
+      userSlackId:
+        description: 'The slack id of the user to notify on failure, no mention within the alert message if omitted'
+        type: string
+        required: false
       dryRun:
         description: 'Whether to perform a dry run where no changes pushed, defaults to true'
         type: boolean
@@ -76,7 +80,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alarm: *Updating the identity version* on `${{ inputs.targetBranch }}` failed! :alarm:\n"
+                    "text": ":alarm: *Updating the identity version* on `${{ inputs.targetBranch }}` failed! :alarm:\n ${{ inputs.userSlackId != '' && format('\\cc <@{0}>', inputs.userSlackId) || '' }}"
                   }
                 },
                 {


### PR DESCRIPTION
## Description

New optional parameter for a slack id to mention on identity update failure.
As part of the release process this will be the release manager, see https://github.com/zeebe-io/zeebe-engineering-processes/pull/324#issuecomment-1571752141 .

## Related issues

relates #12836