### PR TITLE
Apply latest version of event by default

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -140,7 +140,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
 
     final long key = keyGenerator.nextKey();
     responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
-    stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent, 2);
+    stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
 
     distributionBehavior.distributeCommand(key, command);
   }
@@ -149,7 +149,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     final var deploymentEvent = command.getValue();
     createBpmnResources(deploymentEvent);
     createDmnResources(command, deploymentEvent);
-    stateWriter.appendFollowUpEvent(command.getKey(), DeploymentIntent.CREATED, deploymentEvent, 2);
+    stateWriter.appendFollowUpEvent(command.getKey(), DeploymentIntent.CREATED, deploymentEvent);
     distributionBehavior.acknowledgeCommand(command.getKey(), command);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -38,7 +38,8 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-    appendFollowUpEvent(key, intent, value, RecordMetadata.DEFAULT_RECORD_VERSION);
+    final int latestVersion = eventApplier.getLatestVersion(intent);
+    appendFollowUpEvent(key, intent, value, latestVersion);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -16,8 +16,15 @@ public interface TypedEventWriter {
   /**
    * Append a follow up event to the result builder.
    *
-   * <p>If multiple versions of a record exists, consider using {@link #appendFollowUpEvent(long,
-   * Intent, RecordValue, int)} instead.
+   * <p>Different versions of event records may be applied by different {@link
+   * io.camunda.zeebe.engine.state.EventApplier EventApplier}s, leading to differing state changes.
+   * This allows fixing bugs in event appliers because every event applier must produce the same
+   * state changes for an event both when writing it and when replaying it, even on newer versions
+   * of Zeebe.
+   *
+   * <p>This method always uses the latest available {@link
+   * io.camunda.zeebe.engine.state.EventApplier EventApplier}. If a specific needs to be used,
+   * consider using {@link #appendFollowUpEvent(long, Intent, RecordValue, int)} instead.
    *
    * @param key the key of the event
    * @param intent the intent of the event

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
@@ -14,7 +14,16 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 public interface EventApplier {
 
   /**
-   * Apply the state changes of the given event.
+   * Returns the latest EventApplier version of a given Intent.
+   *
+   * @param intent the Intent of the EventApplier
+   * @return the latest version of the given intent, -1 if no EventApplier is found
+   */
+  int getLatestVersion(final Intent intent);
+
+  /**
+   * Apply the state changes of the given event. It will use the event applier that matches the
+   * specified version.
    *
    * @param key the key of the event
    * @param intent the intent of the event

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.util.StreamProcessorRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -55,9 +56,8 @@ public final class MessageStreamProcessorTest {
   public void setup() {
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
     final var mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
-    final var writers =
-        new Writers(
-            () -> mockProcessingResultBuilder, (key, intent, recordValue, recordVersion) -> {});
+    final var mockEventAppliers = mock(EventAppliers.class);
+    final var writers = new Writers(() -> mockProcessingResultBuilder, mockEventAppliers);
     spySubscriptionCommandSender =
         spy(new SubscriptionCommandSender(1, mockInterpartitionCommandSender));
     spySubscriptionCommandSender.setWriters(writers);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -52,9 +53,8 @@ public class SubscriptionCommandSenderTest {
     subscriptionCommandSender =
         new SubscriptionCommandSender(SAME_PARTITION, mockInterPartitionCommandSender);
     mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
-    final var writers =
-        new Writers(
-            () -> mockProcessingResultBuilder, (key, intent, recordValue, recordVersion) -> {});
+    final var mockEventAppliers = mock(EventAppliers.class);
+    final var writers = new Writers(() -> mockProcessingResultBuilder, mockEventAppliers);
     subscriptionCommandSender.setWriters(writers);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -13,6 +13,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,5 +82,58 @@ public class EventAppliersTest {
     // then
     Mockito.verify(mockedApplier, Mockito.never()).applyState(anyLong(), any());
     Mockito.verify(anotherMockedApplier).applyState(anyLong(), any());
+  }
+
+  @Test
+  void shouldGetLatestVersionOfOnlyRegisteredVersion() {
+    // given
+    final var expectedVersion = 1;
+    eventAppliers.register(Intent.UNKNOWN, expectedVersion, mockedApplier);
+
+    // when
+    final var actualVersion = eventAppliers.getLatestVersion(Intent.UNKNOWN);
+
+    // then
+    Assertions.assertEquals(expectedVersion, actualVersion);
+  }
+
+  @Test
+  void shouldGetLatestVersionOfTwoRegisteredVersions() {
+    // given
+    final var expectedVersion = 2;
+    eventAppliers.register(Intent.UNKNOWN, 1, mockedApplier);
+    eventAppliers.register(Intent.UNKNOWN, expectedVersion, mockedApplier);
+
+    // when
+    final var actualVersion = eventAppliers.getLatestVersion(Intent.UNKNOWN);
+
+    // then
+    Assertions.assertEquals(expectedVersion, actualVersion);
+  }
+
+  @Test
+  void shouldGetLatestVersionMinusOneWhenNoRegisteredVersion() {
+    // given
+    final var expectedVersion = -1;
+
+    // when
+    final var actualVersion = eventAppliers.getLatestVersion(Intent.UNKNOWN);
+
+    // then
+    Assertions.assertEquals(expectedVersion, actualVersion);
+  }
+
+  @Test
+  void shouldGetLatestVersionWhenMultipleRegisteredEventAppliersWithDifferentIntents() {
+    // given
+    final var expectedVersion = 1;
+    eventAppliers.register(Intent.UNKNOWN, expectedVersion, mockedApplier);
+    eventAppliers.register(ProcessIntent.CREATED, expectedVersion, mockedApplier);
+
+    // when
+    final var actualVersion = eventAppliers.getLatestVersion(Intent.UNKNOWN);
+
+    // then
+    Assertions.assertEquals(expectedVersion, actualVersion);
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
With this commit we change the behavior of event applying to always apply an event to the latest event applier. This prevents us from always having to specify a version if it's > 1.

Before it would always take version 1 as the default. This works fine and is the latest version for almost all event appliers. However, in the future we will get more and more versioned event appliers. When coding it is nice to not have to worry about versioning. New stuff can always get the latest version. Only when working with old appliers should we have to worry about this and explicitly specify which version  should be used.

In order to achieve this we need to be able to get the latest version in the ResultBuilderBackedEventApplyingStateWriter. In this class we append the record and apply the event applier. As the versions of event appliers is only available in the EventAppliers class I had to add a getLatestVersion method to the interface of this class. Without this we don't know what recordVersion to set on the metadata of the appended record. It is essential that this version matches the actual applied version. If it doesn't we could break our state, as during replay a different applier might be used than during processing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13161 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
