### PR TITLE
Store intent in CommandDistributionRecord

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CommandDistributionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CommandDistributionBehavior.java
@@ -57,6 +57,7 @@ public final class CommandDistributionBehavior {
         new CommandDistributionRecord()
             .setPartitionId(currentPartitionId)
             .setValueType(command.getValueType())
+            .setIntent(command.getIntent())
             .setRecordValue(command.getValue());
 
     final long distributionKey = keyGenerator.nextKey();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -125,6 +125,7 @@ public class DbDistributionState implements MutableDistributionState {
     return new CommandDistributionRecord()
         .setPartitionId(partition)
         .setValueType(persistedDistribution.getValueType())
+        .setIntent(persistedDistribution.getIntent())
         .setRecordValue(persistedDistribution.getCommandValue());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
@@ -10,26 +10,32 @@ package io.camunda.zeebe.engine.state.distribution;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class PersistedCommandDistribution extends UnpackedObject implements DbValue {
 
   private final EnumProperty<ValueType> valueTypeProperty =
       new EnumProperty<>("valueType", ValueType.class);
+  private final IntegerProperty intentProperty = new IntegerProperty("intent", Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>("commandValue", new UnifiedRecordValue());
 
   public PersistedCommandDistribution() {
-    declareProperty(valueTypeProperty).declareProperty(commandValueProperty);
+    declareProperty(valueTypeProperty)
+        .declareProperty(intentProperty)
+        .declareProperty(commandValueProperty);
   }
 
   public PersistedCommandDistribution wrap(
       final CommandDistributionRecord commandDistributionRecord) {
     valueTypeProperty.setValue(commandDistributionRecord.getValueType());
+    intentProperty.setValue(commandDistributionRecord.getIntent().value());
 
     final var commandValue = commandDistributionRecord.getCommandValue();
     final var valueBuffer = new UnsafeBuffer(0, 0);
@@ -43,6 +49,17 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
 
   public ValueType getValueType() {
     return valueTypeProperty.getValue();
+  }
+
+  public Intent getIntent() {
+    final int intentValue = intentProperty.getValue();
+    if (intentValue < 0 || intentValue > Short.MAX_VALUE) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to read the intent, but it's persisted value '%d' is not a short integer",
+              intentValue));
+    }
+    return Intent.fromProtocolValue(getValueType(), (short) intentValue);
   }
 
   public UnifiedRecordValue getCommandValue() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
@@ -16,22 +16,18 @@ import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistribut
 import io.camunda.zeebe.protocol.record.ValueType;
 import org.agrona.concurrent.UnsafeBuffer;
 
-/**
- * The CommandValueAndValueTypeWrapper is used to store a command value with it's corresponding
- * ValueType in the state.
- */
-public class CommandValueAndValueTypeWrapper extends UnpackedObject implements DbValue {
+public class PersistedCommandDistribution extends UnpackedObject implements DbValue {
 
   private final EnumProperty<ValueType> valueTypeProperty =
       new EnumProperty<>("valueType", ValueType.class);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>("commandValue", new UnifiedRecordValue());
 
-  public CommandValueAndValueTypeWrapper() {
+  public PersistedCommandDistribution() {
     declareProperty(valueTypeProperty).declareProperty(commandValueProperty);
   }
 
-  public CommandValueAndValueTypeWrapper wrap(
+  public PersistedCommandDistribution wrap(
       final CommandDistributionRecord commandDistributionRecord) {
     valueTypeProperty.setValue(commandDistributionRecord.getValueType());
 

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -25,6 +25,9 @@
             "valueType": {
               "type": "keyword"
             },
+            "intent": {
+              "type": "keyword"
+            },
             "commandValue": {
               "enabled": false
             }

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -25,6 +25,9 @@
             "valueType": {
               "type": "keyword"
             },
+            "intent": {
+              "type": "keyword"
+            },
             "commandValue": {
               "enabled": false
             }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1258,12 +1258,14 @@ final class JsonSerializableToJsonTest {
               return new CommandDistributionRecord()
                   .setPartitionId(1)
                   .setValueType(ValueType.DEPLOYMENT)
+                  .setIntent(DeploymentIntent.CREATE)
                   .setRecordValue(deploymentRecord);
             },
         """
           {
             "partitionId": 1,
             "valueType": "DEPLOYMENT",
+            "intent": "CREATE",
             "commandValue": {
               "resources": [{
                 "resource": "VGhpcyBpcyB0aGUgY29udGVudHMgb2YgdGhlIEJQTU4=",
@@ -1294,6 +1296,7 @@ final class JsonSerializableToJsonTest {
           {
               "partitionId": 1,
               "valueType": "NULL_VAL",
+              "intent": "UNKNOWN",
               "commandValue": null
           }
           """

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -241,6 +241,7 @@ public final class ProtocolFactory {
           return ImmutableCommandDistributionRecordValue.builder()
               .withPartitionId(random.nextInt())
               .withValueType(valueType)
+              .withIntent(random.nextObject(typeInfo.getIntentClass()))
               .withCommandValue(generateObject(typeInfo.getValueClass()))
               .build();
         });

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -53,22 +53,20 @@ public interface Intent {
           CommandDistributionIntent.class,
           ProcessInstanceBatchIntent.class);
   short NULL_VAL = 255;
-  Intent UNKNOWN =
-      new Intent() {
-        @Override
-        public short value() {
-          return NULL_VAL;
-        }
-
-        @Override
-        public String name() {
-          return "UNKNOWN";
-        }
-      };
+  Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
   short value();
 
   String name();
+
+  enum UnknownIntent implements Intent {
+    UNKNOWN;
+
+    @Override
+    public short value() {
+      return NULL_VAL;
+    }
+  }
 
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   static Intent fromProtocolValue(final ValueType valueType, final short intent) {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CommandDistributionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CommandDistributionRecordValue.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -33,6 +34,11 @@ public interface CommandDistributionRecordValue extends RecordValue {
    * @return the wrapped record value type
    */
   ValueType getValueType();
+
+  /**
+   * @return the wrapped intent
+   */
+  Intent getIntent();
 
   /**
    * @return the wrapped record value


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This is a requirement to implement the `CommandRedistributor`, because it needs to re-send the command with the intent. So it needs to read the intent from the state.

To achieve this, I had to add intent to `CommandDistributionRecord`, as well as to the `PersistedCommandDistribution` (the one that is stored in the state and will be looked up by the `CommandRedistributor`).

In addition, this pull request makes a change to `Intent.UNKNOWN` because it was not serialisable to JSON and broke one of the tests of `JsonSerializableToJsonTest`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #11914 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
