### PR TITLE
Replace usages of JSR305 from FindBugs with SpotBugs annotations #8846

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -188,10 +188,6 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>annotations</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>net.bytebuddy</groupId>
           <artifactId>byte-buddy</artifactId>
         </exclusion>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -84,12 +84,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>
@@ -162,6 +156,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -160,7 +160,6 @@
     <dependency>
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import javax.annotation.concurrent.ThreadSafe;
+import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public final class OAuthCredentialsCache {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -41,7 +41,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.concurrent.ThreadSafe;
+import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -283,7 +283,6 @@
     <dependency>
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -151,11 +151,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>identity-sdk</artifactId>
       <version>${version.identity}</version>
@@ -283,6 +278,12 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/health/impl/GatewayHealthManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/health/impl/GatewayHealthManagerImpl.java
@@ -15,7 +15,7 @@ import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.protobuf.services.HealthStatusManager;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.concurrent.ThreadSafe;
+import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public final class GatewayHealthManagerImpl implements GatewayHealthManager {
@@ -48,16 +48,17 @@ public final class GatewayHealthManagerImpl implements GatewayHealthManager {
     }
   }
 
+  @Override
+  public BindableService getHealthService() {
+    return statusManager.getHealthService();
+  }
+
   private Status computeStatus(final Status currentStatus, final Status newStatus) {
     if (currentStatus == Status.SHUTDOWN) {
       return Status.SHUTDOWN;
     }
 
     return newStatus;
-  }
-
-  public BindableService getHealthService() {
-    return statusManager.getHealthService();
   }
 
   private void updateGrpcHealthStatus(final Status status) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -965,13 +965,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>${version.jsr305}</version>
-        <scope>provided</scope>
-      </dependency>
-
-      <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
         <version>${version.bouncycastle}</version>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -61,8 +61,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -168,6 +168,21 @@
           "code": "java.class.removed",
           "old": "class io.camunda.zeebe.protocol.management.GroupSizeEncodingEncoder",
           "justification": "This is no longer used for listing backups"
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.attributeValueChanged",
+          "old": "@interface io.camunda.zeebe.protocol.record.ImmutableProtocol",
+          "justification": "This is ignored due to javax.annotation removal"
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.removed",
+          "old": {
+            "matcher": "java",
+            "match": "@org.immutables.value.Generated(**) type ^* {}"
+          },
+          "justification": "This is ignored due to javax.annotation removal"
         }
       ]
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ImmutableProtocol.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ImmutableProtocol.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol.Builder;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol.Type;
@@ -22,10 +24,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.Immutable;
-import javax.annotation.concurrent.NotThreadSafe;
+import net.jcip.annotations.Immutable;
+import net.jcip.annotations.NotThreadSafe;
 import org.immutables.annotate.InjectAnnotation;
 import org.immutables.annotate.InjectAnnotation.Where;
 import org.immutables.value.Generated;
@@ -58,7 +58,7 @@ import org.immutables.value.Value.Style.ValidationMethod;
     // transitive dependency changes
     allowedClasspathAnnotations = {
       Generated.class,
-      ParametersAreNonnullByDefault.class,
+      ReturnValuesAreNonnullByDefault.class,
       Immutable.class,
       SuppressFBWarnings.class,
       NotThreadSafe.class,


### PR DESCRIPTION
## Description

In this PR we replace the usages of JSR305 from FindBugs with SpotBugs annotations. This consists of replacing the remaining uses of JSR305 annotations and replacing them with still-supported annotations.

The javax.annotation.ParametersAreNonnullByDefault unlike the other annotations (that had direct annotations with the name in the new plugin) was replaced with an annotation with a different name but the same function in the spotbugs plugin.

Old: https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/javax/annotation/package-summary.html
New: https://spotbugs.readthedocs.io/en/latest/annotations.html

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8846

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
