### PR TITLE
Allow appending serialized journal record received via replication

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
@@ -62,7 +62,8 @@ public class PersistedRaftRecord implements JournalRecord {
 
   @Override
   public DirectBuffer serializedRecord() {
-    return null;
+    throw new UnsupportedOperationException(
+        "Serialized journal record is not available in PersistedRaftRecord");
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
@@ -60,6 +60,11 @@ public class PersistedRaftRecord implements JournalRecord {
     return new UnsafeBuffer(serializedRaftLogEntry);
   }
 
+  @Override
+  public DirectBuffer serializedRecord() {
+    return null;
+  }
+
   /**
    * Returns the approximate size needed when serializing this class. The exact size depends on the
    * serializer.

--- a/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -58,7 +58,7 @@ public interface Journal extends AutoCloseable {
   void append(JournalRecord record);
 
   /**
-   * Appends already serialized journal record.
+   * Appends already serialized journal record. See {@link JournalRecord#serializedRecord()}
    *
    * @param index the index of the record
    * @param checksum checksum of serializedRecord

--- a/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -44,14 +44,27 @@ public interface Journal extends AutoCloseable {
   JournalRecord append(long asqn, BufferWriter recordDataWriter);
 
   /**
-   * Appends a {@link JournalRecord}. If the index of the record is not the next expected index, the
-   * append will fail.
+   * This method was used to append entries received via replication. This is deprecated. {@link
+   * Journal#append(long, long, byte[])} must be used instead.
+   *
+   * <p>Appends a {@link JournalRecord}. If the index of the record is not the next expected index,
+   * the append will fail.
    *
    * @param record the record to be appended
    * @exception InvalidIndex if the index of record is not the next expected index
    * @exception InvalidChecksum if the checksum in record does not match the checksum of the data
    */
+  @Deprecated(since = "8.3.0")
   void append(JournalRecord record);
+
+  /**
+   * Appends already serialized journal record.
+   *
+   * @param index the index of the record
+   * @param checksum checksum of serializedRecord
+   * @param serializedRecord serializedRecord
+   */
+  void append(long index, long checksum, byte[] serializedRecord);
 
   /**
    * Delete all records after indexExclusive. After a call to this method, {@link

--- a/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -44,17 +44,16 @@ public interface Journal extends AutoCloseable {
   JournalRecord append(long asqn, BufferWriter recordDataWriter);
 
   /**
-   * This method was used to append entries received via replication. This is deprecated. {@link
-   * Journal#append(long, long, byte[])} must be used instead.
+   * Appends a {@link JournalRecord}. If the index of the record is not the next expected index, the
+   * append will fail.
    *
-   * <p>Appends a {@link JournalRecord}. If the index of the record is not the next expected index,
-   * the append will fail.
-   *
+   * @deprecated This method was used to append entries received via replication. {@link
+   *     Journal#append(long, long, byte[])} must be used instead.
    * @param record the record to be appended
    * @exception InvalidIndex if the index of record is not the next expected index
    * @exception InvalidChecksum if the checksum in record does not match the checksum of the data
    */
-  @Deprecated(since = "8.3.0")
+  @Deprecated(since = "8.4.0")
   void append(JournalRecord record);
 
   /**

--- a/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -60,11 +60,10 @@ public interface Journal extends AutoCloseable {
   /**
    * Appends already serialized journal record. See {@link JournalRecord#serializedRecord()}
    *
-   * @param index the index of the record
    * @param checksum checksum of serializedRecord
    * @param serializedRecord serializedRecord
    */
-  void append(long index, long checksum, byte[] serializedRecord);
+  void append(long checksum, byte[] serializedRecord);
 
   /**
    * Delete all records after indexExclusive. After a call to this method, {@link

--- a/journal/src/main/java/io/camunda/zeebe/journal/JournalRecord.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/JournalRecord.java
@@ -46,4 +46,6 @@ public interface JournalRecord {
    * @return data
    */
   DirectBuffer data();
+
+  DirectBuffer serializedRecord();
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/JournalRecord.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/JournalRecord.java
@@ -34,7 +34,7 @@ public interface JournalRecord {
   long asqn();
 
   /**
-   * Checksum of the data
+   * Checksum of the serializedRecord
    *
    * @return checksum
    */
@@ -47,5 +47,10 @@ public interface JournalRecord {
    */
   DirectBuffer data();
 
+  /**
+   * Serialized journal record that includes index, asqn and data.
+   *
+   * @return serialized record
+   */
   DirectBuffer serializedRecord();
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -155,7 +155,7 @@ final class SegmentWriter {
     }
 
     writeMetadata(startPosition, frameLength, recordLength, checksum);
-    updateLastWrittenEntry(startPosition, frameLength, metadataLength);
+    updateLastWrittenEntry(startPosition, frameLength, metadataLength, recordLength);
     FrameUtil.writeVersion(buffer, startPosition);
 
     final int appendedBytes = frameLength + metadataLength + recordLength;
@@ -165,10 +165,18 @@ final class SegmentWriter {
   }
 
   private void updateLastWrittenEntry(
-      final int startPosition, final int frameLength, final int metadataLength) {
+      final int startPosition,
+      final int frameLength,
+      final int metadataLength,
+      final int recordLength) {
     final var metadata = serializer.readMetadata(writeBuffer, startPosition + frameLength);
     final var data = serializer.readData(writeBuffer, startPosition + frameLength + metadataLength);
-    lastEntry = new PersistedJournalRecord(metadata, data);
+    lastEntry =
+        new PersistedJournalRecord(
+            metadata,
+            data,
+            new UnsafeBuffer(
+                writeBuffer, startPosition + frameLength + metadataLength, recordLength));
     updateLastAsqn(lastEntry.asqn());
     index.index(lastEntry, startPosition);
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -85,6 +85,13 @@ public final class SegmentedJournal implements Journal {
   }
 
   @Override
+  public void append(final long index, final long checksum, final byte[] serializedRecord) {
+    try (final var ignored = journalMetrics.observeAppendLatency()) {
+      writer.append(index, checksum, serializedRecord);
+    }
+  }
+
+  @Override
   public void deleteAfter(final long indexExclusive) {
     journalMetrics.observeSegmentTruncation(
         () -> {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -85,13 +85,6 @@ public final class SegmentedJournal implements Journal {
   }
 
   @Override
-  public void append(final long index, final long checksum, final byte[] serializedRecord) {
-    try (final var ignored = journalMetrics.observeAppendLatency()) {
-      writer.append(index, checksum, serializedRecord);
-    }
-  }
-
-  @Override
   public void deleteAfter(final long indexExclusive) {
     journalMetrics.observeSegmentTruncation(
         () -> {
@@ -185,6 +178,13 @@ public final class SegmentedJournal implements Journal {
   @Override
   public boolean isOpen() {
     return open;
+  }
+
+  @Override
+  public void append(final long checksum, final byte[] serializedRecord) {
+    try (final var ignored = journalMetrics.observeAppendLatency()) {
+      writer.append(checksum, serializedRecord);
+    }
   }
 
   @Override

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -83,8 +83,8 @@ final class SegmentedJournalWriter {
     }
   }
 
-  void append(final long index, final long checksum, final byte[] serializedRecord) {
-    final var appendResult = currentWriter.append(index, checksum, serializedRecord);
+  void append(final long checksum, final byte[] serializedRecord) {
+    final var appendResult = currentWriter.append(checksum, serializedRecord);
     if (appendResult.isRight()) {
       return;
     }
@@ -94,7 +94,7 @@ final class SegmentedJournalWriter {
     }
 
     journalMetrics.observeSegmentCreation(this::createNewSegment);
-    final var resultInNewSegment = currentWriter.append(index, checksum, serializedRecord);
+    final var resultInNewSegment = currentWriter.append(checksum, serializedRecord);
     if (resultInNewSegment.isLeft()) {
       throw resultInNewSegment.getLeft();
     }

--- a/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
@@ -77,6 +77,7 @@ public final class JournalRecordReaderUtil {
               expectedIndex, record.index()));
     }
     buffer.position(startPosition + metadataLength + recordLength);
-    return new PersistedJournalRecord(metadata, record);
+    return new PersistedJournalRecord(
+        metadata, record, new UnsafeBuffer(buffer, startPosition + metadataLength, recordLength));
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/record/PersistedJournalRecord.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/record/PersistedJournalRecord.java
@@ -16,7 +16,8 @@ import org.agrona.DirectBuffer;
  * <p>A {@link PersistedJournalRecord} consists of two parts. The first part is {@link
  * RecordMetadata}. The second part is {@link RecordData}.
  */
-public record PersistedJournalRecord(RecordMetadata metadata, RecordData record)
+public record PersistedJournalRecord(
+    RecordMetadata metadata, RecordData record, DirectBuffer serializedRecord)
     implements JournalRecord {
 
   @Override

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal;
+
+import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.journal.JournalException.InvalidAsqn;
+import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
+import io.camunda.zeebe.journal.JournalException.InvalidIndex;
+import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
+import io.camunda.zeebe.journal.util.MockJournalMetastore;
+import io.camunda.zeebe.journal.util.TestJournalRecord;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class JournalAppendTest {
+  @TempDir Path directory;
+  final JournalMetaStore metaStore = new MockJournalMetastore();
+  private byte[] entry;
+  private final DirectBufferWriter recordDataWriter = new DirectBufferWriter();
+  private final DirectBufferWriter otherRecordDataWriter = new DirectBufferWriter();
+  private Journal journal;
+
+  @BeforeEach
+  void setup() {
+    entry = "TestData".getBytes();
+    recordDataWriter.wrap(new UnsafeBuffer(entry));
+
+    final var entryOther = "TestData".getBytes();
+    otherRecordDataWriter.wrap(new UnsafeBuffer(entryOther));
+
+    journal = openJournal();
+  }
+
+  @AfterEach
+  void teardown() {
+    CloseHelper.quietClose(journal);
+  }
+
+  private SegmentedJournal openJournal() {
+    return openJournal(b -> {});
+  }
+
+  private SegmentedJournal openJournal(final Consumer<SegmentedJournalBuilder> option) {
+    final var builder =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data").toFile())
+            .withMaxSegmentSize(1024 * 1024) // speeds up certain tests, e.g. shouldCompact
+            .withMetaStore(metaStore)
+            .withJournalIndexDensity(5);
+    option.accept(builder);
+
+    return builder.build();
+  }
+
+  @Test
+  void shouldAppendData() {
+    // when
+    final var recordAppended = journal.append(1, recordDataWriter);
+
+    // then
+    assertThat(recordAppended.index()).isEqualTo(1);
+    assertThat(recordAppended.asqn()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldAppendJournalRecord() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .withMetaStore(new MockJournalMetastore())
+            .build();
+    final var expected = journal.append(10, recordDataWriter);
+
+    // when
+    receiverJournal.append(expected);
+
+    // then
+    final var reader = receiverJournal.openReader();
+    assertThat(reader.hasNext()).isTrue();
+    final var actual = reader.next();
+    assertThat(expected).isEqualTo(actual);
+  }
+
+  @Test
+  void shouldAppendMultipleData() {
+    // when
+    final var firstRecord = journal.append(10, recordDataWriter);
+    final var secondRecord = journal.append(20, otherRecordDataWriter);
+
+    // then
+    assertThat(firstRecord.index()).isEqualTo(1);
+    assertThat(firstRecord.asqn()).isEqualTo(10);
+
+    assertThat(secondRecord.index()).isEqualTo(2);
+    assertThat(secondRecord.asqn()).isEqualTo(20);
+  }
+
+  @Test
+  void shouldNotAppendRecordWithAlreadyAppendedIndex() {
+    // given
+    final var record = journal.append(1, recordDataWriter);
+    journal.append(recordDataWriter);
+
+    // when/then
+    assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
+  }
+
+  @Test
+  void shouldNotAppendRecordWithGapInIndex() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .withMetaStore(new MockJournalMetastore())
+            .build();
+    journal.append(1, recordDataWriter);
+    final var record = journal.append(2, recordDataWriter);
+
+    // when/then
+    assertThatThrownBy(() -> receiverJournal.append(record)).isInstanceOf(InvalidIndex.class);
+  }
+
+  @Test
+  void shouldNotAppendLastRecord() {
+    // given
+    final var record = journal.append(1, recordDataWriter);
+
+    // when/then
+    assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
+  }
+
+  @Test
+  void shouldAppendRecordWithASqnToIgnore() {
+    // given
+    journal.append(1, recordDataWriter);
+
+    // when/then
+    journal.append(ASQN_IGNORE, recordDataWriter);
+  }
+
+  @Test
+  void shouldNotAppendRecordWithInvalidChecksum() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .withMetaStore(new MockJournalMetastore())
+            .build();
+    final var record = journal.append(1, recordDataWriter);
+
+    // when
+    final var invalidChecksumRecord =
+        new TestJournalRecord(
+            record.index(), record.asqn(), -1, record.data(), record.serializedRecord());
+
+    // then
+    assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
+        .isInstanceOf(InvalidChecksum.class);
+  }
+
+  @Test
+  void shouldNotAppendRecordWithTooLowASqn() {
+    // given
+    journal.append(1, recordDataWriter);
+
+    // when/then
+    assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
+    assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
+  }
+
+  @Test
+  void shouldNotAppendRecordWithTooLowASqnIfPreviousRecordIsIgnoreASqn() {
+    // given
+    journal.append(1, recordDataWriter);
+
+    // when
+    journal.append(ASQN_IGNORE, recordDataWriter);
+
+    // then
+    assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
+    assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.journal;
 
 import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.journal.JournalException.InvalidAsqn;
@@ -214,7 +215,7 @@ final class JournalAppendTest {
 
     // when
     final byte[] serializedRecord = getSerializedBytes(expected);
-    receiverJournal.append(expected.index(), expected.checksum(), serializedRecord);
+    receiverJournal.append(expected.checksum(), serializedRecord);
 
     // then
     final var reader = receiverJournal.openReader();
@@ -237,7 +238,7 @@ final class JournalAppendTest {
 
     // when
     final byte[] serializedRecord = getSerializedBytes(recordToWrite);
-    receiverJournal.append(recordToWrite.index(), recordToWrite.checksum(), serializedRecord);
+    receiverJournal.append(recordToWrite.checksum(), serializedRecord);
 
     // then
     final var reader = receiverJournal.openReader();
@@ -255,7 +256,9 @@ final class JournalAppendTest {
     // when
     final byte[] serializedRecord = getSerializedBytes(record);
 
-    assertThatThrownBy(() -> journal.append(record.index(), record.checksum(), serializedRecord))
+    assertThatException()
+        .isThrownBy(() -> journal.append(record.checksum(), serializedRecord))
+        .describedAs("Should fail to append index 1 after index 2")
         .isInstanceOf(InvalidIndex.class);
   }
 
@@ -273,8 +276,9 @@ final class JournalAppendTest {
 
     // when/then
     final byte[] serializedRecord = getSerializedBytes(record);
-    assertThatThrownBy(
-            () -> receiverJournal.append(record.index(), record.checksum(), serializedRecord))
+    assertThatException()
+        .isThrownBy(() -> receiverJournal.append(record.checksum(), serializedRecord))
+        .describedAs("Should fail to append index 2 without index 1")
         .isInstanceOf(InvalidIndex.class);
   }
 
@@ -285,7 +289,9 @@ final class JournalAppendTest {
 
     // when/then
     final byte[] serializedRecord = getSerializedBytes(record);
-    assertThatThrownBy(() -> journal.append(record.index(), record.checksum(), serializedRecord))
+    assertThatException()
+        .isThrownBy(() -> journal.append(record.checksum(), serializedRecord))
+        .describedAs("Should fail to append index 1 again")
         .isInstanceOf(InvalidIndex.class);
   }
 
@@ -302,7 +308,8 @@ final class JournalAppendTest {
 
     // when/then
     final var serializedRecord = getSerializedBytes(record);
-    assertThatThrownBy(() -> receiverJournal.append(record.index(), -1, serializedRecord))
+    assertThatException()
+        .isThrownBy(() -> journal.append(record.checksum(), serializedRecord))
         .isInstanceOf(InvalidChecksum.class);
   }
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
@@ -152,7 +152,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldAppendRecordWithASqnToIgnore() {
+  void shouldAppendRecordWithASQNToIgnore() {
     // given
     journal.append(1, recordDataWriter);
 
@@ -183,7 +183,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendRecordWithTooLowASqn() {
+  void shouldNotAppendRecordWithTooLowASQN() {
     // given
     journal.append(1, recordDataWriter);
 
@@ -193,7 +193,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendRecordWithTooLowASqnIfPreviousRecordIsIgnoreASqn() {
+  void shouldNotAppendRecordWithTooLowASQNIfPreviousRecordIsIgnoreASQN() {
     // given
     journal.append(1, recordDataWriter);
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -459,7 +459,8 @@ final class JournalTest {
 
     // when
     final var invalidChecksumRecord =
-        new TestJournalRecord(record.index(), record.asqn(), -1, record.data());
+        new TestJournalRecord(
+            record.index(), record.asqn(), -1, record.data(), record.serializedRecord());
 
     // then
     assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
@@ -681,11 +682,11 @@ final class JournalTest {
         new RecordData(record.index(), record.asqn(), BufferUtil.cloneBuffer(record.data()));
 
     if (record instanceof PersistedJournalRecord p) {
-      return new PersistedJournalRecord(p.metadata(), data);
+      return new PersistedJournalRecord(p.metadata(), data, p.serializedRecord());
     }
 
     return new PersistedJournalRecord(
-        new RecordMetadata(record.checksum(), data.data().capacity()), data);
+        new RecordMetadata(record.checksum(), data.data().capacity()), data, null);
   }
 
   private SegmentedJournal openJournal() {

--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -7,13 +7,9 @@
  */
 package io.camunda.zeebe.journal;
 
-import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.journal.JournalException.InvalidAsqn;
-import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
-import io.camunda.zeebe.journal.JournalException.InvalidIndex;
 import io.camunda.zeebe.journal.file.LogCorrupter;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
@@ -21,7 +17,6 @@ import io.camunda.zeebe.journal.record.PersistedJournalRecord;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.record.RecordMetadata;
 import io.camunda.zeebe.journal.util.MockJournalMetastore;
-import io.camunda.zeebe.journal.util.TestJournalRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
@@ -76,16 +71,6 @@ final class JournalTest {
 
     // when-then
     assertThat(journal.isEmpty()).isFalse();
-  }
-
-  @Test
-  void shouldAppendData() {
-    // when
-    final var recordAppended = journal.append(1, recordDataWriter);
-
-    // then
-    assertThat(recordAppended.index()).isEqualTo(1);
-    assertThat(recordAppended.asqn()).isEqualTo(1);
   }
 
   @Test
@@ -379,115 +364,6 @@ final class JournalTest {
     assertThat(journal.getLastIndex()).isEqualTo(2);
     reader.next();
     assertThat(reader.hasNext()).isFalse();
-  }
-
-  @Test
-  void shouldAppendJournalRecord() {
-    // given
-    final var receiverJournal =
-        SegmentedJournal.builder()
-            .withDirectory(directory.resolve("data-2").toFile())
-            .withJournalIndexDensity(5)
-            .withMetaStore(new MockJournalMetastore())
-            .build();
-    final var expected = journal.append(10, recordDataWriter);
-
-    // when
-    receiverJournal.append(expected);
-
-    // then
-    final var reader = receiverJournal.openReader();
-    assertThat(reader.hasNext()).isTrue();
-    final var actual = reader.next();
-    assertThat(expected).isEqualTo(actual);
-  }
-
-  @Test
-  void shouldNotAppendRecordWithAlreadyAppendedIndex() {
-    // given
-    final var record = journal.append(1, recordDataWriter);
-    journal.append(recordDataWriter);
-
-    // when/then
-    assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
-  }
-
-  @Test
-  void shouldNotAppendRecordWithGapInIndex() {
-    // given
-    final var receiverJournal =
-        SegmentedJournal.builder()
-            .withDirectory(directory.resolve("data-2").toFile())
-            .withJournalIndexDensity(5)
-            .withMetaStore(new MockJournalMetastore())
-            .build();
-    journal.append(1, recordDataWriter);
-    final var record = journal.append(2, recordDataWriter);
-
-    // when/then
-    assertThatThrownBy(() -> receiverJournal.append(record)).isInstanceOf(InvalidIndex.class);
-  }
-
-  @Test
-  void shouldNotAppendLastRecord() {
-    // given
-    final var record = journal.append(1, recordDataWriter);
-
-    // when/then
-    assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
-  }
-
-  @Test
-  void shouldAppendRecordWithASqnToIgnore() {
-    // given
-    journal.append(1, recordDataWriter);
-
-    // when/then
-    journal.append(ASQN_IGNORE, recordDataWriter);
-  }
-
-  @Test
-  void shouldNotAppendRecordWithInvalidChecksum() {
-    // given
-    final var receiverJournal =
-        SegmentedJournal.builder()
-            .withDirectory(directory.resolve("data-2").toFile())
-            .withJournalIndexDensity(5)
-            .withMetaStore(new MockJournalMetastore())
-            .build();
-    final var record = journal.append(1, recordDataWriter);
-
-    // when
-    final var invalidChecksumRecord =
-        new TestJournalRecord(
-            record.index(), record.asqn(), -1, record.data(), record.serializedRecord());
-
-    // then
-    assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
-        .isInstanceOf(InvalidChecksum.class);
-  }
-
-  @Test
-  void shouldNotAppendRecordWithTooLowASqn() {
-    // given
-    journal.append(1, recordDataWriter);
-
-    // when/then
-    assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
-    assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
-  }
-
-  @Test
-  void shouldNotAppendRecordWithTooLowASqnIfPreviousRecordIsIgnoreASqn() {
-    // given
-    journal.append(1, recordDataWriter);
-
-    // when
-    journal.append(ASQN_IGNORE, recordDataWriter);
-
-    // then
-    assertThatThrownBy(() -> journal.append(0, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
-    assertThatThrownBy(() -> journal.append(1, recordDataWriter)).isInstanceOf(InvalidAsqn.class);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -433,7 +433,8 @@ class SegmentedJournalTest {
             new RecordData(
                 firstRecord.index(),
                 firstRecord.asqn(),
-                BufferUtil.cloneBuffer(firstRecord.data())));
+                BufferUtil.cloneBuffer(firstRecord.data())),
+            null);
     journal.append(journalFactory.entry());
 
     // close the journal before corrupting the segment; since we "flush" when closing, we need to

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -434,7 +434,7 @@ class SegmentedJournalTest {
                 firstRecord.index(),
                 firstRecord.asqn(),
                 BufferUtil.cloneBuffer(firstRecord.data())),
-            null);
+            firstRecord.serializedRecord());
     journal.append(journalFactory.entry());
 
     // close the journal before corrupting the segment; since we "flush" when closing, we need to

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
@@ -39,7 +39,7 @@ class SparseJournalIndexTest {
   }
 
   public static JournalRecord asJournalRecord(final long index, final long asqn) {
-    return new TestJournalRecord(index, asqn, 0, null);
+    return new TestJournalRecord(index, asqn, 0, null, null);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/util/TestJournalRecord.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/util/TestJournalRecord.java
@@ -10,5 +10,6 @@ package io.camunda.zeebe.journal.util;
 import io.camunda.zeebe.journal.JournalRecord;
 import org.agrona.DirectBuffer;
 
-public record TestJournalRecord(long index, long asqn, long checksum, DirectBuffer data)
+public record TestJournalRecord(
+    long index, long asqn, long checksum, DirectBuffer data, DirectBuffer serializedRecord)
     implements JournalRecord {}


### PR DESCRIPTION
## Description

To allow replicating serialized journal record, in this PR
- We add a serializedRecord to JournalRecord. This can be used in raft Append requests instead of `JournalRecord.data()`
- Journal exposes a new append method to append already serialized data, and deprecates the old JournalRecord.

## Related issues

related to #12915

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x ] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
