### PR TITLE
Mark command as processed even on processing error

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -446,6 +446,10 @@ public final class ProcessingStateMachine {
                   processingException, typedCommand, processingResultBuilder);
           pendingWrites = currentProcessingResult.getRecordBatch().entries();
           pendingResponses = currentProcessingResult.getProcessingResponse().stream().toList();
+          // we need to mark the command as processed, even if the processing failed
+          // otherwise we might replay the events, which have been written during
+          // #onProcessingError again on restart
+          lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
         });
   }
 

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -10,15 +10,24 @@ package io.camunda.zeebe.stream.impl;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.stream.util.Records;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -255,6 +264,72 @@ final class StreamProcessorReplayTest {
                     .isEqualTo(4L));
     Assertions.assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey()))
         .isEqualTo(21L);
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
+  public void shouldNotApplyErrorEventOnReplay() throws Exception {
+    // given
+    final var processorWhichFails = setupProcessorWhichFailsOnProcessing();
+    setupOnErrorReactionForProcessor(processorWhichFails);
+
+    streamPlatform.startStreamProcessor();
+    // commands to process -> which should fail
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+
+    // await that two commands are failed and processed, to make sure error event has been committed
+    verify(processorWhichFails, TIMEOUT.times(2)).onProcessingError(any(), any(), any());
+    // the snapshot should contain last processed position
+    streamPlatform.snapshot();
+    streamPlatform.closeStreamProcessor();
+    streamPlatform.resetMockInvocations();
+
+    // when
+    streamPlatform.startStreamProcessor();
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verifyProcessingErrorLifecycle(processorWhichFails);
+    // we shouldn't replay any events - due to snapshot
+    // we shouldn't replay any events - due to snapshot
+    verify(processorWhichFails, never()).replay(any());
+  }
+
+  private static void verifyProcessingErrorLifecycle(final RecordProcessor processorWhichFails) {
+    final var inOrder = inOrder(processorWhichFails);
+    inOrder.verify(processorWhichFails, TIMEOUT).init(any());
+    inOrder.verify(processorWhichFails, TIMEOUT).accepts(ValueType.PROCESS_INSTANCE);
+    inOrder.verify(processorWhichFails, TIMEOUT).process(any(), any());
+    inOrder.verify(processorWhichFails, TIMEOUT).onProcessingError(any(), any(), any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private RecordProcessor setupProcessorWhichFailsOnProcessing() {
+    final var processorWhichFails = streamPlatform.getDefaultMockedRecordProcessor();
+    doThrow(new RuntimeException("processing error"))
+        .when(processorWhichFails)
+        .process(any(), any());
+    return processorWhichFails;
+  }
+
+  private static void setupOnErrorReactionForProcessor(final RecordProcessor processorWhichFails) {
+    doAnswer(
+            invocationOnMock -> {
+              // writing error event on failure
+              final var builder = (ProcessingResultBuilder) invocationOnMock.getArgument(2);
+              final RecordMetadata recordMetadata = new RecordMetadata();
+              recordMetadata
+                  .valueType(ValueType.ERROR)
+                  .intent(ErrorIntent.CREATED)
+                  .recordType(RecordType.EVENT);
+              builder.appendRecord(6, Records.processInstance(6), recordMetadata);
+              return builder.build();
+            })
+        .when(processorWhichFails)
+        .onProcessingError(
+            any(Throwable.class), any(TypedRecord.class), any(ProcessingResultBuilder.class));
   }
 
   @Test

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -280,6 +280,8 @@ final class StreamProcessorReplayTest {
 
     // await that two commands are failed and processed, to make sure error event has been committed
     verify(processorWhichFails, TIMEOUT.times(2)).onProcessingError(any(), any(), any());
+    Awaitility.await("last processed position is updated")
+        .until(() -> streamPlatform.getLastSuccessfulProcessedRecordPosition(), pos -> pos >= 2);
     // the snapshot should contain last processed position
     streamPlatform.snapshot();
     streamPlatform.closeStreamProcessor();

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -295,7 +295,6 @@ final class StreamProcessorReplayTest {
     // then
     verifyProcessingErrorLifecycle(processorWhichFails);
     // we shouldn't replay any events - due to snapshot
-   
     verify(processorWhichFails, never()).replay(any());
   }
 

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -267,7 +267,7 @@ final class StreamProcessorReplayTest {
   }
 
   @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
-  public void shouldNotApplyErrorEventOnReplay() throws Exception {
+  public void shouldNotReplayErrorEventAppliedInSnapshot() throws Exception {
     // given
     final var processorWhichFails = setupProcessorWhichFailsOnProcessing();
     setupOnErrorReactionForProcessor(processorWhichFails);

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -295,7 +295,7 @@ final class StreamProcessorReplayTest {
     // then
     verifyProcessingErrorLifecycle(processorWhichFails);
     // we shouldn't replay any events - due to snapshot
-    // we shouldn't replay any events - due to snapshot
+   
     verify(processorWhichFails, never()).replay(any());
   }
 


### PR DESCRIPTION
## Description

Mark a command as processed even when processing failed due to this command and caused it to call `#onProcessingError`.

If we don't mark it, we might replay events again which have been created during `#onProcessingError`,
this can lead to inconsistency. If the consistency checks are enabled the partition will fail to start.

Added a test which verifies that replay is not called, on the restart, in order to make the test reliable we write some more commands and await them to be processed.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/13101

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
