### PR TITLE
Detect and reject straight-through processing loops

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -35,6 +35,8 @@ public final class FeatureFlagsCfg {
   private boolean enableMessageTtlCheckerAsync = DEFAULT_SETTINGS.enableMessageTTLCheckerAsync();
   private boolean enableTimerDueDateCheckerAsync =
       DEFAULT_SETTINGS.enableTimerDueDateCheckerAsync();
+  private boolean enableStraightThroughProcessingLoopDetector =
+      DEFAULT_SETTINGS.enableStraightThroughProcessingLoopDetector();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -68,12 +70,22 @@ public final class FeatureFlagsCfg {
     this.enableTimerDueDateCheckerAsync = enableTimerDueDateCheckerAsync;
   }
 
+  public boolean isEnableStraightThroughProcessingLoopDetector() {
+    return enableStraightThroughProcessingLoopDetector;
+  }
+
+  public void setEnableStraightThroughProcessingLoopDetector(
+      final boolean enableStraightThroughProcessingLoopDetector) {
+    this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
+  }
+
   public FeatureFlags toFeatureFlags() {
     return new FeatureFlags(
         enableYieldingDueDateChecker,
         enableActorMetrics,
         enableMessageTtlCheckerAsync,
-        enableTimerDueDateCheckerAsync
+        enableTimerDueDateCheckerAsync,
+        enableStraightThroughProcessingLoopDetector
         /*, enableFoo*/ );
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -138,4 +138,28 @@ final class FeatureFlagsCfgTest {
     // then
     assertThat(featureFlagsCfg.isEnableTimerDueDateCheckerAsync()).isTrue();
   }
+
+  @Test
+  void shouldSetEnableStraightThroughProcessingLoopDetectorFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableStraightThroughProcessingLoopDetector()).isFalse();
+  }
+
+  @Test
+  void shouldSetEnableStraightThroughProcessingLoopDetectorFromEnv() {
+    // given
+    environment.put(
+        "zeebe.broker.experimental.features.enableStraightThroughProcessingLoopDetector", "false");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableStraightThroughProcessingLoopDetector()).isFalse();
+  }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -96,14 +96,14 @@ final class FeatureFlagsCfgTest {
   @Test
   void shouldSetEnableMessageTtlCheckerAsyncFromEnv() {
     // given
-    environment.put("zeebe.broker.experimental.features.enableMessageTTLCheckerAsync", "true");
+    environment.put("zeebe.broker.experimental.features.enableMessageTTLCheckerAsync", "false");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
     final var featureFlagsCfg = cfg.getExperimental().getFeatures();
 
     // then
-    assertThat(featureFlagsCfg.isEnableMessageTtlCheckerAsync()).isTrue();
+    assertThat(featureFlagsCfg.isEnableMessageTtlCheckerAsync()).isFalse();
   }
 
   @Test
@@ -129,14 +129,14 @@ final class FeatureFlagsCfgTest {
   @Test
   void shouldSetEnableTimerDueDateCheckerAsyncFromEnv() {
     // given
-    environment.put("zeebe.broker.experimental.features.enableMessageDueDateAsync", "true");
+    environment.put("zeebe.broker.experimental.features.enableTimerDueDateCheckerAsync", "false");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
     final var featureFlagsCfg = cfg.getExperimental().getFeatures();
 
     // then
-    assertThat(featureFlagsCfg.isEnableTimerDueDateCheckerAsync()).isTrue();
+    assertThat(featureFlagsCfg.isEnableTimerDueDateCheckerAsync()).isFalse();
   }
 
   @Test
@@ -153,13 +153,13 @@ final class FeatureFlagsCfgTest {
   void shouldSetEnableStraightThroughProcessingLoopDetectorFromEnv() {
     // given
     environment.put(
-        "zeebe.broker.experimental.features.enableStraightThroughProcessingLoopDetector", "false");
+        "zeebe.broker.experimental.features.enableStraightThroughProcessingLoopDetector", "true");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
     final var featureFlagsCfg = cfg.getExperimental().getFeatures();
 
     // then
-    assertThat(featureFlagsCfg.isEnableStraightThroughProcessingLoopDetector()).isFalse();
+    assertThat(featureFlagsCfg.isEnableStraightThroughProcessingLoopDetector()).isTrue();
   }
 }

--- a/broker/src/test/resources/system/feature-flags-cfg.yaml
+++ b/broker/src/test/resources/system/feature-flags-cfg.yaml
@@ -6,3 +6,4 @@ zeebe:
         enableActorMetrics: true
         enableMessageTTLCheckerAsync: true
         enableTimerDueDateCheckerAsync: true
+        enableStraightThroughProcessingLoopDetector: false

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -120,7 +120,8 @@ public final class EngineProcessors {
         writers,
         partitionsCount,
         deploymentDistributionCommandSender,
-        processingState.getKeyGenerator());
+        processingState.getKeyGenerator(),
+        featureFlags);
     addMessageProcessors(
         bpmnBehaviors,
         subscriptionCommandSender,
@@ -201,7 +202,8 @@ public final class EngineProcessors {
       final Writers writers,
       final int partitionsCount,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final FeatureFlags featureFlags) {
 
     // on deployment partition CREATE Command is received and processed
     // it will cause a distribution to other partitions
@@ -212,7 +214,8 @@ public final class EngineProcessors {
             partitionsCount,
             writers,
             deploymentDistributionCommandSender,
-            keyGenerator);
+            keyGenerator,
+            featureFlags);
     typedRecordProcessors.onCommand(ValueType.DEPLOYMENT, CREATE, processor);
 
     // periodically retries deployment distribution

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.FeatureFlags;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
@@ -62,7 +63,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       final int partitionsCount,
       final Writers writers,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final FeatureFlags featureFlags) {
     processState = processingState.getProcessState();
     timerInstanceState = processingState.getTimerState();
     this.keyGenerator = keyGenerator;
@@ -72,7 +74,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     expressionProcessor = bpmnBehaviors.expressionBehavior();
     deploymentTransformer =
-        new DeploymentTransformer(stateWriter, processingState, expressionProcessor, keyGenerator);
+        new DeploymentTransformer(
+            stateWriter, processingState, expressionProcessor, keyGenerator, featureFlags);
     startEventSubscriptionManager =
         new StartEventSubscriptionManager(processingState, keyGenerator);
     deploymentDistributionBehavior =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableProcess.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableProcess.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -86,5 +87,9 @@ public class ExecutableProcess extends ExecutableFlowElementContainer {
               expectedClass.getSimpleName(),
               element.getClass().getSimpleName()));
     }
