### PR TITLE
Configure Gateway gRPC executor

### DIFF
--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -190,6 +190,21 @@
       # Sets the number of threads the gateway will use to communicate with the broker cluster
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS.
       # managementThreads: 1
+      #
+      # A separate thread pool is used to run the gRPC business logic. The thread pool is elastic
+      # (meaning it will start/stop threads dynamically), but will always keep a minimum number of
+      # threads, and only start up to a maximum number of threads. By default, this range is from
+      # 1 thread per core, up to 2 threads per core.
+      #
+      # Sets the minimum number of threads in the gRPC thread pool. Only accepts static values;
+      # defaults to the number of cores available.
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_THREADS_GRPCMINTHREADS.
+      # grpcMinThreads:
+      #
+      # Sets the maximum number of threads in the gRPC thread pool. Only accepts static values;
+      # defaults to twice the number of cores available.
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_THREADS_GRPCMAXTHREADS.
+      # grpcMaxThreads:
 
     # security:
       # Enables TLS authentication between clients and the gateway

--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -72,6 +72,9 @@ public class StandaloneBroker
         FatalErrorHandler.uncaughtExceptionHandler(Loggers.SYSTEM_LOGGER));
 
     System.setProperty("spring.banner.location", "classpath:/assets/zeebe_broker_banner.txt");
+    System.setProperty(
+        "reactor.schedulers.defaultBoundedElasticSize",
+        String.valueOf(2 * Runtime.getRuntime().availableProcessors()));
     final var application =
         new SpringApplicationBuilder(StandaloneBroker.class)
             .web(WebApplicationType.REACTIVE)

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -80,6 +80,9 @@ public class StandaloneGateway
         FatalErrorHandler.uncaughtExceptionHandler(Loggers.GATEWAY_LOGGER));
 
     System.setProperty("spring.banner.location", "classpath:/assets/zeebe_gateway_banner.txt");
