### PR TITLE
Replace blacklisting term

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/BannedInstanceMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/BannedInstanceMetrics.java
@@ -9,27 +9,27 @@ package io.camunda.zeebe.engine.metrics;
 
 import io.prometheus.client.Gauge;
 
-public final class BlacklistMetrics {
+public final class BannedInstanceMetrics {
 
-  private static final Gauge BLACKLISTED_INSTANCES_COUNTER =
+  private static final Gauge BANNED_INSTANCES_COUNTER =
       Gauge.build()
           .namespace("zeebe")
-          .name("blacklisted_instances_total")
-          .help("Number of blacklisted instances")
+          .name("banned_instances_total")
+          .help("Number of banned instances")
           .labelNames("partition")
           .register();
 
   private final String partitionIdLabel;
 
-  public BlacklistMetrics(final int partitionId) {
+  public BannedInstanceMetrics(final int partitionId) {
     partitionIdLabel = String.valueOf(partitionId);
   }
 
-  public void countBlacklistedInstance() {
-    BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).inc();
+  public void countBannedInstance() {
+    BANNED_INSTANCES_COUNTER.labels(partitionIdLabel).inc();
   }
 
-  public void setBlacklistInstanceCounter(final int counter) {
-    BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).set(counter);
+  public void setBannedInstanceCounter(final int counter) {
+    BANNED_INSTANCES_COUNTER.labels(partitionIdLabel).set(counter);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -25,7 +25,7 @@ import io.camunda.zeebe.engine.state.message.DbMessageState;
 import io.camunda.zeebe.engine.state.message.DbMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationState;
-import io.camunda.zeebe.engine.state.mutable.MutableBlackListState;
+import io.camunda.zeebe.engine.state.mutable.MutableBannedInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
@@ -45,7 +45,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSignalSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
-import io.camunda.zeebe.engine.state.processing.DbBlackListState;
+import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.engine.state.signal.DbSignalSubscriptionState;
 import io.camunda.zeebe.engine.state.variable.DbVariableState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -72,7 +72,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableMessageStartEventSubscriptionState messageStartEventSubscriptionState;
   private final DbProcessMessageSubscriptionState processMessageSubscriptionState;
   private final MutableIncidentState incidentState;
-  private final MutableBlackListState blackListState;
+  private final MutableBannedInstanceState bannedInstanceState;
   private final MutableMigrationState mutableMigrationState;
   private final MutableDecisionState decisionState;
   private final MutableSignalSubscriptionState signalSubscriptionState;
@@ -104,7 +104,7 @@ public class ProcessingDbState implements MutableProcessingState {
     processMessageSubscriptionState =
         new DbProcessMessageSubscriptionState(zeebeDb, transactionContext);
     incidentState = new DbIncidentState(zeebeDb, transactionContext, partitionId);
-    blackListState = new DbBlackListState(zeebeDb, transactionContext, partitionId);
+    bannedInstanceState = new DbBannedInstanceState(zeebeDb, transactionContext, partitionId);
     decisionState = new DbDecisionState(zeebeDb, transactionContext);
     signalSubscriptionState = new DbSignalSubscriptionState(zeebeDb, transactionContext);
     distributionState = new DbDistributionState(zeebeDb, transactionContext);
@@ -116,7 +116,7 @@ public class ProcessingDbState implements MutableProcessingState {
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     messageSubscriptionState.onRecovered(context);
     processMessageSubscriptionState.onRecovered(context);
-    blackListState.onRecovered(context);
+    bannedInstanceState.onRecovered(context);
   }
 
   @Override
@@ -160,8 +160,8 @@ public class ProcessingDbState implements MutableProcessingState {
   }
 
   @Override
-  public MutableBlackListState getBlackListState() {
-    return blackListState;
+  public MutableBannedInstanceState getBannedInstanceState() {
+    return bannedInstanceState;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ErrorCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ErrorCreatedApplier.java
@@ -8,20 +8,20 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableBlackListState;
+import io.camunda.zeebe.engine.state.mutable.MutableBannedInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 
 public class ErrorCreatedApplier implements TypedEventApplier<ErrorIntent, ErrorRecord> {
 
-  private final MutableBlackListState mutableBlackListState;
+  private final MutableBannedInstanceState mutableBannedInstanceState;
 
-  public ErrorCreatedApplier(final MutableBlackListState mutableBlackListState) {
-    this.mutableBlackListState = mutableBlackListState;
+  public ErrorCreatedApplier(final MutableBannedInstanceState mutableBannedInstanceState) {
+    this.mutableBannedInstanceState = mutableBannedInstanceState;
   }
 
   @Override
   public void applyState(final long key, final ErrorRecord value) {
-    mutableBlackListState.blacklistProcessInstance(value.getProcessInstanceKey());
+    mutableBannedInstanceState.banProcessInstance(value.getProcessInstanceKey());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -57,7 +57,7 @@ public final class EventAppliers implements EventApplier {
     registerProcessInstanceModificationAppliers(state);
 
     register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
-    register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBlackListState()));
+    register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBannedInstanceState()));
     registerDeploymentAppliers(state);
 
     registerMessageAppliers(state);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BannedInstanceState.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
-public interface BlackListState extends StreamProcessorLifecycleAware {
+public interface BannedInstanceState extends StreamProcessorLifecycleAware {
 
-  boolean isOnBlacklist(final TypedRecord record);
+  boolean isBanned(final TypedRecord record);
 
   boolean isEmpty();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -28,7 +28,7 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
 
   IncidentState getIncidentState();
 
-  BlackListState getBlackListState();
+  BannedInstanceState getBannedInstanceState();
 
   VariableState getVariableState();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBannedInstanceState.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.zeebe.engine.state.mutable;
 
-import io.camunda.zeebe.engine.state.immutable.BlackListState;
+import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.function.Consumer;
 
-public interface MutableBlackListState extends BlackListState {
+public interface MutableBannedInstanceState extends BannedInstanceState {
 
-  boolean tryToBlacklist(
-      final TypedRecord<?> typedRecord, final Consumer<Long> onBlacklistingInstance);
+  boolean tryToBanInstance(
+      final TypedRecord<?> typedRecord, final Consumer<Long> onBanningInstance);
 
-  void blacklistProcessInstance(final long processInstanceKey);
+  void banProcessInstance(final long processInstanceKey);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -37,7 +37,7 @@ public interface MutableProcessingState extends ProcessingState {
   MutableIncidentState getIncidentState();
 
   @Override
-  MutableBlackListState getBlackListState();
+  MutableBannedInstanceState getBannedInstanceState();
 
   @Override
   MutableVariableState getVariableState();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.engine.Loggers;
-import io.camunda.zeebe.engine.metrics.BlacklistMetrics;
-import io.camunda.zeebe.engine.state.mutable.MutableBlackListState;
+import io.camunda.zeebe.engine.metrics.BannedInstanceMetrics;
+import io.camunda.zeebe.engine.state.mutable.MutableBannedInstanceState;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -26,64 +26,67 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 
-public final class DbBlackListState implements MutableBlackListState {
+public final class DbBannedInstanceState implements MutableBannedInstanceState {
 
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
 
-  private static final String BLACKLIST_INSTANCE_MESSAGE =
-      "Blacklist process instance {}, due to previous errors.";
+  private static final String BAN_INSTANCE_MESSAGE =
+      "Ban process instance {}, due to previous errors.";
 
-  private final ColumnFamily<DbLong, DbNil> blackListColumnFamily;
+  private final ColumnFamily<DbLong, DbNil> bannedInstanceColumnFamily;
   private final DbLong processInstanceKey;
-  private final BlacklistMetrics blacklistMetrics;
+  private final BannedInstanceMetrics bannedInstanceMetrics;
   private boolean empty = true;
 
-  public DbBlackListState(
+  public DbBannedInstanceState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
       final int partitionId) {
     processInstanceKey = new DbLong();
-    blackListColumnFamily =
+    bannedInstanceColumnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.BLACKLIST, transactionContext, processInstanceKey, DbNil.INSTANCE);
-    blacklistMetrics = new BlacklistMetrics(partitionId);
+            ZbColumnFamilies.BANNED_INSTANCE,
+            transactionContext,
+            processInstanceKey,
+            DbNil.INSTANCE);
+    bannedInstanceMetrics = new BannedInstanceMetrics(partitionId);
   }
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     final var counter = new AtomicInteger(0);
-    blackListColumnFamily.forEach(ignore -> counter.getAndIncrement());
+    bannedInstanceColumnFamily.forEach(ignore -> counter.getAndIncrement());
     empty = counter.get() == 0;
-    blacklistMetrics.setBlacklistInstanceCounter(counter.get());
+    bannedInstanceMetrics.setBannedInstanceCounter(counter.get());
   }
 
-  private void blacklist(final long key) {
+  private void banInstance(final long key) {
     if (key >= 0) {
-      LOG.warn(BLACKLIST_INSTANCE_MESSAGE, key);
+      LOG.warn(BAN_INSTANCE_MESSAGE, key);
 
       empty = false;
       processInstanceKey.wrapLong(key);
-      blackListColumnFamily.insert(processInstanceKey, DbNil.INSTANCE);
-      blacklistMetrics.countBlacklistedInstance();
+      bannedInstanceColumnFamily.insert(processInstanceKey, DbNil.INSTANCE);
+      bannedInstanceMetrics.countBannedInstance();
     }
   }
 
-  private boolean isOnBlacklist(final long key) {
+  private boolean isBanned(final long key) {
     if (empty) {
       return false;
     }
 
     processInstanceKey.wrapLong(key);
-    return blackListColumnFamily.exists(processInstanceKey);
+    return bannedInstanceColumnFamily.exists(processInstanceKey);
   }
 
   @Override
-  public boolean isOnBlacklist(final TypedRecord record) {
+  public boolean isBanned(final TypedRecord record) {
     final UnpackedObject value = record.getValue();
     if (value instanceof ProcessInstanceRelated) {
       final long processInstanceKey = ((ProcessInstanceRelated) value).getProcessInstanceKey();
       if (processInstanceKey >= 0) {
-        return isOnBlacklist(processInstanceKey);
+        return isBanned(processInstanceKey);
       }
     }
     return false;
@@ -95,32 +98,32 @@ public final class DbBlackListState implements MutableBlackListState {
   }
 
   @Override
-  public boolean tryToBlacklist(
-      final TypedRecord<?> typedRecord, final Consumer<Long> onBlacklistingInstance) {
+  public boolean tryToBanInstance(
+      final TypedRecord<?> typedRecord, final Consumer<Long> onBanningInstance) {
     final Intent intent = typedRecord.getIntent();
-    if (shouldBeBlacklisted(intent)) {
+    if (shouldBeBanned(intent)) {
       final UnpackedObject value = typedRecord.getValue();
       if (value instanceof ProcessInstanceRelated) {
         final long processInstanceKey = ((ProcessInstanceRelated) value).getProcessInstanceKey();
-        blacklist(processInstanceKey);
-        onBlacklistingInstance.accept(processInstanceKey);
+        banInstance(processInstanceKey);
+        onBanningInstance.accept(processInstanceKey);
       }
     }
     return false;
   }
 
   @Override
-  public void blacklistProcessInstance(final long processInstanceKey) {
-    blacklist(processInstanceKey);
+  public void banProcessInstance(final long processInstanceKey) {
+    banInstance(processInstanceKey);
   }
 
-  public static boolean shouldBeBlacklisted(final Intent intent) {
+  public static boolean shouldBeBanned(final Intent intent) {
 
     if (intent instanceof ProcessInstanceRelatedIntent) {
       final ProcessInstanceRelatedIntent processInstanceRelatedIntent =
           (ProcessInstanceRelatedIntent) intent;
 
-      return processInstanceRelatedIntent.shouldBlacklistInstanceOnError();
+      return processInstanceRelatedIntent.shouldBanInstanceOnError();
     }
 
     return false;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
@@ -261,7 +261,7 @@ public final class EngineErrorHandlingTest {
   }
 
   @Test
-  public void shouldBlacklistInstance() {
+  public void shouldBanInstance() {
     // given
     final AtomicReference<DumpProcessor> dumpProcessorRef = new AtomicReference<>();
     final ErrorProneProcessor processor = new ErrorProneProcessor();
@@ -319,7 +319,7 @@ public final class EngineErrorHandlingTest {
     metadata.valueType(ValueType.PROCESS_INSTANCE);
     final MockTypedRecord<ProcessInstanceRecord> mockTypedRecord =
         new MockTypedRecord<>(0, metadata, Records.processInstance(1));
-    Assertions.assertThat(processingState.getBlackListState().isOnBlacklist(mockTypedRecord))
+    Assertions.assertThat(processingState.getBannedInstanceState().isBanned(mockTypedRecord))
         .isTrue();
 
     verify(dumpProcessorRef.get(), times(1)).processRecord(any());
@@ -327,7 +327,7 @@ public final class EngineErrorHandlingTest {
   }
 
   @Test
-  public void shouldBlacklistInstanceOnReplay() throws Exception {
+  public void shouldBanInstanceOnReplay() throws Exception {
     // given
     final long failedPos =
         streams
@@ -375,11 +375,11 @@ public final class EngineErrorHandlingTest {
     metadata.valueType(ValueType.PROCESS_INSTANCE);
     final MockTypedRecord<ProcessInstanceRecord> mockTypedRecord =
         new MockTypedRecord<>(0, metadata, Records.processInstance(1));
-    waitUntil(() -> processingState.getBlackListState().isOnBlacklist(mockTypedRecord));
+    waitUntil(() -> processingState.getBannedInstanceState().isBanned(mockTypedRecord));
   }
 
   @Test
-  public void shouldNotBlacklistInstanceOnJobCommand() {
+  public void shouldNotBanInstanceOnJobCommand() {
     // given
     final List<Long> processedInstances = new ArrayList<>();
     final AtomicReference<TypedRecordProcessor<JobRecord>> dumpProcessorRef =
@@ -457,7 +457,7 @@ public final class EngineErrorHandlingTest {
     metadata.valueType(ValueType.PROCESS_INSTANCE);
     final MockTypedRecord<ProcessInstanceRecord> mockTypedRecord =
         new MockTypedRecord<>(0, metadata, Records.processInstance(1));
-    Assertions.assertThat(processingState.getBlackListState().isOnBlacklist(mockTypedRecord))
+    Assertions.assertThat(processingState.getBannedInstanceState().isBanned(mockTypedRecord))
         .isFalse();
 
     verify(dumpProcessorRef.get(), timeout(1000).times(2)).processRecord(any());
@@ -465,7 +465,7 @@ public final class EngineErrorHandlingTest {
   }
 
   @Test
-  public void shouldNotBlacklistInstanceAndIgnoreTimerStartEvents() {
+  public void shouldNotBanInstanceAndIgnoreTimerStartEvents() {
     // given
     final List<Long> processedInstances = new ArrayList<>();
 
@@ -533,7 +533,7 @@ public final class EngineErrorHandlingTest {
     metadata.valueType(ValueType.TIMER);
     final MockTypedRecord<TimerRecord> mockTypedRecord =
         new MockTypedRecord<>(0, metadata, Records.timer(TimerInstance.NO_ELEMENT_INSTANCE));
-    Assertions.assertThat(processingState.getBlackListState().isOnBlacklist(mockTypedRecord))
+    Assertions.assertThat(processingState.getBannedInstanceState().isBanned(mockTypedRecord))
         .isFalse();
     assertThat(processedInstances).containsExactly(TimerInstance.NO_ELEMENT_INSTANCE);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
@@ -45,7 +45,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public final class BlacklistInstanceTest {
+public final class BanInstanceTest {
 
   @ClassRule public static final ProcessingStateRule ZEEBE_STATE_RULE = new ProcessingStateRule();
   private static final AtomicLong KEY_GENERATOR = new AtomicLong(0);
@@ -57,11 +57,11 @@ public final class BlacklistInstanceTest {
   public Intent recordIntent;
 
   @Parameter(2)
-  public boolean expectedToBlacklist;
+  public boolean expectedToBan;
 
   private long processInstanceKey;
 
-  @Parameters(name = "{0} {1} should blacklist instance {2}")
+  @Parameters(name = "{0} {1} should ban instance {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       ////////////////////////////////////////
@@ -202,7 +202,7 @@ public final class BlacklistInstanceTest {
   }
 
   @Test
-  public void shouldBlacklist() {
+  public void shouldBanInstance() {
     // given
     final RecordMetadata metadata = new RecordMetadata();
     metadata.intent(recordIntent);
@@ -215,14 +215,16 @@ public final class BlacklistInstanceTest {
 
     // when
     final MutableProcessingState processingState = ZEEBE_STATE_RULE.getProcessingState();
-    processingState.getBlackListState().tryToBlacklist(typedEvent, (processInstanceKey) -> {});
+    processingState
+        .getBannedInstanceState()
+        .tryToBanInstance(typedEvent, (processInstanceKey) -> {});
 
     // then
     metadata.intent(ProcessInstanceIntent.ELEMENT_ACTIVATING);
     metadata.valueType(ValueType.PROCESS_INSTANCE);
     typedEvent.wrap(null, metadata, new Value());
-    assertThat(processingState.getBlackListState().isOnBlacklist(typedEvent))
-        .isEqualTo(expectedToBlacklist);
+    assertThat(processingState.getBannedInstanceState().isBanned(typedEvent))
+        .isEqualTo(expectedToBan);
   }
 
   private final class Value extends UnifiedRecordValue implements ProcessInstanceRelated {

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -76,6 +76,18 @@
         {
           "ignore": true,
           "code": "java.method.removed",
+          "old": "io.camunda.zeebe.protocol.record.intent.IncidentIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "io.camunda.zeebe.protocol.record.intent.JobIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
           "old": "method io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue::withActivatedElementInstanceKeys(java.lang.Long[])",
           "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
         },
@@ -183,6 +195,81 @@
             "match": "@org.immutables.value.Generated(**) type ^* {}"
           },
           "justification": "This is ignored due to javax.annotation removal"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field io.camunda.zeebe.protocol.ZbColumnFamilies.BLACKLIST",
+          "justification": "This constant had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as we use ordinals only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.IncidentIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.JobIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessEventIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.protocol.record.intent.TimerIntent::shouldBlacklistInstanceOnError()",
+          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
         }
       ]
     }

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -76,18 +76,6 @@
         {
           "ignore": true,
           "code": "java.method.removed",
-          "old": "io.camunda.zeebe.protocol.record.intent.IncidentIntent::shouldBlacklistInstanceOnError()",
-          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "io.camunda.zeebe.protocol.record.intent.JobIntent::shouldBlacklistInstanceOnError()",
-          "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
           "old": "method io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue::withActivatedElementInstanceKeys(java.lang.Long[])",
           "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
         },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -91,7 +91,7 @@ public enum ZbColumnFamilies {
   EVENT_SCOPE,
   EVENT_TRIGGER,
 
-  BLACKLIST,
+  BANNED_INSTANCE,
 
   EXPORTER,
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
@@ -22,15 +22,15 @@ public enum IncidentIntent implements ProcessInstanceRelatedIntent {
   RESOLVED((short) 2);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
   IncidentIntent(final short value) {
     this(value, true);
   }
 
-  IncidentIntent(final short value, final boolean shouldBlacklist) {
+  IncidentIntent(final short value, final boolean shouldBanInstance) {
     this.value = value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   public short getIntent() {
@@ -56,7 +56,7 @@ public enum IncidentIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -47,15 +47,15 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   YIELDED((short) 16);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
   JobIntent(final short value) {
     this(value, true);
   }
 
-  JobIntent(final short value, final boolean shouldBlacklist) {
+  JobIntent(final short value, final boolean shouldBanInstance) {
     this.value = value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   public short getIntent() {
@@ -109,7 +109,7 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
@@ -30,15 +30,15 @@ public enum MessageSubscriptionIntent implements ProcessInstanceRelatedIntent {
   DELETED((short) 7);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
   MessageSubscriptionIntent(final short value) {
     this(value, true);
   }
 
-  MessageSubscriptionIntent(final short value, final boolean shouldBlacklist) {
+  MessageSubscriptionIntent(final short value, final boolean shouldBanInstance) {
     this.value = value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   @Override
@@ -72,7 +72,7 @@ public enum MessageSubscriptionIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessEventIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessEventIntent.java
@@ -42,7 +42,7 @@ public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
+  public boolean shouldBanInstanceOnError() {
     return true;
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
@@ -20,15 +20,15 @@ public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
   ACTIVATE(1);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
   ProcessInstanceBatchIntent(final int value) {
     this(value, true);
   }
 
-  ProcessInstanceBatchIntent(final int value, final boolean shouldBlacklist) {
+  ProcessInstanceBatchIntent(final int value, final boolean shouldBanInstance) {
     this.value = (short) value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   public static Intent from(final short value) {
@@ -48,7 +48,7 @@ public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceCreationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceCreationIntent.java
@@ -21,15 +21,15 @@ public enum ProcessInstanceCreationIntent implements Intent, ProcessInstanceRela
   CREATE_WITH_AWAITING_RESULT(2, false);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
-  ProcessInstanceCreationIntent(final int value, final boolean shouldBlacklist) {
-    this((short) value, shouldBlacklist);
+  ProcessInstanceCreationIntent(final int value, final boolean shouldBanInstance) {
+    this((short) value, shouldBanInstance);
   }
 
-  ProcessInstanceCreationIntent(final short value, final boolean shouldBlacklist) {
+  ProcessInstanceCreationIntent(final short value, final boolean shouldBanInstance) {
     this.value = value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   @Override
@@ -51,7 +51,7 @@ public enum ProcessInstanceCreationIntent implements Intent, ProcessInstanceRela
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -39,15 +39,15 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       EnumSet.of(ACTIVATE_ELEMENT, COMPLETE_ELEMENT, TERMINATE_ELEMENT);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
   ProcessInstanceIntent(final short value) {
     this(value, true);
   }
 
-  ProcessInstanceIntent(final short value, final boolean shouldBlacklist) {
+  ProcessInstanceIntent(final short value, final boolean shouldBanInstance) {
     this.value = value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   public short getIntent() {
@@ -89,8 +89,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 
   public static boolean isProcessInstanceCommand(final ProcessInstanceIntent intent) {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
@@ -31,7 +31,7 @@ public enum ProcessInstanceModificationIntent implements Intent, ProcessInstance
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
+  public boolean shouldBanInstanceOnError() {
     return true;
   }
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceRelatedIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceRelatedIntent.java
@@ -17,5 +17,5 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public interface ProcessInstanceRelatedIntent extends Intent {
 
-  boolean shouldBlacklistInstanceOnError();
+  boolean shouldBanInstanceOnError();
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceResultIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceResultIntent.java
@@ -19,15 +19,15 @@ public enum ProcessInstanceResultIntent implements Intent, ProcessInstanceRelate
   COMPLETED(0, false);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
-  ProcessInstanceResultIntent(final int value, final boolean shouldBlacklist) {
-    this((short) value, shouldBlacklist);
+  ProcessInstanceResultIntent(final int value, final boolean shouldBanInstance) {
+    this((short) value, shouldBanInstance);
   }
 
-  ProcessInstanceResultIntent(final short value, final boolean shouldBlacklist) {
+  ProcessInstanceResultIntent(final short value, final boolean shouldBanInstance) {
     this.value = value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   @Override
@@ -45,7 +45,7 @@ public enum ProcessInstanceResultIntent implements Intent, ProcessInstanceRelate
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
@@ -28,15 +28,15 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
   DELETED((short) 7);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
   ProcessMessageSubscriptionIntent(final short value) {
     this(value, true);
   }
 
-  ProcessMessageSubscriptionIntent(final short value, final boolean shouldBlacklist) {
+  ProcessMessageSubscriptionIntent(final short value, final boolean shouldBanInstance) {
     this.value = value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   @Override
@@ -68,7 +68,7 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
@@ -30,15 +30,15 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
   CANCELED((short) 4);
 
   private final short value;
-  private final boolean shouldBlacklist;
+  private final boolean shouldBanInstance;
 
   TimerIntent(final short value) {
     this(value, true);
   }
 
-  TimerIntent(final short value, final boolean shouldBlacklist) {
+  TimerIntent(final short value, final boolean shouldBanInstance) {
     this.value = value;
-    this.shouldBlacklist = shouldBlacklist;
+    this.shouldBanInstance = shouldBanInstance;
   }
 
   @Override
@@ -64,7 +64,7 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
-  public boolean shouldBlacklistInstanceOnError() {
-    return shouldBlacklist;
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
   }
 }


### PR DESCRIPTION
## Description

> **Note**: Right now we use blacklisting as a term when a process instance is marked as there is no continuation is allowed or possible. In essence, we ban the instance from further progressing. 

This concept is unfortunately already a long time overdue (to be replaced) but we have had not enough time for it yet. Due to our growing community, it makes sense to document also such edge-case aspects of our system, since more and more people running into this.

In order to make the world a better place and to document and speak about this concept in public it also makes sense to not use such a racially overloaded term.

With this PR I tried to replace the term with a less bad name like: ban. In consequence, we need to adjust other places where we use the old term ofc. But step by step.

Instead of blacklisting an instance, it is now banning an instance or an instance has been banned, which sounds much better (in my opinion).

We need to verify whether this is really backward compatible with some benchmarks, currently, I think this is the case since we use for the column families the ordinals. The API methods are only use internally, but it needs to be verified ofc.


> **Note:**  I'm of course also open for another term if you think it is better. This is more a proposal, which I found when searching for [alternatives to blacklisting](https://www.thesaurus.com/browse/blacklist)
<!-- Please explain the changes you made here. -->



## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda-cloud/runbook/issues/54

BTW also kudos to @korthout who brought this up a while ago.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
