### PR TITLE
Enable SST partition per default

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -994,10 +994,10 @@
         # Configures if the RocksDB SST files should be partitioned based on some virtual column families.
         # By default RocksDB will not partition the SST files, which might have influence on the compacting of certain key ranges.
         # Enabling this option gives RocksDB some good hints how to improve compaction and reduce the write amplification.
-        # Benchmarks have show impressive results allowing to sustain performance on larger states, but it is not yet 100% clear what implications it else has except
-        # increasing the file count of runtime and snapshots.
+        # Benchmarks have show impressive results allowing to sustain performance on larger states.  This setting might
+        # increase the general file count of runtime and snapshots.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_ENABLESSTPARTITIONING
-        # enableSstPartitioning: false
+        # enableSstPartitioning: true
 
       # consistencyChecks:
         # Configures if the basic operations on RocksDB, such as inserting or deleting key-value pairs, should check preconditions,

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -994,7 +994,7 @@
         # Configures if the RocksDB SST files should be partitioned based on some virtual column families.
         # By default RocksDB will not partition the SST files, which might have influence on the compacting of certain key ranges.
         # Enabling this option gives RocksDB some good hints how to improve compaction and reduce the write amplification.
-        # Benchmarks have show impressive results allowing to sustain performance on larger states.  This setting might
+        # Benchmarks have show impressive results allowing to sustain performance on larger states.  This setting will
         # increase the general file count of runtime and snapshots.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_ENABLESSTPARTITIONING
         # enableSstPartitioning: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -904,10 +904,10 @@
         # Configures if the RocksDB SST files should be partitioned based on some virtual column families.
         # By default RocksDB will not partition the SST files, which might have influence on the compacting of certain key ranges.
         # Enabling this option gives RocksDB some good hints how to improve compaction and reduce the write amplification.
-        # Benchmarks have show impressive results allowing to sustain performance on larger states, but it is not yet 100% clear what implications it else has except
-        # increasing the file count of runtime and snapshots.
+        # Benchmarks have show impressive results allowing to sustain performance on larger states. This setting might
+        # increase the general file count of runtime and snapshots.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_ENABLESSTPARTITIONING
-        # enableSstPartitioning: false
+        # enableSstPartitioning: true
 
       # consistencyChecks:
         # Configures if the basic operations on RocksDB, such as inserting or deleting key-value pairs, should check preconditions,

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -904,7 +904,7 @@
         # Configures if the RocksDB SST files should be partitioned based on some virtual column families.
         # By default RocksDB will not partition the SST files, which might have influence on the compacting of certain key ranges.
         # Enabling this option gives RocksDB some good hints how to improve compaction and reduce the write amplification.
-        # Benchmarks have show impressive results allowing to sustain performance on larger states. This setting might
+        # Benchmarks have show impressive results allowing to sustain performance on larger states. This setting will
         # increase the general file count of runtime and snapshots.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_ENABLESSTPARTITIONING
         # enableSstPartitioning: true

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -33,12 +33,13 @@ public final class RocksDbConfiguration {
   public static final boolean DEFAULT_WAL_DISABLED = true;
 
   /**
-   * This is an experimental feature, it is not 100% clear yet what the implications are besides
-   * having much better performance (shown in several benchmarks) and generating more SST files.
+   * Enabling this feature gives a hint to the RocksDB compaction to compact based on virtual column
+   * family prefixes. In consequence this means we will have more SST files, but split up into
+   * related data sets.
    *
-   * <p>There will be files created for each virtual colum family.
+   * <p>Benchmarks have shown that this allows better performance even on large RocksDB state.
    */
-  public static final boolean DEFAULT_SST_PARTITIONING_ENABLED = false;
+  public static final boolean DEFAULT_SST_PARTITIONING_ENABLED = true;
 
   public static final int DEFAULT_IO_RATE_BYTES_PER_SECOND = 0;
 


### PR DESCRIPTION
## Description

As agreed and shown in https://github.com/camunda/zeebe/issues/12955 we will use SST partitioning as a solution for supporting stable performance of new instances on larger state, which is why we enabling this feature by default.


Do we want to backport this? I guess @megglos ?
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12955

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
