### PR TITLE
[Backport stable/8.2] Allow ActorFuture.onComplete to be called by non-actors

### DIFF
--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -160,6 +160,11 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
     return thread;
   }
 
+  public static boolean isCalledFromActorThread() {
+    final ActorThread thread = ActorThread.current();
+    return thread != null;
+  }
+
   public ActorJob newJob() {
     ActorJob job = jobs.poll();
 

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.scheduler.future;
 
 import io.camunda.zeebe.scheduler.ActorTask;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -28,8 +29,11 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
   void block(ActorTask onCompletion);
 
   /**
-   * Registers an consumer, which is executed after the future was completed. The consumer is
-   * executed in the current actor thread, which is used to register the consumer.
+   * Registers an consumer, which is executed after the future was completed. If the caller of this
+   * method is an actor, the consumer is executed in the caller's actor thread. If the caller is not
+   * an actor, the consumer is executed in the actor which completes this future. If the caller is
+   * not an actor, it is recommended to use {@link ActorFuture#onComplete(BiConsumer, Executor)}
+   * instead.
    *
    * <p>Example:
    *
@@ -47,9 +51,17 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * </pre>
    *
    * @param consumer the consumer which should be called after the future was completed
-   * @throws UnsupportedOperationException when not called on actor thread
    */
   void onComplete(BiConsumer<V, Throwable> consumer);
+
+  /**
+   * Registers a consumer, which is executed after the future was completed. The consumer is
+   * executed in the provided executor.
+   *
+   * @param consumer the callback which should be called after the future was completed
+   * @param executor the executor on which the callback will be executed
+   */
+  void onComplete(BiConsumer<V, Throwable> consumer, Executor executor);
 
   boolean isCompletedExceptionally();
 

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -161,7 +161,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
       this.value = value;
       state = COMPLETED;
       completedAt = System.nanoTime();
-      notifyBlockedTasks();
+      notifyAllBlocked();
     } else {
       final String err =
           "Cannot complete future, the future is already completed "
@@ -182,7 +182,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
       this.failure = failure;
       failureCause = throwable;
       state = COMPLETED_EXCEPTIONALLY;
-      notifyBlockedTasks();
+      notifyAllBlocked();
     } else {
       final String err =
           "Cannot complete future, the future is already completed "
@@ -250,9 +250,9 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     return failureCause;
   }
 
-  private void notifyBlockedTasks() {
-    notifyAllInQueue(blockedTasks);
-    notifyAllCallbacks();
+  private void notifyAllBlocked() {
+    notifyBlockedTasks(blockedTasks);
+    notifyBlockedCallBacks();
 
     try {
       completionLock.lock();
@@ -262,7 +262,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     }
   }
 
-  private void notifyAllCallbacks() {
+  private void notifyBlockedCallBacks() {
     while (!blockedCallbacks.isEmpty()) {
       final var callBack = blockedCallbacks.poll();
       if (callBack != null) {
@@ -271,7 +271,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     }
   }
 
-  private void notifyAllInQueue(final Queue<ActorTask> tasks) {
+  private void notifyBlockedTasks(final Queue<ActorTask> tasks) {
     while (!tasks.isEmpty()) {
       final ActorTask task = tasks.poll();
 
@@ -289,7 +289,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
       value = null;
       failure = null;
       failureCause = null;
-      notifyBlockedTasks();
+      notifyAllBlocked();
     }
 
     return prevState != CLOSED;

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
@@ -509,17 +509,6 @@ public final class ActorFutureTest {
   }
 
   @Test
-  public void shouldNotRunOnCompleteInMainThread() {
-    // given
-    final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
-
-    // expect exception
-    // when
-    assertThatThrownBy(() -> future.onComplete((v, t) -> {}))
-        .isInstanceOf(UnsupportedOperationException.class);
-  }
-
-  @Test
   public void shouldRunOnComplete() {
     // given
     final ActorB actorB = new ActorB();

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
@@ -87,6 +88,11 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
     if (isDone()) {
       triggerOnCompleteListener(consumer);
     }
+  }
+
+  @Override
+  public void onComplete(final BiConsumer<V, Throwable> consumer, final Executor executor) {
+    onComplete((res, error) -> executor.execute(() -> consumer.accept(res, error)));
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #13043 to `stable/8.2`.

relates to #13037