### PR TITLE
Redistribute command distributions

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -156,7 +156,11 @@ public final class EngineProcessors {
     addResourceDeletionProcessors(typedRecordProcessors, writers, processingState);
     addSignalBroadcastProcessors(typedRecordProcessors, bpmnBehaviors, writers, processingState);
     addCommandDistributionProcessors(
-        typedRecordProcessors, writers, processingState, interPartitionCommandSender);
+        typedRecordProcessors,
+        writers,
+        processingState,
+        scheduledTaskDbState,
+        interPartitionCommandSender);
 
     return typedRecordProcessors;
   }
@@ -323,12 +327,13 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final ProcessingState processingState,
+      final ScheduledTaskDbState scheduledTaskDbState,
       final InterPartitionCommandSender interPartitionCommandSender) {
 
     // periodically retries command distribution
     typedRecordProcessors.withListener(
         new CommandRedistributor(
-            processingState.getDistributionState(), interPartitionCommandSender));
+            scheduledTaskDbState.getDistributionState(), interPartitionCommandSender));
 
     final var commandDistributionAcknowledgeProcessor =
         new CommandDistributionAcknowledgeProcessor(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistri
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionAcknowledgeProcessor;
+import io.camunda.zeebe.engine.processing.distribution.CommandRedistributor;
 import io.camunda.zeebe.engine.processing.dmn.EvaluateDecisionProcessor;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
@@ -109,6 +110,11 @@ public final class EngineProcessors {
             partitionsCount,
             interPartitionCommandSender,
             processingState.getKeyGenerator());
+
+    // periodically retries command distribution
+    typedRecordProcessors.withListener(
+        new CommandRedistributor(
+            processingState.getDistributionState(), interPartitionCommandSender));
 
     final var deploymentDistributionCommandSender =
         new DeploymentDistributionCommandSender(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -66,6 +66,7 @@ public final class EngineProcessors {
       final JobStreamer jobStreamer) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
+    final var scheduledTaskDbState = typedRecordProcessorContext.getScheduledTaskDbState();
     final var writers = typedRecordProcessorContext.getWriters();
     final TypedRecordProcessors typedRecordProcessors =
         TypedRecordProcessors.processors(processingState.getKeyGenerator(), writers);
@@ -79,8 +80,7 @@ public final class EngineProcessors {
     final var config = typedRecordProcessorContext.getConfig();
 
     final DueDateTimerChecker timerChecker =
-        new DueDateTimerChecker(
-            typedRecordProcessorContext.getScheduledTaskDbState().getTimerState(), featureFlags);
+        new DueDateTimerChecker(scheduledTaskDbState.getTimerState(), featureFlags);
 
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());
@@ -127,7 +127,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         subscriptionCommandSender,
         processingState,
-        typedRecordProcessorContext.getScheduledTaskDbState(),
+        scheduledTaskDbState,
         typedRecordProcessors,
         writers,
         config,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -100,9 +100,6 @@ public final class EngineProcessors {
             jobMetrics,
             decisionBehavior);
 
-    final DeploymentDistributionCommandSender deploymentDistributionCommandSender =
-        new DeploymentDistributionCommandSender(
-            typedRecordProcessorContext.getPartitionId(), interPartitionCommandSender);
     // TODO unused for now, will be used with the implementation of
     // https://github.com/camunda/zeebe/issues/11661
     final var commandDistributionBehavior =
@@ -113,6 +110,9 @@ public final class EngineProcessors {
             interPartitionCommandSender,
             processingState.getKeyGenerator());
 
+    final var deploymentDistributionCommandSender =
+        new DeploymentDistributionCommandSender(
+            typedRecordProcessorContext.getPartitionId(), interPartitionCommandSender);
     addDeploymentRelatedProcessorAndServices(
         bpmnBehaviors,
         processingState,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.distribution;
 
-import static io.camunda.zeebe.protocol.Protocol.DEPLOYMENT_PARTITION;
-
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
@@ -73,10 +71,6 @@ public final class CommandRedistributor implements StreamProcessorLifecycleAware
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    if (context.getPartitionId() != DEPLOYMENT_PARTITION) {
-      return;
-    }
-
     context
         .getScheduleService()
         .runAtFixedRate(COMMAND_REDISTRIBUTION_INTERVAL, this::runRetryCycle);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
@@ -9,8 +9,9 @@ package io.camunda.zeebe.engine.processing.distribution;
 
 import static io.camunda.zeebe.protocol.Protocol.DEPLOYMENT_PARTITION;
 
-import io.camunda.zeebe.engine.state.immutable.DeploymentState;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.engine.state.immutable.DistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.time.Duration;
@@ -18,26 +19,56 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.function.Predicate;
-import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CommandRedistributor implements StreamProcessorLifecycleAware {
+/**
+ * The Command Redistributor provides a mechanism to retry sending {@link
+ * CommandDistributionRecord}s to other partitions. This is needed because the communication between
+ * partitions is unreliable.
+ *
+ * <p>A simple exponential backoff is used for retrying these pending distributions. This
+ * exponential backoff is statically configured to start of at 10 seconds {@link
+ * #COMMAND_REDISTRIBUTION_INTERVAL} until it reaches a maximum of 5 minutes {@link
+ * #RETRY_MAX_BACKOFF_DURATION}, doubling every time. This backoff is tracked for each pending
+ * distribution individually.
+ */
+public final class CommandRedistributor implements StreamProcessorLifecycleAware {
 
-  public static final Duration DEPLOYMENT_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
+  /**
+   * Specifies how often this redistributor runs, i.e. the fixed delay between runs. It is also used
+   * to specify the initial interval for retrying a specific pending distribution.
+   */
+  public static final Duration COMMAND_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
+
+  /**
+   * Specifies the maximum backoff interval for retrying a specific pending distribution, i.e. the
+   * maximum delay between two retries of the same pending distribution.
+   */
   private static final Duration RETRY_MAX_BACKOFF_DURATION = Duration.ofMinutes(5);
+
+  /**
+   * This calculated value specifies the maximum number of retry cycles until the {@link
+   * #RETRY_MAX_BACKOFF_DURATION} is reached by the exponential backoff.
+   */
   private static final long MAX_RETRY_CYCLES =
-      RETRY_MAX_BACKOFF_DURATION.dividedBy(DEPLOYMENT_REDISTRIBUTION_INTERVAL);
-  private static final Logger LOG = LoggerFactory.getLogger(DeploymentRedistributor.class);
-  private final DeploymentDistributionCommandSender deploymentDistributionCommandSender;
-  private final DeploymentState deploymentState;
+      RETRY_MAX_BACKOFF_DURATION.dividedBy(COMMAND_REDISTRIBUTION_INTERVAL);
+
+  private static final Logger LOG = LoggerFactory.getLogger(CommandRedistributor.class);
+
+  private final DistributionState distributionState;
+  private final InterPartitionCommandSender commandSender;
+
+  /**
+   * Tracks the number of attempted retry cycles for each pending distribution. Note that this
+   * includes retry cycles where the pending distribution was not resend due to exponential backoff.
+   */
   private final Map<PendingDistribution, Long> retryCyclesPerDistribution = new HashMap<>();
 
-  public DeploymentRedistributor(
-      final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
-      final DeploymentState deploymentState) {
-    this.deploymentDistributionCommandSender = deploymentDistributionCommandSender;
-    this.deploymentState = deploymentState;
+  public CommandRedistributor(
+      final DistributionState distributionState, final InterPartitionCommandSender commandSender) {
+    this.distributionState = distributionState;
+    this.commandSender = commandSender;
   }
 
   @Override
@@ -48,40 +79,52 @@ public class CommandRedistributor implements StreamProcessorLifecycleAware {
 
     context
         .getScheduleService()
-        .runAtFixedRate(DEPLOYMENT_REDISTRIBUTION_INTERVAL, this::runRetryCycle);
+        .runAtFixedRate(COMMAND_REDISTRIBUTION_INTERVAL, this::runRetryCycle);
   }
 
   private void runRetryCycle() {
     final var pendingDistributions = new HashSet<PendingDistribution>();
-    deploymentState.foreachPendingDeploymentDistribution(
-        (deploymentKey, partitionId, directBuffer) -> {
-          final var pending = new PendingDistribution(deploymentKey, partitionId);
+    distributionState.foreachPendingDistribution(
+        (distributionKey, record) -> {
+          final var pending = new PendingDistribution(distributionKey, record.getPartitionId());
           pendingDistributions.add(pending);
-          retryDistribution(pending, directBuffer);
+          retryDistribution(pending, record);
         });
-    // Remove retry cycle tracking for completed distributions
+
+    // Remove retry cycle tracking for completed distributions, i.e. those not visited in this cycle
     retryCyclesPerDistribution.keySet().removeIf(Predicate.not(pendingDistributions::contains));
   }
 
   private void retryDistribution(
-      final PendingDistribution pending, final DirectBuffer copiedDeploymentBuffer) {
+      final PendingDistribution pending,
+      final CommandDistributionRecord commandDistributionRecord) {
     if (!shouldRetryNow(pending)) {
       return;
     }
 
     LOG.info(
-        "Retrying to distribute deployment {} to partition {}",
-        pending.deploymentKey,
+        "Retrying to distribute pending command {} to partition {}",
+        pending.distributionKey,
         pending.partitionId);
-    final var deploymentRecord = new DeploymentRecord();
-    deploymentRecord.wrap(copiedDeploymentBuffer);
-    deploymentDistributionCommandSender.distributeToPartition(
-        pending.deploymentKey, pending.partitionId, deploymentRecord);
+
+    commandSender.sendCommand(
+        pending.partitionId,
+        commandDistributionRecord.getValueType(),
+        commandDistributionRecord.getIntent(),
+        pending.distributionKey,
+        commandDistributionRecord.getCommandValue());
   }
 
+  /**
+   * Returns whether a pending distribution should be retried now, or not in this cycle.
+   *
+   * <p>Calling this method increments the retry cycles tracking ({@link
+   * #retryCyclesPerDistribution}) of that pending distribution, or initiates it at 0. The number of
+   * cycles is used to implement a simple exponential backoff.
+   */
   private boolean shouldRetryNow(final PendingDistribution pendingDistribution) {
-    // retryCycles starts off at 0, ensuring that we wait between DEPLOYMENT_REDISTRIBUTION_INTERVAL
-    // and 2 * DEPLOYMENT_REDISTRIBUTION_INTERVAL before retrying distribution.
+    // retryCycles starts off at 0, ensuring that we wait between COMMAND_REDISTRIBUTION_INTERVAL
+    // and 2 * COMMAND_REDISTRIBUTION_INTERVAL before retrying distribution.
     final long retryCycle =
         retryCyclesPerDistribution.compute(
             pendingDistribution, (k, retryCycles) -> retryCycles != null ? retryCycles + 1 : 0L);
@@ -90,11 +133,11 @@ public class CommandRedistributor implements StreamProcessorLifecycleAware {
       // Retry in intervals of RETRY_MAX_BACKOFF_DURATION
       return retryCycle % MAX_RETRY_CYCLES == 0;
     } else {
-      // Retry in intervals of DEPLOYMENT_REDISTRIBUTION_INTERVAL
+      // Retry in intervals of COMMAND_REDISTRIBUTION_INTERVAL
       // The interval is doubling until we reached RETRY_MAX_BACKOFF_DURATION
       return Long.bitCount(retryCycle) == 1;
     }
   }
 
-  private record PendingDistribution(long deploymentKey, int partitionId) {}
+  private record PendingDistribution(long distributionKey, int partitionId) {}
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.distribution;
+
+import static io.camunda.zeebe.protocol.Protocol.DEPLOYMENT_PARTITION;
+
+import io.camunda.zeebe.engine.state.immutable.DeploymentState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CommandRedistributor implements StreamProcessorLifecycleAware {
+
+  public static final Duration DEPLOYMENT_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
+  private static final Duration RETRY_MAX_BACKOFF_DURATION = Duration.ofMinutes(5);
+  private static final long MAX_RETRY_CYCLES =
+      RETRY_MAX_BACKOFF_DURATION.dividedBy(DEPLOYMENT_REDISTRIBUTION_INTERVAL);
+  private static final Logger LOG = LoggerFactory.getLogger(DeploymentRedistributor.class);
+  private final DeploymentDistributionCommandSender deploymentDistributionCommandSender;
+  private final DeploymentState deploymentState;
+  private final Map<PendingDistribution, Long> retryCyclesPerDistribution = new HashMap<>();
+
+  public DeploymentRedistributor(
+      final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
+      final DeploymentState deploymentState) {
+    this.deploymentDistributionCommandSender = deploymentDistributionCommandSender;
+    this.deploymentState = deploymentState;
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    if (context.getPartitionId() != DEPLOYMENT_PARTITION) {
+      return;
+    }
+
+    context
+        .getScheduleService()
+        .runAtFixedRate(DEPLOYMENT_REDISTRIBUTION_INTERVAL, this::runRetryCycle);
+  }
+
+  private void runRetryCycle() {
+    final var pendingDistributions = new HashSet<PendingDistribution>();
+    deploymentState.foreachPendingDeploymentDistribution(
+        (deploymentKey, partitionId, directBuffer) -> {
+          final var pending = new PendingDistribution(deploymentKey, partitionId);
+          pendingDistributions.add(pending);
+          retryDistribution(pending, directBuffer);
+        });
+    // Remove retry cycle tracking for completed distributions
+    retryCyclesPerDistribution.keySet().removeIf(Predicate.not(pendingDistributions::contains));
+  }
+
+  private void retryDistribution(
+      final PendingDistribution pending, final DirectBuffer copiedDeploymentBuffer) {
+    if (!shouldRetryNow(pending)) {
+      return;
+    }
+
+    LOG.info(
+        "Retrying to distribute deployment {} to partition {}",
+        pending.deploymentKey,
+        pending.partitionId);
+    final var deploymentRecord = new DeploymentRecord();
+    deploymentRecord.wrap(copiedDeploymentBuffer);
+    deploymentDistributionCommandSender.distributeToPartition(
+        pending.deploymentKey, pending.partitionId, deploymentRecord);
+  }
+
+  private boolean shouldRetryNow(final PendingDistribution pendingDistribution) {
+    // retryCycles starts off at 0, ensuring that we wait between DEPLOYMENT_REDISTRIBUTION_INTERVAL
+    // and 2 * DEPLOYMENT_REDISTRIBUTION_INTERVAL before retrying distribution.
+    final long retryCycle =
+        retryCyclesPerDistribution.compute(
+            pendingDistribution, (k, retryCycles) -> retryCycles != null ? retryCycles + 1 : 0L);
+
+    if (retryCycle >= MAX_RETRY_CYCLES) {
+      // Retry in intervals of RETRY_MAX_BACKOFF_DURATION
+      return retryCycle % MAX_RETRY_CYCLES == 0;
+    } else {
+      // Retry in intervals of DEPLOYMENT_REDISTRIBUTION_INTERVAL
+      // The interval is doubling until we reached RETRY_MAX_BACKOFF_DURATION
+      return Long.bitCount(retryCycle) == 1;
+    }
+  }
+
+  private record PendingDistribution(long deploymentKey, int partitionId) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.state;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
+import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.instance.DbTimerInstanceState;
@@ -17,13 +19,19 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 /** Contains read-only state that can be accessed safely by scheduled tasks. */
 public final class ScheduledTaskDbState {
+  private final DistributionState distributionState;
   private final MessageState messageState;
   private final TimerInstanceState timerInstanceState;
 
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    this.distributionState = new DbDistributionState(zeebeDb, transactionContext);
     this.messageState = new DbMessageState(zeebeDb, transactionContext);
     this.timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
+  }
+
+  public DistributionState getDistributionState() {
+    return distributionState;
   }
 
   public MessageState getMessageState() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -144,6 +144,7 @@ public class DbDistributionState implements MutableDistributionState {
           final var distributionKey = compositeKey.first().inner().getValue();
           final var partitionId = compositeKey.second().getValue();
 
+          // we may encounter the same distribution key for several partitions, we can reuse it
           if (lastDistributionKey.value != distributionKey) {
             final var pendingDistribution =
                 getCommandDistributionRecord(distributionKey, partitionId);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -39,4 +39,28 @@ public interface DistributionState {
    * @return an new instance of the {@link CommandDistributionRecord}
    */
   CommandDistributionRecord getCommandDistributionRecord(long distributionKey, int partition);
+
+  /**
+   * Visits each persisted pending distribution, providing both the key of that distribution and the
+   * {@link CommandDistributionRecord}.
+   *
+   * <p>Note that a new instance of the record is provided for each visit, so the visitor does not
+   * have to make a copy when long term access is needed.
+   *
+   * @param visitor Each pending distribution is visited by this visitor
+   */
+  void foreachPendingDistribution(PendingDistributionVisitor visitor);
+
+  /** This visitor can visit pending distributions of {@link CommandDistributionRecord}. */
+  @FunctionalInterface
+  interface PendingDistributionVisitor {
+
+    /**
+     * Visits a pending distribution.
+     *
+     * @param distributionKey The key of the pending distribution
+     * @param pendingDistribution The pending distribution itself as command distribution record
+     */
+    void visit(final long distributionKey, final CommandDistributionRecord pendingDistribution);
+  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -183,10 +183,10 @@ public final class DistributionStateTest {
         distributionKey, pendingDistribution, partitionId2, partitionId3);
 
     // when
-    final List<VisitedPendingDistribution> visits = new ArrayList<>();
+    final List<PendingDistribution> visits = new ArrayList<>();
     distributionState.foreachPendingDistribution(
         (key, commandDistributionRecord) ->
-            visits.add(new VisitedPendingDistribution(key, commandDistributionRecord)));
+            visits.add(new PendingDistribution(key, commandDistributionRecord)));
 
     // then
     assertThat(visits)
@@ -197,7 +197,7 @@ public final class DistributionStateTest {
                     .hasIntent(pendingDistribution.getIntent())
                     .hasValueType(pendingDistribution.getValueType())
                     .hasCommandValue(pendingDistribution.getCommandValue()))
-        .extracting(VisitedPendingDistribution::record)
+        .extracting(PendingDistribution::record)
         .extracting(CommandDistributionRecord::getPartitionId)
         .describedAs("Expect that pending distributions are visited for all other partitions")
         .containsExactly(partitionId2, partitionId3);
@@ -217,14 +217,14 @@ public final class DistributionStateTest {
     }
 
     // when
-    final List<VisitedPendingDistribution> visits = new ArrayList<>();
+    final List<PendingDistribution> visits = new ArrayList<>();
     distributionState.foreachPendingDistribution(
         (key, commandDistributionRecord) ->
-            visits.add(new VisitedPendingDistribution(key, commandDistributionRecord)));
+            visits.add(new PendingDistribution(key, commandDistributionRecord)));
 
     // then
     assertThat(visits)
-        .extracting(VisitedPendingDistribution::key)
+        .extracting(PendingDistribution::key)
         .describedAs("Expect that all pending distribution are visited")
         .containsOnly(1L, 2L, 3L, 4L, 5L);
     assertThat(visits)
@@ -235,7 +235,7 @@ public final class DistributionStateTest {
                     .hasValueType(distributions.get(visited.key).getValueType())
                     .hasCommandValue(distributions.get(visited.key).getCommandValue()));
     assertThat(visits)
-        .extracting(VisitedPendingDistribution::record)
+        .extracting(PendingDistribution::record)
         .extracting(CommandDistributionRecord::getPartitionId)
         .describedAs("Expect that pending distributions are visited for all other partitions")
         .containsOnly(partitionId2, partitionId3);
@@ -255,10 +255,10 @@ public final class DistributionStateTest {
     distributionState.removeCommandDistribution(distributionKey);
 
     // when
-    final List<VisitedPendingDistribution> visits = new ArrayList<>();
+    final List<PendingDistribution> visits = new ArrayList<>();
     distributionState.foreachPendingDistribution(
         (key, commandDistributionRecord) ->
-            visits.add(new VisitedPendingDistribution(key, commandDistributionRecord)));
+            visits.add(new PendingDistribution(key, commandDistributionRecord)));
 
     // then
     assertThat(visits).isEmpty();
@@ -305,5 +305,5 @@ public final class DistributionStateTest {
             partitionId -> distributionState.addPendingDistribution(distributionKey, partitionId));
   }
 
-  record VisitedPendingDistribution(long key, CommandDistributionRecord record) {}
+  record PendingDistribution(long key, CommandDistributionRecord record) {}
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -55,6 +55,14 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .declareProperty(commandValueProperty);
   }
 
+  public CommandDistributionRecord wrap(final CommandDistributionRecord other) {
+    this.setPartitionId(other.getPartitionId())
+        .setValueType(other.getValueType())
+        .setIntent(other.getIntent())
+        .setRecordValue(other.getCommandValue());
+    return this;
+  }
+
   @Override
   public int getPartitionId() {
     return partitionIdProperty.getValue();
@@ -121,6 +129,11 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   }
 
   public CommandDistributionRecord setRecordValue(final UnifiedRecordValue recordValue) {
+    if (recordValue == null) {
+      commandValueProperty.reset();
+      return this;
+    }
+
     // inspired by IndexedRecord.setValue
     final var valueBuffer = new UnsafeBuffer(0, 0);
     final int encodedLength = recordValue.getLength();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Introduces a new CommandRedistributor class that retries sending pending command distributions to other partitions. An exponential backoff is used, as it is almost a 1:1 copy of the DeploymentRedistributor.

In addition, the redistribution has been made ready to be scheduled as async tasks. For now, it does not yet run async, as this will be added using a feature flag in the future (#12308).

Not all functionalities of this can be tested yet, but they will be tested when we switch over Deployment Distribution to the new Command Distribution (#11962).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11914 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
