### PR TITLE
refactor(cluster): improve logging in swim

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -36,6 +36,7 @@ import io.atomix.utils.net.Address;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
 import io.atomix.utils.serializer.Serializer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,7 +69,13 @@ public class SwimMembershipProtocol
     implements GroupMembershipProtocol {
 
   public static final Type TYPE = new Type();
-  private static final Logger LOGGER = LoggerFactory.getLogger(SwimMembershipProtocol.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger("io.atomix.cluster.protocol.swim");
+  private static final Logger GOSSIP_LOGGER =
+      LoggerFactory.getLogger("io.atomix.cluster.protocol.swim.gossip");
+  private static final Logger PROBE_LOGGER =
+      LoggerFactory.getLogger("io.atomix.cluster.protocol.swim.probe");
+  private static final Logger SYNC_LOGGER =
+      LoggerFactory.getLogger("io.atomix.cluster.protocol.swim.sync");
   private static final String MEMBERSHIP_SYNC = "atomix-membership-sync";
   private static final String MEMBERSHIP_GOSSIP = "atomix-membership-gossip";
   private static final String MEMBERSHIP_PROBE = "atomix-membership-probe";
@@ -236,17 +243,21 @@ public class SwimMembershipProtocol
 
     // If the local member is not present, add the member in the ALIVE state.
     if (swimMember == null) {
-      LOGGER.trace("Member not exist yet {}", member);
       if (member.state() == State.ALIVE) {
         swimMember = new SwimMember(member);
         members.put(swimMember.id(), swimMember);
         randomMembers.add(swimMember);
         Collections.shuffle(randomMembers);
-        LOGGER.debug("{} - Member added {}", localMember.id(), swimMember);
+        LOGGER.info("{} - Member added {}", localMember.id(), swimMember);
         swimMember.setState(State.ALIVE);
         post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, swimMember.copy()));
         recordUpdate(swimMember.copy());
         return true;
+      } else {
+        LOGGER.info(
+            "{} - Ignoring update about not alive member {}. Member is already removed.",
+            localMember.id(),
+            member);
       }
       return false;
     }
@@ -262,7 +273,7 @@ public class SwimMembershipProtocol
         members.put(member.id(), swimMember);
         randomMembers.add(swimMember);
         Collections.shuffle(randomMembers);