+  }
+
+  public Collection<AbstractFlowElement> getFlowElements() {
+    return flowElements.values();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+
+public final class StraightThroughProcessingLoopValidator {
+
+  private static final EnumSet<BpmnElementType> STRAIGHT_THROUGH_PROCESSING_ELEMENT_TYPES =
+      EnumSet.of(
+          BpmnElementType.MANUAL_TASK,
+          BpmnElementType.TASK,
+          BpmnElementType.EXCLUSIVE_GATEWAY,
+          BpmnElementType.INCLUSIVE_GATEWAY,
+          BpmnElementType.PARALLEL_GATEWAY);
+  private static final EnumSet<BpmnElementType> WHITELISTED_ELEMENT_TYPES =
+      EnumSet.of(
+          BpmnElementType.EXCLUSIVE_GATEWAY,
+          BpmnElementType.INCLUSIVE_GATEWAY,
+          BpmnElementType.PARALLEL_GATEWAY);
+
+  /**
+   * Validates a list of processes for straight-through processing loops. These are loops of
+   * elements that don't have any execution logic, such as undefined tasks and manual tasks.
+   *
+   * @param resource the resource file that's getting validated
+   * @param executableProcesses the list of processes in this resource
+   * @return an Either of which the left contains the failure message if any loops have been found
+   */
+  public static Either<Failure, ?> validate(
+      final DeploymentResource resource, final List<ExecutableProcess> executableProcesses) {
+
+    final List<Failure> failures = new ArrayList<>();
+    for (final ExecutableProcess executableProcess : executableProcesses) {
+      hasStraightThroughProcessingLoop(resource, executableProcess).ifLeft(failures::add);
+    }
+
+    if (failures.isEmpty()) {
+      return Either.right(null);
+    } else {
+      final StringWriter writer = new StringWriter();
+      failures.forEach(failure -> writer.write(failure.getMessage()));
+      return Either.left(new Failure(writer.toString()));
+    }
+  }
+
+  /**
+   * Checks a given process for any straight-through processing loops.
+   *
+   * <p>Note that once we've found a loop we don't keep searching to see if there are more!
+   *
+   * @param resource the resource file that's getting validated
+   * @param executableProcess the process we are validating
+   * @return an Either of which the left contains the failure message if any loops have been found
+   */
+  private static Either<Failure, ?> hasStraightThroughProcessingLoop(
+      final DeploymentResource resource, final ExecutableProcess executableProcess) {
+    final var straightThroughElements = getStraightThroughElementsInProcess(executableProcess);
+
+    for (final ExecutableFlowNode element : straightThroughElements) {
+      final var potentialLoop = new LinkedList<ExecutableFlowNode>();
+      final var result = checkForStraightThroughProcessingLoop(potentialLoop, element);
+      if (result.isLeft()) {
+        final String failureMessage =
+            createFailureMessage(resource, executableProcess, result.getLeft());
+        return Either.left(new Failure(failureMessage));
+      }
+    }
+
+    return Either.right(null);
+  }
+
+  /**
+   * When looking for straight-through processing loops it is not necessary to check in all places
+   * of the process. We only have to check the path of straight-through elements. This method
+   * returns a list of all the straight-through elements in a process.
+   *
+   * @param executableProcess the process
+   * @return a list of all straight-through elements in the given process
+   */
+  private static List<ExecutableFlowNode> getStraightThroughElementsInProcess(
+      final ExecutableProcess executableProcess) {
+
+    return executableProcess.getFlowElements().stream()
+        .filter(
+            flowElement ->
+                STRAIGHT_THROUGH_PROCESSING_ELEMENT_TYPES.contains(flowElement.getElementType())
+                    && !WHITELISTED_ELEMENT_TYPES.contains(flowElement.getElementType()))
+        .map(ExecutableFlowNode.class::cast)
+        .toList();
+  }
+
+  /**
+   * This method is the part that actually tries to find any loops. It takes a LinkedList in which
+   * it keeps track of elements that are part of the (potential) loop. It also takes an element
+   * which is used to detect if we are in a loop.
+   *
+   * <p>Upon entering this method there are 3 possibilities:
+   *
+   * <ul>
+   *   <li>This element is part of the potentialLoop list. This means that we have passed this
+   *       element before. As a result we can conclude that we are in a loop.
+   *   <li>The element is not part of the potentialLoop list. We haven't passed the element before
+   *       so we are not in a loop yet. However, the element is a straight-through processing
+   *       element. We must check the outgoing sequence flow of this element to see if it loops back
+   *       around to an element that is part of the potentialLoop list.
+   *   <li>We have not encountered this element before, nor is it a straight-through processing
+   *       element. We can conclude that this path is not part of a straight-through processing
+   *       loop.
+   * </ul>
+   *
+   * @param potentialLoop a list which keeps track of elements that are part of a potential loop
+   * @param element the element used to determine if we reached a loop, or are definitely not part
+   *     of a loop
+   * @return an Either of which the left contains a list of the straight-through processing loop.
+   */
+  private static Either<List<ExecutableFlowNode>, ?> checkForStraightThroughProcessingLoop(
+      final LinkedList<ExecutableFlowNode> potentialLoop, final ExecutableFlowNode element) {
+
+    if (foundLoop(potentialLoop, element)) {
+      // It could happen that we detect a loop which doesn't involve the first element we checked.
+      // By taking a sublist we make sure we've isolated the loop.
+      final var loop = potentialLoop.subList(potentialLoop.indexOf(element), potentialLoop.size());
+      // This element is added to the loop twice. This is useful when creating an error message
+      // describing the loop.
+      loop.add(element);
+      return Either.left(loop);
+    } else if (STRAIGHT_THROUGH_PROCESSING_ELEMENT_TYPES.contains(element.getElementType())) {
+      // We are not in a loop yet, but the element is a straight-through processing element. We must
+      // keep checking for loops by analysing the outgoing sequence flows of this element.
+      potentialLoop.addLast(element);
+      Either<List<ExecutableFlowNode>, ?> isPartOfLoop = Either.right(null);
+      for (final ExecutableSequenceFlow outgoing : element.getOutgoing()) {
+        isPartOfLoop = checkForStraightThroughProcessingLoop(potentialLoop, outgoing.getTarget());
+        if (isPartOfLoop.isLeft()) {
+          break;
+        }
+      }
+
+      if (isPartOfLoop.isRight()) {
+        potentialLoop.remove(element);
+      }
+      return isPartOfLoop;
+
+    } else {
+      // No loops have been found. We can return an Either.Right to indicate success.
+      return Either.right(null);
+    }
+  }
+
+  /**
+   * This method will decide if we are in a loop or not. It does so by checking if the potentialLoop
+   * list contains the element we are currently checking. It also has an extra check to make sure we
+   * don't detect loops between just gateways. As of the time of writing it is unclear whether we
+   * should reject these or not.
+   *
+   * @param potentialLoop the list of elements in a potential loop
+   * @param element the element we are currently checking
+   * @return a boolean indicating if we are in a loop or not
+   */
+  private static boolean foundLoop(
+      final LinkedList<ExecutableFlowNode> potentialLoop, final ExecutableFlowNode element) {
+    final var isLoopOfOnlyWhitelistedElements =
+        potentialLoop.stream()
+            .map(AbstractFlowElement::getElementType)
+            .allMatch(WHITELISTED_ELEMENT_TYPES::contains);
+    return potentialLoop.contains(element) && !isLoopOfOnlyWhitelistedElements;
+  }
+
+  /**
+   * Create a descriptive failure message which will be part of the rejection message. It mentions
+   * which resource and process contain the issue. It also lists the chain of element ids that are
+   * looping.
+   *
+   * @param resource the resource file that we've validated for loops
+   * @param executableProcess the process that we've validated for loops
+   * @param loopingElements a list of looping elements. The first and last element of this list will
+   *     be the same.
+   * @return a descriptive failure message
+   */
+  private static String createFailureMessage(
+      final DeploymentResource resource,
+      final ExecutableProcess executableProcess,
+      final List<ExecutableFlowNode> loopingElements) {
+    final List<String> loopingElementIds =
+        loopingElements.stream()
+            .map(AbstractFlowElement::getId)
+            .map(BufferUtil::bufferAsString)
+            .toList();
+
+    final StringWriter writer = new StringWriter();
+    writer.write(
+        String.format(
+            "`%s`: - Process: %s",
+            resource.getResourceName(), BufferUtil.bufferAsString(executableProcess.getId())));
+    writer.write("\n");
+    writer.write(
+        String.format(
+            "    - ERROR: Processes are not allowed to contain a straight-through processing loop: %s",
+            String.join(" > ", loopingElementIds)));
+    writer.write("\n");
+    return writer.toString();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
@@ -35,7 +35,8 @@ public final class StraightThroughProcessingLoopValidator {
           BpmnElementType.PARALLEL_GATEWAY,
           BpmnElementType.START_EVENT,
           BpmnElementType.END_EVENT,
-          BpmnElementType.SUB_PROCESS);
+          BpmnElementType.SUB_PROCESS,
+          BpmnElementType.MULTI_INSTANCE_BODY);
 
   /**
    * Loops must contain any of the rejected element types for it to be considered a loop. This makes

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.FeatureFlags;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
@@ -46,7 +47,8 @@ public final class DeploymentTransformer {
       final StateWriter stateWriter,
       final ProcessingState processingState,
       final ExpressionProcessor expressionProcessor,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final FeatureFlags featureFlags) {
 
     try {
       // We get an alert by LGTM, since MD5 is a weak cryptographic hash function,
@@ -65,7 +67,8 @@ public final class DeploymentTransformer {
             stateWriter,
             this::getChecksum,
             processingState.getProcessState(),
-            expressionProcessor);
+            expressionProcessor,
+            featureFlags.enableStraightThroughProcessingLoopDetector());
     final var dmnResourceTransformer =
         new DmnResourceTransformer(
             keyGenerator, stateWriter, this::getChecksum, processingState.getDecisionState());

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationDisabledTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationDisabledTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.FeatureFlags;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class StraightThroughProcessingLoopValidationDisabledTest {
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          // Disable loop detector feature flag
+          .withFeatureFlags(new FeatureFlags(true, false, true, true, false));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporter = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDeployProcessWithRegularLoops() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    // when
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .task("task1")
+                    .task("task2")
+                    .connectTo("task1")
+                    .done())
+            .deploy();
+
+    // then
+    assertThat(deployment.getKey())
+        .describedAs("Don't reject loops if FeatureFlag is disabled")
+        .isNotNegative();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class StraightThroughProcessingLoopValidationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String GENERIC_REJECTION_MESSAGE =
+      "ERROR: Processes are not allowed to contain a straight-through processing loop: ";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporter = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectDeploymentWithSimpleUndefinedTaskLoop() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .task("task1")
+                    .task("task2")
+                    .connectTo("task1")
+                    .done())
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(String.format("Process: %s", processId))
+        .contains(GENERIC_REJECTION_MESSAGE + "task1 > task2 > task1");
+  }
+
+  @Test
+  public void shouldRejectDeploymentWithSimpleManualTaskLoop() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .manualTask("task1")
+                    .manualTask("task2")
+                    .connectTo("task1")
+                    .done())
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(String.format("Process: %s", processId))
+        .contains(GENERIC_REJECTION_MESSAGE + "task1 > task2 > task1");
+  }
+
+  @Test
+  public void shouldRejectDeploymentWithComplexStraightThroughProcessingLoop() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    // when
+    // Straight through loop: task1 > parallel2 > manualTask1 > exclusive2 > task1
+    final var rejectedDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("userTask1")
+                    .parallelGateway("parallel1")
+                    .exclusiveGateway("exclusive1")
+                    .task("task1")
+                    .parallelGateway("parallel2")
+                    .manualTask("manualTask1")
+                    .exclusiveGateway("exclusive2")
+                    .defaultFlow()
+                    .userTask("userTask2")
+                    .connectTo("exclusive1")
+                    .moveToNode("parallel2")
+                    .userTask("userTask3")
+                    .endEvent()
+                    .moveToNode("exclusive2")
+                    .sequenceFlowId("sequenceToLoop")
+                    .conditionExpression("true")
+                    .connectTo("task1")
+                    .moveToNode("parallel1")
+                    .task("task2")
+                    .task("task3")
+                    .endEvent()
+                    .done())
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(String.format("Process: %s", processId))
+        .contains(
+            GENERIC_REJECTION_MESSAGE
+                + "manualTask1 > exclusive2 > task1 > parallel2 > manualTask1");
+  }
+
+  @Test
+  public void shouldRejectDeploymentWithStraightThroughProcessingLoopNotStartingAtFirstElement() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .task("task1")
+                    .task("task2")
+                    .task("task3")
+                    .task("task4")
+                    .task("task5")
+                    .task("task6")
+                    .task("task7")
+                    .task("task8")
+                    .task("task9")
+                    .connectTo("task7")
+                    .done())
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(String.format("Process: %s", processId))
+        .contains(GENERIC_REJECTION_MESSAGE + "task7 > task8 > task9 > task7");
+  }
+
+  @Test
+  public void shouldRejectDeploymentWithCollaborationContainingStraightThroughProcessingLoop() {
+    // given
+    final String resource = "/processes/collaboration_straight_through_processing_loop.bpmn";
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("Process: process1")
+        .contains(GENERIC_REJECTION_MESSAGE + "task1 > task2 > task1")
+        .contains("Process: process2")
+        .contains(GENERIC_REJECTION_MESSAGE + "manualTask2 > manualTask1 > manualTask2");
+  }
+
+  @Test
+  public void shouldDeployProcessWithRegularLoops() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    // when
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("task1")
+                    .userTask("task2")
+                    .connectTo("task1")
+                    .done())
+            .deploy();
+
+    // then
+    assertThat(deployment.getKey())
+        .describedAs("Allow deployments of loops that aren't straight-through processed")
+        .isNotNegative();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationTest.java
@@ -226,4 +226,29 @@ public class StraightThroughProcessingLoopValidationTest {
         .describedAs("Allow deployments of loops that aren't straight-through processed")
         .isNotNegative();
   }
+
+  @Test
+  public void shouldDeployProcessWithRegularTaskBetweenStraightThroughTasks() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+
+    // when
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .task("task1")
+                    .userTask("test")
+                    .task("task2")
+                    .connectTo("task1")
+                    .done())
+            .deploy();
+
+    // then
+    assertThat(deployment.getKey())
+        .describedAs("Allow deployments of loops that aren't straight-through processed")
+        .isNotNegative();
+  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
@@ -56,7 +56,7 @@ public class ReachEndOfLogTest {
         .withXmlResource(
             Bpmn.createExecutableProcess("process")
                 .startEvent()
-                .manualTask("test")
+                .intermediateThrowEvent("test")
                 .connectTo("test")
                 .endEvent()
                 .done())

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -107,6 +107,8 @@ public final class EngineRule extends ExternalResource {
   private long lastProcessedPosition = -1L;
   private JobStreamer jobStreamer = JobStreamer.noop();
 
+  private FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
+
   private EngineRule(final int partitionCount) {
     this(partitionCount, null);
   }
@@ -160,6 +162,11 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
+  public EngineRule withFeatureFlags(final FeatureFlags featureFlags) {
+    this.featureFlags = featureFlags;
+    return this;
+  }
+
   public EngineRule withOnProcessedCallback(final Consumer<TypedRecord> onProcessedCallback) {
     this.onProcessedCallback = this.onProcessedCallback.andThen(onProcessedCallback);
     return this;
@@ -185,7 +192,6 @@ public final class EngineRule extends ExternalResource {
         partitionId -> {
           final var reprocessingCompletedListener = new ReprocessingCompletedListener();
           partitionReprocessingCompleteListeners.put(partitionId, reprocessingCompletedListener);
-          final var featureFlags = FeatureFlags.createDefaultForTests();
 
           final var interPartitionCommandSender = new TestInterPartitionCommandSender();
           interPartitionCommandSenders.add(interPartitionCommandSender);

--- a/engine/src/test/resources/processes/collaboration_straight_through_processing_loop.bpmn
+++ b/engine/src/test/resources/processes/collaboration_straight_through_processing_loop.bpmn
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_00ytkz4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:collaboration id="Collaboration_0csqr2g">
+    <bpmn:participant id="Participant_09s1711" processRef="process1" />
+    <bpmn:participant id="Participant_1phgo6f" processRef="process2" />
+  </bpmn:collaboration>
+  <bpmn:process id="process1" name="process1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_11rrnoj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="task1" name="task1">
+      <bpmn:incoming>Flow_11rrnoj</bpmn:incoming>
+      <bpmn:incoming>Flow_1lr5sfz</bpmn:incoming>
+      <bpmn:outgoing>Flow_0y4nu60</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_11rrnoj" sourceRef="StartEvent_1" targetRef="task1" />
+    <bpmn:task id="task2" name="task2">
+      <bpmn:incoming>Flow_0y4nu60</bpmn:incoming>
+      <bpmn:outgoing>Flow_1lr5sfz</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0y4nu60" sourceRef="task1" targetRef="task2" />
+    <bpmn:sequenceFlow id="Flow_1lr5sfz" sourceRef="task2" targetRef="task1" />
+  </bpmn:process>
+  <bpmn:process id="process2" name="process2" isExecutable="true">
+    <bpmn:startEvent id="Event_0sukec7">
+      <bpmn:outgoing>Flow_09vll0e</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_09vll0e" sourceRef="Event_0sukec7" targetRef="manualTask1" />
+    <bpmn:sequenceFlow id="Flow_1jsroue" sourceRef="manualTask1" targetRef="manualTask2" />
+    <bpmn:sequenceFlow id="Flow_0s2f27e" sourceRef="manualTask2" targetRef="manualTask1" />
+    <bpmn:manualTask id="manualTask1" name="manualTask1">
+      <bpmn:incoming>Flow_09vll0e</bpmn:incoming>
+      <bpmn:incoming>Flow_0s2f27e</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jsroue</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:manualTask id="manualTask2" name="manualTask2">
+      <bpmn:incoming>Flow_1jsroue</bpmn:incoming>
+      <bpmn:outgoing>Flow_0s2f27e</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0csqr2g">
+      <bpmndi:BPMNShape id="Participant_09s1711_di" bpmnElement="Participant_09s1711" isHorizontal="true">
+        <dc:Bounds x="129" y="60" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_176tqly_di" bpmnElement="task1">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08dlbgu_di" bpmnElement="task2">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_11rrnoj_di" bpmnElement="Flow_11rrnoj">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y4nu60_di" bpmnElement="Flow_0y4nu60">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lr5sfz_di" bpmnElement="Flow_1lr5sfz">
+        <di:waypoint x="480" y="137" />
+        <di:waypoint x="480" y="110" />
+        <di:waypoint x="320" y="110" />
+        <di:waypoint x="320" y="137" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_1phgo6f_di" bpmnElement="Participant_1phgo6f" isHorizontal="true">
+        <dc:Bounds x="129" y="360" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0sukec7_di" bpmnElement="Event_0sukec7">
+        <dc:Bounds x="192" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tegj3o_di" bpmnElement="manualTask1">
+        <dc:Bounds x="280" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05nxf4p_di" bpmnElement="manualTask2">
+        <dc:Bounds x="440" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09vll0e_di" bpmnElement="Flow_09vll0e">
+        <di:waypoint x="228" y="490" />
+        <di:waypoint x="280" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jsroue_di" bpmnElement="Flow_1jsroue">
+        <di:waypoint x="380" y="490" />
+        <di:waypoint x="440" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0s2f27e_di" bpmnElement="Flow_0s2f27e">
+        <di:waypoint x="490" y="450" />
+        <di:waypoint x="490" y="410" />
+        <di:waypoint x="330" y="410" />
+        <di:waypoint x="330" y="450" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -14,7 +14,8 @@ public record FeatureFlags(
     boolean yieldingDueDateChecker,
     boolean enableActorMetrics,
     boolean enableMessageTTLCheckerAsync,
-    boolean enableTimerDueDateCheckerAsync
+    boolean enableTimerDueDateCheckerAsync,
+    boolean enableStraightThroughProcessingLoopDetector
     /*, boolean foo*/ ) {
 
   /* To add a new feature toggle, please follow these steps:
@@ -49,13 +50,15 @@ public record FeatureFlags(
 
   private static final boolean ENABLE_MSG_TTL_CHECKER_ASYNC = false;
   private static final boolean ENABLE_DUE_DATE_CHECKER_ASYNC = false;
+  private static final boolean ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR = true;
 
   public static FeatureFlags createDefault() {
     return new FeatureFlags(
         YIELDING_DUE_DATE_CHECKER,
         ENABLE_ACTOR_METRICS,
         ENABLE_MSG_TTL_CHECKER_ASYNC,
-        ENABLE_DUE_DATE_CHECKER_ASYNC
+        ENABLE_DUE_DATE_CHECKER_ASYNC,
+        ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR
         /*, FOO_DEFAULT*/ );
   }
 
