### PR TITLE
Add a new version of AppendRequest to allow changing the replication protocol

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -41,6 +41,7 @@ import io.atomix.raft.metrics.RaftRoleMetrics;
 import io.atomix.raft.metrics.RaftServiceMetrics;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.protocol.ProtocolVersionHandler;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.RaftServerProtocol;
@@ -286,7 +287,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     protocol.registerInstallHandler(request -> runOnContext(() -> role.onInstall(request)));
     protocol.registerReconfigureHandler(request -> runOnContext(() -> role.onReconfigure(request)));
     protocol.registerTransferHandler(request -> runOnContext(() -> role.onTransfer(request)));
-    protocol.registerAppendHandler(request -> runOnContext(() -> role.onAppend(request)));
+    protocol.registerAppendV1Handler(
+        request -> runOnContext(() -> role.onAppend(ProtocolVersionHandler.transform(request))));
+    protocol.registerAppendV2Handler(
+        request -> runOnContext(() -> role.onAppend(ProtocolVersionHandler.transform(request))));
     protocol.registerPollHandler(request -> runOnContext(() -> role.onPoll(request)));
     protocol.registerVoteHandler(request -> runOnContext(() -> role.onVote(request)));
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -32,7 +32,8 @@ class RaftMessageContext {
   final String transferSubject;
   final String pollSubject;
   final String voteSubject;
-  final String appendSubject;
+  final String appendV1subject;
+  final String appendV2subject;
   final String leaderHeartbeatSubject;
   private final String prefix;
 
@@ -51,7 +52,8 @@ class RaftMessageContext {
     transferSubject = getSubject(prefix, "transfer");
     pollSubject = getSubject(prefix, "poll");
     voteSubject = getSubject(prefix, "vote");
-    appendSubject = getSubject(prefix, "append");
+    appendV1subject = getSubject(prefix, "append");
+    appendV2subject = getSubject(prefix, "append-v2");
     leaderHeartbeatSubject = getSubject(prefix, "leaderHeartbeat");
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -53,7 +53,7 @@ class RaftMessageContext {
     pollSubject = getSubject(prefix, "poll");
     voteSubject = getSubject(prefix, "vote");
     appendV1subject = getSubject(prefix, "append");
-    appendV2subject = getSubject(prefix, "append-v2");
+    appendV2subject = getSubject(prefix, "append-versioned");
     leaderHeartbeatSubject = getSubject(prefix, "leaderHeartbeat");
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -18,6 +18,7 @@ package io.atomix.raft.partition.impl;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftError;
+import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.protocol.AppendRequest;
@@ -29,11 +30,12 @@ import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
-import io.atomix.raft.protocol.RaftResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.utils.serializer.Namespace;
@@ -65,9 +67,9 @@ public final class RaftNamespaces {
           .register(VoteResponse.class)
           .register(AppendRequest.class)
           .register(AppendResponse.class)
-          .register(RaftResponse.Status.class)
+          .register(Status.class)
           .register(RaftError.class)
-          .register(RaftError.Type.class)
+          .register(Type.class)
           .nextId(517) // for backwards compatibility
           .register(ArrayList.class)
           .register(LinkedList.class)
@@ -81,6 +83,7 @@ public final class RaftNamespaces {
           .register(PersistedRaftRecord.class)
           .register(TransferRequest.class)
           .register(TransferResponse.class)
+          .register(VersionedAppendRequest.class)
           .name("RaftProtocol")
           .build();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -110,6 +110,12 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<AppendResponse> append(
+      final MemberId memberId, final VersionedAppendRequest request) {
+    return sendAndReceive(context.appendV2subject, request, memberId);
+  }
+
+  @Override
   public void registerTransferHandler(
       final Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
     clusterCommunicator.replyTo(

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequest.java
@@ -23,7 +23,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Append entries request that represent old version (version = 1)
+ * Append entries request that represent old version (version = 1) which only replicated the raft
+ * entry and not the complete serialized journal record.
  *
  * <p>Append entries requests are at the core of the replication protocol. Leaders send append
  * requests to followers to replicate and commit log entries, and followers sent append requests to

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequest.java
@@ -17,11 +17,8 @@
 package io.atomix.raft.protocol;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.cluster.MemberId;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -54,15 +51,6 @@ public class AppendRequest extends AbstractRaftRequest {
     this.prevLogTerm = prevLogTerm;
     this.entries = entries;
     this.commitIndex = commitIndex;
-  }
-
-  /**
-   * Returns a new append request builder.
-   *
-   * @return A new append request builder.
-   */
-  public static Builder builder() {
-    return new Builder();
   }
 
   /**
@@ -148,125 +136,5 @@ public class AppendRequest extends AbstractRaftRequest {
         .add("entries", entries.size())
         .add("commitIndex", commitIndex)
         .toString();
-  }
-
-  /** Append request builder. */
-  public static class Builder extends AbstractRaftRequest.Builder<Builder, AppendRequest> {
-
-    private static final String NULL_ENTRIES_ERR = "entries cannot be null";
-    private long term;
-    private String leader;
-    private long logIndex;
-    private long logTerm;
-    private List<PersistedRaftRecord> entries;
-    private long commitIndex = -1;
-
-    /**
-     * Sets the request term.
-     *
-     * @param term The request term.
-     * @return The append request builder.
-     * @throws IllegalArgumentException if the {@code term} is not positive
-     */
-    public Builder withTerm(final long term) {
-      checkArgument(term > 0, "term must be positive");
-      this.term = term;
-      return this;
-    }
-
-    /**
-     * Sets the request leader.
-     *
-     * @param leader The request leader.
-     * @return The append request builder.
-     * @throws IllegalArgumentException if the {@code leader} is not positive
-     */
-    public Builder withLeader(final MemberId leader) {
-      this.leader = checkNotNull(leader, "leader cannot be null").id();
-      return this;
-    }
-
-    /**
-     * Sets the request last log index.
-     *
-     * @param prevLogIndex The request last log index.
-     * @return The append request builder.
-     * @throws IllegalArgumentException if the {@code index} is not positive
-     */
-    public Builder withPrevLogIndex(final long prevLogIndex) {
-      checkArgument(prevLogIndex >= 0, "prevLogIndex must be positive");
-      logIndex = prevLogIndex;
-      return this;
-    }
-
-    /**
-     * Sets the request last log term.
-     *
-     * @param prevLogTerm The request last log term.
-     * @return The append request builder.
-     * @throws IllegalArgumentException if the {@code term} is not positive
-     */
-    public Builder withPrevLogTerm(final long prevLogTerm) {
-      checkArgument(prevLogTerm >= 0, "prevLogTerm must be positive");
-      logTerm = prevLogTerm;
-      return this;
-    }
-
-    /**
-     * Sets the request entries.
-     *
-     * @param entries The request entries.
-     * @return The append request builder.
-     * @throws NullPointerException if {@code entries} is null
-     */
-    public Builder withEntries(final PersistedRaftRecord... entries) {
-      return withEntries(Arrays.asList(checkNotNull(entries, NULL_ENTRIES_ERR)));
-    }
-
-    /**
-     * Sets the request entries.
-     *
-     * @param entries The request entries.
-     * @return The append request builder.
-     * @throws NullPointerException if {@code entries} is null
-     */
-    public Builder withEntries(final List<PersistedRaftRecord> entries) {
-      this.entries = checkNotNull(entries, NULL_ENTRIES_ERR);
-      return this;
-    }
-
-    /**
-     * Sets the request commit index.
-     *
-     * @param commitIndex The request commit index.
-     * @return The append request builder.
-     * @throws IllegalArgumentException if index is not positive
-     */
-    public Builder withCommitIndex(final long commitIndex) {
-      checkArgument(commitIndex >= 0, "commitIndex must be positive");
-      this.commitIndex = commitIndex;
-      return this;
-    }
-
-    /**
-     * @throws IllegalStateException if the term, log term, log index, commit index, or global index
-     *     are not positive, or if entries is null
-     */
-    @Override
-    public AppendRequest build() {
-      validate();
-      return new AppendRequest(term, leader, logIndex, logTerm, entries, commitIndex);
-    }
-
-    @Override
-    protected void validate() {
-      super.validate();
-      checkArgument(term > 0, "term must be positive");
-      checkNotNull(leader, "leader cannot be null");
-      checkArgument(logIndex >= 0, "prevLogIndex must be positive");
-      checkArgument(logTerm >= 0, "prevLogTerm must be positive");
-      checkNotNull(entries, NULL_ENTRIES_ERR);
-      checkArgument(commitIndex >= 0, "commitIndex must be positive");
-    }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/InternalAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/InternalAppendRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+import io.atomix.cluster.MemberId;
+import java.util.List;
+
+/** Used by RaftRoles to handle AppendRequest from multiple versions uniformly. */
+public record InternalAppendRequest(
+    int version,
+    long term,
+    MemberId leader,
+    long prevLogIndex,
+    long prevLogTerm,
+    long commitIndex,
+    List<PersistedRaftRecord> entries) {}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -7,9 +7,13 @@
  */
 package io.atomix.raft.protocol;
 
-public class ProtocolVersionHandler {
+public final class ProtocolVersionHandler {
 
   private static final int APPENDREQUEST_WITH_RAFTRECORDS = 1;
+
+  private ProtocolVersionHandler() {
+    // To hide the public constructor
+  }
 
   public static InternalAppendRequest transform(final AppendRequest request) {
     return new InternalAppendRequest(
@@ -17,7 +21,7 @@ public class ProtocolVersionHandler {
         request.term(),
         request.leader(),
         request.prevLogIndex(),
-        request.prevLogIndex(),
+        request.prevLogTerm(),
         request.commitIndex(),
         request.entries());
   }
@@ -28,7 +32,7 @@ public class ProtocolVersionHandler {
         request.term(),
         request.leader(),
         request.prevLogIndex(),
-        request.prevLogIndex(),
+        request.prevLogTerm(),
         request.commitIndex(),
         request.entries());
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+public class ProtocolVersionHandler {
+
+  private static final int VERSION_APPENDREQUEST = 1;
+  private static final int VERSION_APPENDREQUEST_V2 = 2;
+
+  public static InternalAppendRequest transform(final AppendRequest request) {
+    return new InternalAppendRequest(
+        VERSION_APPENDREQUEST,
+        request.term(),
+        request.leader(),
+        request.prevLogIndex(),
+        request.prevLogIndex(),
+        request.commitIndex(),
+        request.entries());
+  }
+
+  public static InternalAppendRequest transform(final VersionedAppendRequest request) {
+    return new InternalAppendRequest(
+        VERSION_APPENDREQUEST_V2,
+        request.term(),
+        request.leader(),
+        request.prevLogIndex(),
+        request.prevLogIndex(),
+        request.commitIndex(),
+        request.entries());
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -9,12 +9,11 @@ package io.atomix.raft.protocol;
 
 public class ProtocolVersionHandler {
 
-  private static final int VERSION_APPENDREQUEST = 1;
-  private static final int VERSION_APPENDREQUEST_V2 = 2;
+  private static final int APPENDREQUEST_WITH_RAFTRECORDS = 1;
 
   public static InternalAppendRequest transform(final AppendRequest request) {
     return new InternalAppendRequest(
-        VERSION_APPENDREQUEST,
+        APPENDREQUEST_WITH_RAFTRECORDS,
         request.term(),
         request.leader(),
         request.prevLogIndex(),
@@ -25,7 +24,7 @@ public class ProtocolVersionHandler {
 
   public static InternalAppendRequest transform(final VersionedAppendRequest request) {
     return new InternalAppendRequest(
-        VERSION_APPENDREQUEST_V2,
+        request.version(),
         request.term(),
         request.leader(),
         request.prevLogIndex(),

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -154,7 +154,10 @@ public interface RaftServerProtocol {
    *
    * @param handler the open session request handler to register
    */
-  void registerAppendHandler(Function<AppendRequest, CompletableFuture<AppendResponse>> handler);
+  void registerAppendV1Handler(Function<AppendRequest, CompletableFuture<AppendResponse>> handler);
+
+  void registerAppendV2Handler(
+      Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> handler);
 
   /** Unregisters the append request handler. */
   void unregisterAppendHandler();

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -86,6 +86,8 @@ public interface RaftServerProtocol {
    */
   CompletableFuture<AppendResponse> append(MemberId memberId, AppendRequest request);
 
+  CompletableFuture<AppendResponse> append(MemberId memberId, VersionedAppendRequest request);
+
   /**
    * Registers a transfer request callback.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import io.atomix.cluster.MemberId;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Append entries request that represent new versions (version > 1)
@@ -126,21 +125,46 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), term, leader, prevLogIndex, prevLogTerm, entries, commitIndex);
+    int result = version;
+    result = 31 * result + (int) (term ^ (term >>> 32));
+    result = 31 * result + leader.hashCode();
+    result = 31 * result + (int) (prevLogIndex ^ (prevLogIndex >>> 32));
+    result = 31 * result + (int) (prevLogTerm ^ (prevLogTerm >>> 32));
+    result = 31 * result + entries.hashCode();
+    result = 31 * result + (int) (commitIndex ^ (commitIndex >>> 32));
+    return result;
   }
 
   @Override
-  public boolean equals(final Object object) {
-    if (object != null && object.getClass() == getClass()) {
-      final VersionedAppendRequest request = (VersionedAppendRequest) object;
-      return request.term == term
-          && request.leader.equals(leader)
-          && request.prevLogIndex == prevLogIndex
-          && request.prevLogTerm == prevLogTerm
-          && request.entries.equals(entries)
-          && request.commitIndex == commitIndex;
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
     }
-    return false;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final VersionedAppendRequest that = (VersionedAppendRequest) o;
+
+    if (version != that.version) {
+      return false;
+    }
+    if (term != that.term) {
+      return false;
+    }
+    if (prevLogIndex != that.prevLogIndex) {
+      return false;
+    }
+    if (prevLogTerm != that.prevLogTerm) {
+      return false;
+    }
+    if (commitIndex != that.commitIndex) {
+      return false;
+    }
+    if (!leader.equals(that.leader)) {
+      return false;
+    }
+    return entries.equals(that.entries);
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -34,6 +34,9 @@ import java.util.Objects;
  */
 public class VersionedAppendRequest extends AbstractRaftRequest {
 
+  private static final int CURRENT_VERSION = 2;
+
+  private final int version;
   private final long term;
   private final String leader;
   private final long prevLogIndex;
@@ -42,12 +45,14 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
   private final long commitIndex;
 
   public VersionedAppendRequest(
+      final int version,
       final long term,
       final String leader,
       final long prevLogIndex,
       final long prevLogTerm,
       final List<PersistedRaftRecord> entries,
       final long commitIndex) {
+    this.version = version;
     this.term = term;
     this.leader = leader;
     this.prevLogIndex = prevLogIndex;
@@ -141,6 +146,7 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
   @Override
   public String toString() {
     return toStringHelper(this)
+        .add("version", version)
         .add("term", term)
         .add("leader", leader)
         .add("prevLogIndex", prevLogIndex)
@@ -148,6 +154,10 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
         .add("entries", entries.size())
         .add("commitIndex", commitIndex)
         .toString();
+  }
+
+  public int version() {
+    return version;
   }
 
   /** Append request builder. */
@@ -160,7 +170,20 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
     private long logTerm;
     private List<PersistedRaftRecord> entries;
     private long commitIndex = -1;
+    private int version = CURRENT_VERSION;
 
+    /**
+     * Sets the request version. The default is the latest version.
+     *
+     * @param version The request version.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code version} is not positive
+     */
+    public Builder withVersion(final int version) {
+      checkArgument(version > 0, "version must be positive");
+      this.version = version;
+      return this;
+    }
     /**
      * Sets the request term.
      *
@@ -255,7 +278,8 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
     @Override
     public VersionedAppendRequest build() {
       validate();
-      return new VersionedAppendRequest(term, leader, logIndex, logTerm, entries, commitIndex);
+      return new VersionedAppendRequest(
+          version, term, leader, logIndex, logTerm, entries, commitIndex);
     }
 
     @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -184,6 +184,7 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
       this.version = version;
       return this;
     }
+
     /**
      * Sets the request term.
      *

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -26,13 +26,13 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Append entries request that represent old version (version = 1)
+ * Append entries request that represent new versions (version > 1)
  *
  * <p>Append entries requests are at the core of the replication protocol. Leaders send append
  * requests to followers to replicate and commit log entries, and followers sent append requests to
  * passive members to replicate committed log entries.
  */
-public class AppendRequest extends AbstractRaftRequest {
+public class VersionedAppendRequest extends AbstractRaftRequest {
 
   private final long term;
   private final String leader;
@@ -41,7 +41,7 @@ public class AppendRequest extends AbstractRaftRequest {
   private final List<PersistedRaftRecord> entries;
   private final long commitIndex;
 
-  public AppendRequest(
+  public VersionedAppendRequest(
       final long term,
       final String leader,
       final long prevLogIndex,
@@ -127,7 +127,7 @@ public class AppendRequest extends AbstractRaftRequest {
   @Override
   public boolean equals(final Object object) {
     if (object != null && object.getClass() == getClass()) {
-      final AppendRequest request = (AppendRequest) object;
+      final VersionedAppendRequest request = (VersionedAppendRequest) object;
       return request.term == term
           && request.leader.equals(leader)
           && request.prevLogIndex == prevLogIndex
@@ -151,7 +151,7 @@ public class AppendRequest extends AbstractRaftRequest {
   }
 
   /** Append request builder. */
-  public static class Builder extends AbstractRaftRequest.Builder<Builder, AppendRequest> {
+  public static class Builder extends AbstractRaftRequest.Builder<Builder, VersionedAppendRequest> {
 
     private static final String NULL_ENTRIES_ERR = "entries cannot be null";
     private long term;
@@ -253,9 +253,9 @@ public class AppendRequest extends AbstractRaftRequest {
      *     are not positive, or if entries is null
      */
     @Override
-    public AppendRequest build() {
+    public VersionedAppendRequest build() {
       validate();
-      return new AppendRequest(term, leader, logIndex, logTerm, entries, commitIndex);
+      return new VersionedAppendRequest(term, leader, logIndex, logTerm, entries, commitIndex);
     }
 
     @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
@@ -58,9 +58,8 @@ public abstract class AbstractRole implements RaftRole {
   public abstract RaftServer.Role role();
 
   /** Logs a request. */
-  protected final <R extends RaftRequest> R logRequest(final R request) {
+  protected final void logRequest(final Object request) {
     log.trace("Received {}", request);
-    return request;
   }
 
   /** Logs a response. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
@@ -18,8 +18,8 @@ package io.atomix.raft.roles;
 
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftRequest;
@@ -38,7 +38,7 @@ public abstract class ActiveRole extends PassiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
     raft.checkThread();
     logRequest(request);
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -22,8 +22,8 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftMemberContext;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
@@ -264,7 +264,7 @@ public final class CandidateRole extends ActiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
     raft.checkThread();
 
     // If the request indicates a term that is greater than the current term then

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -26,12 +26,12 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftMemberContext;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.VoteRequest;
@@ -183,7 +183,7 @@ public final class FollowerRole extends ActiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
     final CompletableFuture<AppendResponse> future = super.onAppend(request);
     if (isRequestFromCurrentLeader(request.term(), request.leader())) {
       onHeartbeatFromLeader();

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -19,12 +19,12 @@ package io.atomix.raft.roles;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftResponse;
@@ -111,7 +111,7 @@ public class InactiveRole extends AbstractRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
     logRequest(request);
     final var result =
         logResponse(

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -26,10 +26,10 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftMemberContext;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftResponse;
@@ -408,7 +408,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
     raft.checkThread();
     if (updateTermAndLeader(request.term(), request.leader())) {
       final CompletableFuture<AppendResponse> future = super.onAppend(request);

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -20,10 +20,10 @@ import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.SnapshotReplicationMetrics;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
@@ -283,7 +283,7 @@ public class PassiveRole extends InactiveRole {
   }
 
   @Override
-  public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
+  public CompletableFuture<AppendResponse> onAppend(final InternalAppendRequest request) {
     raft.checkThread();
     logRequest(request);
     updateTermAndLeader(request.term(), request.leader());
@@ -350,7 +350,7 @@ public class PassiveRole extends InactiveRole {
   }
 
   /** Handles an AppendRequest. */
-  protected CompletableFuture<AppendResponse> handleAppend(final AppendRequest request) {
+  protected CompletableFuture<AppendResponse> handleAppend(final InternalAppendRequest request) {
     final CompletableFuture<AppendResponse> future = new CompletableFuture<>();
 
     // Check that the term of the given request matches the local term or update the term.
@@ -377,7 +377,7 @@ public class PassiveRole extends InactiveRole {
    * continue handling the request.
    */
   protected boolean checkTerm(
-      final AppendRequest request, final CompletableFuture<AppendResponse> future) {
+      final InternalAppendRequest request, final CompletableFuture<AppendResponse> future) {
     if (request.term() < raft.getTerm()) {
       log.debug(
           "Rejected {}: request term is less than the current term ({})", request, raft.getTerm());
@@ -391,7 +391,7 @@ public class PassiveRole extends InactiveRole {
    * continue handling the request.
    */
   protected boolean checkPreviousEntry(
-      final AppendRequest request, final CompletableFuture<AppendResponse> future) {
+      final InternalAppendRequest request, final CompletableFuture<AppendResponse> future) {
     // If the previous term is set, validate that it matches the local log.
     // We check the previous log term since that indicates whether any entry is present in the
     // leader's
@@ -426,7 +426,7 @@ public class PassiveRole extends InactiveRole {
   }
 
   private boolean checkPreviousEntry(
-      final AppendRequest request,
+      final InternalAppendRequest request,
       final long lastEntryIndex,
       final long lastEntryTerm,
       final CompletableFuture<AppendResponse> future) {
@@ -480,7 +480,7 @@ public class PassiveRole extends InactiveRole {
 
   /** Appends entries from the given AppendRequest. */
   protected void appendEntries(
-      final AppendRequest request, final CompletableFuture<AppendResponse> future) {
+      final InternalAppendRequest request, final CompletableFuture<AppendResponse> future) {
     // Compute the last entry index from the previous log index and request entry count.
     final long lastEntryIndex = request.prevLogIndex() + request.entries().size();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -17,12 +17,12 @@
 package io.atomix.raft.roles;
 
 import io.atomix.raft.RaftServer;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.ReconfigureRequest;
@@ -82,7 +82,7 @@ public interface RaftRole extends Managed<RaftRole> {
    * @param request The request to handle.
    * @return A completable future to be completed with the request response.
    */
-  CompletableFuture<AppendResponse> onAppend(AppendRequest request);
+  CompletableFuture<AppendResponse> onAppend(InternalAppendRequest request);
 
   /**
    * Handles a poll request.

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
@@ -237,6 +237,12 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<AppendResponse> append(
+      final MemberId memberId, final VersionedAppendRequest request) {
+    return null;
+  }
+
+  @Override
   public void registerTransferHandler(
       final Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
     transferHandler = handler;
@@ -303,10 +309,14 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   }
 
   @Override
-  public void registerAppendHandler(
+  public void registerAppendV1Handler(
       final Function<AppendRequest, CompletableFuture<AppendResponse>> handler) {
     appendHandler = handler;
   }
+
+  @Override
+  public void registerAppendV2Handler(
+      final Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> handler) {}
 
   @Override
   public void unregisterAppendHandler() {

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -104,6 +104,12 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   }
 
   @Override
+  public CompletableFuture<AppendResponse> append(
+      final MemberId memberId, final VersionedAppendRequest request) {
+    return null;
+  }
+
+  @Override
   public void registerTransferHandler(
       final Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
     transferHandler = handler;
@@ -170,10 +176,14 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   }
 
   @Override
-  public void registerAppendHandler(
+  public void registerAppendV1Handler(
       final Function<AppendRequest, CompletableFuture<AppendResponse>> handler) {
     appendHandler = handler;
   }
+
+  @Override
+  public void registerAppendV2Handler(
+      final Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> handler) {}
 
   @Override
   public void unregisterAppendHandler() {

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -34,7 +34,7 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
   private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
   private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
-  private Function<AppendRequest, CompletableFuture<AppendResponse>> appendHandler;
+  private Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> appendHandler;
   private final Set<MemberId> partitions = Sets.newCopyOnWriteArraySet();
 
   public TestRaftServerProtocol(
@@ -100,13 +100,13 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public CompletableFuture<AppendResponse> append(
       final MemberId memberId, final AppendRequest request) {
-    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.append(request)));
+    throw new IllegalArgumentException("Using old version not supported in tests");
   }
 
   @Override
   public CompletableFuture<AppendResponse> append(
       final MemberId memberId, final VersionedAppendRequest request) {
-    return null;
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.append(request)));
   }
 
   @Override
@@ -178,12 +178,14 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public void registerAppendV1Handler(
       final Function<AppendRequest, CompletableFuture<AppendResponse>> handler) {
-    appendHandler = handler;
+    // Ignore as old version is not supported in tests
   }
 
   @Override
   public void registerAppendV2Handler(
-      final Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> handler) {}
+      final Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> handler) {
+    appendHandler = handler;
+  }
 
   @Override
   public void unregisterAppendHandler() {
@@ -199,7 +201,7 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
     }
   }
 
-  CompletableFuture<AppendResponse> append(final AppendRequest request) {
+  CompletableFuture<AppendResponse> append(final VersionedAppendRequest request) {
     if (appendHandler != null) {
       return appendHandler.apply(request);
     } else {

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -28,6 +28,7 @@ import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ProtocolVersionHandler;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
@@ -87,7 +88,8 @@ public class PassiveRoleTest {
         .thenThrow(new JournalException.InvalidChecksum("expected"));
 
     // when
-    final AppendResponse response = role.handleAppend(request).join();
+    final AppendResponse response =
+        role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     assertThat(response.succeeded()).isFalse();
@@ -107,7 +109,8 @@ public class PassiveRoleTest {
         .thenReturn(mock(IndexedRaftLogEntry.class));
 
     // when
-    final AppendResponse response = role.handleAppend(request).join();
+    final AppendResponse response =
+        role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     verify(log, times(1)).flush();
@@ -128,7 +131,8 @@ public class PassiveRoleTest {
         .thenThrow(new InvalidChecksum.InvalidChecksum("expected"));
 
     // when
-    final AppendResponse response = role.handleAppend(request).join();
+    final AppendResponse response =
+        role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     verify(log, times(1)).flush();
@@ -146,7 +150,8 @@ public class PassiveRoleTest {
         .thenThrow(new InvalidChecksum.InvalidChecksum("expected"));
 
     // when
-    final AppendResponse response = role.handleAppend(request).join();
+    final AppendResponse response =
+        role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     verify(log, never()).flush();
@@ -170,7 +175,7 @@ public class PassiveRoleTest {
     when(ctx.getLog()).thenReturn(log);
 
     // when
-    role.handleAppend(request).join();
+    role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
     verify(log, times(1)).flush();

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -23,12 +23,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
-import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.ProtocolVersionHandler;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
@@ -82,7 +83,15 @@ public class PassiveRoleTest {
     // given
     final List<PersistedRaftRecord> entries =
         List.of(new PersistedRaftRecord(1, 1, 1, 12345, new byte[1]));
-    final AppendRequest request = new AppendRequest(2, "", 0, 0, entries, 1);
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(2)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(1)
+            .build();
 
     when(log.append(any(PersistedRaftRecord.class)))
         .thenThrow(new JournalException.InvalidChecksum("expected"));
@@ -102,7 +111,15 @@ public class PassiveRoleTest {
         List.of(
             new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
             new PersistedRaftRecord(1, 2, 2, 1, new byte[1]));
-    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(2)
+            .build();
 
     when(log.append(any(PersistedRaftRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class))
@@ -124,7 +141,15 @@ public class PassiveRoleTest {
         List.of(
             new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
             new PersistedRaftRecord(1, 2, 2, 1, new byte[1]));
-    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(2)
+            .build();
 
     when(log.append(any(PersistedRaftRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class))
@@ -144,7 +169,15 @@ public class PassiveRoleTest {
     // given
     final List<PersistedRaftRecord> entries =
         List.of(new PersistedRaftRecord(1, 1, 1, 1, new byte[1]));
-    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(2)
+            .build();
 
     when(log.append(any(PersistedRaftRecord.class)))
         .thenThrow(new InvalidChecksum.InvalidChecksum("expected"));
@@ -166,7 +199,15 @@ public class PassiveRoleTest {
             new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
             new PersistedRaftRecord(1, 2, 2, 1, new byte[1]),
             new PersistedRaftRecord(1, 3, 3, 1, new byte[1]));
-    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 3);
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(3)
+            .build();
 
     when(log.append(any(PersistedRaftRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class))


### PR DESCRIPTION
## Description

- Define a new topic which is used to subscribe new version of append request. This is required because the request type is changed, and semantics will be changed in the follow up PR.
- Add a new VersionedAppendRequest to allow changing the behavior in future.
- The new versions of leader send `VersionedAppendRequest`, while the old version sends `AppendRequest`. The new versions can process both types. Thus, during rolling updates new versions can still receive events from the leader.

Note that this PR is preparation for sending the serialized journal record data in `VersionedAppendRequest`. This will be done in a follow up PR, as it requires #13100 

## Related issues

relates #12915 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
