### PR TITLE
[Backport stable/8.1] test(qa): fix flakiness by awaiting snapshot on restarted broker

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -108,7 +108,7 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
                                         partitionStatuses.put(partition.getPartitionId(), ps);
                                       }
                                     }))
-                    .collect(Collectors.toList());
+                    .toList();
             CompletableFuture.allOf(statusFutures.toArray(CompletableFuture[]::new))
                 .thenAccept(r -> future.complete(partitionStatuses));
           }

--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -165,7 +165,10 @@ final class RollingUpdateTest {
           .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, brokerId));
     }
 
-    assertBrokerHasAtLeastOneSnapshot(1);
+    Awaitility.await("until restarted broker has snapshot")
+        .atMost(Duration.ofSeconds(120))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(() -> assertBrokerHasAtLeastOneSnapshot(brokerId));
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #13112 to `stable/8.1`.

relates to #10954