### PR TITLE
Guarantee the order of loop detection

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -118,6 +119,7 @@ public final class StraightThroughProcessingLoopValidator {
     return executableProcess.getFlowElements().stream()
         .filter(flowElement -> REJECTED_ELEMENT_TYPES.contains(flowElement.getElementType()))
         .map(ExecutableFlowNode.class::cast)
+        .sorted(Comparator.comparing(ExecutableFlowNode::getId))
         .toList();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationTest.java
@@ -201,7 +201,7 @@ public class StraightThroughProcessingLoopValidationTest {
         .contains("Process: process1")
         .contains(GENERIC_REJECTION_MESSAGE + "task1 > task2 > task1")
         .contains("Process: process2")
-        .contains(GENERIC_REJECTION_MESSAGE + "manualTask2 > manualTask1 > manualTask2");
+        .contains(GENERIC_REJECTION_MESSAGE + "manualTask1 > manualTask2 > manualTask1");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The loop detector first looks for all elements of a specific type. This order is not always the same. This can result in flakiness in our tests, where sometimes the order will be `task1 > task2 > task1` and other times it will be `task2 > task1 > task2`.

 By sorting them on id we will always have the same order.


## Related issues

<!-- Which issues are closed by this PR or are related -->

Related to #12957 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
