### PR TITLE
fix(engine): don't mutate state when checking for timed out jobs

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -45,7 +45,7 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
     final JobState.State state = jobState.getState(jobKey);
 
     if (state == State.FAILED) {
-      final JobRecord recurredJob = record.getValue();
+      final JobRecord recurredJob = jobState.getJob(jobKey);
 
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.RECURRED_AFTER_BACKOFF, recurredJob);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
@@ -46,7 +46,7 @@ public final class JobYieldProcessor implements TypedRecordProcessor<JobRecord> 
         .check(state, jobKey)
         .ifRightOrLeft(
             ok -> {
-              final JobRecord yieldedJob = record.getValue();
+              final JobRecord yieldedJob = jobState.getJob(jobKey);
 
               stateWriter.appendFollowUpEvent(jobKey, JobIntent.YIELDED, yieldedJob);
               jobActivationBehavior.notifyJobAvailableAsSideEffect(yieldedJob);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
@@ -14,7 +14,7 @@ import org.agrona.DirectBuffer;
 
 public interface JobState {
 
-  void forEachTimedOutEntry(long upperBound, BiFunction<Long, JobRecord, Boolean> callback);
+  void forEachTimedOutEntry(long upperBound, BiPredicate<Long, JobRecord> callback);
 
   boolean exists(long jobKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -245,15 +245,14 @@ public final class DbJobState implements JobState, MutableJobState {
 
   @Override
   public void forEachTimedOutEntry(
-      final long upperBound, final BiFunction<Long, JobRecord, Boolean> callback) {
+      final long upperBound, final BiPredicate<Long, JobRecord> callback) {
     deadlinesColumnFamily.whileTrue(
         (key, value) -> {
           final long deadline = key.first().getValue();
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().inner().getValue();
-            return visitJob(
-                jobKey1, callback::apply, () -> deadlinesColumnFamily.deleteExisting(key));
+            return visitJob(jobKey1, callback, () -> deadlinesColumnFamily.deleteExisting(key));
           }
           return false;
         });

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -252,7 +252,7 @@ public final class DbJobState implements JobState, MutableJobState {
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().inner().getValue();
-            return visitJob(jobKey1, callback, () -> deadlinesColumnFamily.deleteExisting(key));
+            return visitJob(jobKey1, callback, () -> {});
           }
           return false;
         });


### PR DESCRIPTION
This PR closes #12797, ensuring that job deadlines are reliably cleaned up by event appliers. This is necessary so that the job timeout checker does not have to mutate state.

With 91da1e89a9e39b29d6ae9f1cbf6a5f1ca77ce271, we fix the job yield and recur processors to produce events with the current job state. Previously, these propagated the job record from the command into new follow-up events which may overwrite already persisted changes to a job. 
With 330ce0b1980a609a978a9680f8a037070669090a, it is now clear when deadlines are set and removed. This follows the [rules we discussed](https://github.com/camunda/zeebe/issues/12797#issuecomment-1573731298), essentially adding a deadline on activation and removing whe the job is no longer activated or deleted.
Finally, cfdef6d037b78f5c78505049aa74bab00260035f is removing the illegal state modification from the checker. With the previous changes we can be sure that deadlines are cleaned up reliably and don't need to do redundant cleanup in the checker anymore.
