### PR TITLE
[backport-8.1]: Refactor job processors

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -12,28 +12,23 @@ import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor.Comma
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
+import java.util.List;
 
 /**
  * Default implementation to process JobCommands to reduce duplication in CommandProcessor
  * implementations.
  */
 final class DefaultJobCommandPreconditionGuard {
-
-  private static final String NO_JOB_FOUND_MESSAGE =
-      "Expected to %s job with key '%d', but no such job was found";
-  private static final String INVALID_JOB_STATE_MESSAGE =
-      "Expected to %s job with key '%d', but it is in state '%s'";
-
-  private final String intent;
   private final JobState state;
   private final JobAcceptFunction acceptCommand;
+  private final JobCommandPreconditionChecker preconditionChecker;
 
   public DefaultJobCommandPreconditionGuard(
       final String intent, final JobState state, final JobAcceptFunction acceptCommand) {
-    this.intent = intent;
     this.state = state;
     this.acceptCommand = acceptCommand;
+    preconditionChecker =
+        new JobCommandPreconditionChecker(intent, List.of(State.ACTIVATABLE, State.ACTIVATED));
   }
 
   public boolean onCommand(
@@ -41,16 +36,11 @@ final class DefaultJobCommandPreconditionGuard {
     final long jobKey = command.getKey();
     final State jobState = state.getState(jobKey);
 
-    if (jobState == State.ACTIVATABLE || jobState == State.ACTIVATED) {
-      acceptCommand.accept(command, commandControl);
-
-    } else if (jobState == State.NOT_FOUND) {
-      final String message = String.format(NO_JOB_FOUND_MESSAGE, intent, jobKey);
-      commandControl.reject(RejectionType.NOT_FOUND, message);
-    } else {
-      final String message = String.format(INVALID_JOB_STATE_MESSAGE, intent, jobKey, jobState);
-      commandControl.reject(RejectionType.INVALID_STATE, message);
-    }
+    preconditionChecker
+        .check(jobState, jobKey)
+        .ifRightOrLeft(
+            ok -> acceptCommand.accept(command, commandControl),
+            violation -> commandControl.reject(violation.getLeft(), violation.getRight()));
 
     return true;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionChecker.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class JobCommandPreconditionChecker {
+
+  private static final String NO_JOB_FOUND_MESSAGE =
+      "Expected to %s job with key '%d', but no such job was found";
+  private static final String INVALID_JOB_STATE_MESSAGE =
+      "Expected to %s job with key '%d', but it is in state '%s'";
+
+  private final List<JobState.State> validStates;
+  private final String intent;
+
+  public JobCommandPreconditionChecker(
+      final String intent, final List<JobState.State> validStates) {
+    this.intent = intent;
+    this.validStates = validStates;
+  }
+
+  protected Either<Tuple<RejectionType, String>, Void> check(
+      final JobState.State state, final long jobKey) {
+    if (validStates.contains(state)) {
+      return Either.right(null);
+    }
+
+    if (state == State.NOT_FOUND) {
+      return Either.left(
+          Tuple.of(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, intent, jobKey)));
+    }
+
+    return Either.left(
+        Tuple.of(
+            RejectionType.INVALID_STATE,
+            String.format(INVALID_JOB_STATE_MESSAGE, intent, jobKey, state)));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -66,13 +66,17 @@ public final class JobEventProcessors {
                 keyGenerator,
                 jobMetrics))
         .onCommand(
-            ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(processingState, jobMetrics))
+            ValueType.JOB,
+            JobIntent.TIME_OUT,
+            new JobTimeOutProcessor(processingState, writers, jobMetrics))
         .onCommand(
             ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(processingState))
         .onCommand(
             ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(processingState, jobMetrics))
         .onCommand(
-            ValueType.JOB, JobIntent.RECUR_AFTER_BACKOFF, new JobRecurProcessor(processingState))
+            ValueType.JOB,
+            JobIntent.RECUR_AFTER_BACKOFF,
+            new JobRecurProcessor(processingState, writers))
         .onCommand(
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -8,7 +8,10 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
-import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -16,24 +19,29 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
-public class JobRecurProcessor implements CommandProcessor<JobRecord> {
+public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
 
   private static final String NOT_FAILED_JOB_MESSAGE =
       "Expected to back off failed job with key '%d', but %s";
   private final JobState jobState;
 
-  public JobRecurProcessor(final ProcessingState processingState) {
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+
+  public JobRecurProcessor(final ProcessingState processingState, final Writers writers) {
     jobState = processingState.getJobState();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
   }
 
   @Override
-  public boolean onCommand(
-      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
-    final long jobKey = command.getKey();
+  public void processRecord(final TypedRecord<JobRecord> record) {
+    final long jobKey = record.getKey();
     final JobState.State state = jobState.getState(jobKey);
 
     if (state == State.FAILED) {
-      commandControl.accept(JobIntent.RECURRED_AFTER_BACKOFF, command.getValue());
+      final JobRecord recurredJob = record.getValue();
+      stateWriter.appendFollowUpEvent(jobKey, JobIntent.RECURRED_AFTER_BACKOFF, recurredJob);
     } else {
       final String textState;
 
@@ -52,9 +60,8 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
           break;
       }
 
-      commandControl.reject(
-          RejectionType.NOT_FOUND, String.format(NOT_FAILED_JOB_MESSAGE, jobKey, textState));
+      final String errorMessage = String.format(NOT_FAILED_JOB_MESSAGE, jobKey, textState);
+      rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);
     }
-    return true;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -9,7 +9,10 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
-import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -17,26 +20,31 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
-public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
+public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
       "Expected to time out activated job with key '%d', but %s";
   private final JobState jobState;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
   private final JobMetrics jobMetrics;
 
-  public JobTimeOutProcessor(final ProcessingState state, final JobMetrics jobMetrics) {
+  public JobTimeOutProcessor(
+      final ProcessingState state, final Writers writers, final JobMetrics jobMetrics) {
     jobState = state.getJobState();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
     this.jobMetrics = jobMetrics;
   }
 
   @Override
-  public boolean onCommand(
-      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
-    final long jobKey = command.getKey();
+  public void processRecord(final TypedRecord<JobRecord> record) {
+    final long jobKey = record.getKey();
     final JobState.State state = jobState.getState(jobKey);
 
     if (state == State.ACTIVATED) {
-      commandControl.accept(JobIntent.TIMED_OUT, command.getValue());
-      jobMetrics.jobTimedOut(command.getValue().getType());
+      final JobRecord timedOutJob = record.getValue();
+      stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, timedOutJob);
+      jobMetrics.jobTimedOut(timedOutJob.getType());
     } else {
       final String textState;
 
@@ -52,9 +60,8 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
           break;
       }
 
-      commandControl.reject(
-          RejectionType.NOT_FOUND, String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, textState));
+      final String errorMessage = String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, textState);
+      rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);
     }
-    return true;
   }
 }


### PR DESCRIPTION
## Description

Backports the refactorings from https://github.com/camunda/zeebe/pull/12943 and https://github.com/camunda/zeebe/pull/12753

I've backported the refactorings of the job processors so that it makes future backports easier, i.e so we don't have to resolve merge conflicts all the time. I also needed to backport the refactoring of the `JobCommandPreconditionChecker`.

cc: @oleschoenburg

## Related issues

related to https://github.com/camunda/zeebe/issues/12933

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
