### PR TITLE
[Backport stable/8.2] Mark command as processed even on processing error

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -445,6 +445,10 @@ public final class ProcessingStateMachine {
                   processingException, typedCommand, processingResultBuilder);
           pendingWrites = currentProcessingResult.getRecordBatch().entries();
           pendingResponses = currentProcessingResult.getProcessingResponse().stream().toList();
+          // we need to mark the command as processed, even if the processing failed
+          // otherwise we might replay the events, which have been written during
+          // #onProcessingError again on restart
+          lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
         });
   }
 

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -10,15 +10,24 @@ package io.camunda.zeebe.stream.impl;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.stream.util.Records;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -255,6 +264,72 @@ final class StreamProcessorReplayTest {
                     .isEqualTo(4L));
     Assertions.assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey()))
         .isEqualTo(21L);
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
+  public void shouldNotApplyErrorEventOnReplay() throws Exception {
+    // given
+    final var processorWhichFails = setupProcessorWhichFailsOnProcessing();
+    setupOnErrorReactionForProcessor(processorWhichFails);
+
+    streamPlatform.startStreamProcessor();
+    // commands to process -> which should fail
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+
+    // await that two commands are failed and processed, to make sure error event has been committed
+    verify(processorWhichFails, TIMEOUT.times(2)).onProcessingError(any(), any(), any());
+    // the snapshot should contain last processed position
+    streamPlatform.snapshot();
+    streamPlatform.closeStreamProcessor();
+    streamPlatform.resetMockInvocations();
+
+    // when
+    streamPlatform.startStreamProcessor();
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verifyProcessingErrorLifecycle(processorWhichFails);
+    // we shouldn't replay any events - due to snapshot
+    // we shouldn't replay any events - due to snapshot
+    verify(processorWhichFails, never()).replay(any());
+  }
+
+  private static void verifyProcessingErrorLifecycle(final RecordProcessor processorWhichFails) {
+    final var inOrder = inOrder(processorWhichFails);
+    inOrder.verify(processorWhichFails, TIMEOUT).init(any());
+    inOrder.verify(processorWhichFails, TIMEOUT).accepts(ValueType.PROCESS_INSTANCE);
+    inOrder.verify(processorWhichFails, TIMEOUT).process(any(), any());
+    inOrder.verify(processorWhichFails, TIMEOUT).onProcessingError(any(), any(), any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private RecordProcessor setupProcessorWhichFailsOnProcessing() {
+    final var processorWhichFails = streamPlatform.getDefaultMockedRecordProcessor();
+    doThrow(new RuntimeException("processing error"))
+        .when(processorWhichFails)
+        .process(any(), any());
+    return processorWhichFails;
+  }
+
+  private static void setupOnErrorReactionForProcessor(final RecordProcessor processorWhichFails) {
+    doAnswer(
+            invocationOnMock -> {
+              // writing error event on failure
+              final var builder = (ProcessingResultBuilder) invocationOnMock.getArgument(2);
+              final RecordMetadata recordMetadata = new RecordMetadata();
+              recordMetadata
+                  .valueType(ValueType.ERROR)
+                  .intent(ErrorIntent.CREATED)
+                  .recordType(RecordType.EVENT);
+              builder.appendRecord(6, Records.processInstance(6), recordMetadata);
+              return builder.build();
+            })
+        .when(processorWhichFails)
+        .onProcessingError(
+            any(Throwable.class), any(TypedRecord.class), any(ProcessingResultBuilder.class));
   }
 
   @Test

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -280,6 +280,8 @@ final class StreamProcessorReplayTest {
 
     // await that two commands are failed and processed, to make sure error event has been committed
     verify(processorWhichFails, TIMEOUT.times(2)).onProcessingError(any(), any(), any());
+    Awaitility.await("last processed position is updated")
+        .until(() -> streamPlatform.getLastSuccessfulProcessedRecordPosition(), pos -> pos >= 2);
     // the snapshot should contain last processed position
     streamPlatform.snapshot();
     streamPlatform.closeStreamProcessor();

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -295,7 +295,6 @@ final class StreamProcessorReplayTest {
     // then
     verifyProcessingErrorLifecycle(processorWhichFails);
     // we shouldn't replay any events - due to snapshot
-   
     verify(processorWhichFails, never()).replay(any());
   }
 

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
@@ -325,7 +326,13 @@ final class StreamProcessorReplayTest {
                   .valueType(ValueType.ERROR)
                   .intent(ErrorIntent.CREATED)
                   .recordType(RecordType.EVENT);
-              builder.appendRecord(6, Records.processInstance(6), recordMetadata);
+              builder.appendRecord(
+                  6,
+                  RecordType.EVENT,
+                  ErrorIntent.CREATED,
+                  RejectionType.NULL_VAL,
+                  "",
+                  Records.processInstance(6));
               return builder.build();
             })
         .when(processorWhichFails)

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -267,7 +267,7 @@ final class StreamProcessorReplayTest {
   }
 
   @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
-  public void shouldNotApplyErrorEventOnReplay() throws Exception {
+  public void shouldNotReplayErrorEventAppliedInSnapshot() throws Exception {
     // given
     final var processorWhichFails = setupProcessorWhichFailsOnProcessing();
     setupOnErrorReactionForProcessor(processorWhichFails);

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -295,7 +295,7 @@ final class StreamProcessorReplayTest {
     // then
     verifyProcessingErrorLifecycle(processorWhichFails);
     // we shouldn't replay any events - due to snapshot
-    // we shouldn't replay any events - due to snapshot
+   
     verify(processorWhichFails, never()).replay(any());
   }
 


### PR DESCRIPTION
# Description
Backport of #13206 to `stable/8.2`.

relates to camunda/zeebe#13101