### PR TITLE
test(journal): clone buffer when copying record

### DIFF
--- a/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -558,11 +558,14 @@ final class JournalTest {
         new RecordData(record.index(), record.asqn(), BufferUtil.cloneBuffer(record.data()));
 
     if (record instanceof PersistedJournalRecord p) {
-      return new PersistedJournalRecord(p.metadata(), data, p.serializedRecord());
+      return new PersistedJournalRecord(
+          p.metadata(), data, BufferUtil.cloneBuffer(p.serializedRecord()));
     }
 
     return new PersistedJournalRecord(
-        new RecordMetadata(record.checksum(), data.data().capacity()), data, null);
+        new RecordMetadata(record.checksum(), data.data().capacity()),
+        data,
+        BufferUtil.cloneBuffer(record.serializedRecord()));
   }
 
   private SegmentedJournal openJournal() {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -434,7 +434,7 @@ class SegmentedJournalTest {
                 firstRecord.index(),
                 firstRecord.asqn(),
                 BufferUtil.cloneBuffer(firstRecord.data())),
-            firstRecord.serializedRecord());
+            BufferUtil.cloneBuffer(firstRecord.serializedRecord()));
     journal.append(journalFactory.entry());
 
     // close the journal before corrupting the segment; since we "flush" when closing, we need to


### PR DESCRIPTION
## Description

This test was failing occasionally in CI. I believe the reason was the underlying memory mapped buffer was changed, because the journal was closed and re-opened. I guess copying the buffer before closing the journal will fix the issue. It was not reproducible locally though.

https://github.com/camunda/zeebe/actions/runs/5275815569/jobs/9541731074#step:7:3240
