### PR TITLE
[Backport stable/8.0] fix: fix log info arguments #13137

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/utils/StateUtil.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/utils/StateUtil.java
@@ -36,10 +36,14 @@ public class StateUtil {
               partitionId, firstIndex, snapshotIndex));
     } else {
       log.info(
-          "In partition %d current snapshot index ({}) is lower than log's first index {}. "
+          "In partition {} current snapshot index ({}) is lower than log's first index {}. "
               + "But the log is empty. Most likely the node crashed while committing a snapshot "
               + "at index {}. Resetting log to {}",
-          partitionId, snapshotIndex, firstIndex, firstIndex - 1, snapshotIndex + 1);
+          partitionId,
+          snapshotIndex,
+          firstIndex,
+          firstIndex - 1,
+          snapshotIndex + 1);
       logResetter.accept(snapshotIndex + 1);
     }
   }


### PR DESCRIPTION
# Description
Backport of #13138 to `stable/8.0`.

relates to #13137