### PR TITLE
Allow concurrent state access between streamprocessor and scheduled tasks

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
@@ -77,8 +76,6 @@ public class Engine implements RecordProcessor {
             zeebeDb,
             recordProcessorContext.getTransactionContext(),
             recordProcessorContext.getKeyGenerator());
-    final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory =
-        () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
 
     eventApplier = new EventAppliers().registerEventAppliers(processingState);
 
@@ -89,7 +86,7 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getScheduleService(),
             processingState,
-            scheduledTaskDbStateFactory,
+            zeebeDb,
             writers,
             recordProcessorContext.getPartitionCommandSender(),
             config);

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -69,14 +69,14 @@ public class Engine implements RecordProcessor {
 
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
+    eventApplier = new EventAppliers();
+    writers = new Writers(resultBuilderMutex, eventApplier);
+
     final var typedProcessorContext =
         new TypedRecordProcessorContextImpl(recordProcessorContext, writers, config);
     processingState = typedProcessorContext.getProcessingState();
 
-    eventApplier = new EventAppliers().registerEventAppliers(processingState);
-
-    writers = new Writers(resultBuilderMutex, eventApplier);
-
+    ((EventAppliers) eventApplier).registerEventAppliers(processingState);
     final TypedRecordProcessors typedRecordProcessors =
         typedRecordProcessorFactory.createProcessors(typedProcessorContext);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -77,7 +77,8 @@ public class Engine implements RecordProcessor {
             zeebeDb,
             recordProcessorContext.getTransactionContext(),
             recordProcessorContext.getKeyGenerator());
-    final var scheduledTaskDbState = new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
+    final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory =
+        () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
 
     eventApplier = new EventAppliers().registerEventAppliers(processingState);
 
@@ -88,7 +89,7 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getScheduleService(),
             processingState,
-            scheduledTaskDbState,
+            scheduledTaskDbStateFactory,
             writers,
             recordProcessorContext.getPartitionCommandSender(),
             config);

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFa
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -49,7 +49,7 @@ public class Engine implements RecordProcessor {
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;
-  private ProcessingDbState processingState;
+  private MutableProcessingState processingState;
 
   private final ErrorRecord errorRecord = new ErrorRecord();
 
@@ -69,27 +69,13 @@ public class Engine implements RecordProcessor {
 
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
-    final var zeebeDb = recordProcessorContext.getZeebeDb();
-    processingState =
-        new ProcessingDbState(
-            recordProcessorContext.getPartitionId(),
-            zeebeDb,
-            recordProcessorContext.getTransactionContext(),
-            recordProcessorContext.getKeyGenerator());
+    final var typedProcessorContext =
+        new TypedRecordProcessorContextImpl(recordProcessorContext, writers, config);
+    processingState = typedProcessorContext.getProcessingState();
 
     eventApplier = new EventAppliers().registerEventAppliers(processingState);
 
     writers = new Writers(resultBuilderMutex, eventApplier);
-
-    final var typedProcessorContext =
-        new TypedRecordProcessorContextImpl(
-            recordProcessorContext.getPartitionId(),
-            recordProcessorContext.getScheduleService(),
-            processingState,
-            zeebeDb,
-            writers,
-            recordProcessorContext.getPartitionCommandSender(),
-            config);
 
     final TypedRecordProcessors typedRecordProcessors =
         typedRecordProcessorFactory.createProcessors(typedProcessorContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -52,6 +52,7 @@ import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.FeatureFlags;
+import java.util.function.Supplier;
 
 public final class EngineProcessors {
 
@@ -66,7 +67,8 @@ public final class EngineProcessors {
       final JobStreamer jobStreamer) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
-    final var scheduledTaskDbState = typedRecordProcessorContext.getScheduledTaskDbState();
+    final var scheduledTaskDbStateFactory =
+        typedRecordProcessorContext.getScheduledTaskDbStateFactory();
     final var writers = typedRecordProcessorContext.getWriters();
     final TypedRecordProcessors typedRecordProcessors =
         TypedRecordProcessors.processors(processingState.getKeyGenerator(), writers);
@@ -80,7 +82,7 @@ public final class EngineProcessors {
     final var config = typedRecordProcessorContext.getConfig();
 
     final DueDateTimerChecker timerChecker =
-        new DueDateTimerChecker(scheduledTaskDbState.getTimerState(), featureFlags);
+        new DueDateTimerChecker(scheduledTaskDbStateFactory.get().getTimerState(), featureFlags);
 
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());
@@ -124,7 +126,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         subscriptionCommandSender,
         processingState,
-        scheduledTaskDbState,
+        scheduledTaskDbStateFactory,
         typedRecordProcessors,
         writers,
         config,
@@ -156,7 +158,7 @@ public final class EngineProcessors {
         typedRecordProcessors,
         writers,
         processingState,
-        scheduledTaskDbState,
+        scheduledTaskDbStateFactory,
         interPartitionCommandSender);
 
     return typedRecordProcessors;
@@ -260,7 +262,7 @@ public final class EngineProcessors {
       final BpmnBehaviorsImpl bpmnBehaviors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableProcessingState processingState,
-      final ScheduledTaskDbState scheduledTaskDbState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final EngineConfiguration config,
@@ -269,7 +271,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         typedRecordProcessors,
         processingState,
-        scheduledTaskDbState,
+        scheduledTaskDbStateFactory,
         subscriptionCommandSender,
         writers,
         config,
@@ -323,13 +325,13 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final ProcessingState processingState,
-      final ScheduledTaskDbState scheduledTaskDbState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final InterPartitionCommandSender interPartitionCommandSender) {
 
     // periodically retries command distribution
     typedRecordProcessors.withListener(
         new CommandRedistributor(
-            scheduledTaskDbState.getDistributionState(), interPartitionCommandSender));
+            scheduledTaskDbStateFactory.get().getDistributionState(), interPartitionCommandSender));
 
     final var commandDistributionAcknowledgeProcessor =
         new CommandDistributionAcknowledgeProcessor(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -37,8 +37,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorCo
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationController;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -67,8 +67,8 @@ public final class EngineProcessors {
       final JobStreamer jobStreamer) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
-    final var scheduledTaskDbStateFactory =
-        typedRecordProcessorContext.getScheduledTaskDbStateFactory();
+    final var scheduledTaskStateFactory =
+        typedRecordProcessorContext.getScheduledTaskStateFactory();
     final var writers = typedRecordProcessorContext.getWriters();
     final TypedRecordProcessors typedRecordProcessors =
         TypedRecordProcessors.processors(processingState.getKeyGenerator(), writers);
@@ -82,7 +82,7 @@ public final class EngineProcessors {
     final var config = typedRecordProcessorContext.getConfig();
 
     final DueDateTimerChecker timerChecker =
-        new DueDateTimerChecker(scheduledTaskDbStateFactory.get().getTimerState(), featureFlags);
+        new DueDateTimerChecker(scheduledTaskStateFactory.get().getTimerState(), featureFlags);
 
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());
@@ -126,7 +126,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         subscriptionCommandSender,
         processingState,
-        scheduledTaskDbStateFactory,
+        scheduledTaskStateFactory,
         typedRecordProcessors,
         writers,
         config,
@@ -158,7 +158,7 @@ public final class EngineProcessors {
         typedRecordProcessors,
         writers,
         processingState,
-        scheduledTaskDbStateFactory,
+        scheduledTaskStateFactory,
         interPartitionCommandSender);
 
     return typedRecordProcessors;
@@ -262,7 +262,7 @@ public final class EngineProcessors {
       final BpmnBehaviorsImpl bpmnBehaviors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableProcessingState processingState,
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final EngineConfiguration config,
@@ -271,7 +271,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         typedRecordProcessors,
         processingState,
-        scheduledTaskDbStateFactory,
+        scheduledTaskStateFactory,
         subscriptionCommandSender,
         writers,
         config,
@@ -325,13 +325,13 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final ProcessingState processingState,
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final InterPartitionCommandSender interPartitionCommandSender) {
 
     // periodically retries command distribution
     typedRecordProcessors.withListener(
         new CommandRedistributor(
-            scheduledTaskDbStateFactory.get().getDistributionState(), interPartitionCommandSender));
+            scheduledTaskStateFactory.get().getDistributionState(), interPartitionCommandSender));
 
     final var commandDistributionAcknowledgeProcessor =
         new CommandDistributionAcknowledgeProcessor(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.FeatureFlags;
+import java.util.function.Supplier;
 
 public final class MessageEventProcessors {
 
@@ -30,7 +31,7 @@ public final class MessageEventProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
-      final ScheduledTaskDbState scheduledTaskDbState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
       final EngineConfiguration config,
@@ -95,7 +96,7 @@ public final class MessageEventProcessors {
                 messageState, subscriptionState, subscriptionCommandSender, writers))
         .withListener(
             new MessageObserver(
-                scheduledTaskDbState.getMessageState(),
+                scheduledTaskDbStateFactory,
                 processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender,
                 config.getMessagesTtlCheckerInterval(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
@@ -31,7 +31,7 @@ public final class MessageEventProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
       final EngineConfiguration config,
@@ -96,7 +96,7 @@ public final class MessageEventProcessors {
                 messageState, subscriptionState, subscriptionCommandSender, writers))
         .withListener(
             new MessageObserver(
-                scheduledTaskDbStateFactory,
+                scheduledTaskStateFactory,
                 processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender,
                 config.getMessagesTtlCheckerInterval(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -8,11 +8,12 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
-import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.time.Duration;
+import java.util.function.Supplier;
 
 public final class MessageObserver implements StreamProcessorLifecycleAware {
 
@@ -20,21 +21,21 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   public static final Duration SUBSCRIPTION_CHECK_INTERVAL = Duration.ofSeconds(30);
 
   private final SubscriptionCommandSender subscriptionCommandSender;
-  private final MessageState messageState;
+  private final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory;
   private final PendingMessageSubscriptionState pendingState;
   private final int messagesTtlCheckerBatchLimit;
   private final Duration messagesTtlCheckerInterval;
   private final boolean enableMessageTtlCheckerAsync;
 
   public MessageObserver(
-      final MessageState messageState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final PendingMessageSubscriptionState pendingState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Duration messagesTtlCheckerInterval,
       final int messagesTtlCheckerBatchLimit,
       final boolean enableMessageTtlCheckerAsync) {
     this.subscriptionCommandSender = subscriptionCommandSender;
-    this.messageState = messageState;
+    this.scheduledTaskDbStateFactory = scheduledTaskDbStateFactory;
     this.pendingState = pendingState;
     this.messagesTtlCheckerInterval = messagesTtlCheckerInterval;
     this.messagesTtlCheckerBatchLimit = messagesTtlCheckerBatchLimit;
@@ -49,6 +50,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
 
   private void scheduleMessageTtlChecker(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
+    final var messageState = scheduledTaskDbStateFactory.get().getMessageState();
     final var timeToLiveChecker =
         new MessageTimeToLiveChecker(
             messagesTtlCheckerInterval,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -43,6 +43,11 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    scheduleMessageTtlChecker(context);
+    schedulePendingMessageSubscriptionChecker(context);
+  }
+
+  private void scheduleMessageTtlChecker(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
     final var timeToLiveChecker =
         new MessageTimeToLiveChecker(
@@ -56,7 +61,11 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
     } else {
       scheduleService.runDelayed(messagesTtlCheckerInterval, timeToLiveChecker);
     }
+  }
 
+  private void schedulePendingMessageSubscriptionChecker(
+      final ReadonlyStreamProcessorContext context) {
+    final var scheduleService = context.getScheduleService();
     final var pendingSubscriptionChecker =
         new PendingMessageSubscriptionChecker(
             subscriptionCommandSender, pendingState, SUBSCRIPTION_TIMEOUT.toMillis());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.time.Duration;
@@ -21,21 +21,21 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   public static final Duration SUBSCRIPTION_CHECK_INTERVAL = Duration.ofSeconds(30);
 
   private final SubscriptionCommandSender subscriptionCommandSender;
-  private final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory;
+  private final Supplier<ScheduledTaskState> scheduledTaskStateFactory;
   private final PendingMessageSubscriptionState pendingState;
   private final int messagesTtlCheckerBatchLimit;
   private final Duration messagesTtlCheckerInterval;
   private final boolean enableMessageTtlCheckerAsync;
 
   public MessageObserver(
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final PendingMessageSubscriptionState pendingState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Duration messagesTtlCheckerInterval,
       final int messagesTtlCheckerBatchLimit,
       final boolean enableMessageTtlCheckerAsync) {
     this.subscriptionCommandSender = subscriptionCommandSender;
-    this.scheduledTaskDbStateFactory = scheduledTaskDbStateFactory;
+    this.scheduledTaskStateFactory = scheduledTaskStateFactory;
     this.pendingState = pendingState;
     this.messagesTtlCheckerInterval = messagesTtlCheckerInterval;
     this.messagesTtlCheckerBatchLimit = messagesTtlCheckerBatchLimit;
@@ -50,7 +50,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
 
   private void scheduleMessageTtlChecker(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
-    final var messageState = scheduledTaskDbStateFactory.get().getMessageState();
+    final var messageState = scheduledTaskStateFactory.get().getMessageState();
     final var timeToLiveChecker =
         new MessageTimeToLiveChecker(
             messagesTtlCheckerInterval,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -27,6 +27,7 @@ public interface TypedRecordProcessorContext {
 
   InterPartitionCommandSender getPartitionCommandSender();
 
+  /** Returns a state factory, where each created state has a separate transaction context. */
   Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory();
 
   EngineConfiguration getConfig();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
@@ -28,7 +28,7 @@ public interface TypedRecordProcessorContext {
   InterPartitionCommandSender getPartitionCommandSender();
 
   /** Returns a state factory, where each created state has a separate transaction context. */
-  Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory();
+  Supplier<ScheduledTaskState> getScheduledTaskStateFactory();
 
   EngineConfiguration getConfig();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import java.util.function.Supplier;
 
 public interface TypedRecordProcessorContext {
 
@@ -26,7 +27,7 @@ public interface TypedRecordProcessorContext {
 
   InterPartitionCommandSender getPartitionCommandSender();
 
-  ScheduledTaskDbState getScheduledTaskDbState();
+  Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory();
 
   EngineConfiguration getConfig();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
@@ -21,7 +22,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
   private final ProcessingDbState processingState;
-  private final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory;
+  private final ZeebeDb zeebeDb;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
   private final EngineConfiguration config;
@@ -30,14 +31,14 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
       final int partitionId,
       final ProcessingScheduleService scheduleService,
       final ProcessingDbState processingState,
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final ZeebeDb zeebeDb,
       final Writers writers,
       final InterPartitionCommandSender partitionCommandSender,
       final EngineConfiguration config) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.processingState = processingState;
-    this.scheduledTaskDbStateFactory = scheduledTaskDbStateFactory;
+    this.zeebeDb = zeebeDb;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
     this.config = config;
@@ -70,7 +71,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
 
   @Override
   public Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory() {
-    return scheduledTaskDbStateFactory;
+    return () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
@@ -69,7 +70,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   }
 
   @Override
-  public Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory() {
+  public Supplier<ScheduledTaskState> getScheduledTaskStateFactory() {
     return () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -14,13 +14,14 @@ import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import java.util.function.Supplier;
 
 public class TypedRecordProcessorContextImpl implements TypedRecordProcessorContext {
 
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
   private final ProcessingDbState processingState;
-  private final ScheduledTaskDbState scheduledTaskDbState;
+  private final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
   private final EngineConfiguration config;
@@ -29,14 +30,14 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
       final int partitionId,
       final ProcessingScheduleService scheduleService,
       final ProcessingDbState processingState,
-      final ScheduledTaskDbState scheduledTaskDbState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final Writers writers,
       final InterPartitionCommandSender partitionCommandSender,
       final EngineConfiguration config) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.processingState = processingState;
-    this.scheduledTaskDbState = scheduledTaskDbState;
+    this.scheduledTaskDbStateFactory = scheduledTaskDbStateFactory;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
     this.config = config;
@@ -68,8 +69,8 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   }
 
   @Override
-  public ScheduledTaskDbState getScheduledTaskDbState() {
-    return scheduledTaskDbState;
+  public Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory() {
+    return scheduledTaskDbStateFactory;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.RecordProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import java.util.function.Supplier;
 
@@ -28,19 +29,17 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final EngineConfiguration config;
 
   public TypedRecordProcessorContextImpl(
-      final int partitionId,
-      final ProcessingScheduleService scheduleService,
-      final ProcessingDbState processingState,
-      final ZeebeDb zeebeDb,
+      final RecordProcessorContext context,
       final Writers writers,
-      final InterPartitionCommandSender partitionCommandSender,
       final EngineConfiguration config) {
-    this.partitionId = partitionId;
-    this.scheduleService = scheduleService;
-    this.processingState = processingState;
-    this.zeebeDb = zeebeDb;
+    this.partitionId = context.getPartitionId();
+    this.scheduleService = context.getScheduleService();
+    this.zeebeDb = context.getZeebeDb();
+    this.processingState =
+        new ProcessingDbState(
+            partitionId, zeebeDb, context.getTransactionContext(), context.getKeyGenerator());
     this.writers = writers;
-    this.partitionCommandSender = partitionCommandSender;
+    this.partitionCommandSender = context.getPartitionCommandSender();
     this.config = config;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -12,13 +12,14 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.instance.DbTimerInstanceState;
 import io.camunda.zeebe.engine.state.message.DbMessageState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 /** Contains read-only state that can be accessed safely by scheduled tasks. */
-public final class ScheduledTaskDbState {
+public final class ScheduledTaskDbState implements ScheduledTaskState {
   private final DistributionState distributionState;
   private final MessageState messageState;
   private final TimerInstanceState timerInstanceState;
@@ -30,14 +31,17 @@ public final class ScheduledTaskDbState {
     this.timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
   }
 
+  @Override
   public DistributionState getDistributionState() {
     return distributionState;
   }
 
+  @Override
   public MessageState getMessageState() {
     return messageState;
   }
 
+  @Override
   public TimerInstanceState getTimerState() {
     return timerInstanceState;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+public interface ScheduledTaskState {
+
+  DistributionState getDistributionState();
+
+  MessageState getMessageState();
+
+  TimerInstanceState getTimerState();
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -65,7 +65,7 @@ public final class MessageStreamProcessorTest {
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
           final var processingState = processingContext.getProcessingState();
-          final var scheduledTaskDbState = processingContext.getScheduledTaskDbState();
+          final var scheduledTaskDbState = processingContext.getScheduledTaskDbStateFactory();
           MessageEventProcessors.addMessageProcessors(
               mock(BpmnBehaviors.class),
               typedRecordProcessors,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -65,12 +65,12 @@ public final class MessageStreamProcessorTest {
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
           final var processingState = processingContext.getProcessingState();
-          final var scheduledTaskDbState = processingContext.getScheduledTaskDbStateFactory();
+          final var scheduledTaskState = processingContext.getScheduledTaskStateFactory();
           MessageEventProcessors.addMessageProcessors(
               mock(BpmnBehaviors.class),
               typedRecordProcessors,
               processingState,
-              scheduledTaskDbState,
+              scheduledTaskState,
               spySubscriptionCommandSender,
               processingContext.getWriters(),
               DEFAULT_ENGINE_CONFIGURATION,


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This fixes a potential segfault that can occur when the state is accessed concurrently:
- on released versions (`8.2.7-` and `8.1.13-`, but not on any `8.3` alphas) when only one of these experimental feature flags are enabled and the other is disabled:
  - `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEMESSAGETTLCHECKERASYNC`
  - `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLETIMERDUEDATECHECKERASYNC`
- on `main` branch when one or both feature flags are enabled
- on `main` branch in tests (because both feature flags are enabled)

That happened because when one or more of these feature flags are enabled, the streamprocessor and the scheduled tasks (message ttl checker, timer due date checker, or command redistributor) may concurrently access the state from RocksDB in an unsafe way. There are two parts to this unsafety:
- the state tree (object) is not threadsafe
- the transaction context is reused between them

This pull request fixes the bug by constructing new state trees with their own transaction context for each scheduled task. That separates them completely from the streamprocessor's state access. 

> The state tree for scheduled tasks is called a `ScheduledTaskState`, while the state tree for the streamprocessor is called a `ProcessingState`.

Most of this pull request consists of refactorings, so I suggest reviewing it per commit.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13164 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