@@ -69,7 +72,8 @@ public record FeatureFlags(
         true, /* YIELDING_DUE_DATE_CHECKER*/
         false, /* ENABLE_ACTOR_METRICS */
         true, /* ENABLE_MSG_TTL_CHECKER_ASYNC */
-        true /* ENABLE_DUE_DATE_CHECKER_ASYNC */
+        true, /* ENABLE_DUE_DATE_CHECKER_ASYNC */
+        true /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
         /*, FOO_DEFAULT*/ );
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds a validation to deployments. It will check for any straight-through processing loops. If it detects one the deployments gets rejected with a clear message indicating the location of the loop.

An example of looping process:
<img width="1105" alt="image" src="https://github.com/camunda/zeebe/assets/5787702/6d0c55ea-0952-4398-9855-c5d7bab2aa24">

Which will result in the subsequence rejection message:

```
Command 'CREATE' rejected with code 'INVALID_ARGUMENT': Expected to deploy new resources, but encountered the following errors:
`diagram_8.bpmn`: - Process: id-dd9da612-1419-4d32-86ed-95956c353797
    - ERROR: Processes are not allowed to contain a straight-through processing loop: manualTask1 > exclusive2 > task1 > parallel2 > manualTask1
 [ deploy-error ]
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #12957 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
