### PR TITLE
ci: add support label to issues with support reference

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,3 @@
+# Add/remove 'support' label if issue contains a Jira Support issue id
+support:
+  - '(SUPPORT|SEC)-\d+'

--- a/.github/workflows/issue-add-support-label.yml
+++ b/.github/workflows/issue-add-support-label.yml
@@ -1,0 +1,20 @@
+name: Add support label to issue
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  check-and-add-support-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.1
+      with:
+        configuration-path: .github/issue-labeler.yml
+        enable-versioned-regex: 0


### PR DESCRIPTION
## Description
Will remove automate adding a `support` label to issues and just require us to mention/link the Jira issue id which needs to be done anyway according to https://confluence.camunda.com/display/HAN/C8+Support+to+Product+Escalation+Process#C8SupporttoProductEscalationProcess-ProductEngineer-Process

## Related issues

closes #12655