### PR TITLE
fix(engine): don't NPE when timing out job that doesn't exist anymore

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -49,11 +49,7 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
     final var job = jobState.getJob(jobKey);
     final var state = jobState.getState(jobKey);
 
-    final var now = ActorClock.currentTimeMillis();
-    final var deadline = job.getDeadline();
-    final var hasTimedOut = now > deadline;
-
-    if (state == State.ACTIVATED && hasTimedOut) {
+    if (state == State.ACTIVATED && hasTimedOut(job)) {
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, job);
       jobMetrics.jobTimedOut(job.getType());
       jobActivationBehavior.publishWork(jobKey, job);
@@ -70,5 +66,9 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
       final String errorMessage = String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, reason);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);
     }
+  }
+
+  private boolean hasTimedOut(final JobRecord job) {
+    return job.getDeadline() < ActorClock.currentTimeMillis();
   }
 }


### PR DESCRIPTION
Delays the lookup of the job deadline until we are sure that the state is `ACTIVATED`. Otherwise, the state could be `NOT_FOUND` and looking up a deadline would result in an NPE.

Closes #13123