-        LOGGER.debug("{} - Evicted member for new version {}", localMember.id(), swimMember);
+        LOGGER.info("{} - Evicted member for new version {}", localMember.id(), swimMember);
         post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, swimMember.copy()));
         recordUpdate(swimMember.copy());
       } else {
@@ -305,7 +316,7 @@ public class SwimMembershipProtocol
 
       // If the updated state is SUSPECT, post a REACHABILITY_CHANGED event and record an update.
       if (member.state() == State.SUSPECT) {
-        LOGGER.debug("{} - Member unreachable {}", localMember.id(), swimMember);
+        LOGGER.info("{} - Member unreachable {}", localMember.id(), swimMember);
         post(
             new GroupMembershipEvent(
                 GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
@@ -328,7 +339,7 @@ public class SwimMembershipProtocol
   private void triggerReachabilityEventOnDeath(final SwimMember swimMember) {
     if (swimMember.getState() == State.ALIVE) {
       swimMember.setState(State.SUSPECT);
-      LOGGER.debug("{} - Member unreachable {}", localMember.id(), swimMember);
+      LOGGER.info("{} - Member unreachable {}", localMember.id(), swimMember);
       post(
           new GroupMembershipEvent(
               GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
@@ -345,7 +356,7 @@ public class SwimMembershipProtocol
       post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, swimMember.copy()));
     }
     swimMember.setState(State.SUSPECT);
-    LOGGER.debug("{} - Member unreachable {}", localMember.id(), swimMember);
+    LOGGER.info("{} - Member unreachable {}", localMember.id(), swimMember);
     post(
         new GroupMembershipEvent(
             GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
@@ -357,7 +368,7 @@ public class SwimMembershipProtocol
   private void triggerReachabilityChangedEventOnAlive(
       final ImmutableMember member, final SwimMember swimMember) {
     swimMember.setState(State.ALIVE);
-    LOGGER.debug("{} - Member reachable {}", localMember.id(), swimMember);
+    LOGGER.info("{} - Member reachable {}", localMember.id(), swimMember);
     post(
         new GroupMembershipEvent(
             GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
@@ -382,9 +393,14 @@ public class SwimMembershipProtocol
   /** Checks suspect nodes for failures. */
   private void checkFailures() {
     for (final SwimMember member : members.values()) {
+      final long suspectedDuration = System.currentTimeMillis() - member.getUpdated();
       if (member.getState() == State.SUSPECT
-          && System.currentTimeMillis() - member.getUpdated()
-              > config.getFailureTimeout().toMillis()) {
+          && suspectedDuration > config.getFailureTimeout().toMillis()) {
+        LOGGER.info(
+            "{} - Member {} not reachable for {}",
+            localMember.id(),
+            member.id(),
+            Duration.ofMillis(suspectedDuration));
         member.setState(State.DEAD);
 
         tryRemoveMember(member);
@@ -397,8 +413,9 @@ public class SwimMembershipProtocol
     final var deadMember = members.remove(member.id());
     if (deadMember != null) {
       randomMembers.remove(member);
+      syncMembers.remove(member);
       Collections.shuffle(randomMembers);
-      LOGGER.debug("{} - Member removed {}", localMember.id(), member);
+      LOGGER.info("{} - Member removed {}", localMember.id(), member.id());
       post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, member.copy()));
     }
   }
@@ -409,7 +426,7 @@ public class SwimMembershipProtocol
    * @param member the peer with which to synchronize the node state
    */
   private void sync(final ImmutableMember member) {
-    LOGGER.debug("{} - Start synchronizing membership with {}", localMember.id(), member);
+    SYNC_LOGGER.debug("{} - Start synchronizing membership with {}", localMember.id(), member);
     bootstrapService
         .getMessagingService()
         .sendAndReceive(
@@ -422,14 +439,14 @@ public class SwimMembershipProtocol
             (response, error) -> {
               if (error == null) {
                 final Collection<ImmutableMember> members = SERIALIZER.decode(response);
-                LOGGER.debug(
+                SYNC_LOGGER.debug(
                     "{} - Finished synchronizing membership with {}, received: '{}'",
                     localMember.id(),
                     member,
                     members);
                 members.forEach(this::updateState);
               } else {
-                LOGGER.debug(
+                SYNC_LOGGER.warn(
                     "{} - Failed to synchronize membership with {}",
                     localMember.id(),
                     member,
@@ -464,6 +481,7 @@ public class SwimMembershipProtocol
    * @param member the peer from which to handle the request
    */
   private Collection<ImmutableMember> handleSync(final ImmutableMember member) {
+    SYNC_LOGGER.trace("{} - Received sync request from {}", localMember.id(), member);
     updateState(member);
     return members.values().stream().map(SwimMember::copy).collect(Collectors.toList());
   }
@@ -488,7 +506,7 @@ public class SwimMembershipProtocol
     // If there are members to probe, select the next member to probe using a counter for round
     // robin probes.
     if (!probeMembers.isEmpty()) {
-      LOGGER.trace("Possible members to probe '{}'", probeMembers);
+      PROBE_LOGGER.trace("Possible members to probe '{}'", probeMembers);
       final SwimMember probeMember =
           probeMembers.get(Math.abs(probeCounter.incrementAndGet() % probeMembers.size()));
       probe(probeMember.copy());
@@ -503,7 +521,7 @@ public class SwimMembershipProtocol
    * @param member the member to probe
    */
   private void probe(final ImmutableMember member) {
-    LOGGER.trace("{} - Probing {}", localMember.id(), member);
+    PROBE_LOGGER.trace("{} - Probing {}", localMember.id(), member);
     bootstrapService
         .getMessagingService()
         .sendAndReceive(
@@ -517,11 +535,13 @@ public class SwimMembershipProtocol
               if (error == null) {
                 updateState(SERIALIZER.decode(response));
               } else {
-                LOGGER.debug("{} - Failed to probe {}", localMember.id(), member, error);
+                PROBE_LOGGER.trace("{} - Failed to probe {}", localMember.id(), member, error);
                 // Verify that the local member term has not changed and request probes from peers.
                 final SwimMember swimMember = members.get(member.id());
                 if (swimMember != null
                     && swimMember.getIncarnationNumber() == member.incarnationNumber()) {
+                  PROBE_LOGGER.warn(
+                      "{} - Failed to probe {}", localMember.id(), member.id(), error);
                   requestProbes(swimMember.copy());
                 }
               }
@@ -541,7 +561,7 @@ public class SwimMembershipProtocol
     final ImmutableMember remoteMember = members.getLeft();
     final ImmutableMember localMember = members.getRight();
 
-    LOGGER.trace(
+    PROBE_LOGGER.trace(
         "{} - Received probe {} from {}", this.localMember.id(), localMember, remoteMember);
 
     // If the probe indicates a term greater than the local term, update the local term, increment
@@ -572,6 +592,8 @@ public class SwimMembershipProtocol
     if (!members.isEmpty()) {
       final AtomicInteger counter = new AtomicInteger();
       final AtomicBoolean succeeded = new AtomicBoolean();
+      PROBE_LOGGER.debug(
+          "{} - Requesting probe of {} from [{}]", localMember.id(), suspect, members);
       for (final SwimMember member : members) {
         requestProbe(member, suspect)
             .whenCompleteAsync(
@@ -596,7 +618,8 @@ public class SwimMembershipProtocol
   /** Marks the given member suspect after all probes failing. */
   private void failProbes(final ImmutableMember suspect) {
     final SwimMember swimMember = new SwimMember(suspect);
-    LOGGER.debug("{} - Failed all probes of {}", localMember.id(), swimMember);
+    PROBE_LOGGER.info(
+        "{} - Failed all probes of {}. Marking as suspect.", localMember.id(), swimMember);
     swimMember.setState(State.SUSPECT);
     if (updateState(swimMember.copy()) && config.isBroadcastUpdates()) {
       broadcast(swimMember.copy());
@@ -611,7 +634,6 @@ public class SwimMembershipProtocol
    */
   private CompletableFuture<Boolean> requestProbe(
       final SwimMember member, final ImmutableMember suspect) {
-    LOGGER.debug("{} - Requesting probe of {} from {}", localMember.id(), suspect, member);
     return bootstrapService
         .getMessagingService()
         .sendAndReceive(
@@ -624,7 +646,7 @@ public class SwimMembershipProtocol
         .exceptionally(e -> false)
         .thenApply(
             succeeded -> {
-              LOGGER.debug(
+              PROBE_LOGGER.debug(
                   "{} - Probe request of {} from {} {}",
                   localMember.id(),
                   suspect,
@@ -662,7 +684,7 @@ public class SwimMembershipProtocol
     final CompletableFuture<Boolean> future = new CompletableFuture<>();
     swimScheduler.execute(
         () -> {
-          LOGGER.trace("{} - Probing {}", localMember.id(), member);
+          PROBE_LOGGER.trace("{} - Probing {}", localMember.id(), member);
           bootstrapService
               .getMessagingService()
               .sendAndReceive(
@@ -674,7 +696,7 @@ public class SwimMembershipProtocol
               .whenCompleteAsync(
                   (response, error) -> {
                     if (error != null) {
-                      LOGGER.debug("{} - Failed to probe {}", localMember.id(), member);
+                      PROBE_LOGGER.info("{} - Failed to probe {}", localMember.id(), member.id());
                       future.complete(false);
                     } else {
                       future.complete(true);
@@ -756,7 +778,7 @@ public class SwimMembershipProtocol
    * @param updates the updated members to gossip
    */
   private void gossip(final SwimMember member, final Collection<ImmutableMember> updates) {
-    LOGGER.trace("{} - Gossipping updates {} to {}", localMember.id(), updates, member);
+    GOSSIP_LOGGER.trace("{} - Gossipping updates {} to {}", localMember.id(), updates, member);
     bootstrapService
         .getUnicastService()
         .unicast(member.address(), MEMBERSHIP_GOSSIP, SERIALIZER.encode(updates));
@@ -765,6 +787,7 @@ public class SwimMembershipProtocol
   /** Handles a gossip message from a peer. */
   private void handleGossipUpdates(final Collection<ImmutableMember> updates) {
     for (final ImmutableMember update : updates) {
+      GOSSIP_LOGGER.trace("{} - Received gossip {}", localMember.id(), update);
       updateState(update);
     }
   }


### PR DESCRIPTION
## Description

This PR contains some minimal improvements in swim
- Add separate loggers for probe, sync and gossip. This way we can adjust the log level for each separately.
- All importance state changes are logged at info level. 

