### PR TITLE
[Backport stable/8.1] fix(scheduler): ensure callbacks added after future is completed are executed

### DIFF
--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -56,7 +56,9 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
 
   /**
    * Registers a consumer, which is executed after the future was completed. The consumer is
-   * executed in the provided executor.
+   * executed in the provided executor. It is recommended to not use this method if the caller is an
+   * actor (use {@link ActorFuture#onComplete(BiConsumer)} instead), as it has some extra overhead
+   * for synchronization.
    *
    * @param consumer the callback which should be called after the future was completed
    * @param executor the executor on which the callback will be executed


### PR DESCRIPTION
# Description
Backport of #13139 to `stable/8.1`.

relates to 