### PR TITLE
Distribute DMN resource deletions

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder;
@@ -53,6 +54,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.SIGNAL, SignalRecord::new);
     RECORDS_BY_TYPE.put(ValueType.COMMAND_DISTRIBUTION, CommandDistributionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -150,7 +150,8 @@ public final class EngineProcessors {
         typedRecordProcessors,
         writers,
         bpmnBehaviors.jobActivationBehavior());
-    addResourceDeletionProcessors(typedRecordProcessors, writers, processingState);
+    addResourceDeletionProcessors(
+        typedRecordProcessors, writers, processingState, commandDistributionBehavior);
     addSignalBroadcastProcessors(typedRecordProcessors, bpmnBehaviors, writers, processingState);
     addCommandDistributionProcessors(
         typedRecordProcessors,
@@ -293,10 +294,14 @@ public final class EngineProcessors {
   private static void addResourceDeletionProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
-      final MutableProcessingState processingState) {
+      final MutableProcessingState processingState,
+      final CommandDistributionBehavior commandDistributionBehavior) {
     final var resourceDeletionProcessor =
         new ResourceDeletionProcessor(
-            writers, processingState.getKeyGenerator(), processingState.getDecisionState());
+            writers,
+            processingState.getKeyGenerator(),
+            processingState.getDecisionState(),
+            commandDistributionBehavior);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CommandDistributionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CommandDistributionBehavior.java
@@ -62,7 +62,7 @@ public final class CommandDistributionBehavior {
             .setPartitionId(currentPartitionId)
             .setValueType(command.getValueType())
             .setIntent(command.getIntent())
-            .setRecordValue(command.getValue());
+            .setCommandValue(command.getValue());
 
     stateWriter.appendFollowUpEvent(
         distributionKey, CommandDistributionIntent.STARTED, distributionRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -92,7 +92,7 @@ public final class DeploymentCreateProcessor
   }
 
   @Override
-  public void processCommand(final TypedRecord<DeploymentRecord> command) {
+  public void processNewCommand(final TypedRecord<DeploymentRecord> command) {
     transformAndDistributeDeployment(command);
     // manage the top-level start event subscriptions except for timers
     startEventSubscriptionManager.tryReOpenStartEventSubscription(command.getValue(), stateWriter);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.resource;
 
+import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -36,14 +37,19 @@ public class ResourceDeletionProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final KeyGenerator keyGenerator;
   private final DecisionState decisionState;
+  private final CommandDistributionBehavior commandDistributionBehavior;
 
   public ResourceDeletionProcessor(
-      final Writers writers, final KeyGenerator keyGenerator, final DecisionState decisionState) {
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final DecisionState decisionState,
+      final CommandDistributionBehavior commandDistributionBehavior) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
     this.decisionState = decisionState;
+    this.commandDistributionBehavior = commandDistributionBehavior;
   }
 
   @Override
@@ -67,9 +73,7 @@ public class ResourceDeletionProcessor
   }
 
   @Override
-  public void processDistributedCommand(final TypedRecord<ResourceDeletionRecord> command) {
-
-  }
+  public void processDistributedCommand(final TypedRecord<ResourceDeletionRecord> command) {}
 
   private void deleteDecisionRequirements(final PersistedDecisionRequirements drg) {
     decisionState

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -27,12 +27,6 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class ResourceDeletionProcessor implements TypedRecordProcessor<ResourceDeletionRecord> {
-
-  public static final boolean RESOURCE_DELETION_IMPLEMENTED = false;
-  private static final String ERROR_MESSAGE_NOT_IMPLEMENTED =
-      """
-          Resource deletion has not been fully implemented yet. Stay posted on the latest Camunda \
-          releases to know when this feature will become available.""";
   private static final String ERROR_MESSAGE_RESOURCE_NOT_FOUND =
       "Expected to delete resource but no resource found with key `%d`";
 
@@ -53,16 +47,6 @@ public class ResourceDeletionProcessor implements TypedRecordProcessor<ResourceD
 
   @Override
   public void processRecord(final TypedRecord<ResourceDeletionRecord> command) {
-    // Reject resource deletions for now, as the feature is not yet ready for release in Zeebe 8.2
-    // When enabling again please don't forget to un-ignore the tests.
-    if (!RESOURCE_DELETION_IMPLEMENTED) {
-      rejectionWriter.appendRejection(
-          command, RejectionType.PROCESSING_ERROR, ERROR_MESSAGE_NOT_IMPLEMENTED);
-      responseWriter.writeRejectionOnCommand(
-          command, RejectionType.PROCESSING_ERROR, ERROR_MESSAGE_NOT_IMPLEMENTED);
-      return;
-    }
-
     final var value = command.getValue();
 
     final var drgOptional = decisionState.findDecisionRequirementsByKey(value.getResourceKey());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -51,7 +51,7 @@ public class ResourceDeletionProcessor
   }
 
   @Override
-  public void processCommand(final TypedRecord<ResourceDeletionRecord> command) {
+  public void processNewCommand(final TypedRecord<ResourceDeletionRecord> command) {
     final var value = command.getValue();
     deleteResources(command);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -53,7 +53,7 @@ public class ResourceDeletionProcessor
   @Override
   public void processNewCommand(final TypedRecord<ResourceDeletionRecord> command) {
     final var value = command.getValue();
-    deleteResources(command);
+    tryDeleteResources(command);
 
     final long eventKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
@@ -65,7 +65,7 @@ public class ResourceDeletionProcessor
   @Override
   public void processDistributedCommand(final TypedRecord<ResourceDeletionRecord> command) {
     final var value = command.getValue();
-    deleteResources(command);
+    tryDeleteResources(command);
     stateWriter.appendFollowUpEvent(command.getKey(), ResourceDeletionIntent.DELETED, value);
     commandDistributionBehavior.acknowledgeCommand(command.getKey(), command);
   }
@@ -83,7 +83,7 @@ public class ResourceDeletionProcessor
     return ProcessingError.UNEXPECTED_ERROR;
   }
 
-  private void deleteResources(final TypedRecord<ResourceDeletionRecord> command) {
+  private void tryDeleteResources(final TypedRecord<ResourceDeletionRecord> command) {
     final var value = command.getValue();
     final var drgOptional = decisionState.findDecisionRequirementsByKey(value.getResourceKey());
     if (drgOptional.isPresent()) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -58,6 +58,8 @@ public class ResourceDeletionProcessor
     final long eventKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
     responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETED, value, command);
+
+    commandDistributionBehavior.distributeCommand(eventKey, command);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -53,13 +53,7 @@ public class ResourceDeletionProcessor
   @Override
   public void processCommand(final TypedRecord<ResourceDeletionRecord> command) {
     final var value = command.getValue();
-
-    final var drgOptional = decisionState.findDecisionRequirementsByKey(value.getResourceKey());
-    if (drgOptional.isPresent()) {
-      deleteDecisionRequirements(drgOptional.get());
-    } else {
-      throw new NoSuchResourceException(value.getResourceKey());
-    }
+    deleteResources(command);
 
     final long eventKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
@@ -80,6 +74,16 @@ public class ResourceDeletionProcessor
     }
 
     return ProcessingError.UNEXPECTED_ERROR;
+  }
+
+  private void deleteResources(final TypedRecord<ResourceDeletionRecord> command) {
+    final var value = command.getValue();
+    final var drgOptional = decisionState.findDecisionRequirementsByKey(value.getResourceKey());
+    if (drgOptional.isPresent()) {
+      deleteDecisionRequirements(drgOptional.get());
+    } else {
+      throw new NoSuchResourceException(value.getResourceKey());
+    }
   }
 
   private void deleteDecisionRequirements(final PersistedDecisionRequirements drg) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -63,7 +63,12 @@ public class ResourceDeletionProcessor
   }
 
   @Override
-  public void processDistributedCommand(final TypedRecord<ResourceDeletionRecord> command) {}
+  public void processDistributedCommand(final TypedRecord<ResourceDeletionRecord> command) {
+    final var value = command.getValue();
+    deleteResources(command);
+    stateWriter.appendFollowUpEvent(command.getKey(), ResourceDeletionIntent.DELETED, value);
+    commandDistributionBehavior.acknowledgeCommand(command.getKey(), command);
+  }
 
   @Override
   public ProcessingError tryHandleError(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/DistributedTypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/DistributedTypedRecordProcessor.java
@@ -30,7 +30,7 @@ public interface DistributedTypedRecordProcessor<T extends UnifiedRecordValue>
     if (command.isCommandDistributed()) {
       processDistributedCommand(command);
     } else {
-      processCommand(command);
+      processNewCommand(command);
     }
   }
 
@@ -39,12 +39,12 @@ public interface DistributedTypedRecordProcessor<T extends UnifiedRecordValue>
    *
    * @param command the not yet distributed command to process
    */
-  default void processCommand(final TypedRecord<T> command) {}
+  void processNewCommand(final TypedRecord<T> command);
 
   /**
    * Process a command that has been distributed. Be aware to not distribute it again!
    *
    * @param command the already distributed command to process
    */
-  default void processDistributedCommand(final TypedRecord<T> command) {}
+  void processDistributedCommand(final TypedRecord<T> command);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/DistributedTypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/DistributedTypedRecordProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+/**
+ * Some commands are distributed to different partitions. During distribution the command gets
+ * written on the other partitions. Depending on whether it is distributed the behavior of the
+ * processor may slightly change. For example, if it was distributed before we don't want to
+ * distribute it a second time.
+ *
+ * <p>This interface provides some convenience for commands that get distributed. Instead of
+ * checking if the command was distributed in the processor directly, the interface taskes care of
+ * it.
+ *
+ * @param <T>
+ */
+public interface DistributedTypedRecordProcessor<T extends UnifiedRecordValue>
+    extends TypedRecordProcessor<T> {
+
+  @Override
+  default void processRecord(final TypedRecord<T> command) {
+    if (command.isCommandDistributed()) {
+      processDistributedCommand(command);
+    } else {
+      processCommand(command);
+    }
+  }
+
+  /**
+   * Process a command that is not distributed yet
+   *
+   * @param command the not yet distributed command to process
+   */
+  default void processCommand(final TypedRecord<T> command) {}
+
+  /**
+   * Process a command that has been distributed. Be aware to not distribute it again!
+   *
+   * @param command the already distributed command to process
+   */
+  default void processDistributedCommand(final TypedRecord<T> command) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -131,7 +131,7 @@ public class DbDistributionState implements MutableDistributionState {
         .setPartitionId(partition)
         .setValueType(persistedDistribution.getValueType())
         .setIntent(persistedDistribution.getIntent())
-        .setRecordValue(persistedDistribution.getCommandValue());
+        .setCommandValue(persistedDistribution.getCommandValue());
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,14 +49,10 @@ public class ResourceDeletionMultiPartitionTest {
     engine.resourceDeletion().withResourceKey(resourceKey).delete();
 
     // then
-    final var index = new AtomicInteger();
     assertThat(
             RecordingExporter.records()
                 .withPartitionId(1)
-                .limit(
-                    r ->
-                        r.getIntent().equals(ResourceDeletionIntent.DELETED)
-                            && index.incrementAndGet() == 3))
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
         .extracting(
             Record::getIntent,
             Record::getRecordType,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ResourceDeletionMultiPartitionTest {
+
+  private static final int PARTITION_COUNT = 3;
+  private static final String DMN_RESOURCE = "/dmn/decision-table.dmn";
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldTestDmnLifecycle() {
+    // given
+    engine.deployment().withXmlClasspathResource(DMN_RESOURCE).deploy();
+
+    final var resourceKey =
+        RecordingExporter.decisionRequirementsRecords()
+            .withIntent(DecisionRequirementsIntent.CREATED)
+            .withDecisionRequirementsId("force_users")
+            .getFirst()
+            .getKey();
+
+    // when
+    engine.resourceDeletion().withResourceKey(resourceKey).delete();
+
+    // then
+    final var index = new AtomicInteger();
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limit(
+                    r ->
+                        r.getIntent().equals(ResourceDeletionIntent.DELETED)
+                            && index.incrementAndGet() == 3))
+        .extracting(
+            Record::getIntent,
+            Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the deletion was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(ResourceDeletionIntent.DELETE, RecordType.COMMAND, 1),
+            tuple(DecisionIntent.DELETED, RecordType.EVENT, 1),
+            tuple(DecisionRequirementsIntent.DELETED, RecordType.EVENT, 1),
+            tuple(ResourceDeletionIntent.DELETED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.records()
+                  .withPartitionId(partitionId)
+                  .limit(r -> r.getIntent().equals(DecisionRequirementsIntent.DELETED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .endsWith(
+              ResourceDeletionIntent.DELETE,
+              DecisionIntent.DELETED,
+              DecisionRequirementsIntent.DELETED);
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
@@ -12,11 +12,9 @@ import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-@Ignore("Resoure deletion is disabled for version 8.2")
 public class ResourceDeletionRejectionTest {
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -28,11 +28,9 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMet
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.io.IOException;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-@Ignore("Resoure deletion is disabled for version 8.2")
 public class ResourceDeletionTest {
 
   private static final String DRG_SINGLE_DECISION = "/dmn/decision-table.dmn";

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -268,7 +268,7 @@ public final class DistributionStateTest {
         .setPartitionId(1)
         .setValueType(ValueType.DEPLOYMENT)
         .setIntent(DeploymentIntent.CREATE)
-        .setRecordValue(createDeploymentRecord());
+        .setCommandValue(createDeploymentRecord());
   }
 
   private DeploymentRecord createDeploymentRecord() {
@@ -294,6 +294,8 @@ public final class DistributionStateTest {
     return deploymentRecord;
   }
 
+  record PendingDistribution(long key, CommandDistributionRecord record) {}
+
   /** Little helper class, to simplify test setup of the State */
   final class StateHelper {
     private void addPendingDistributionForPartitions(
@@ -305,6 +307,4 @@ public final class DistributionStateTest {
                   distributionState.addPendingDistribution(pendingDistribution.key, partitionId));
     }
   }
-
-  record PendingDistribution(long key, CommandDistributionRecord record) {}
 }

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -194,4 +194,8 @@ public class ObjectValue extends BaseValue {
     }
     return length;
   }
+
+  public boolean isEmpty() {
+    return declaredProperties.isEmpty() && undeclaredProperties.isEmpty();
+  }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -27,6 +27,12 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
   }
 
   @Override
+  @JsonIgnore
+  public boolean isEmpty() {
+    return super.isEmpty();
+  }
+
+  @Override
   public String toJson() {
     return MsgPackConverter.convertJsonSerializableObjectToJson(this);
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentResource.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentResource.java
@@ -10,12 +10,19 @@ package io.camunda.zeebe.protocol.impl.record.value.deployment;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapArray;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "length",
+  "empty"
+})
 public final class DeploymentResource extends UnpackedObject
     implements io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource {
 
@@ -62,18 +69,6 @@ public final class DeploymentResource extends UnpackedObject
   @JsonIgnore
   public DirectBuffer getResourceNameBuffer() {
     return resourceNameProp.getValue();
-  }
-
-  @Override
-  @JsonIgnore
-  public int getLength() {
-    return super.getLength();
-  }
-
-  @Override
-  @JsonIgnore
-  public int getEncodedLength() {
-    return super.getEncodedLength();
   }
 
   public DeploymentResource setResource(

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -94,6 +94,12 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     if (valueType == ValueType.NULL_VAL) {
       return null;
     }
+
+    final var storedCommandValue = commandValueProperty.getValue();
+    if (storedCommandValue.isEmpty()) {
+      return storedCommandValue;
+    }
+
     final var concrecteRecordValueSupplier = RECORDS_BY_TYPE.get(valueType);
     if (concrecteRecordValueSupplier == null) {
       throw new IllegalStateException(
@@ -104,11 +110,10 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     final var concreteRecordValue = concrecteRecordValueSupplier.get();
 
     // write the record value property's content into a buffer
-    final var storedRecordValue = commandValueProperty.getValue();
     final var recordValueBuffer = new UnsafeBuffer(0, 0);
-    final int encodedLength = storedRecordValue.getEncodedLength();
+    final int encodedLength = storedCommandValue.getEncodedLength();
     recordValueBuffer.wrap(new byte[encodedLength]);
-    storedRecordValue.write(recordValueWriter.wrap(recordValueBuffer, 0));
+    storedCommandValue.write(recordValueWriter.wrap(recordValueBuffer, 0));
 
     // read the value back from the buffer into the concrete record value
     concreteRecordValue.wrap(recordValueBuffer);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -47,8 +47,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final IntegerProperty intentProperty = new IntegerProperty("intent", Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>("commandValue", new UnifiedRecordValue());
-  private final MsgPackWriter recordValueWriter = new MsgPackWriter();
-  private final MsgPackReader recordValueReader = new MsgPackReader();
+  private final MsgPackWriter commandValueWriter = new MsgPackWriter();
+  private final MsgPackReader commandValueReader = new MsgPackReader();
 
   public CommandDistributionRecord() {
     declareProperty(partitionIdProperty)
@@ -61,7 +61,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     setPartitionId(other.getPartitionId())
         .setValueType(other.getValueType())
         .setIntent(other.getIntent())
-        .setRecordValue(other.getCommandValue());
+        .setCommandValue(other.getCommandValue());
     return this;
   }
 
@@ -100,24 +100,40 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
       return storedCommandValue;
     }
 
-    final var concrecteRecordValueSupplier = RECORDS_BY_TYPE.get(valueType);
-    if (concrecteRecordValueSupplier == null) {
+    final var concrecteCommandValueSupplier = RECORDS_BY_TYPE.get(valueType);
+    if (concrecteCommandValueSupplier == null) {
       throw new IllegalStateException(
           "Expected to read the record value, but it's type `"
               + valueType.name()
               + "` is unknown. Please add it to CommandDistributionRecord.RECORDS_BY_TYPE");
     }
-    final var concreteRecordValue = concrecteRecordValueSupplier.get();
+    final var concreteCommandValue = concrecteCommandValueSupplier.get();
 
-    // write the record value property's content into a buffer
-    final var recordValueBuffer = new UnsafeBuffer(0, 0);
+    // write the command value property's content into a buffer
+    final var commandValueBuffer = new UnsafeBuffer(0, 0);
     final int encodedLength = storedCommandValue.getEncodedLength();
-    recordValueBuffer.wrap(new byte[encodedLength]);
-    storedCommandValue.write(recordValueWriter.wrap(recordValueBuffer, 0));
+    commandValueBuffer.wrap(new byte[encodedLength]);
+    storedCommandValue.write(commandValueWriter.wrap(commandValueBuffer, 0));
 
-    // read the value back from the buffer into the concrete record value
-    concreteRecordValue.wrap(recordValueBuffer);
-    return concreteRecordValue;
+    // read the value back from the buffer into the concrete command value
+    concreteCommandValue.wrap(commandValueBuffer);
+    return concreteCommandValue;
+  }
+
+  public CommandDistributionRecord setCommandValue(final UnifiedRecordValue commandValue) {
+    if (commandValue == null) {
+      commandValueProperty.reset();
+      return this;
+    }
+
+    // inspired by IndexedRecord.setValue
+    final var valueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = commandValue.getLength();
+    valueBuffer.wrap(new byte[encodedLength]);
+
+    commandValue.write(valueBuffer, 0);
+    commandValueProperty.getValue().read(commandValueReader.wrap(valueBuffer, 0, encodedLength));
+    return this;
   }
 
   public CommandDistributionRecord setIntent(final Intent intent) {
@@ -132,22 +148,6 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
-    return this;
-  }
-
-  public CommandDistributionRecord setRecordValue(final UnifiedRecordValue recordValue) {
-    if (recordValue == null) {
-      commandValueProperty.reset();
-      return this;
-    }
-
-    // inspired by IndexedRecord.setValue
-    final var valueBuffer = new UnsafeBuffer(0, 0);
-    final int encodedLength = recordValue.getLength();
-    valueBuffer.wrap(new byte[encodedLength]);
-
-    recordValue.write(valueBuffer, 0);
-    commandValueProperty.getValue().read(recordValueReader.wrap(valueBuffer, 0, encodedLength));
     return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -31,6 +32,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   // You'll need to register any of the records value's that you want to distribute
   static {
     RECORDS_BY_TYPE.put(ValueType.DEPLOYMENT, DeploymentRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord::new);
   }
 
   /*
@@ -56,7 +58,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   }
 
   public CommandDistributionRecord wrap(final CommandDistributionRecord other) {
-    this.setPartitionId(other.getPartitionId())
+    setPartitionId(other.getPartitionId())
         .setValueType(other.getValueType())
         .setIntent(other.getIntent())
         .setRecordValue(other.getCommandValue());
@@ -113,6 +115,11 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     return concreteRecordValue;
   }
 
+  public CommandDistributionRecord setIntent(final Intent intent) {
+    intentProperty.setValue(intent.value());
+    return this;
+  }
+
   public CommandDistributionRecord setValueType(final ValueType valueType) {
     valueTypeProperty.setValue(valueType);
     return this;
@@ -120,11 +127,6 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
-    return this;
-  }
-
-  public CommandDistributionRecord setIntent(final Intent intent) {
-    intentProperty.setValue(intent.value());
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
@@ -16,9 +16,9 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
-  /* 'encodedLength' is a technical field needed for MsgPack and inherited from ObjectValue; it has
-  no purpose in exported JSON records*/
-  "encodedLength"
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
 })
 public final class ProcessInstanceCreationStartInstruction extends ObjectValue
     implements ProcessInstanceCreationStartInstructionValue {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
@@ -23,9 +23,9 @@ import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
-  /* 'encodedLength' is a technical field needed for MsgPack and inherited from ObjectValue; it has
-  no purpose in exported JSON records*/
-  "encodedLength"
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
 })
 public final class ProcessInstanceModificationActivateInstruction extends ObjectValue
     implements ProcessInstanceModificationActivateInstructionValue {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationTerminateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationTerminateInstruction.java
@@ -13,9 +13,9 @@ import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 
 @JsonIgnoreProperties({
-  /* 'encodedLength' is a technical field needed for MsgPack and inherited from ObjectValue; it has
-  no purpose in exported JSON records*/
-  "encodedLength"
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
 })
 public final class ProcessInstanceModificationTerminateInstruction extends ObjectValue
     implements ProcessInstanceModificationTerminateInstructionValue {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
@@ -19,9 +19,9 @@ import java.util.Map;
 import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
-  /* 'encodedLength' is a technical field needed for MsgPack and inherited from ObjectValue; it has
-  no purpose in exported JSON records*/
-  "encodedLength"
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
 })
 public final class ProcessInstanceModificationVariableInstruction extends ObjectValue
     implements ProcessInstanceModificationVariableInstructionValue {

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1259,7 +1259,7 @@ final class JsonSerializableToJsonTest {
                   .setPartitionId(1)
                   .setValueType(ValueType.DEPLOYMENT)
                   .setIntent(DeploymentIntent.CREATE)
-                  .setRecordValue(deploymentRecord);
+                  .setCommandValue(deploymentRecord);
             },
         """
           {

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -5,7 +5,9 @@
     "configuration": {
       "archives": {
         "justification": "Ignore everything not included in the module itself",
-        "include": ["io\\.camunda:zeebe-protocol:.*"]
+        "include": [
+          "io\\.camunda:zeebe-protocol:.*"
+        ]
       }
     }
   },
@@ -225,21 +227,18 @@
           "code": "java.method.removed",
           "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent::shouldBlacklistInstanceOnError()",
           "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
-
         },
         {
           "ignore": true,
           "code": "java.method.removed",
           "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent::shouldBlacklistInstanceOnError()",
           "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
-
         },
         {
           "ignore": true,
           "code": "java.method.removed",
           "old": "method boolean io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent::shouldBlacklistInstanceOnError()",
           "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
-
         },
         {
           "ignore": true,
@@ -258,6 +257,29 @@
           "code": "java.method.removed",
           "old": "method boolean io.camunda.zeebe.protocol.record.intent.TimerIntent::shouldBlacklistInstanceOnError()",
           "justification": "This method had a racial loaded term. It was replaced with a better name, this shouldn't been an issue as it was for internally use only."
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "old": "interface io.camunda.zeebe.protocol.record.RecordValue",
+          "new": "interface io.camunda.zeebe.protocol.record.RecordValue",
+          "annotation": "@io.camunda.zeebe.protocol.record.ImmutableProtocol(builder = io.camunda.zeebe.protocol.record.ImmutableRecordValue.Builder.class)",
+          "justification": "Annotations added allow us to deserialize a UnifiedRecordValue object to JSON. No backwards compatibility is broken with this."
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "old": "interface io.camunda.zeebe.protocol.record.RecordValue",
+          "new": "interface io.camunda.zeebe.protocol.record.RecordValue",
+          "annotation": "@org.immutables.value.Value.Immutable",
+          "justification": "Annotations added allow us to deserialize a UnifiedRecordValue object to JSON. No backwards compatibility is broken with this."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChangedCovariantly",
+          "old": "method io.camunda.zeebe.protocol.record.RecordValue io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue::getCommandValue()",
+          "new": "method io.camunda.zeebe.protocol.record.ImmutableRecordValue io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue::getCommandValue()",
+          "justification": "This is a result of adding the Immutable annotation on RecordValue. This doesn't break any backwards compatibility."
         }
       ]
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/RecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/RecordValue.java
@@ -15,4 +15,8 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableRecordValue.Builder.class)
 public interface RecordValue extends JsonSerializable {}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
@@ -19,9 +19,16 @@ public enum DeploymentIntent implements Intent {
   CREATE((short) 0),
   CREATED((short) 1),
 
+  /**
+   * Intent related to distribution are deprecated as of 8.3.0. A generalised way of distributing
+   * commands has been introduced in this version. The DeploymentCreateProcessor is now using this
+   * new way. This intent only remains to stay backwards compatible.
+   */
+  @Deprecated
   DISTRIBUTE((short) 2),
+  @Deprecated
   DISTRIBUTED((short) 3),
-
+  @Deprecated
   FULLY_DISTRIBUTED((short) 4);
 
   private final short value;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
With the (almost) completion of #11456 we are now able to use this upon deleting a resource. As of this time only DMN resource deletion is implemented. This PR does some refactorings to this code and adds the distribution and acknowledgements.

I recommend reviewing this per commit.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13204 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
