### PR TITLE
Detect and reject call activities calling itself in a straight-through loop

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
+import io.camunda.zeebe.el.impl.StaticExpression;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
@@ -24,6 +26,7 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 public final class StraightThroughProcessingLoopValidator {
 
@@ -37,14 +40,15 @@ public final class StraightThroughProcessingLoopValidator {
           BpmnElementType.START_EVENT,
           BpmnElementType.END_EVENT,
           BpmnElementType.SUB_PROCESS,
-          BpmnElementType.MULTI_INSTANCE_BODY);
+          BpmnElementType.MULTI_INSTANCE_BODY,
+          BpmnElementType.CALL_ACTIVITY);
 
   /**
    * Loops must contain any of the rejected element types for it to be considered a loop. This makes
    * sure we don't reject deployments containing a loop of just gateways.
    */
   private static final EnumSet<BpmnElementType> REJECTED_ELEMENT_TYPES =
-      EnumSet.of(BpmnElementType.MANUAL_TASK, BpmnElementType.TASK);
+      EnumSet.of(BpmnElementType.MANUAL_TASK, BpmnElementType.TASK, BpmnElementType.CALL_ACTIVITY);
 
   /**
    * Validates a list of processes for straight-through processing loops. These are loops of
@@ -60,7 +64,8 @@ public final class StraightThroughProcessingLoopValidator {
     final List<Failure> failures = new ArrayList<>();
     for (final ExecutableProcess executableProcess : executableProcesses) {
       try {
-        hasStraightThroughProcessingLoop(resource, executableProcess).ifLeft(failures::add);
+        hasStraightThroughProcessingLoop(resource, executableProcess, executableProcesses)
+            .ifLeft(failures::add);
       } catch (final StackOverflowError e) {
         final var message =
             String.format(
@@ -89,12 +94,15 @@ public final class StraightThroughProcessingLoopValidator {
    * @return an Either of which the left contains the failure message if any loops have been found
    */
   private static Either<Failure, ?> hasStraightThroughProcessingLoop(
-      final DeploymentResource resource, final ExecutableProcess executableProcess) {
+      final DeploymentResource resource,
+      final ExecutableProcess executableProcess,
+      final List<ExecutableProcess> executableProcesses) {
     final var straightThroughElements = getStraightThroughElementsInProcess(executableProcess);
 
     for (final ExecutableFlowNode element : straightThroughElements) {
       final var potentialLoop = new LinkedList<ExecutableFlowNode>();
-      final var result = checkForStraightThroughProcessingLoop(potentialLoop, element);
+      final var result =
+          checkForStraightThroughProcessingLoop(potentialLoop, element, executableProcesses);
       if (result.isLeft()) {
         final String failureMessage =
             createFailureMessage(resource, executableProcess, result.getLeft());
@@ -148,7 +156,9 @@ public final class StraightThroughProcessingLoopValidator {
    * @return an Either of which the left contains a list of the straight-through processing loop.
    */
   private static Either<List<ExecutableFlowNode>, ?> checkForStraightThroughProcessingLoop(
-      final LinkedList<ExecutableFlowNode> potentialLoop, final ExecutableFlowNode element) {
+      final LinkedList<ExecutableFlowNode> potentialLoop,
+      final ExecutableFlowNode element,
+      final List<ExecutableProcess> executableProcesses) {
 
     if (foundLoop(potentialLoop, element)) {
       // It could happen that we detect a loop which doesn't involve the first element we checked.
@@ -163,8 +173,9 @@ public final class StraightThroughProcessingLoopValidator {
       // keep checking for loops by analysing the outgoing sequence flows of this element.
       potentialLoop.addLast(element);
       Either<List<ExecutableFlowNode>, ?> isPartOfLoop = Either.right(null);
-      for (final ExecutableFlowNode nextElement : getNextElements(element)) {
-        isPartOfLoop = checkForStraightThroughProcessingLoop(potentialLoop, nextElement);
+      for (final ExecutableFlowNode nextElement : getNextElements(element, executableProcesses)) {
+        isPartOfLoop =
+            checkForStraightThroughProcessingLoop(potentialLoop, nextElement, executableProcesses);
         if (isPartOfLoop.isLeft()) {
           break;
         }
@@ -188,12 +199,32 @@ public final class StraightThroughProcessingLoopValidator {
    * @param element the element for which we need to check the next element in the execution path
    * @return a list of sequence flows
    */
-  private static List<ExecutableFlowNode> getNextElements(final ExecutableFlowNode element) {
+  private static List<? extends ExecutableFlowNode> getNextElements(
+      final ExecutableFlowNode element, final List<ExecutableProcess> executableProcesses) {
     switch (element.getElementType()) {
       case SUB_PROCESS -> {
         final var subProcess = (ExecutableFlowElementContainer) element;
         // A subprocess must have exactly 1 none start event
         return List.of(subProcess.getNoneStartEvent());
+      }
+      case CALL_ACTIVITY -> {
+        // For Call Activities we only check processes in the current resource. This is not a
+        // catch-all! However, this will catch the most basic example of a process calling itself.
+        final var callActivity = (ExecutableCallActivity) element;
+        final var expression = callActivity.getCalledElementProcessId();
+        if (expression.isStatic()) {
+          final var calledActivityId = ((StaticExpression) expression).getString();
+          final Optional<ExecutableProcess> calledProcess =
+              executableProcesses.stream()
+                  .filter(
+                      process ->
+                          BufferUtil.bufferAsString(process.getId()).equals(calledActivityId))
+                  .findFirst();
+          return calledProcess
+              .map(process -> List.of(process.getNoneStartEvent()))
+              .orElseGet(Collections::emptyList);
+        }
+        return Collections.emptyList();
       }
       default -> {
         final var outgoingFlows = element.getOutgoing();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds Call Activities to the `StraightThroughProcessingLoopValidator`. Note that this is not a catch-all! It is limited to processes that are included in a single resource file. This means there is some scenarios that are not caught

**What do we catch?**
A simple process calling itself without wait-state in between:
<img width="605" alt="image" src="https://github.com/camunda/zeebe/assets/5787702/bcd95613-0580-4cf1-89d8-6b952d8f6879">

A simple process calling a different process within the same resource file:
<img width="433" alt="image" src="https://github.com/camunda/zeebe/assets/5787702/53c20778-0c04-4239-b666-d0a51de8a70b">

**What don't we catch?**
A call-activity with a wait state in between:
<img width="589" alt="image" src="https://github.com/camunda/zeebe/assets/5787702/1081c411-e21b-42cd-bba6-d19d005c1e6b">

A call activity calling itself with a FEEL expression:
<img width="339" alt="image" src="https://github.com/camunda/zeebe/assets/5787702/e81b230c-6d83-442d-84d1-c3c63caf0b16">

A call-activity calling a straight-through loop in a different resource file:
<img width="888" alt="image" src="https://github.com/camunda/zeebe/assets/5787702/08f4d1ba-c322-49eb-a290-d07a05f5e674">


## Related issues

<!-- Which issues are closed by this PR or are related -->

Related to #12957 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
