### PR TITLE
refactor(engine): migrate job processors to typed record processor

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -70,7 +70,7 @@ public final class JobEventProcessors {
             ValueType.JOB,
             JobIntent.TIME_OUT,
             new JobTimeOutProcessor(
-                processingState, jobMetrics, bpmnBehaviors.jobActivationBehavior()))
+                processingState, writers, jobMetrics, bpmnBehaviors.jobActivationBehavior()))
         .onCommand(
             ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(processingState))
         .onCommand(
@@ -78,7 +78,7 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.RECUR_AFTER_BACKOFF,
-            new JobRecurProcessor(processingState, bpmnBehaviors.jobActivationBehavior()))
+            new JobRecurProcessor(processingState, writers, bpmnBehaviors.jobActivationBehavior()))
         .onCommand(
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -13,38 +13,43 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
-import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.List;
 import org.agrona.DirectBuffer;
 
-public final class JobFailProcessor implements CommandProcessor<JobRecord> {
+public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
 
   private static final DirectBuffer DEFAULT_ERROR_MESSAGE = wrapString("No more retries left.");
   private static final int MAX_ERROR_MESSAGE_SIZE = 500;
   private final IncidentRecord incidentEvent = new IncidentRecord();
 
   private final JobState jobState;
-  private final DefaultJobCommandPreconditionGuard defaultProcessor;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
   private final KeyGenerator keyGenerator;
   private final JobMetrics jobMetrics;
   private final JobBackoffChecker jobBackoffChecker;
   private final VariableBehavior variableBehavior;
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final SideEffectWriter sideEffectWriter;
+  private final JobCommandPreconditionChecker preconditionChecker;
 
   public JobFailProcessor(
       final ProcessingState state,
@@ -54,30 +59,74 @@ public final class JobFailProcessor implements CommandProcessor<JobRecord> {
       final JobBackoffChecker jobBackoffChecker,
       final BpmnBehaviors bpmnBehaviors) {
     jobState = state.getJobState();
-    this.keyGenerator = keyGenerator;
-    this.jobBackoffChecker = jobBackoffChecker;
-    defaultProcessor =
-        new DefaultJobCommandPreconditionGuard("fail", jobState, this::acceptCommand);
-    this.jobMetrics = jobMetrics;
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    sideEffectWriter = writers.sideEffect();
     variableBehavior = bpmnBehaviors.variableBehavior();
     jobActivationBehavior = bpmnBehaviors.jobActivationBehavior();
-    sideEffectWriter = writers.sideEffect();
+    preconditionChecker =
+        new JobCommandPreconditionChecker("fail", List.of(State.ACTIVATABLE, State.ACTIVATED));
+    this.keyGenerator = keyGenerator;
+    this.jobBackoffChecker = jobBackoffChecker;
+    this.jobMetrics = jobMetrics;
   }
 
   @Override
-  public boolean onCommand(
-      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
-    return defaultProcessor.onCommand(command, commandControl);
+  public void processRecord(final TypedRecord<JobRecord> record) {
+    final long jobKey = record.getKey();
+    final JobState.State state = jobState.getState(jobKey);
+
+    preconditionChecker
+        .check(state, jobKey)
+        .ifRightOrLeft(
+            ok -> failJob(record),
+            violation -> {
+              rejectionWriter.appendRejection(record, violation.getLeft(), violation.getRight());
+              responseWriter.writeRejectionOnCommand(
+                  record, violation.getLeft(), violation.getRight());
+            });
   }
 
-  @Override
-  public void afterAccept(
-      final TypedCommandWriter commandWriter,
-      final StateWriter stateWriter,
-      final long key,
-      final Intent intent,
-      final JobRecord value) {
+  private void failJob(final TypedRecord<JobRecord> record) {
+    final long jobKey = record.getKey();
+    final JobRecord failJobCommandRecord = record.getValue();
+    final var retries = failJobCommandRecord.getRetries();
+    final var retryBackOff = failJobCommandRecord.getRetryBackoff();
 
+    final JobRecord failedJob = jobState.getJob(jobKey);
+    failedJob.setRetries(retries);
+    failedJob.setErrorMessage(
+        limitString(failJobCommandRecord.getErrorMessage(), MAX_ERROR_MESSAGE_SIZE));
+    failedJob.setRetryBackoff(retryBackOff);
+    failedJob.setVariables(failJobCommandRecord.getVariablesBuffer());
+
+    if (retries > 0 && retryBackOff > 0) {
+      final long receivedTime = record.getTimestamp();
+      failedJob.setRecurringTime(receivedTime + retryBackOff);
+      sideEffectWriter.appendSideEffect(
+          () -> {
+            jobBackoffChecker.scheduleBackOff(retryBackOff + receivedTime);
+            return true;
+          });
+    }
+    stateWriter.appendFollowUpEvent(jobKey, JobIntent.FAILED, failedJob);
+    responseWriter.writeEventOnCommand(jobKey, JobIntent.FAILED, failedJob, record);
+    jobMetrics.jobFailed(failedJob.getType());
+
+    setFailedVariables(failedJob);
+
+    final boolean retryImmediately = retries > 0 && retryBackOff <= 0;
+    if (retryImmediately) {
+      jobActivationBehavior.publishWork(jobKey, failedJob);
+    }
+
+    if (retries <= 0) {
+      raiseIncident(jobKey, failedJob);
+    }
+  }
+
+  private void setFailedVariables(final JobRecord value) {
     // set fail job variables locally
     final DirectBuffer variables = value.getVariablesBuffer();
     if (variables.capacity() > 0) {
@@ -88,58 +137,27 @@ public final class JobFailProcessor implements CommandProcessor<JobRecord> {
           value.getBpmnProcessIdBuffer(),
           variables);
     }
-
-    if (value.getRetries() <= 0) {
-      final DirectBuffer jobErrorMessage = value.getErrorMessageBuffer();
-      DirectBuffer incidentErrorMessage = DEFAULT_ERROR_MESSAGE;
-      if (jobErrorMessage.capacity() > 0) {
-        incidentErrorMessage = jobErrorMessage;
-      }
-
-      incidentEvent.reset();
-      incidentEvent
-          .setErrorType(ErrorType.JOB_NO_RETRIES)
-          .setErrorMessage(incidentErrorMessage)
-          .setBpmnProcessId(value.getBpmnProcessIdBuffer())
-          .setProcessDefinitionKey(value.getProcessDefinitionKey())
-          .setProcessInstanceKey(value.getProcessInstanceKey())
-          .setElementId(value.getElementIdBuffer())
-          .setElementInstanceKey(value.getElementInstanceKey())
-          .setJobKey(key)
-          .setVariableScopeKey(value.getElementInstanceKey());
-
-      stateWriter.appendFollowUpEvent(
-          keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
-    }
   }
 
-  private void acceptCommand(
-      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
-    final long jobKey = command.getKey();
-    final JobRecord failedJob = jobState.getJob(jobKey);
-    final var retries = command.getValue().getRetries();
-    final var retryBackOff = command.getValue().getRetryBackoff();
-    failedJob.setRetries(retries);
-    failedJob.setErrorMessage(
-        limitString(command.getValue().getErrorMessage(), MAX_ERROR_MESSAGE_SIZE));
-    failedJob.setRetryBackoff(retryBackOff);
-    failedJob.setVariables(command.getValue().getVariablesBuffer());
-
-    if (retries > 0 && retryBackOff > 0) {
-      final long receivedTime = command.getTimestamp();
-      failedJob.setRecurringTime(receivedTime + retryBackOff);
-      sideEffectWriter.appendSideEffect(
-          () -> {
-            jobBackoffChecker.scheduleBackOff(retryBackOff + receivedTime);
-            return true;
-          });
+  private void raiseIncident(final long key, final JobRecord value) {
+    final DirectBuffer jobErrorMessage = value.getErrorMessageBuffer();
+    DirectBuffer incidentErrorMessage = DEFAULT_ERROR_MESSAGE;
+    if (jobErrorMessage.capacity() > 0) {
+      incidentErrorMessage = jobErrorMessage;
     }
-    commandControl.accept(JobIntent.FAILED, failedJob);
-    jobMetrics.jobFailed(failedJob.getType());
 
-    final boolean retryImmediately = retries > 0 && retryBackOff <= 0;
-    if (retryImmediately) {
-      jobActivationBehavior.publishWork(jobKey, failedJob);
-    }
+    incidentEvent.reset();
+    incidentEvent
+        .setErrorType(ErrorType.JOB_NO_RETRIES)
+        .setErrorMessage(incidentErrorMessage)
+        .setBpmnProcessId(value.getBpmnProcessIdBuffer())
+        .setProcessDefinitionKey(value.getProcessDefinitionKey())
+        .setProcessInstanceKey(value.getProcessInstanceKey())
+        .setElementId(value.getElementIdBuffer())
+        .setElementInstanceKey(value.getElementInstanceKey())
+        .setJobKey(key)
+        .setVariableScopeKey(value.getElementInstanceKey());
+
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavio
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
@@ -28,7 +27,6 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
   private final JobState jobState;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
-  private final TypedResponseWriter responseWriter;
   private final BpmnJobActivationBehavior jobActivationBehavior;
 
   public JobRecurProcessor(
@@ -38,7 +36,6 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
     jobState = processingState.getJobState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
-    responseWriter = writers.response();
     this.jobActivationBehavior = jobActivationBehavior;
   }
 
@@ -51,8 +48,6 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
       final JobRecord recurredJob = record.getValue();
 
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.RECURRED_AFTER_BACKOFF, recurredJob);
-      responseWriter.writeEventOnCommand(
-          jobKey, JobIntent.RECURRED_AFTER_BACKOFF, recurredJob, record);
 
       jobActivationBehavior.publishWork(jobKey, recurredJob);
     } else {
@@ -75,7 +70,6 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
 
       final String errorMesage = String.format(NOT_FAILED_JOB_MESSAGE, jobKey, textState);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMesage);
-      responseWriter.writeRejectionOnCommand(record, RejectionType.NOT_FOUND, errorMesage);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavio
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
@@ -28,7 +27,6 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
   private final JobState jobState;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
-  private final TypedResponseWriter responseWriter;
   private final JobMetrics jobMetrics;
   private final BpmnJobActivationBehavior jobActivationBehavior;
 
@@ -40,7 +38,6 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
     jobState = state.getJobState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
-    responseWriter = writers.response();
     this.jobMetrics = jobMetrics;
     this.jobActivationBehavior = jobActivationBehavior;
   }
@@ -55,7 +52,6 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
 
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, timedOutJob);
       jobMetrics.jobTimedOut(timedOutJob.getType());
-      responseWriter.writeEventOnCommand(jobKey, JobIntent.TIMED_OUT, timedOutJob, record);
 
       jobActivationBehavior.publishWork(jobKey, timedOutJob);
     } else {
@@ -75,7 +71,6 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
 
       final String errorMessage = String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, textState);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(record, RejectionType.NOT_FOUND, errorMessage);
     }
   }
 }


### PR DESCRIPTION
## Description

Refactor the `JobFailProcessor`, `JobTimeOutProcessor`, and `JobRecurProcessor` classes to use the `TypedRecordProcessor` instead of the `CommandProcessor` interface. When using the `CommandProcessor` interface, it is not always clear when an event is appended to the log. This increases the probability of bugs.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12933 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
