### PR TITLE
fix: provide github token to issue-labeler action

### DIFF
--- a/.github/workflows/issue-add-support-label.yml
+++ b/.github/workflows/issue-add-support-label.yml
@@ -18,3 +18,4 @@ jobs:
       with:
         configuration-path: .github/issue-labeler.yml
         enable-versioned-regex: 0
+        repo-token: "${{ github.token }}"


### PR DESCRIPTION
## Description

The issue-label action's docs were already updated according to https://github.com/github/issue-labeler/pull/67 however it wasn't released yet 🤦 , thus have to provide the token as input.

Follow-up to https://github.com/camunda/zeebe/pull/12932.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12655