### PR TITLE
feat(atomix-utils): allow pre-release dot-separated identifiers

### DIFF
--- a/atomix/utils/src/test/java/io/atomix/utils/VersionTest.java
+++ b/atomix/utils/src/test/java/io/atomix/utils/VersionTest.java
@@ -35,6 +35,9 @@ public class VersionTest {
     assertTrue(Version.from("1.1.1").compareTo(Version.from("1.0.3")) > 0);
     assertTrue(Version.from("1.0.0").compareTo(Version.from("1.0.0-beta1")) > 0);
     assertTrue(Version.from("1.0.0-rc2").compareTo(Version.from("1.0.0-rc1")) > 0);
+    assertTrue(Version.from("1.0.0-rc2.1").compareTo(Version.from("1.0.0-rc2")) > 0);
+    assertTrue(Version.from("1.0.0-rc2.1.1").compareTo(Version.from("1.0.0-rc2.1")) > 0);
+    assertTrue(Version.from("1.0.0-rc2").compareTo(Version.from("1.0.0-rc2.1")) < 0);
     assertTrue(Version.from("1.0.0-rc1").compareTo(Version.from("1.0.0-beta1")) > 0);
     assertTrue(Version.from("2.0.0-beta1").compareTo(Version.from("1.0.0")) > 0);
     assertTrue(Version.from("1.0.0-alpha1").compareTo(Version.from("1.0.0-SNAPSHOT")) > 0);
@@ -46,6 +49,7 @@ public class VersionTest {
     assertEquals("1.0.0-alpha1", Version.from("1.0.0-alpha1").toString());
     assertEquals("1.0.0-beta1", Version.from("1.0.0-beta1").toString());
     assertEquals("1.0.0-rc1", Version.from("1.0.0-rc1").toString());
+    assertEquals("1.0.0-rc1.2", Version.from("1.0.0-rc1.2").toString());
     assertEquals("1.0.0-SNAPSHOT", Version.from("1.0.0-SNAPSHOT").toString());
   }
 
@@ -54,6 +58,7 @@ public class VersionTest {
     assertIllegalArgument(() -> Version.from("1"));
     assertIllegalArgument(() -> Version.from("1.0"));
     assertIllegalArgument(() -> Version.from("1.0-beta1"));
+    assertIllegalArgument(() -> Version.from("1.0.0-beta1XYZ"));
     assertIllegalArgument(() -> Version.from("1.0.0.0"));
     assertIllegalArgument(() -> Version.from("1.0.0.0-beta1"));
     assertIllegalArgument(() -> Version.from("1.0.0-not1"));


### PR DESCRIPTION
## Description

Any zeebe builds containing dot separators on the prerelease currently fail to start with:
```
Caused by: java.lang.IllegalArgumentException: alpha2.1 is not a valid build version string
	at io.atomix.utils.Version$Build.from(Version.java:155) ~[zeebe-atomix-utils-8.3.0-alpha2.1.jar:8.3.0-alpha2.1]
	at io.atomix.utils.Version.<init>(Version.java:40) ~[zeebe-atomix-utils-8.3.0-alpha2.1.jar:8.3.0-alpha2.1]
	at io.atomix.utils.Version.from(Version.java:57) ~[zeebe-atomix-utils-8.3.0-alpha2.1.jar:8.3.0-alpha2.1]
	at io.camunda.zeebe.broker.BrokerClusterConfiguration.atomixCluster(BrokerClusterConfiguration.java:29) ~[camunda-zeebe-8.3.0-alpha2.1.jar:8.3.0-alpha2.1]
```
due to the fact that the Version class is only supporting single digit pre-release identifiers.

This change adds support for as many dot denoted identifiers as specified in alignment with https://semver.org/#spec-item-9 . However, it still deviates from the semver spec in terms of the alphanumeric identifier not being separated by a dot. According to semver an alpha release should be `alpha.1` instead of `alpha1` + it doesn't support multiple alphanumeric identifiers.

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
