### PR TITLE
[Backport stable/8.0]: add partition id to verifySnapshotLogConsistent message #12818

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -202,7 +202,12 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         .getLatestSnapshot()
         .ifPresent(persistedSnapshot -> currentSnapshot = persistedSnapshot);
     StateUtil.verifySnapshotLogConsistent(
-        getCurrentSnapshotIndex(), raftLog.getFirstIndex(), raftLog.isEmpty(), raftLog::reset, log);
+        partitionId,
+        getCurrentSnapshotIndex(),
+        raftLog.getFirstIndex(),
+        raftLog.isEmpty(),
+        raftLog::reset,
+        log);
 
     logCompactor = new LogCompactor(this);
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/utils/StateUtil.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/utils/StateUtil.java
@@ -14,6 +14,7 @@ public class StateUtil {
 
   /** throws IllegalStateException if state is inconsistent */
   public static void verifySnapshotLogConsistent(
+      final long partitionId,
       final long snapshotIndex,
       final long firstIndex,
       final boolean isLogEmpty,
@@ -30,15 +31,15 @@ public class StateUtil {
       // There is a gap between snapshot and first log entry
       throw new IllegalStateException(
           String.format(
-              "Expected to find a snapshot at index >= log's first index %d, but found snapshot %d. A previous snapshot is most likely corrupted.",
-              firstIndex, snapshotIndex));
+              "In partition %d expected to find a snapshot at index >= log's first index %d,"
+                  + " but found snapshot %d. A previous snapshot is most likely corrupted.",
+              partitionId, firstIndex, snapshotIndex));
     } else {
       log.info(
-          "Current snapshot index ({}) is lower than log's first index {}. But the log is empty. Most likely the node crashed while committing a snapshot at index {}. Resetting log to {}",
-          snapshotIndex,
-          firstIndex,
-          firstIndex - 1,
-          snapshotIndex + 1);
+          "In partition %d current snapshot index ({}) is lower than log's first index {}. "
+              + "But the log is empty. Most likely the node crashed while committing a snapshot "
+              + "at index {}. Resetting log to {}",
+          partitionId, snapshotIndex, firstIndex, firstIndex - 1, snapshotIndex + 1);
       logResetter.accept(snapshotIndex + 1);
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/utils/StateUtilTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/utils/StateUtilTest.java
@@ -31,7 +31,7 @@ class StateUtilTest {
     assertThatThrownBy(
             () ->
                 StateUtil.verifySnapshotLogConsistent(
-                    snapshotIndex, firstIndex, isLogEmpty, i -> {}, LOG))
+                    1L, snapshotIndex, firstIndex, isLogEmpty, i -> {}, LOG))
         .isInstanceOf(IllegalStateException.class);
   }
 
@@ -43,6 +43,7 @@ class StateUtilTest {
         .isThrownBy(
             () ->
                 StateUtil.verifySnapshotLogConsistent(
+                    1L,
                     snapshotIndex,
                     firstIndex,
                     isLogEmpty,
@@ -60,7 +61,7 @@ class StateUtilTest {
         .isThrownBy(
             () ->
                 StateUtil.verifySnapshotLogConsistent(
-                    snapshotIndex, firstIndex, isLogEmpty, logReset::complete, LOG));
+                    1L, snapshotIndex, firstIndex, isLogEmpty, logReset::complete, LOG));
     assertThat(logReset).succeedsWithin(Duration.ofMillis(100)).isEqualTo(snapshotIndex + 1);
   }
 


### PR DESCRIPTION
## Description

Add partition id to verifySnapshotLogConsistent message.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
