### PR TITLE
Replicate serialized journal record

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -33,6 +33,7 @@ import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VersionedAppendRequest;
@@ -84,6 +85,7 @@ public final class RaftNamespaces {
           .register(TransferRequest.class)
           .register(TransferResponse.class)
           .register(VersionedAppendRequest.class)
+          .register(ReplicatableJournalRecord.class)
           .name("RaftProtocol")
           .build();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/InternalAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/InternalAppendRequest.java
@@ -17,4 +17,4 @@ public record InternalAppendRequest(
     long prevLogIndex,
     long prevLogTerm,
     long commitIndex,
-    List<? extends ReplicatableRecord> entries) {}
+    List<? extends ReplicatableRaftRecord> entries) {}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/InternalAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/InternalAppendRequest.java
@@ -12,17 +12,9 @@ import java.util.List;
 
 /** Used by RaftRoles to handle AppendRequest from multiple versions uniformly. */
 public record InternalAppendRequest(
-    int version,
     long term,
     MemberId leader,
     long prevLogIndex,
     long prevLogTerm,
     long commitIndex,
-    List<PersistedRaftRecord> raftRecords,
-    List<ReplicatableJournalRecord> serializedJournalRecords) {
-  static final int APPEND_REQUEST_WITH_RAFT_RECORDS = 1;
-
-  public List<? extends ReplicatableRecord> entries() {
-    return version == APPEND_REQUEST_WITH_RAFT_RECORDS ? raftRecords : serializedJournalRecords;
-  }
-}
+    List<? extends ReplicatableRecord> entries) {}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/InternalAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/InternalAppendRequest.java
@@ -18,4 +18,11 @@ public record InternalAppendRequest(
     long prevLogIndex,
     long prevLogTerm,
     long commitIndex,
-    List<PersistedRaftRecord> entries) {}
+    List<PersistedRaftRecord> raftRecords,
+    List<ReplicatableJournalRecord> serializedJournalRecords) {
+  static final int APPEND_REQUEST_WITH_RAFT_RECORDS = 1;
+
+  public List<? extends ReplicatableRecord> entries() {
+    return version == APPEND_REQUEST_WITH_RAFT_RECORDS ? raftRecords : serializedJournalRecords;
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.journal.JournalRecord;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-public class PersistedRaftRecord implements JournalRecord {
+public final class PersistedRaftRecord implements JournalRecord, ReplicatableRecord {
 
   private final long index;
   private final long asqn;
@@ -81,6 +81,7 @@ public class PersistedRaftRecord implements JournalRecord {
    *
    * @return term
    */
+  @Override
   public long term() {
     return term;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.journal.JournalRecord;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-public class PersistedRaftRecord implements JournalRecord, ReplicatableRecord {
+public class PersistedRaftRecord implements JournalRecord, ReplicatableRaftRecord {
 
   private final long index;
   private final long asqn;

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.journal.JournalRecord;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-public final class PersistedRaftRecord implements JournalRecord, ReplicatableRecord {
+public class PersistedRaftRecord implements JournalRecord, ReplicatableRecord {
 
   private final long index;
   private final long asqn;

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
@@ -67,16 +67,6 @@ public class PersistedRaftRecord implements JournalRecord, ReplicatableRaftRecor
   }
 
   /**
-   * Returns the approximate size needed when serializing this class. The exact size depends on the
-   * serializer.
-   *
-   * @return approximate size
-   */
-  public int approximateSize() {
-    return serializedRaftLogEntry.length + Long.BYTES + Long.BYTES + Long.BYTES;
-  }
-
-  /**
    * Returns the term for this record
    *
    * @return term

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -9,21 +9,20 @@ package io.atomix.raft.protocol;
 
 public final class ProtocolVersionHandler {
 
-  private static final int APPENDREQUEST_WITH_RAFTRECORDS = 1;
-
   private ProtocolVersionHandler() {
     // To hide the public constructor
   }
 
   public static InternalAppendRequest transform(final AppendRequest request) {
     return new InternalAppendRequest(
-        APPENDREQUEST_WITH_RAFTRECORDS,
+        InternalAppendRequest.APPEND_REQUEST_WITH_RAFT_RECORDS,
         request.term(),
         request.leader(),
         request.prevLogIndex(),
         request.prevLogTerm(),
         request.commitIndex(),
-        request.entries());
+        request.entries(),
+        null);
   }
 
   public static InternalAppendRequest transform(final VersionedAppendRequest request) {
@@ -34,6 +33,7 @@ public final class ProtocolVersionHandler {
         request.prevLogIndex(),
         request.prevLogTerm(),
         request.commitIndex(),
+        null,
         request.entries());
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ProtocolVersionHandler.java
@@ -15,25 +15,21 @@ public final class ProtocolVersionHandler {
 
   public static InternalAppendRequest transform(final AppendRequest request) {
     return new InternalAppendRequest(
-        InternalAppendRequest.APPEND_REQUEST_WITH_RAFT_RECORDS,
         request.term(),
         request.leader(),
         request.prevLogIndex(),
         request.prevLogTerm(),
         request.commitIndex(),
-        request.entries(),
-        null);
+        request.entries());
   }
 
   public static InternalAppendRequest transform(final VersionedAppendRequest request) {
     return new InternalAppendRequest(
-        request.version(),
         request.term(),
         request.leader(),
         request.prevLogIndex(),
         request.prevLogTerm(),
         request.commitIndex(),
-        null,
         request.entries());
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.raft.protocol;
 
-public final class ReplicatableJournalRecord implements ReplicatableRecord {
+public final class ReplicatableJournalRecord implements ReplicatableRaftRecord {
 
   private final long index;
   private final long checksum;

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -15,45 +15,57 @@
  */
 package io.atomix.raft.protocol;
 
-public final class ReplicatableJournalRecord implements ReplicatableRaftRecord {
+import java.util.Arrays;
 
-  private final long index;
-  private final long checksum;
-  private final byte[] serializedJournalRecord;
-  private final long term;
+public record ReplicatableJournalRecord(
+    long term, long index, long checksum, byte[] serializedJournalRecord)
+    implements ReplicatableRaftRecord {
 
-  public ReplicatableJournalRecord(
-      final long term,
-      final long index,
-      final long checksum,
-      final byte[] serializedJournalRecord) {
-    this.index = index;
-    this.checksum = checksum;
-    this.serializedJournalRecord = serializedJournalRecord;
-    this.term = term;
+  // Due to having and array member, it is recommended to override equals, hashcode and toString
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ReplicatableJournalRecord that = (ReplicatableJournalRecord) o;
+
+    if (term != that.term) {
+      return false;
+    }
+    if (index != that.index) {
+      return false;
+    }
+    if (checksum != that.checksum) {
+      return false;
+    }
+    return Arrays.equals(serializedJournalRecord, that.serializedJournalRecord);
   }
 
   @Override
-  public long index() {
-    return index;
+  public int hashCode() {
+    int result = (int) (term ^ (term >>> 32));
+    result = 31 * result + (int) (index ^ (index >>> 32));
+    result = 31 * result + (int) (checksum ^ (checksum >>> 32));
+    result = 31 * result + Arrays.hashCode(serializedJournalRecord);
+    return result;
   }
 
-  /**
-   * Returns the term for this record
-   *
-   * @return term
-   */
   @Override
-  public long term() {
-    return term;
-  }
-
-  public long checksum() {
-    return checksum;
-  }
-
-  public byte[] serializedJournalRecord() {
-    return serializedJournalRecord;
+  public String toString() {
+    return "ReplicatableJournalRecord{"
+        + "term="
+        + term
+        + ", index="
+        + index
+        + ", checksum="
+        + checksum
+        + ", serializedJournalRecord="
+        + Arrays.toString(serializedJournalRecord)
+        + '}';
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -63,6 +63,7 @@ public final class ReplicatableJournalRecord implements ReplicatableRaftRecord {
    * @return approximate size
    */
   public int approximateSize() {
-    return serializedJournalRecord.length + Long.BYTES + Long.BYTES;
+    // serializedJournalRecord + index + term + checksum
+    return serializedJournalRecord.length + (3 * Long.BYTES);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+public final class ReplicatableJournalRecord implements ReplicatableRecord {
+
+  private final long index;
+  private final long checksum;
+  private final byte[] serializedJournalRecord;
+  private final long term;
+
+  public ReplicatableJournalRecord(
+      final long term,
+      final long index,
+      final long checksum,
+      final byte[] serializedJournalRecord) {
+    this.index = index;
+    this.checksum = checksum;
+    this.serializedJournalRecord = serializedJournalRecord;
+    this.term = term;
+  }
+
+  @Override
+  public long index() {
+    return index;
+  }
+
+  /**
+   * Returns the term for this record
+   *
+   * @return term
+   */
+  @Override
+  public long term() {
+    return term;
+  }
+
+  public long checksum() {
+    return checksum;
+  }
+
+  public byte[] serializedJournalRecord() {
+    return serializedJournalRecord;
+  }
+
+  /**
+   * Returns the approximate size needed when serializing this class. The exact size depends on the
+   * serializer.
+   *
+   * @return approximate size
+   */
+  public int approximateSize() {
+    return serializedJournalRecord.length + Long.BYTES + Long.BYTES;
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableRaftRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableRaftRecord.java
@@ -7,7 +7,7 @@
  */
 package io.atomix.raft.protocol;
 
-public interface ReplicatableRecord {
+public interface ReplicatableRaftRecord {
   long index();
 
   long term();

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableRecord.java
@@ -7,7 +7,7 @@
  */
 package io.atomix.raft.protocol;
 
-public sealed interface ReplicatableRecord permits PersistedRaftRecord, ReplicatableJournalRecord {
+public interface ReplicatableRecord {
   long index();
 
   long term();

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableRecord.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableRecord.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+public sealed interface ReplicatableRecord permits PersistedRaftRecord, ReplicatableJournalRecord {
+  long index();
+
+  long term();
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.cluster.MemberId;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -40,7 +39,7 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
   private final String leader;
   private final long prevLogIndex;
   private final long prevLogTerm;
-  private final List<PersistedRaftRecord> entries;
+  private final List<ReplicatableJournalRecord> entries;
   private final long commitIndex;
 
   public VersionedAppendRequest(
@@ -49,7 +48,7 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
       final String leader,
       final long prevLogIndex,
       final long prevLogTerm,
-      final List<PersistedRaftRecord> entries,
+      final List<ReplicatableJournalRecord> entries,
       final long commitIndex) {
     this.version = version;
     this.term = term;
@@ -110,7 +109,7 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
    *
    * @return A list of log entries.
    */
-  public List<PersistedRaftRecord> entries() {
+  public List<ReplicatableJournalRecord> entries() {
     return entries;
   }
 
@@ -192,7 +191,7 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
     private String leader;
     private long logIndex;
     private long logTerm;
-    private List<PersistedRaftRecord> entries;
+    private List<ReplicatableJournalRecord> entries;
     private long commitIndex = -1;
     private int version = CURRENT_VERSION;
 
@@ -267,18 +266,7 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
      * @return The append request builder.
      * @throws NullPointerException if {@code entries} is null
      */
-    public Builder withEntries(final PersistedRaftRecord... entries) {
-      return withEntries(Arrays.asList(checkNotNull(entries, NULL_ENTRIES_ERR)));
-    }
-
-    /**
-     * Sets the request entries.
-     *
-     * @param entries The request entries.
-     * @return The append request builder.
-     * @throws NullPointerException if {@code entries} is null
-     */
-    public Builder withEntries(final List<PersistedRaftRecord> entries) {
+    public Builder withEntries(final List<ReplicatableJournalRecord> entries) {
       this.entries = checkNotNull(entries, NULL_ENTRIES_ERR);
       return this;
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -182,7 +182,7 @@ final class LeaderAppender {
     while (member.hasNextEntry()) {
       // Otherwise, read the next entry and add it to the batch.
       final IndexedRaftLogEntry entry = member.nextEntry();
-      final var replicatableRecord = entry.getReplicatedJournalRecord();
+      final var replicatableRecord = entry.getReplicatableJournalRecord();
       entries.add(replicatableRecord);
       size += replicatableRecord.approximateSize();
       if (entry.index() == lastIndex || size >= maxBatchSizePerAppend) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -31,9 +31,9 @@ import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
-import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.RaftRequest;
 import io.atomix.raft.protocol.RaftResponse;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.snapshot.impl.SnapshotChunkImpl;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -168,7 +168,7 @@ final class LeaderAppender {
             .withCommitIndex(raft.getCommitIndex());
 
     // Build a list of entries to send to the member.
-    final List<PersistedRaftRecord> entries = new ArrayList<>();
+    final List<ReplicatableJournalRecord> entries = new ArrayList<>();
 
     // Build a list of entries up to the MAX_BATCH_SIZE. Note that entries in the log may
     // be null if they've been compacted and the member to which we're sending entries is just
@@ -182,7 +182,7 @@ final class LeaderAppender {
     while (member.hasNextEntry()) {
       // Otherwise, read the next entry and add it to the batch.
       final IndexedRaftLogEntry entry = member.nextEntry();
-      final var replicatableRecord = entry.getPersistedRaftRecord();
+      final var replicatableRecord = entry.getReplicatedJournalRecord();
       entries.add(replicatableRecord);
       size += replicatableRecord.approximateSize();
       if (entry.index() == lastIndex || size >= maxBatchSizePerAppend) {
@@ -645,7 +645,7 @@ final class LeaderAppender {
       metrics.observeAppend(
           member.getMember().memberId().id(),
           request.entries().size(),
-          request.entries().stream().mapToInt(PersistedRaftRecord::approximateSize).sum());
+          request.entries().stream().mapToInt(ReplicatableJournalRecord::approximateSize).sum());
 
       commitEntries();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -646,19 +646,22 @@ public class PassiveRole extends InactiveRole {
       log.trace("Appended {}", indexed);
       raft.getReplicationMetrics().setAppendIndex(indexed.index());
     } catch (final JournalException.OutOfDiskSpace e) {
-      log.trace("Append failed: ", e);
+      log.trace("Failed to append entry at index {} due to out of disk space", index, e);
       raft.getLogCompactor().compact();
       failAppend(index - 1, future);
       return false;
     } catch (final InvalidChecksum e) {
-      log.debug("Entry checksum doesn't match entry data: ", e);
+      log.debug(
+          "Failed to append entry at index {}. Entry checksum doesn't match entry data: ",
+          index,
+          e);
       failAppend(index - 1, future);
       return false;
     } catch (final InvalidIndex e) {
       failAppend(index - 1, future);
       return false;
     } catch (final Exception e) {
-      log.debug("Failed to append entry at index {}", entry.index(), e);
+      log.error("Failed to append entry at index {}", entry.index(), e);
       failAppend(index - 1, future);
       return false;
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -31,7 +31,7 @@ import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.ReplicatableJournalRecord;
-import io.atomix.raft.protocol.ReplicatableRecord;
+import io.atomix.raft.protocol.ReplicatableRaftRecord;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.snapshot.impl.SnapshotChunkImpl;
@@ -504,7 +504,7 @@ public class PassiveRole extends InactiveRole {
       }
 
       // Iterate through entries and append them.
-      for (final ReplicatableRecord entry : request.entries()) {
+      for (final ReplicatableRaftRecord entry : request.entries()) {
         final long index = ++lastLogIndex;
 
         // Get the last entry written to the log by the writer.
@@ -548,7 +548,7 @@ public class PassiveRole extends InactiveRole {
 
   private boolean tryToAppend(
       final CompletableFuture<AppendResponse> future,
-      final ReplicatableRecord entry,
+      final ReplicatableRaftRecord entry,
       final long index,
       final IndexedRaftLogEntry lastEntry) {
     boolean failedToAppend = false;
@@ -579,7 +579,7 @@ public class PassiveRole extends InactiveRole {
 
   private boolean appendEntry(
       final CompletableFuture<AppendResponse> future,
-      final ReplicatableRecord entry,
+      final ReplicatableRaftRecord entry,
       final long index,
       final IndexedRaftLogEntry lastEntry) {
     // If the last entry index isn't the previous index, throw an exception because
@@ -595,7 +595,7 @@ public class PassiveRole extends InactiveRole {
 
   private boolean replaceExistingEntry(
       final CompletableFuture<AppendResponse> future,
-      final ReplicatableRecord entry,
+      final ReplicatableRaftRecord entry,
       final long index) {
 
     try (final RaftLogReader reader = raft.getLog().openUncommittedReader()) {
@@ -629,7 +629,7 @@ public class PassiveRole extends InactiveRole {
    */
   private boolean appendEntry(
       final long index,
-      final ReplicatableRecord entry,
+      final ReplicatableRaftRecord entry,
       final CompletableFuture<AppendResponse> future) {
     try {
       final IndexedRaftLogEntry indexed;

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntry.java
@@ -17,6 +17,7 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
 
@@ -59,4 +60,9 @@ public interface IndexedRaftLogEntry {
    * @return a record to replicate
    */
   PersistedRaftRecord getPersistedRaftRecord();
+
+  /**
+   * @return a record to replicate
+   */
+  ReplicatableJournalRecord getReplicatedJournalRecord();
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntry.java
@@ -64,5 +64,5 @@ public interface IndexedRaftLogEntry {
   /**
    * @return a record to replicate
    */
-  ReplicatableJournalRecord getReplicatedJournalRecord();
+  ReplicatableJournalRecord getReplicatableJournalRecord();
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java
@@ -17,6 +17,7 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
 import io.camunda.zeebe.journal.JournalRecord;
@@ -45,5 +46,12 @@ record IndexedRaftLogEntryImpl(long index, long term, RaftEntry entry, JournalRe
     record.data().getBytes(0, serializedRaftLogEntry);
     return new PersistedRaftRecord(
         term, index, record.asqn(), record.checksum(), serializedRaftLogEntry);
+  }
+
+  @Override
+  public ReplicatableJournalRecord getReplicatedJournalRecord() {
+    final byte[] serializedRecord = new byte[record.serializedRecord().capacity()];
+    record.serializedRecord().getBytes(0, serializedRecord);
+    return new ReplicatableJournalRecord(term, index, record.checksum(), serializedRecord);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java
@@ -49,7 +49,7 @@ record IndexedRaftLogEntryImpl(long index, long term, RaftEntry entry, JournalRe
   }
 
   @Override
-  public ReplicatableJournalRecord getReplicatedJournalRecord() {
+  public ReplicatableJournalRecord getReplicatableJournalRecord() {
     final byte[] serializedRecord = new byte[record.serializedRecord().capacity()];
     record.serializedRecord().getBytes(0, serializedRecord);
     return new ReplicatableJournalRecord(term, index, record.checksum(), serializedRecord);

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -19,6 +19,7 @@ package io.atomix.raft.storage.log;
 import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
@@ -154,6 +155,14 @@ public final class RaftLog implements Closeable {
 
     final RaftLogEntry raftEntry = serializer.readRaftLogEntry(entry.data());
     lastAppendedEntry = new IndexedRaftLogEntryImpl(entry.term(), raftEntry.entry(), entry);
+    return lastAppendedEntry;
+  }
+
+  public IndexedRaftLogEntry append(final ReplicatableJournalRecord entry) {
+    final var writtenRecord = journal.append(entry.checksum(), entry.serializedJournalRecord());
+
+    final RaftLogEntry raftEntry = serializer.readRaftLogEntry(writtenRecord.data());
+    lastAppendedEntry = new IndexedRaftLogEntryImpl(entry.term(), raftEntry.entry(), writtenRecord);
     return lastAppendedEntry;
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -27,6 +27,7 @@ import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.primitive.TestMember;
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.roles.LeaderRole;
@@ -703,6 +704,11 @@ public final class RaftRule extends ExternalResource {
 
     @Override
     public PersistedRaftRecord getPersistedRaftRecord() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReplicatableJournalRecord getReplicatedJournalRecord() {
       throw new UnsupportedOperationException();
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -708,7 +708,7 @@ public final class RaftRule extends ExternalResource {
     }
 
     @Override
-    public ReplicatableJournalRecord getReplicatedJournalRecord() {
+    public ReplicatableJournalRecord getReplicatableJournalRecord() {
       throw new UnsupportedOperationException();
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -32,6 +32,7 @@ import io.atomix.raft.impl.LogCompactor;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
@@ -401,6 +402,11 @@ public class LeaderRoleTest {
 
     @Override
     public PersistedRaftRecord getPersistedRaftRecord() {
+      return null;
+    }
+
+    @Override
+    public ReplicatableJournalRecord getReplicatedJournalRecord() {
       return null;
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -406,7 +406,7 @@ public class LeaderRoleTest {
     }
 
     @Override
-    public ReplicatableJournalRecord getReplicatedJournalRecord() {
+    public ReplicatableJournalRecord getReplicatableJournalRecord() {
       return null;
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -29,6 +29,7 @@ import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.ProtocolVersionHandler;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -81,8 +82,7 @@ public class PassiveRoleTest {
   @Test
   public void shouldFailAppendWithIncorrectChecksum() {
     // given
-    final List<PersistedRaftRecord> entries =
-        List.of(new PersistedRaftRecord(1, 1, 1, 12345, new byte[1]));
+    final var entries = List.of(new ReplicatableJournalRecord(1, 1, 12345, new byte[1]));
     final VersionedAppendRequest request =
         VersionedAppendRequest.builder()
             .withTerm(2)
@@ -107,10 +107,10 @@ public class PassiveRoleTest {
   @Test
   public void shouldFlushAfterAppendRequest() {
     // given
-    final List<PersistedRaftRecord> entries =
+    final var entries =
         List.of(
-            new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
-            new PersistedRaftRecord(1, 2, 2, 1, new byte[1]));
+            new ReplicatableJournalRecord(1, 1, 1, new byte[1]),
+            new ReplicatableJournalRecord(1, 2, 1, new byte[1]));
     final VersionedAppendRequest request =
         VersionedAppendRequest.builder()
             .withTerm(1)
@@ -137,10 +137,10 @@ public class PassiveRoleTest {
   @Test
   public void shouldFlushAfterPartiallyAppendedRequest() {
     // given
-    final List<PersistedRaftRecord> entries =
+    final var entries =
         List.of(
-            new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
-            new PersistedRaftRecord(1, 2, 2, 1, new byte[1]));
+            new ReplicatableJournalRecord(1, 1, 1, new byte[1]),
+            new ReplicatableJournalRecord(1, 2, 1, new byte[1]));
     final VersionedAppendRequest request =
         VersionedAppendRequest.builder()
             .withTerm(1)
@@ -167,8 +167,7 @@ public class PassiveRoleTest {
   @Test
   public void shouldNotFlushIfNoEntryIsAppended() {
     // given
-    final List<PersistedRaftRecord> entries =
-        List.of(new PersistedRaftRecord(1, 1, 1, 1, new byte[1]));
+    final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
     final VersionedAppendRequest request =
         VersionedAppendRequest.builder()
             .withTerm(1)
@@ -194,11 +193,11 @@ public class PassiveRoleTest {
   @Test
   public void shouldFlushEventWithFailure() {
     // given
-    final List<PersistedRaftRecord> entries =
+    final var entries =
         List.of(
-            new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
-            new PersistedRaftRecord(1, 2, 2, 1, new byte[1]),
-            new PersistedRaftRecord(1, 3, 3, 1, new byte[1]));
+            new ReplicatableJournalRecord(1, 1, 1, new byte[1]),
+            new ReplicatableJournalRecord(1, 2, 1, new byte[1]),
+            new ReplicatableJournalRecord(1, 3, 1, new byte[1]));
     final VersionedAppendRequest request =
         VersionedAppendRequest.builder()
             .withTerm(1)

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
@@ -57,7 +57,7 @@ public class TestIndexedRaftLogEntry implements IndexedRaftLogEntry {
   }
 
   @Override
-  public ReplicatableJournalRecord getReplicatedJournalRecord() {
+  public ReplicatableJournalRecord getReplicatableJournalRecord() {
     return null;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
+import io.atomix.raft.protocol.ReplicatableJournalRecord;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
@@ -52,6 +53,11 @@ public class TestIndexedRaftLogEntry implements IndexedRaftLogEntry {
 
   @Override
   public PersistedRaftRecord getPersistedRaftRecord() {
+    return null;
+  }
+
+  @Override
+  public ReplicatableJournalRecord getReplicatedJournalRecord() {
     return null;
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -62,7 +62,7 @@ public interface Journal extends AutoCloseable {
    * @param checksum checksum of serializedRecord
    * @param serializedRecord serializedRecord
    */
-  void append(long checksum, byte[] serializedRecord);
+  JournalRecord append(long checksum, byte[] serializedRecord);
 
   /**
    * Delete all records after indexExclusive. After a call to this method, {@link

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -233,12 +233,9 @@ final class SegmentWriter {
 
   private Either<SegmentFull, Integer> writeRecord(
       final long index, final long asqn, final int offset, final BufferWriter recordDataWriter) {
-    final var recordLength =
-        serializer.writeData(index, asqn, recordDataWriter, writeBuffer, offset);
-    if (recordLength.isLeft()) {
-      return Either.left(new SegmentFull("Not enough space to write record"));
-    }
-    return Either.right(recordLength.get());
+    return serializer
+        .writeData(index, asqn, recordDataWriter, writeBuffer, offset)
+        .mapLeft(e -> new SegmentFull("Not enough space to write record"));
   }
 
   private void invalidateNextEntry(final int position) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -190,6 +190,10 @@ final class SegmentWriter {
     }
 
     writeMetadata(startPosition, frameLength, recordLength, checksum);
+
+    final int nextEntryOffset = startPosition + frameLength + metadataLength + recordLength;
+    invalidateNextEntry(nextEntryOffset);
+
     updateLastWrittenEntry(startPosition, frameLength, metadataLength, recordLength);
     FrameUtil.writeVersion(buffer, startPosition);
 
@@ -234,8 +238,6 @@ final class SegmentWriter {
     if (recordLength.isLeft()) {
       return Either.left(new SegmentFull("Not enough space to write record"));
     }
-    final int nextEntryOffset = offset + recordLength.get();
-    invalidateNextEntry(nextEntryOffset);
     return Either.right(recordLength.get());
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -85,6 +85,13 @@ public final class SegmentedJournal implements Journal {
   }
 
   @Override
+  public JournalRecord append(final long checksum, final byte[] serializedRecord) {
+    try (final var ignored = journalMetrics.observeAppendLatency()) {
+      return writer.append(checksum, serializedRecord);
+    }
+  }
+
+  @Override
   public void deleteAfter(final long indexExclusive) {
     journalMetrics.observeSegmentTruncation(
         () -> {
@@ -178,13 +185,6 @@ public final class SegmentedJournal implements Journal {
   @Override
   public boolean isOpen() {
     return open;
-  }
-
-  @Override
-  public void append(final long checksum, final byte[] serializedRecord) {
-    try (final var ignored = journalMetrics.observeAppendLatency()) {
-      writer.append(checksum, serializedRecord);
-    }
   }
 
   @Override

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -83,10 +83,10 @@ final class SegmentedJournalWriter {
     }
   }
 
-  void append(final long checksum, final byte[] serializedRecord) {
+  JournalRecord append(final long checksum, final byte[] serializedRecord) {
     final var appendResult = currentWriter.append(checksum, serializedRecord);
     if (appendResult.isRight()) {
-      return;
+      return appendResult.get();
     }
 
     if (currentSegment.index() == currentWriter.getNextIndex()) {
@@ -98,6 +98,7 @@ final class SegmentedJournalWriter {
     if (resultInNewSegment.isLeft()) {
       throw resultInNewSegment.getLeft();
     }
+    return resultInNewSegment.get();
   }
 
   void reset(final long index) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -9,19 +9,28 @@ package io.camunda.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import org.agrona.CloseHelper;
+import org.agrona.IoUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 final class SegmentedJournalWriterTest {
-  private final TestJournalFactory journalFactory = new TestJournalFactory();
+  private final TestJournalFactory journalFactory =
+      new TestJournalFactory("data", 2, this::fillWithOnes);
   private final SegmentsFlusher flusher = new SegmentsFlusher(journalFactory.metaStore());
-
   private SegmentsManager segments;
   private SegmentedJournalWriter writer;
+
+  private void fillWithOnes(final FileChannel channel, final long size) {
+    // Fill with ones to verify in tests that the append invalidates next entry by overwriting with
+    // 0
+    IoUtil.fill(channel, 0, size, (byte) 0xff);
+  }
 
   @BeforeEach
   void beforeEach(final @TempDir Path tempDir) {
@@ -65,5 +74,48 @@ final class SegmentedJournalWriterTest {
     // then
     assertThat(flusher.nextFlushIndex()).isEqualTo(8L);
     assertThat(journalFactory.metaStore().hasLastFlushedIndex()).isFalse();
+  }
+
+  @Test
+  void shouldInvalidateNextEntryAfterAppend() {
+    try (final SegmentedJournalReader reader =
+        new SegmentedJournalReader(journalFactory.journal(segments))) {
+      // when
+      writer.append(-1, journalFactory.entry());
+
+      // then
+      assertThat(reader.hasNext()).isTrue();
+      reader.next();
+      assertThat(reader.hasNext()).describedAs("Second entry does not exists").isFalse();
+    }
+  }
+
+  @Test
+  void shouldInvalidateNextEntryAfterAppendingSerializedRecord(@TempDir final Path tempDir) {
+    // given
+    final var writtenRecord = writer.append(-1, journalFactory.entry());
+
+    final var followerJournalFactory = new TestJournalFactory("data", 5, this::fillWithOnes);
+    final var followerSegments = followerJournalFactory.segmentsManager(tempDir);
+    followerSegments.open();
+    final var followerWriter =
+        new SegmentedJournalWriter(
+            followerSegments,
+            new SegmentsFlusher(followerJournalFactory.metaStore()),
+            followerJournalFactory.metrics());
+
+    try (final SegmentedJournalReader reader =
+        new SegmentedJournalReader(followerJournalFactory.journal(followerSegments))) {
+      // when
+      final byte[] serializedRecord = BufferUtil.bufferAsArray(writtenRecord.serializedRecord());
+      followerWriter.append(writtenRecord.checksum(), serializedRecord);
+
+      // then
+      assertThat(reader.hasNext()).isTrue();
+      reader.next();
+      assertThat(reader.hasNext()).describedAs("Second entry does not exists").isFalse();
+    }
+
+    followerSegments.close();
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
@@ -61,12 +61,16 @@ final class TestJournalFactory {
    * @param maxEntryCount the max number of entries per segment
    */
   TestJournalFactory(final String data, final int maxEntryCount) {
+    this(data, maxEntryCount, SegmentAllocator.noop());
+  }
+
+  TestJournalFactory(final String data, final int maxEntryCount, final SegmentAllocator allocator) {
     entryData = BufferUtil.wrapString(data);
     entry = new DirectBufferWriter().wrap(entryData);
     size = getSerializedSize(entryData);
     this.maxEntryCount = maxEntryCount;
 
-    loader = new SegmentLoader(2 * maxSegmentSize(), metrics);
+    loader = new SegmentLoader(2L * maxSegmentSize(), metrics, allocator);
   }
 
   int serializedEntrySize() {


### PR DESCRIPTION
## Description

Follow up of PRs #13100, #13120 

In this PR: Raft leaders sends a new VersionedAppendRequest with a list of `ReplicatableJournalRecord` which contains the full serialized journal record. The checksum in the request matches the checksum of serialized journal record. The followers that receive this can simply write the serialized bytes directly to the journal, without serializing again. This ensures that the followers can still successfully handle append requests even if the journal sbe version of leader and follower is different.

In addition, this PR also fixes a bug introduced in #13100 https://github.com/camunda/zeebe/pull/13143/commits/fbeef235d8c128917abe9c1bb97f7a7883a7928d 

For backward compatibility, followers on newer version can still receive and process the old version of `AppendRequest` send by the leaders at old version.

No new backward compatibility tests are added, as the existing `RollingUpdateTest` covers them.

## Related issues

closes #12915 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