+    System.setProperty(
+        "reactor.schedulers.defaultBoundedElasticSize",
+        String.valueOf(2 * Runtime.getRuntime().availableProcessors()));
     final var application =
         new SpringApplicationBuilder(StandaloneGateway.class)
             .web(WebApplicationType.REACTIVE)

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -129,7 +129,7 @@ public class StandaloneGateway
   public void close() {
     if (gateway != null) {
       try {
-        gateway.stop();
+        gateway.close();
       } catch (final Exception e) {
         LOG.warn("Failed to gracefully shutdown gRPC gateway", e);
       }

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -10,6 +10,17 @@ logging.register-shutdown-hook=false
 # configurations
 server.address=0.0.0.0
 server.port=9600
+# WebFlux/Reactor configuration
+# The actual threading configuration is done via the Reactor properties; these are unfortunately
+# not configured via Spring, but rather plain System.properties. Default values (where C is the
+# number of available cores, are:
+# - [0-2C] for any scheduled tasks, such as the delayed health indicators (default is [0, 10C])
+# - [1-max(C, 4)] for the request handling event loop (defaults)
+# These are either customized in each `main` (e.g. StandaloneBroker#main) that we have, or are plain
+# defaults from the Reactor project.
+# Default quiet period is 2s, meaning it waits for the server to be idle for 2 seconds before
+# shutting down. This isn't very useful for a management server.
+spring.reactor.netty.shutdown-quiet-period=0s
 # General management configuration; disable all endpoints by default but exposes all enabled ones
 # via web. Endpoints should be enabled individually based on the target application
 management.endpoints.enabled-by-default=false
@@ -27,4 +38,6 @@ management.endpoint.loggers.enabled=true
 # Elastic client which spawns 16 threads)
 spring.autoconfigure.exclude=\
   org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration, \
-  org.springframework.boot.autoconfigure.netty.NettyAutoConfiguration
+  org.springframework.boot.autoconfigure.netty.NettyAutoConfiguration, \
+  org.springframework.boot.autoconfigure.web.reactive.function.client.ClientHttpConnectorAutoConfiguration, \
+  org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -77,9 +77,6 @@ public final class EndpointManager {
   private final RequestRetryHandler requestRetryHandler;
   private final ClientStreamAdapter clientStreamAdapter;
 
-  @SuppressWarnings({"FieldCanBeLocal", "unused"})
-  private final Executor executor;
-
   public EndpointManager(
       final BrokerClient brokerClient,
       final ActivateJobsHandler activateJobsHandler,
@@ -87,9 +84,8 @@ public final class EndpointManager {
       final Executor executor) {
     this.brokerClient = brokerClient;
     this.activateJobsHandler = activateJobsHandler;
-    this.executor = executor;
 
-    clientStreamAdapter = new ClientStreamAdapter(jobStreamer);
+    clientStreamAdapter = new ClientStreamAdapter(jobStreamer, executor);
     topologyManager = brokerClient.getTopologyManager();
     requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -66,6 +66,7 @@ import io.grpc.stub.ServerCallStreamObserver;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 public final class EndpointManager {
@@ -76,12 +77,17 @@ public final class EndpointManager {
   private final RequestRetryHandler requestRetryHandler;
   private final ClientStreamAdapter clientStreamAdapter;
 
+  @SuppressWarnings({"FieldCanBeLocal", "unused"})
+  private final Executor executor;
+
   public EndpointManager(
       final BrokerClient brokerClient,
       final ActivateJobsHandler activateJobsHandler,
-      final ClientStreamer<JobActivationProperties> jobStreamer) {
+      final ClientStreamer<JobActivationProperties> jobStreamer,
+      final Executor executor) {
     this.brokerClient = brokerClient;
     this.activateJobsHandler = activateJobsHandler;
+    this.executor = executor;
 
     clientStreamAdapter = new ClientStreamAdapter(jobStreamer);
     topologyManager = brokerClient.getTopologyManager();
@@ -115,21 +121,11 @@ public final class EndpointManager {
 
               final var status = topology.getPartitionHealth(brokerId, partitionId);
               switch (status) {
-                case HEALTHY:
-                  partitionBuilder.setHealth(PartitionBrokerHealth.HEALTHY);
-                  break;
-
-                case UNHEALTHY:
-                  partitionBuilder.setHealth(PartitionBrokerHealth.UNHEALTHY);
-                  break;
-
-                case DEAD:
-                  partitionBuilder.setHealth(PartitionBrokerHealth.DEAD);
-                  break;
-
-                default:
-                  Loggers.GATEWAY_LOGGER.debug(
-                      "Unsupported partition broker health status '{}'", status.name());
+                case HEALTHY -> partitionBuilder.setHealth(PartitionBrokerHealth.HEALTHY);
+                case UNHEALTHY -> partitionBuilder.setHealth(PartitionBrokerHealth.UNHEALTHY);
+                case DEAD -> partitionBuilder.setHealth(PartitionBrokerHealth.DEAD);
+                default -> Loggers.GATEWAY_LOGGER.debug(
+                    "Unsupported partition broker health status '{}'", status.name());
               }
               brokerInfo.addPartitions(partitionBuilder);
             });

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -147,7 +147,7 @@ public final class Gateway implements CloseableSilently {
             0,
             2 * Runtime.getRuntime().availableProcessors(),
             1,
-            null,
+            pool -> false,
             1,
             TimeUnit.MINUTES);
     builder.executor(grpcExecutor);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ThreadsCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ThreadsCfg.java
@@ -14,6 +14,8 @@ import java.util.Objects;
 public final class ThreadsCfg {
 
   private int managementThreads = DEFAULT_MANAGEMENT_THREADS;
+  private int grpcMinThreads = Runtime.getRuntime().availableProcessors();
+  private int grpcMaxThreads = 2 * Runtime.getRuntime().availableProcessors();
 
   public int getManagementThreads() {
     return managementThreads;
@@ -24,9 +26,25 @@ public final class ThreadsCfg {
     return this;
   }
 
+  public int getGrpcMinThreads() {
+    return grpcMinThreads;
+  }
+
+  public void setGrpcMinThreads(final int grpcMinThreads) {
+    this.grpcMinThreads = grpcMinThreads;
+  }
+
+  public int getGrpcMaxThreads() {
+    return grpcMaxThreads;
+  }
+
+  public void setGrpcMaxThreads(final int grpcMaxThreads) {
+    this.grpcMaxThreads = grpcMaxThreads;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(managementThreads);
+    return Objects.hash(managementThreads, grpcMinThreads, grpcMaxThreads);
   }
 
   @Override
@@ -38,11 +56,20 @@ public final class ThreadsCfg {
       return false;
     }
     final ThreadsCfg that = (ThreadsCfg) o;
-    return managementThreads == that.managementThreads;
+    return managementThreads == that.managementThreads
+        && grpcMinThreads == that.grpcMinThreads
+        && grpcMaxThreads == that.grpcMaxThreads;
   }
 
   @Override
   public String toString() {
-    return "ThreadsCfg{" + "managementThreads=" + managementThreads + '}';
+    return "ThreadsCfg{"
+        + "managementThreads="
+        + managementThreads
+        + ", grpcMinThreads="
+        + grpcMinThreads
+        + ", grpcMaxThreads="
+        + grpcMaxThreads
+        + '}';
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -42,7 +42,6 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.awaitility.Awaitility;
 
-@SuppressWarnings({"unchecked"})
 public final class StubbedGateway {
 
   private static final String SERVER_NAME = "server";
@@ -69,7 +68,7 @@ public final class StubbedGateway {
     submitActorToActivateJobs(activateJobsHandler);
 
     final EndpointManager endpointManager =
-        new EndpointManager(brokerClient, activateJobsHandler, jobStreamer);
+        new EndpointManager(brokerClient, activateJobsHandler, jobStreamer, Runnable::run);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
 
     final InProcessServerBuilder serverBuilder =


### PR DESCRIPTION
## Description

Configures a gRPC executor for the gateway, also making it available for the endpoint manager. I took the liberty of simplifying the gateway startup/closing as well, as we now have more resources to manage there.

Also fixes a bug (#13796) by ensuring we always call `onComplete` with an executor, as otherwise the underlying call to `Actor#call` will fail since the callback is executed within the same actor.


> **Note**
> I'm not sure why this behavior is necessary - it's a little unnecessary and overhead of course, but unsure why `call` cannot be called from the same actor when `run` can :shrug: But it's good to use an executor anyway, so it's still valuable to do that now.

## Related issues

closes #13048 
closes #13796

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
