### PR TITLE
Monitor Snyk projects on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         id: maven-release
         env:
           SKIP_REPO_DEPLOY: ${{ inputs.dryRun }}
-        run : |
+        run: |
           # This var is used to include the previously built go artifacts into the final maven release build.
           # As the maven build of the tag happens in a sub-directory to which maven checks out the release tag to build it.
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
@@ -316,3 +316,22 @@ jobs:
             --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
             ${{ inputs.isLatest && format('--tag {0}:latest', env.DOCKER_IMAGE) || '' }} \
             ${{ steps.build-docker.outputs.image }}
+  snyk:
+    name: Snyk Monitor
+    needs: [ docker, release ]
+    # skip if the version contains a dash as a quick test for -alpha, -rc, -SNAPSHOT, etc.
+    if: ${{ !contains(inputs.releaseVersion, '-') }}
+    concurrency:
+      group: release-snyk-${{ inputs.releaseVersion }}
+      cancel-in-progress: false
+    uses: ./.github/workflows/snyk.yml
+    with:
+      # test instead of monitor during dry-runs
+      monitor: ${{ !inputs.dryRun }}
+      version: ${{ inputs.releaseVersion }}
+      useMinorVersion: true
+      # the docker image will not be pushed during a dry-run, so we need to build it locally
+      build: ${{ !inputs.dryRun }}
+    secrets: inherit
+
+

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,6 +13,10 @@ on:
         description: Allows overriding the project target reference directly; defaults to the current branch
         required: false
         type: string
+      dockerImage:
+        description: The full name of the Docker image; if absent and build is true, will use the built image name; if not building, infers from the version
+        required: false
+        type: string
       monitor:
         description: Upload Snyk snapshot instead of test
         required: false
@@ -34,6 +38,10 @@ on:
         type: string
       target:
         description: Allows overriding the project target reference directly; defaults to the current branch
+        required: false
+        type: string
+      dockerImage:
+        description: The full name of the Docker image; if absent and build is true, will use the built image name; if not building, infers from the version
         required: false
         type: string
       monitor:
@@ -94,6 +102,9 @@ jobs:
           export VERSION_TAG=$([[ "${VERSION}" == *-SNAPSHOT ]] && echo 'development' || echo "${VERSION}")
           export LIFECYCLE=$([[ "${VERSION}" == *-SNAPSHOT ]] && echo 'development' || echo 'production')
 
+          # use inputs.dockerImage if present; otherwise if building, use the output of the build step; otherwise infer from version and default repository camunda/zeebe
+          export DOCKER_IMAGE=$([[ ! -z '${{ inputs.dockerImage }}' ]] && echo '${{ inputs.dockerImage }}' || ([[ '${{ inputs.build }}' == 'true' ]] && echo '${{ steps.build-docker.outputs.image }}' || echo "camunda/zeebe:${VERSION}"))
+
           echo "SNYK_ARGS=" \
             "--show-vulnerable-paths=all" \
             "--severity-threshold=high" \
@@ -104,7 +115,7 @@ jobs:
           echo "TARGET=${TARGET}" >> $GITHUB_ENV
           echo "SNYK_COMMAND=${{ (inputs.monitor && 'monitor') || 'test' }}" >> $GITHUB_ENV
           echo "SARIF=${{ (inputs.monitor && 'false') || 'true' }}" >> $GITHUB_ENV
-          echo "DOCKER_IMAGE=${{ steps.build-docker.outputs.image }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_IMAGE}" >> $GITHUB_ENV
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
       - name: Run Snyk
         env:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: true
+      useMinorVersion:
+        description: Uses the major and minor version only for target and version
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     secrets:
       SNYK_TOKEN:
@@ -54,6 +59,11 @@ on:
         required: false
         type: boolean
         default: true
+      useMinorVersion:
+        description: Uses the major and minor version only for target and version
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -104,6 +114,10 @@ jobs:
 
           # use inputs.dockerImage if present; otherwise if building, use the output of the build step; otherwise infer from version and default repository camunda/zeebe
           export DOCKER_IMAGE=$([[ ! -z '${{ inputs.dockerImage }}' ]] && echo '${{ inputs.dockerImage }}' || ([[ '${{ inputs.build }}' == 'true' ]] && echo '${{ steps.build-docker.outputs.image }}' || echo "camunda/zeebe:${VERSION}"))
+
+          if [[ '${{ inputs.useMinorVersion }}' == 'true' ]]; then
+            export TARGET="$(echo $VERSION | sed -E -e 's/\.[^.]*$//')"
+          fi
 
           echo "SNYK_ARGS=" \
             "--show-vulnerable-paths=all" \
@@ -157,7 +171,13 @@ jobs:
           # feature at the moment. It's added here anyway for now, and hopefully support will come soon.
           PROJECT_NAME="zeebe(${TARGET}):Dockerfile"
           snyk container "${SNYK_COMMAND}" "${DOCKER_IMAGE}" --file=Dockerfile "'--project-name=${PROJECT_NAME}'" ${SNYK_ARGS} "$(output "${SARIF}" 'docker')" || exitCode=1
-          exit "${exitCode}"
+
+          # Only fail if we entirely failed to parse the projects
+          if [[ $exitCode -ge 1 ]]; then
+            exit "${exitCode}"
+          else
+            exit 0
+          fi
       # This makes the result of our test available in GitHub Code Scanning (look for the Snyk tools)
       # You can filter by your PR ID, by branch, etc.
       # This step is only executed if we're testing, as otherwise no SARIF files are emitted

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -173,7 +173,7 @@ jobs:
           snyk container "${SNYK_COMMAND}" "${DOCKER_IMAGE}" --file=Dockerfile "'--project-name=${PROJECT_NAME}'" ${SNYK_ARGS} "$(output "${SARIF}" 'docker')" || exitCode=1
 
           # Only fail if we entirely failed to parse the projects
-          if [[ $exitCode -ge 1 ]]; then
+          if [[ $exitCode -gt 1 ]]; then
             exit "${exitCode}"
           else
             exit 0


### PR DESCRIPTION
## Description

This PR adds a job to the release workflow to also monitor Snyk project for the given release. It uses the released Docker image and the local Maven POMs from the release branch, overriding the version and the Docker image name. 

During a dry run, we run a test of the Snyk artifacts instead. It's not perfect, but better than nothing, as it will at least make sure Snyk can parse our artifacts.

> **Note**
> The Docker image is built during a dry-run since no previous Docker images are built. However, the job still waits for the Docker and release jobs to go through. I'm not aware of any way to make the `needs` parameter conditional.

Projects monitored during release will be created under the grouping using only the major and minor release, e.g. 8.2, 8.1, 8.0. The project names include only the minor release as well, so projects will be replaced on patch release, meaning we only keep track of the latest release on a minor branch.

> **Warning**
> This does not contain clearing out the out-of-date minor version.

## Related issues

related to #9245

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
