### PR TITLE
[Backport stable/8.2] Add partition id to verifySnapshotLogConsistent message #12818

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -208,7 +208,12 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         .getLatestSnapshot()
         .ifPresent(persistedSnapshot -> currentSnapshot = persistedSnapshot);
     StateUtil.verifySnapshotLogConsistent(
-        getCurrentSnapshotIndex(), raftLog.getFirstIndex(), raftLog.isEmpty(), raftLog::reset, log);
+        partitionId,
+        getCurrentSnapshotIndex(),
+        raftLog.getFirstIndex(),
+        raftLog.isEmpty(),
+        raftLog::reset,
+        log);
 
     logCompactor =
         new LogCompactor(

--- a/atomix/cluster/src/main/java/io/atomix/raft/utils/StateUtil.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/utils/StateUtil.java
@@ -14,6 +14,7 @@ public class StateUtil {
 
   /** throws IllegalStateException if state is inconsistent */
   public static void verifySnapshotLogConsistent(
+      final long partitionId,
       final long snapshotIndex,
       final long firstIndex,
       final boolean isLogEmpty,
@@ -30,15 +31,15 @@ public class StateUtil {
       // There is a gap between snapshot and first log entry
       throw new IllegalStateException(
           String.format(
-              "Expected to find a snapshot at index >= log's first index %d, but found snapshot %d. A previous snapshot is most likely corrupted.",
-              firstIndex, snapshotIndex));
+              "In partition %d expected to find a snapshot at index >= log's first index %d,"
+                  + " but found snapshot %d. A previous snapshot is most likely corrupted.",
+              partitionId, firstIndex, snapshotIndex));
     } else {
       log.info(
-          "Current snapshot index ({}) is lower than log's first index {}. But the log is empty. Most likely the node crashed while committing a snapshot at index {}. Resetting log to {}",
-          snapshotIndex,
-          firstIndex,
-          firstIndex - 1,
-          snapshotIndex + 1);
+          "In partition %d current snapshot index ({}) is lower than log's first index {}. "
+              + "But the log is empty. Most likely the node crashed while committing a snapshot "
+              + "at index {}. Resetting log to {}",
+          partitionId, snapshotIndex, firstIndex, firstIndex - 1, snapshotIndex + 1);
       logResetter.accept(snapshotIndex + 1);
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/utils/StateUtilTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/utils/StateUtilTest.java
@@ -32,7 +32,12 @@ class StateUtilTest {
         .isThrownBy(
             () ->
                 StateUtil.verifySnapshotLogConsistent(
-                    state.snapshotIndex(), state.firstIndex(), state.isLogEmpty(), i -> {}, LOG));
+                    1L,
+                    state.snapshotIndex(),
+                    state.firstIndex(),
+                    state.isLogEmpty(),
+                    i -> {},
+                    LOG));
   }
 
   @ParameterizedTest
@@ -42,6 +47,7 @@ class StateUtilTest {
         .isThrownBy(
             () ->
                 StateUtil.verifySnapshotLogConsistent(
+                    1L,
                     state.snapshotIndex(),
                     state.firstIndex(),
                     state.isLogEmpty(),
@@ -59,6 +65,7 @@ class StateUtilTest {
         .isThrownBy(
             () ->
                 StateUtil.verifySnapshotLogConsistent(
+                    1L,
                     state.snapshotIndex(),
                     state.firstIndex(),
                     state.isLogEmpty(),


### PR DESCRIPTION
# Description
Backport of #12956 to `stable/8.2`.

relates to #12818