### PR TITLE
[poc] Send entire journal record in AppendRequest instead of just the raft entry

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -41,6 +41,7 @@ import io.atomix.raft.metrics.RaftRoleMetrics;
 import io.atomix.raft.metrics.RaftServiceMetrics;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.protocol.ProtocolVersionHandler;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.RaftServerProtocol;
@@ -281,7 +282,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     protocol.registerInstallHandler(request -> runOnContext(() -> role.onInstall(request)));
     protocol.registerReconfigureHandler(request -> runOnContext(() -> role.onReconfigure(request)));
     protocol.registerTransferHandler(request -> runOnContext(() -> role.onTransfer(request)));
-    protocol.registerAppendHandler(request -> runOnContext(() -> role.onAppend(request)));
+    protocol.registerAppendV1Handler(
+        request -> runOnContext(() -> role.onAppend(ProtocolVersionHandler.transform(request))));
+    protocol.registerAppendV2Handler(
+        request -> runOnContext(() -> role.onAppend(ProtocolVersionHandler.transform(request))));
     protocol.registerPollHandler(request -> runOnContext(() -> role.onPoll(request)));
     protocol.registerVoteHandler(request -> runOnContext(() -> role.onVote(request)));
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -32,7 +32,8 @@ class RaftMessageContext {
   final String transferSubject;
   final String pollSubject;
   final String voteSubject;
-  final String appendSubject;
+  final String appendV1subject;
+  final String appendV2subject;
   final String leaderHeartbeatSubject;
   private final String prefix;
 
@@ -51,7 +52,8 @@ class RaftMessageContext {
     transferSubject = getSubject(prefix, "transfer");
     pollSubject = getSubject(prefix, "poll");
     voteSubject = getSubject(prefix, "vote");
-    appendSubject = getSubject(prefix, "append");
+    appendV1subject = getSubject(prefix, "append");
+    appendV2subject = getSubject(prefix, "append-v2");
     leaderHeartbeatSubject = getSubject(prefix, "leaderHeartbeat");
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -18,6 +18,7 @@ package io.atomix.raft.partition.impl;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftError;
+import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.protocol.AppendRequest;
@@ -30,9 +31,10 @@ import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
-import io.atomix.raft.protocol.RaftResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
+import io.atomix.raft.protocol.ReplicatedJournalRecord;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteRequest;
@@ -66,9 +68,9 @@ public final class RaftNamespaces {
           .register(VoteResponse.class)
           .register(AppendRequest.class)
           .register(AppendResponse.class)
-          .register(RaftResponse.Status.class)
+          .register(Status.class)
           .register(RaftError.class)
-          .register(RaftError.Type.class)
+          .register(Type.class)
           .nextId(517) // for backwards compatibility
           .register(ArrayList.class)
           .register(LinkedList.class)
@@ -83,6 +85,7 @@ public final class RaftNamespaces {
           .register(TransferRequest.class)
           .register(TransferResponse.class)
           .register(AppendRequestV2.class)
+          .register(ReplicatedJournalRecord.class)
           .name("RaftProtocol")
           .build();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -21,6 +21,7 @@ import io.atomix.raft.RaftError;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.protocol.AppendRequest;
+import io.atomix.raft.protocol.AppendRequestV2;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
@@ -81,6 +82,7 @@ public final class RaftNamespaces {
           .register(PersistedRaftRecord.class)
           .register(TransferRequest.class)
           .register(TransferResponse.class)
+          .register(AppendRequestV2.class)
           .name("RaftProtocol")
           .build();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -224,6 +224,12 @@ public class RaftServerCommunicator implements RaftServerProtocol {
     clusterCommunicator.unsubscribe(context.appendV1subject);
   }
 
+  @Override
+  public CompletableFuture<AppendResponse> append(
+      final MemberId memberId, final AppendRequestV2 request) {
+    return sendAndReceive(context.appendV2subject, request, memberId);
+  }
+
   private <T, U> CompletableFuture<U> sendAndReceive(
       final String subject, final T request, final MemberId memberId) {
     return sendAndReceive(subject, request, memberId, requestTimeout);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -110,6 +110,12 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<AppendResponse> append(
+      final MemberId memberId, final AppendRequestV2 request) {
+    return sendAndReceive(context.appendV2subject, request, memberId);
+  }
+
+  @Override
   public void registerTransferHandler(
       final Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
     clusterCommunicator.subscribe(
@@ -222,12 +228,6 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   @Override
   public void unregisterAppendHandler() {
     clusterCommunicator.unsubscribe(context.appendV1subject);
-  }
-
-  @Override
-  public CompletableFuture<AppendResponse> append(
-      final MemberId memberId, final AppendRequestV2 request) {
-    return sendAndReceive(context.appendV2subject, request, memberId);
   }
 
   private <T, U> CompletableFuture<U> sendAndReceive(

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequestV2.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequestV2.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2015-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.atomix.cluster.MemberId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Append entries request.
+ *
+ * <p>Append entries requests are at the core of the replication protocol. Leaders send append
+ * requests to followers to replicate and commit log entries, and followers sent append requests to
+ * passive members to replicate committed log entries.
+ */
+public class AppendRequestV2 extends AbstractRaftRequest {
+
+  private final long term;
+  private final String leader;
+  private final long prevLogIndex;
+  private final long prevLogTerm;
+  private final List<PersistedRaftRecord> entries;
+  private final long commitIndex;
+
+  public AppendRequestV2(
+      final long term,
+      final String leader,
+      final long prevLogIndex,
+      final long prevLogTerm,
+      final List<PersistedRaftRecord> entries,
+      final long commitIndex) {
+    this.term = term;
+    this.leader = leader;
+    this.prevLogIndex = prevLogIndex;
+    this.prevLogTerm = prevLogTerm;
+    this.entries = entries;
+    this.commitIndex = commitIndex;
+  }
+
+  /**
+   * Returns a new append request builder.
+   *
+   * @return A new append request builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns the requesting node's current term.
+   *
+   * @return The requesting node's current term.
+   */
+  public long term() {
+    return term;
+  }
+
+  /**
+   * Returns the requesting leader address.
+   *
+   * @return The leader's address.
+   */
+  public MemberId leader() {
+    return MemberId.from(leader);
+  }
+
+  /**
+   * Returns the index of the log entry preceding the new entry.
+   *
+   * @return The index of the log entry preceding the new entry.
+   */
+  public long prevLogIndex() {
+    return prevLogIndex;
+  }
+
+  /**
+   * Returns the term of the log entry preceding the new entry.
+   *
+   * @return The index of the term preceding the new entry.
+   */
+  public long prevLogTerm() {
+    return prevLogTerm;
+  }
+
+  /**
+   * Returns the log entries to append.
+   *
+   * @return A list of log entries.
+   */
+  public List<PersistedRaftRecord> entries() {
+    return entries;
+  }
+
+  /**
+   * Returns the leader's commit index.
+   *
+   * @return The leader commit index.
+   */
+  public long commitIndex() {
+    return commitIndex;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), term, leader, prevLogIndex, prevLogTerm, entries, commitIndex);
+  }
+
+  @Override
+  public boolean equals(final Object object) {
+    if (object != null && object.getClass() == getClass()) {
+      final AppendRequestV2 request = (AppendRequestV2) object;
+      return request.term == term
+          && request.leader.equals(leader)
+          && request.prevLogIndex == prevLogIndex
+          && request.prevLogTerm == prevLogTerm
+          && request.entries.equals(entries)
+          && request.commitIndex == commitIndex;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("term", term)
+        .add("leader", leader)
+        .add("prevLogIndex", prevLogIndex)
+        .add("prevLogTerm", prevLogTerm)
+        .add("entries", entries.size())
+        .add("commitIndex", commitIndex)
+        .toString();
+  }
+
+  /** Append request builder. */
+  public static class Builder extends AbstractRaftRequest.Builder<Builder, AppendRequestV2> {
+
+    private static final String NULL_ENTRIES_ERR = "entries cannot be null";
+    private long term;
+    private String leader;
+    private long logIndex;
+    private long logTerm;
+    private List<PersistedRaftRecord> entries;
+    private long commitIndex = -1;
+
+    /**
+     * Sets the request term.
+     *
+     * @param term The request term.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code term} is not positive
+     */
+    public Builder withTerm(final long term) {
+      checkArgument(term > 0, "term must be positive");
+      this.term = term;
+      return this;
+    }
+
+    /**
+     * Sets the request leader.
+     *
+     * @param leader The request leader.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code leader} is not positive
+     */
+    public Builder withLeader(final MemberId leader) {
+      this.leader = checkNotNull(leader, "leader cannot be null").id();
+      return this;
+    }
+
+    /**
+     * Sets the request last log index.
+     *
+     * @param prevLogIndex The request last log index.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code index} is not positive
+     */
+    public Builder withPrevLogIndex(final long prevLogIndex) {
+      checkArgument(prevLogIndex >= 0, "prevLogIndex must be positive");
+      logIndex = prevLogIndex;
+      return this;
+    }
+
+    /**
+     * Sets the request last log term.
+     *
+     * @param prevLogTerm The request last log term.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code term} is not positive
+     */
+    public Builder withPrevLogTerm(final long prevLogTerm) {
+      checkArgument(prevLogTerm >= 0, "prevLogTerm must be positive");
+      logTerm = prevLogTerm;
+      return this;
+    }
+
+    /**
+     * Sets the request entries.
+     *
+     * @param entries The request entries.
+     * @return The append request builder.
+     * @throws NullPointerException if {@code entries} is null
+     */
+    public Builder withEntries(final PersistedRaftRecord... entries) {
+      return withEntries(Arrays.asList(checkNotNull(entries, NULL_ENTRIES_ERR)));
+    }
+
+    /**
+     * Sets the request entries.
+     *
+     * @param entries The request entries.
+     * @return The append request builder.
+     * @throws NullPointerException if {@code entries} is null
+     */
+    public Builder withEntries(final List<PersistedRaftRecord> entries) {
+      this.entries = checkNotNull(entries, NULL_ENTRIES_ERR);
+      return this;
+    }
+
+    /**
+     * Sets the request commit index.
+     *
+     * @param commitIndex The request commit index.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if index is not positive
+     */
+    public Builder withCommitIndex(final long commitIndex) {
+      checkArgument(commitIndex >= 0, "commitIndex must be positive");
+      this.commitIndex = commitIndex;
+      return this;
+    }
+
+    /**
+     * @throws IllegalStateException if the term, log term, log index, commit index, or global index
+     *     are not positive, or if entries is null
+     */
+    @Override
+    public AppendRequestV2 build() {
+      validate();
+      return new AppendRequestV2(term, leader, logIndex, logTerm, entries, commitIndex);
+    }
+
+    @Override
+    protected void validate() {
+      super.validate();
+      checkArgument(term > 0, "term must be positive");
+      checkNotNull(leader, "leader cannot be null");
+      checkArgument(logIndex >= 0, "prevLogIndex must be positive");
+      checkArgument(logTerm >= 0, "prevLogTerm must be positive");
+      checkNotNull(entries, NULL_ENTRIES_ERR);
+      checkArgument(commitIndex >= 0, "commitIndex must be positive");
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequestV2.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequestV2.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.cluster.MemberId;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -38,7 +37,7 @@ public class AppendRequestV2 extends AbstractRaftRequest {
   private final String leader;
   private final long prevLogIndex;
   private final long prevLogTerm;
-  private final List<PersistedRaftRecord> entries;
+  private final List<ReplicatedJournalRecord> entries;
   private final long commitIndex;
 
   public AppendRequestV2(
@@ -46,7 +45,7 @@ public class AppendRequestV2 extends AbstractRaftRequest {
       final String leader,
       final long prevLogIndex,
       final long prevLogTerm,
-      final List<PersistedRaftRecord> entries,
+      final List<ReplicatedJournalRecord> entries,
       final long commitIndex) {
     this.term = term;
     this.leader = leader;
@@ -106,7 +105,7 @@ public class AppendRequestV2 extends AbstractRaftRequest {
    *
    * @return A list of log entries.
    */
-  public List<PersistedRaftRecord> entries() {
+  public List<ReplicatedJournalRecord> entries() {
     return entries;
   }
 
@@ -158,7 +157,7 @@ public class AppendRequestV2 extends AbstractRaftRequest {
     private String leader;
     private long logIndex;
     private long logTerm;
-    private List<PersistedRaftRecord> entries;
+    private List<ReplicatedJournalRecord> entries;
     private long commitIndex = -1;
 
     /**
@@ -219,18 +218,7 @@ public class AppendRequestV2 extends AbstractRaftRequest {
      * @return The append request builder.
      * @throws NullPointerException if {@code entries} is null
      */
-    public Builder withEntries(final PersistedRaftRecord... entries) {
-      return withEntries(Arrays.asList(checkNotNull(entries, NULL_ENTRIES_ERR)));
-    }
-
-    /**
-     * Sets the request entries.
-     *
-     * @param entries The request entries.
-     * @return The append request builder.
-     * @throws NullPointerException if {@code entries} is null
-     */
-    public Builder withEntries(final List<PersistedRaftRecord> entries) {
+    public Builder withEntries(final List<ReplicatedJournalRecord> entries) {
       this.entries = checkNotNull(entries, NULL_ENTRIES_ERR);
       return this;
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
@@ -60,6 +60,12 @@ public class PersistedRaftRecord implements JournalRecord {
     return new UnsafeBuffer(serializedRaftLogEntry);
   }
 
+  @Override
+  public DirectBuffer serializedRecord() {
+    // TODO
+    return null;
+  }
+
   /**
    * Returns the approximate size needed when serializing this class. The exact size depends on the
    * serializer.

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+public class ProtocolVersionHandler {
+
+  private static final int VERSION_APPENDREQUEST = 1;
+  private static final int VERSION_APPENDREQUEST_V2 = 2;
+
+  public static VersionedAppendRequest transform(final AppendRequest request) {
+    return new VersionedAppendRequest(
+        VERSION_APPENDREQUEST,
+        request.term(),
+        request.leader(),
+        request.prevLogIndex(),
+        request.prevLogIndex(),
+        request.commitIndex(),
+        request.entries());
+  }
+
+  public static VersionedAppendRequest transform(final AppendRequestV2 request) {
+    return new VersionedAppendRequest(
+        VERSION_APPENDREQUEST_V2,
+        request.term(),
+        request.leader(),
+        request.prevLogIndex(),
+        request.prevLogIndex(),
+        request.commitIndex(),
+        request.entries());
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -7,10 +7,10 @@
  */
 package io.atomix.raft.protocol;
 
-public final class ProtocolVersionHandler {
+import static io.atomix.raft.protocol.VersionedAppendRequest.VERSION_APPENDREQUEST;
+import static io.atomix.raft.protocol.VersionedAppendRequest.VERSION_APPENDREQUEST_V2;
 
-  private static final int VERSION_APPENDREQUEST = 1;
-  private static final int VERSION_APPENDREQUEST_V2 = 2;
+public final class ProtocolVersionHandler {
 
   private ProtocolVersionHandler() {
     // override public one
@@ -24,7 +24,8 @@ public final class ProtocolVersionHandler {
         request.prevLogIndex(),
         request.prevLogTerm(),
         request.commitIndex(),
-        request.entries());
+        request.entries(),
+        null);
   }
 
   public static VersionedAppendRequest transform(final AppendRequestV2 request) {
@@ -35,6 +36,7 @@ public final class ProtocolVersionHandler {
         request.prevLogIndex(),
         request.prevLogTerm(),
         request.commitIndex(),
+        null,
         request.entries());
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -7,7 +7,7 @@
  */
 package io.atomix.raft.protocol;
 
-public class ProtocolVersionHandler {
+public final class ProtocolVersionHandler {
 
   private static final int VERSION_APPENDREQUEST = 1;
   private static final int VERSION_APPENDREQUEST_V2 = 2;

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -12,13 +12,17 @@ public class ProtocolVersionHandler {
   private static final int VERSION_APPENDREQUEST = 1;
   private static final int VERSION_APPENDREQUEST_V2 = 2;
 
+  private ProtocolVersionHandler() {
+    // override public one
+  }
+
   public static VersionedAppendRequest transform(final AppendRequest request) {
     return new VersionedAppendRequest(
         VERSION_APPENDREQUEST,
         request.term(),
         request.leader(),
         request.prevLogIndex(),
-        request.prevLogIndex(),
+        request.prevLogTerm(),
         request.commitIndex(),
         request.entries());
   }
@@ -29,7 +33,7 @@ public class ProtocolVersionHandler {
         request.term(),
         request.leader(),
         request.prevLogIndex(),
-        request.prevLogIndex(),
+        request.prevLogTerm(),
         request.commitIndex(),
         request.entries());
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -86,6 +86,8 @@ public interface RaftServerProtocol {
    */
   CompletableFuture<AppendResponse> append(MemberId memberId, AppendRequest request);
 
+  CompletableFuture<AppendResponse> append(MemberId memberId, AppendRequestV2 request);
+
   /**
    * Registers a transfer request callback.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -154,7 +154,10 @@ public interface RaftServerProtocol {
    *
    * @param handler the open session request handler to register
    */
-  void registerAppendHandler(Function<AppendRequest, CompletableFuture<AppendResponse>> handler);
+  void registerAppendV1Handler(Function<AppendRequest, CompletableFuture<AppendResponse>> handler);
+
+  void registerAppendV2Handler(
+      Function<AppendRequestV2, CompletableFuture<AppendResponse>> handler);
 
   /** Unregisters the append request handler. */
   void unregisterAppendHandler();

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatedJournalRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatedJournalRecord.java
@@ -15,65 +15,27 @@
  */
 package io.atomix.raft.protocol;
 
-import io.camunda.zeebe.journal.JournalRecord;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
-
-public class PersistedRaftRecord implements JournalRecord, ReplicatedRecord {
+public class ReplicatedJournalRecord implements ReplicatedRecord {
 
   private final long index;
-  private final long asqn;
   private final long checksum;
-  private final byte[] serializedRaftLogEntry;
+  private final byte[] serializedJournalRecord;
   private final long term;
 
-  public PersistedRaftRecord(
+  public ReplicatedJournalRecord(
       final long term,
       final long index,
-      final long asqn,
       final long checksum,
-      final byte[] serializedRaftLogEntry) {
+      final byte[] serializedJournalRecord) {
     this.index = index;
-    this.asqn = asqn;
     this.checksum = checksum;
-    this.serializedRaftLogEntry = serializedRaftLogEntry;
+    this.serializedJournalRecord = serializedJournalRecord;
     this.term = term;
   }
 
   @Override
   public long index() {
     return index;
-  }
-
-  @Override
-  public long asqn() {
-    return asqn;
-  }
-
-  @Override
-  public long checksum() {
-    return checksum;
-  }
-
-  @Override
-  public DirectBuffer data() {
-    return new UnsafeBuffer(serializedRaftLogEntry);
-  }
-
-  @Override
-  public DirectBuffer serializedRecord() {
-    // TODO
-    return null;
-  }
-
-  /**
-   * Returns the approximate size needed when serializing this class. The exact size depends on the
-   * serializer.
-   *
-   * @return approximate size
-   */
-  public int approximateSize() {
-    return serializedRaftLogEntry.length + Long.BYTES + Long.BYTES + Long.BYTES;
   }
 
   /**
@@ -84,5 +46,23 @@ public class PersistedRaftRecord implements JournalRecord, ReplicatedRecord {
   @Override
   public long term() {
     return term;
+  }
+
+  public long checksum() {
+    return checksum;
+  }
+
+  public byte[] serializedJournalRecord() {
+    return serializedJournalRecord;
+  }
+
+  /**
+   * Returns the approximate size needed when serializing this class. The exact size depends on the
+   * serializer.
+   *
+   * @return approximate size
+   */
+  public int approximateSize() {
+    return serializedJournalRecord.length + Long.BYTES + Long.BYTES;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatedRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatedRecord.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+public interface ReplicatedRecord {
+  long index();
+
+  long term();
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -17,4 +17,17 @@ public record VersionedAppendRequest(
     long prevLogIndex,
     long prevLogTerm,
     long commitIndex,
-    List<PersistedRaftRecord> entries) {}
+    List<PersistedRaftRecord> oldVersionEntries,
+    List<ReplicatedJournalRecord> serializedJournalRecords) {
+
+  static final int VERSION_APPENDREQUEST = 1;
+  static final int VERSION_APPENDREQUEST_V2 = 2;
+
+  public int entriesSize() {
+    return entries().size();
+  }
+
+  public List<? extends ReplicatedRecord> entries() {
+    return version == VERSION_APPENDREQUEST ? oldVersionEntries : serializedJournalRecords;
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+import io.atomix.cluster.MemberId;
+import java.util.List;
+
+public record VersionedAppendRequest(
+    int version,
+    long term,
+    MemberId leader,
+    long prevLogIndex,
+    long prevLogTerm,
+    long commitIndex,
+    List<PersistedRaftRecord> entries) {}

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
@@ -58,9 +58,8 @@ public abstract class AbstractRole implements RaftRole {
   public abstract RaftServer.Role role();
 
   /** Logs a request. */
-  protected final <R extends RaftRequest> R logRequest(final R request) {
+  protected final void logRequest(final Object request) {
     log.trace("Received {}", request);
-    return request;
   }
 
   /** Logs a response. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
@@ -18,12 +18,12 @@ package io.atomix.raft.roles;
 
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftRequest;
 import io.atomix.raft.protocol.RaftResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -38,7 +38,7 @@ public abstract class ActiveRole extends PassiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final VersionedAppendRequest request) {
     raft.checkThread();
     logRequest(request);
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -22,9 +22,9 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftMemberContext;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.RaftResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -264,7 +264,7 @@ public final class CandidateRole extends ActiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final VersionedAppendRequest request) {
     raft.checkThread();
 
     // If the request indicates a term that is greater than the current term then

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -26,7 +26,6 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftMemberContext;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
@@ -34,6 +33,7 @@ import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -183,7 +183,7 @@ public final class FollowerRole extends ActiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final VersionedAppendRequest request) {
     final CompletableFuture<AppendResponse> future = super.onAppend(request);
     if (isRequestFromCurrentLeader(request.term(), request.leader())) {
       onHeartbeatFromLeader();

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -19,7 +19,6 @@ package io.atomix.raft.roles;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
@@ -33,6 +32,7 @@ import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.system.Configuration;
@@ -111,7 +111,7 @@ public class InactiveRole extends AbstractRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final VersionedAppendRequest request) {
     logRequest(request);
     final var result =
         logResponse(

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -32,9 +32,9 @@ import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
-import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.RaftRequest;
 import io.atomix.raft.protocol.RaftResponse;
+import io.atomix.raft.protocol.ReplicatedJournalRecord;
 import io.atomix.raft.snapshot.impl.SnapshotChunkImpl;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.utils.logging.ContextualLoggerFactory;
@@ -166,7 +166,7 @@ final class LeaderAppender {
             .withCommitIndex(raft.getCommitIndex());
 
     // Build a list of entries to send to the member.
-    final List<PersistedRaftRecord> entries = new ArrayList<>();
+    final List<ReplicatedJournalRecord> entries = new ArrayList<>();
 
     // Build a list of entries up to the MAX_BATCH_SIZE. Note that entries in the log may
     // be null if they've been compacted and the member to which we're sending entries is just
@@ -180,7 +180,7 @@ final class LeaderAppender {
     while (member.hasNextEntry()) {
       // Otherwise, read the next entry and add it to the batch.
       final IndexedRaftLogEntry entry = member.nextEntry();
-      final var replicatableRecord = entry.getPersistedRaftRecord();
+      final var replicatableRecord = entry.getReplicatedJournalRecord();
       entries.add(replicatableRecord);
       size += replicatableRecord.approximateSize();
       if (entry.index() == lastIndex || size >= maxBatchSizePerAppend) {
@@ -642,7 +642,7 @@ final class LeaderAppender {
       metrics.observeAppend(
           member.getMember().memberId().id(),
           request.entries().size(),
-          request.entries().stream().mapToInt(PersistedRaftRecord::approximateSize).sum());
+          request.entries().stream().mapToInt(ReplicatedJournalRecord::approximateSize).sum());
 
       commitEntries();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -26,7 +26,6 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftMemberContext;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
@@ -37,6 +36,7 @@ import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -408,7 +408,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final VersionedAppendRequest request) {
     raft.checkThread();
     if (updateTermAndLeader(request.term(), request.leader())) {
       final CompletableFuture<AppendResponse> future = super.onAppend(request);

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -20,7 +20,6 @@ import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.SnapshotReplicationMetrics;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
@@ -30,6 +29,7 @@ import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.snapshot.impl.SnapshotChunkImpl;
@@ -283,7 +283,7 @@ public class PassiveRole extends InactiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final VersionedAppendRequest request) {
     raft.checkThread();
     logRequest(request);
     updateTermAndLeader(request.term(), request.leader());
@@ -350,7 +350,7 @@ public class PassiveRole extends InactiveRole {
   }
 
   /** Handles an AppendRequest. */
-  protected CompletableFuture<AppendResponse> handleAppend(final AppendRequest request) {
+  protected CompletableFuture<AppendResponse> handleAppend(final VersionedAppendRequest request) {
     final CompletableFuture<AppendResponse> future = new CompletableFuture<>();
 
     // Check that the term of the given request matches the local term or update the term.
@@ -377,7 +377,7 @@ public class PassiveRole extends InactiveRole {
    * continue handling the request.
    */
   protected boolean checkTerm(
-      final AppendRequest request, final CompletableFuture<AppendResponse> future) {
+      final VersionedAppendRequest request, final CompletableFuture<AppendResponse> future) {
     if (request.term() < raft.getTerm()) {
       log.debug(
           "Rejected {}: request term is less than the current term ({})", request, raft.getTerm());
@@ -391,7 +391,7 @@ public class PassiveRole extends InactiveRole {
    * continue handling the request.
    */
   protected boolean checkPreviousEntry(
-      final AppendRequest request, final CompletableFuture<AppendResponse> future) {
+      final VersionedAppendRequest request, final CompletableFuture<AppendResponse> future) {
     // If the previous term is set, validate that it matches the local log.
     // We check the previous log term since that indicates whether any entry is present in the
     // leader's
@@ -426,7 +426,7 @@ public class PassiveRole extends InactiveRole {
   }
 
   private boolean checkPreviousEntry(
-      final AppendRequest request,
+      final VersionedAppendRequest request,
       final long lastEntryIndex,
       final long lastEntryTerm,
       final CompletableFuture<AppendResponse> future) {
@@ -480,7 +480,7 @@ public class PassiveRole extends InactiveRole {
 
   /** Appends entries from the given AppendRequest. */
   protected void appendEntries(
-      final AppendRequest request, final CompletableFuture<AppendResponse> future) {
+      final VersionedAppendRequest request, final CompletableFuture<AppendResponse> future) {
     // Compute the last entry index from the previous log index and request entry count.
     final long lastEntryIndex = request.prevLogIndex() + request.entries().size();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -17,7 +17,6 @@
 package io.atomix.raft.roles;
 
 import io.atomix.raft.RaftServer;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
@@ -29,6 +28,7 @@ import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.utils.Managed;
@@ -82,7 +82,7 @@ public interface RaftRole extends Managed<RaftRole> {
    * @param request The request to handle.
    * @return A completable future to be completed with the request response.
    */
-  CompletableFuture<AppendResponse> onAppend(AppendRequest request);
+  CompletableFuture<AppendResponse> onAppend(VersionedAppendRequest request);
 
   /**
    * Handles a poll request.

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntry.java
@@ -17,6 +17,7 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatedJournalRecord;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
 
@@ -59,4 +60,6 @@ public interface IndexedRaftLogEntry {
    * @return a record to replicate
    */
   PersistedRaftRecord getPersistedRaftRecord();
+
+  ReplicatedJournalRecord getReplicatedJournalRecord();
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java
@@ -17,6 +17,7 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatedJournalRecord;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
 import io.camunda.zeebe.journal.JournalRecord;
@@ -45,5 +46,12 @@ record IndexedRaftLogEntryImpl(long index, long term, RaftEntry entry, JournalRe
     record.data().getBytes(0, serializedRaftLogEntry);
     return new PersistedRaftRecord(
         term, index, record.asqn(), record.checksum(), serializedRaftLogEntry);
+  }
+
+  @Override
+  public ReplicatedJournalRecord getReplicatedJournalRecord() {
+    final byte[] serializedRecord = new byte[record.serializedRecord().capacity()];
+    record.serializedRecord().getBytes(0, serializedRecord);
+    return new ReplicatedJournalRecord(term, index, record.checksum(), serializedRecord);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -19,6 +19,7 @@ package io.atomix.raft.storage.log;
 import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatedJournalRecord;
 import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
@@ -154,6 +155,15 @@ public final class RaftLog implements Closeable {
 
     final RaftLogEntry raftEntry = serializer.readRaftLogEntry(entry.data());
     lastAppendedEntry = new IndexedRaftLogEntryImpl(entry.term(), raftEntry.entry(), entry);
+    return lastAppendedEntry;
+  }
+
+  public IndexedRaftLogEntry append(final ReplicatedJournalRecord entry) {
+    final var writtenRecord =
+        journal.append(entry.index(), entry.checksum(), entry.serializedJournalRecord());
+
+    final RaftLogEntry raftEntry = serializer.readRaftLogEntry(writtenRecord.data());
+    lastAppendedEntry = new IndexedRaftLogEntryImpl(entry.term(), raftEntry.entry(), writtenRecord);
     return lastAppendedEntry;
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -27,6 +27,7 @@ import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.primitive.TestMember;
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatedJournalRecord;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.roles.LeaderRole;
@@ -703,6 +704,11 @@ public final class RaftRule extends ExternalResource {
 
     @Override
     public PersistedRaftRecord getPersistedRaftRecord() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReplicatedJournalRecord getReplicatedJournalRecord() {
       throw new UnsupportedOperationException();
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
@@ -237,6 +237,12 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<AppendResponse> append(
+      final MemberId memberId, final AppendRequestV2 request) {
+    return null;
+  }
+
+  @Override
   public void registerTransferHandler(
       final Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
     transferHandler = handler;

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
@@ -303,10 +303,14 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   }
 
   @Override
-  public void registerAppendHandler(
+  public void registerAppendV1Handler(
       final Function<AppendRequest, CompletableFuture<AppendResponse>> handler) {
     appendHandler = handler;
   }
+
+  @Override
+  public void registerAppendV2Handler(
+      final Function<AppendRequestV2, CompletableFuture<AppendResponse>> handler) {}
 
   @Override
   public void unregisterAppendHandler() {

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -170,10 +170,14 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   }
 
   @Override
-  public void registerAppendHandler(
+  public void registerAppendV1Handler(
       final Function<AppendRequest, CompletableFuture<AppendResponse>> handler) {
     appendHandler = handler;
   }
+
+  @Override
+  public void registerAppendV2Handler(
+      final Function<AppendRequestV2, CompletableFuture<AppendResponse>> handler) {}
 
   @Override
   public void unregisterAppendHandler() {

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -104,6 +104,12 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   }
 
   @Override
+  public CompletableFuture<AppendResponse> append(
+      final MemberId memberId, final AppendRequestV2 request) {
+    return null;
+  }
+
+  @Override
   public void registerTransferHandler(
       final Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
     transferHandler = handler;

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -34,7 +34,7 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
   private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
   private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
-  private Function<AppendRequest, CompletableFuture<AppendResponse>> appendHandler;
+  private Function<AppendRequestV2, CompletableFuture<AppendResponse>> appendHandler;
   private final Set<MemberId> partitions = Sets.newCopyOnWriteArraySet();
 
   public TestRaftServerProtocol(
@@ -100,13 +100,13 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public CompletableFuture<AppendResponse> append(
       final MemberId memberId, final AppendRequest request) {
-    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.append(request)));
+    throw new IllegalArgumentException("Using old version not supported in tests");
   }
 
   @Override
   public CompletableFuture<AppendResponse> append(
       final MemberId memberId, final AppendRequestV2 request) {
-    return null;
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.append(request)));
   }
 
   @Override
@@ -178,12 +178,14 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public void registerAppendV1Handler(
       final Function<AppendRequest, CompletableFuture<AppendResponse>> handler) {
-    appendHandler = handler;
+    // Ignore as old version is not supported in tests
   }
 
   @Override
   public void registerAppendV2Handler(
-      final Function<AppendRequestV2, CompletableFuture<AppendResponse>> handler) {}
+      final Function<AppendRequestV2, CompletableFuture<AppendResponse>> handler) {
+    appendHandler = handler;
+  }
 
   @Override
   public void unregisterAppendHandler() {
@@ -199,7 +201,7 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
     }
   }
 
-  CompletableFuture<AppendResponse> append(final AppendRequest request) {
+  CompletableFuture<AppendResponse> append(final AppendRequestV2 request) {
     if (appendHandler != null) {
       return appendHandler.apply(request);
     } else {

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -32,6 +32,7 @@ import io.atomix.raft.impl.LogCompactor;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatedJournalRecord;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
@@ -401,6 +402,11 @@ public class LeaderRoleTest {
 
     @Override
     public PersistedRaftRecord getPersistedRaftRecord() {
+      return null;
+    }
+
+    @Override
+    public ReplicatedJournalRecord getReplicatedJournalRecord() {
       return null;
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -28,6 +28,7 @@ import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ProtocolVersionHandler;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
@@ -87,7 +88,8 @@ public class PassiveRoleTest {
         .thenThrow(new JournalException.InvalidChecksum("expected"));
 
     // when
-    final AppendResponse response = role.handleAppend(request).join();
+    final AppendResponse response =
+        role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     assertThat(response.succeeded()).isFalse();
@@ -107,7 +109,8 @@ public class PassiveRoleTest {
         .thenReturn(mock(IndexedRaftLogEntry.class));
 
     // when
-    final AppendResponse response = role.handleAppend(request).join();
+    final AppendResponse response =
+        role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     verify(log, times(1)).flush();
@@ -128,7 +131,8 @@ public class PassiveRoleTest {
         .thenThrow(new InvalidChecksum.InvalidChecksum("expected"));
 
     // when
-    final AppendResponse response = role.handleAppend(request).join();
+    final AppendResponse response =
+        role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     verify(log, times(1)).flush();
@@ -146,7 +150,8 @@ public class PassiveRoleTest {
         .thenThrow(new InvalidChecksum.InvalidChecksum("expected"));
 
     // when
-    final AppendResponse response = role.handleAppend(request).join();
+    final AppendResponse response =
+        role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     verify(log, never()).flush();
@@ -170,7 +175,7 @@ public class PassiveRoleTest {
     when(ctx.getLog()).thenReturn(log);
 
     // when
-    role.handleAppend(request).join();
+    role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     verify(log, times(1)).flush();

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatedJournalRecord;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
@@ -52,6 +53,11 @@ public class TestIndexedRaftLogEntry implements IndexedRaftLogEntry {
 
   @Override
   public PersistedRaftRecord getPersistedRaftRecord() {
+    return null;
+  }
+
+  @Override
+  public ReplicatedJournalRecord getReplicatedJournalRecord() {
     return null;
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -60,7 +60,7 @@ public interface Journal extends AutoCloseable {
    * @param checksum
    * @param serializedRecord
    */
-  void append(long index, long checksum, byte[] serializedRecord);
+  JournalRecord append(long index, long checksum, byte[] serializedRecord);
 
   /**
    * Delete all records after indexExclusive. After a call to this method, {@link

--- a/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -54,6 +54,15 @@ public interface Journal extends AutoCloseable {
   void append(JournalRecord record);
 
   /**
+   * Appends already serialized journal record.
+   *
+   * @param index
+   * @param checksum
+   * @param serializedRecord
+   */
+  void append(long index, long checksum, byte[] serializedRecord);
+
+  /**
    * Delete all records after indexExclusive. After a call to this method, {@link
    * Journal#getLastIndex()} should return indexExclusive.
    *

--- a/journal/src/main/java/io/camunda/zeebe/journal/JournalRecord.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/JournalRecord.java
@@ -46,4 +46,6 @@ public interface JournalRecord {
    * @return data
    */
   DirectBuffer data();
+
+  DirectBuffer serializedRecord();
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -221,7 +221,7 @@ final class SegmentWriter {
             metadata,
             data,
             new UnsafeBuffer(
-                writeBuffer, startPosition + frameLength, metadataLength + recordLength));
+                writeBuffer, startPosition + frameLength + metadataLength, recordLength));
     updateLastAsqn(lastEntry.asqn());
     index.index(lastEntry, startPosition);
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -155,7 +155,7 @@ final class SegmentWriter {
     }
 
     writeMetadata(startPosition, frameLength, recordLength, checksum);
-    updateLastWrittenEntry(startPosition, frameLength, metadataLength);
+    updateLastWrittenEntry(startPosition, frameLength, metadataLength, recordLength);
     FrameUtil.writeVersion(buffer, startPosition);
 
     final int appendedBytes = frameLength + metadataLength + recordLength;
@@ -165,10 +165,18 @@ final class SegmentWriter {
   }
 
   private void updateLastWrittenEntry(
-      final int startPosition, final int frameLength, final int metadataLength) {
+      final int startPosition,
+      final int frameLength,
+      final int metadataLength,
+      final int recordLength) {
     final var metadata = serializer.readMetadata(writeBuffer, startPosition + frameLength);
     final var data = serializer.readData(writeBuffer, startPosition + frameLength + metadataLength);
-    lastEntry = new PersistedJournalRecord(metadata, data);
+    lastEntry =
+        new PersistedJournalRecord(
+            metadata,
+            data,
+            new UnsafeBuffer(
+                writeBuffer, startPosition + frameLength, metadataLength + recordLength));
     updateLastAsqn(lastEntry.asqn());
     index.index(lastEntry, startPosition);
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -85,6 +85,13 @@ public final class SegmentedJournal implements Journal {
   }
 
   @Override
+  public void append(final long index, final long checksum, final byte[] serializedRecord) {
+    try (final var ignored = journalMetrics.observeAppendLatency()) {
+      writer.append(index, checksum, serializedRecord);
+    }
+  }
+
+  @Override
   public void deleteAfter(final long indexExclusive) {
     journalMetrics.observeSegmentTruncation(
         () -> {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -85,9 +85,10 @@ public final class SegmentedJournal implements Journal {
   }
 
   @Override
-  public void append(final long index, final long checksum, final byte[] serializedRecord) {
+  public JournalRecord append(
+      final long index, final long checksum, final byte[] serializedRecord) {
     try (final var ignored = journalMetrics.observeAppendLatency()) {
-      writer.append(index, checksum, serializedRecord);
+      return writer.append(index, checksum, serializedRecord);
     }
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -83,10 +83,10 @@ final class SegmentedJournalWriter {
     }
   }
 
-  void append(final long index, final long checksum, final byte[] serializedRecord) {
+  JournalRecord append(final long index, final long checksum, final byte[] serializedRecord) {
     final var appendResult = currentWriter.append(index, checksum, serializedRecord);
     if (appendResult.isRight()) {
-      return;
+      return appendResult.get();
     }
 
     if (currentSegment.index() == currentWriter.getNextIndex()) {
@@ -98,6 +98,7 @@ final class SegmentedJournalWriter {
     if (resultInNewSegment.isLeft()) {
       throw resultInNewSegment.getLeft();
     }
+    return resultInNewSegment.get();
   }
 
   void reset(final long index) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
@@ -77,6 +77,7 @@ public final class JournalRecordReaderUtil {
               expectedIndex, record.index()));
     }
     buffer.position(startPosition + metadataLength + recordLength);
-    return new PersistedJournalRecord(metadata, record);
+    return new PersistedJournalRecord(
+        metadata, record, new UnsafeBuffer(buffer, startPosition, metadataLength + recordLength));
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
@@ -78,6 +78,6 @@ public final class JournalRecordReaderUtil {
     }
     buffer.position(startPosition + metadataLength + recordLength);
     return new PersistedJournalRecord(
-        metadata, record, new UnsafeBuffer(buffer, startPosition, metadataLength + recordLength));
+        metadata, record, new UnsafeBuffer(buffer, startPosition + metadataLength, recordLength));
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/record/PersistedJournalRecord.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/record/PersistedJournalRecord.java
@@ -16,7 +16,8 @@ import org.agrona.DirectBuffer;
  * <p>A {@link PersistedJournalRecord} consists of two parts. The first part is {@link
  * RecordMetadata}. The second part is {@link RecordData}.
  */
-public record PersistedJournalRecord(RecordMetadata metadata, RecordData record)
+public record PersistedJournalRecord(
+    RecordMetadata metadata, RecordData record, DirectBuffer serializedRecord)
     implements JournalRecord {
 
   @Override

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -459,7 +459,8 @@ final class JournalTest {
 
     // when
     final var invalidChecksumRecord =
-        new TestJournalRecord(record.index(), record.asqn(), -1, record.data());
+        new TestJournalRecord(
+            record.index(), record.asqn(), -1, record.data(), record.serializedRecord());
 
     // then
     assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
@@ -681,11 +682,11 @@ final class JournalTest {
         new RecordData(record.index(), record.asqn(), BufferUtil.cloneBuffer(record.data()));
 
     if (record instanceof PersistedJournalRecord p) {
-      return new PersistedJournalRecord(p.metadata(), data);
+      return new PersistedJournalRecord(p.metadata(), data, p.serializedRecord());
     }
 
     return new PersistedJournalRecord(
-        new RecordMetadata(record.checksum(), data.data().capacity()), data);
+        new RecordMetadata(record.checksum(), data.data().capacity()), data, null);
   }
 
   private SegmentedJournal openJournal() {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -433,7 +433,8 @@ class SegmentedJournalTest {
             new RecordData(
                 firstRecord.index(),
                 firstRecord.asqn(),
-                BufferUtil.cloneBuffer(firstRecord.data())));
+                BufferUtil.cloneBuffer(firstRecord.data())),
+            null);
     journal.append(journalFactory.entry());
 
     // close the journal before corrupting the segment; since we "flush" when closing, we need to

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -434,7 +434,7 @@ class SegmentedJournalTest {
                 firstRecord.index(),
                 firstRecord.asqn(),
                 BufferUtil.cloneBuffer(firstRecord.data())),
-            null);
+            firstRecord.serializedRecord());
     journal.append(journalFactory.entry());
 
     // close the journal before corrupting the segment; since we "flush" when closing, we need to

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
@@ -39,7 +39,7 @@ class SparseJournalIndexTest {
   }
 
   public static JournalRecord asJournalRecord(final long index, final long asqn) {
-    return new TestJournalRecord(index, asqn, 0, null);
+    return new TestJournalRecord(index, asqn, 0, null, null);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/util/TestJournalRecord.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/util/TestJournalRecord.java
@@ -10,5 +10,6 @@ package io.camunda.zeebe.journal.util;
 import io.camunda.zeebe.journal.JournalRecord;
 import org.agrona.DirectBuffer;
 
-public record TestJournalRecord(long index, long asqn, long checksum, DirectBuffer data)
+public record TestJournalRecord(
+    long index, long asqn, long checksum, DirectBuffer data, DirectBuffer serializedRecord)
     implements JournalRecord {}


### PR DESCRIPTION
related to #12915 

- For backward compatibility, in this PR we define two types of AppendRequest to differentiate between old and new versions. `VersionedAppendRequest` unifies both types and is used to handle the append request. 
- New broker version can accept AppendRequest from old versions.
- But new broker cannot send AppendRequest to old brokers. We can make the new brokers send old version of append request, but this does not help as the checksum verification fails. So, we choose not to handle this case, and the new leader will send new version, which the old version cannot read and fail the append request.
- Added new api in Journal to handle new version of append where we provide entire serialized journal record.
- Based on the version of AppendRequest, RaftLog.append writes the entire record to the journal or write using the old api.
