### PR TITLE
[Backport stable/8.1] Allow concurrent state access between streamprocessor and scheduled tasks

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -76,7 +76,8 @@ public class Engine implements RecordProcessor {
             zeebeDb,
             recordProcessorContext.getTransactionContext(),
             recordProcessorContext.getKeyGenerator());
-    final var scheduledTaskDbState = new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
+    final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory =
+        () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
 
     eventApplier = recordProcessorContext.getEventApplierFactory().apply(processingState);
 
@@ -87,7 +88,7 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getScheduleService(),
             processingState,
-            scheduledTaskDbState,
+            scheduledTaskDbStateFactory,
             writers,
             recordProcessorContext.getPartitionCommandSender(),
             config);

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -76,8 +75,6 @@ public class Engine implements RecordProcessor {
             zeebeDb,
             recordProcessorContext.getTransactionContext(),
             recordProcessorContext.getKeyGenerator());
-    final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory =
-        () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
 
     eventApplier = recordProcessorContext.getEventApplierFactory().apply(processingState);
 
@@ -88,7 +85,7 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getPartitionId(),
             recordProcessorContext.getScheduleService(),
             processingState,
-            scheduledTaskDbStateFactory,
+            zeebeDb,
             writers,
             recordProcessorContext.getPartitionCommandSender(),
             config);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationController;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -53,8 +54,8 @@ public final class EngineProcessors {
       final FeatureFlags featureFlags) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
-    final var scheduledTaskDbStateFactory =
-        typedRecordProcessorContext.getScheduledTaskDbStateFactory();
+    final var scheduledTaskStateFactory =
+        typedRecordProcessorContext.getScheduledTaskStateFactory();
     final var writers = typedRecordProcessorContext.getWriters();
     final TypedRecordProcessors typedRecordProcessors =
         TypedRecordProcessors.processors(processingState.getKeyGenerator(), writers);
@@ -68,7 +69,7 @@ public final class EngineProcessors {
     final var config = typedRecordProcessorContext.getConfig();
 
     final DueDateTimerChecker timerChecker =
-        new DueDateTimerChecker(scheduledTaskDbStateFactory.get().getTimerState(), featureFlags);
+        new DueDateTimerChecker(scheduledTaskStateFactory.get().getTimerState(), featureFlags);
 
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());
@@ -96,7 +97,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         subscriptionCommandSender,
         processingState,
-        scheduledTaskDbStateFactory,
+        scheduledTaskStateFactory,
         typedRecordProcessors,
         writers,
         config,
@@ -218,7 +219,7 @@ public final class EngineProcessors {
       final BpmnBehaviorsImpl bpmnBehaviors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableProcessingState processingState,
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final EngineConfiguration config,
@@ -227,7 +228,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         typedRecordProcessors,
         processingState,
-        scheduledTaskDbStateFactory,
+        scheduledTaskStateFactory,
         subscriptionCommandSender,
         writers,
         config,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationController;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public final class EngineProcessors {
 
@@ -52,6 +53,8 @@ public final class EngineProcessors {
       final FeatureFlags featureFlags) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
+    final var scheduledTaskDbStateFactory =
+        typedRecordProcessorContext.getScheduledTaskDbStateFactory();
     final var writers = typedRecordProcessorContext.getWriters();
     final TypedRecordProcessors typedRecordProcessors =
         TypedRecordProcessors.processors(processingState.getKeyGenerator(), writers);
@@ -65,8 +68,7 @@ public final class EngineProcessors {
     final var config = typedRecordProcessorContext.getConfig();
 
     final DueDateTimerChecker timerChecker =
-        new DueDateTimerChecker(
-            typedRecordProcessorContext.getScheduledTaskDbState().getTimerState(), featureFlags);
+        new DueDateTimerChecker(scheduledTaskDbStateFactory.get().getTimerState(), featureFlags);
 
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());
@@ -94,7 +96,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         subscriptionCommandSender,
         processingState,
-        typedRecordProcessorContext.getScheduledTaskDbState(),
+        scheduledTaskDbStateFactory,
         typedRecordProcessors,
         writers,
         config,
@@ -216,7 +218,7 @@ public final class EngineProcessors {
       final BpmnBehaviorsImpl bpmnBehaviors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final MutableProcessingState processingState,
-      final ScheduledTaskDbState scheduledTaskDbState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final EngineConfiguration config,
@@ -225,7 +227,7 @@ public final class EngineProcessors {
         bpmnBehaviors,
         typedRecordProcessors,
         processingState,
-        scheduledTaskDbState,
+        scheduledTaskDbStateFactory,
         subscriptionCommandSender,
         writers,
         config,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSen
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
@@ -31,7 +31,7 @@ public final class MessageEventProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
       final EngineConfiguration config,
@@ -96,7 +96,7 @@ public final class MessageEventProcessors {
                 messageState, subscriptionState, subscriptionCommandSender, writers))
         .withListener(
             new MessageObserver(
-                scheduledTaskDbStateFactory,
+                scheduledTaskStateFactory,
                 processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender,
                 config.getMessagesTtlCheckerInterval(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.util.FeatureFlags;
+import java.util.function.Supplier;
 
 public final class MessageEventProcessors {
 
@@ -30,7 +31,7 @@ public final class MessageEventProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
-      final ScheduledTaskDbState scheduledTaskDbState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
       final EngineConfiguration config,
@@ -95,7 +96,7 @@ public final class MessageEventProcessors {
                 messageState, subscriptionState, subscriptionCommandSender, writers))
         .withListener(
             new MessageObserver(
-                scheduledTaskDbState.getMessageState(),
+                scheduledTaskDbStateFactory,
                 processingState.getPendingMessageSubscriptionState(),
                 subscriptionCommandSender,
                 config.getMessagesTtlCheckerInterval(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -43,6 +43,11 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    scheduleMessageTtlChecker(context);
+    schedulePendingMessageSubscriptionChecker(context);
+  }
+
+  private void scheduleMessageTtlChecker(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
     final var timeToLiveChecker =
         new MessageTimeToLiveChecker(
@@ -56,7 +61,11 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
     } else {
       scheduleService.runDelayed(messagesTtlCheckerInterval, timeToLiveChecker);
     }
+  }
 
+  private void schedulePendingMessageSubscriptionChecker(
+      final ReadonlyStreamProcessorContext context) {
+    final var scheduleService = context.getScheduleService();
     final var pendingSubscriptionChecker =
         new PendingMessageSubscriptionChecker(
             subscriptionCommandSender, pendingState, SUBSCRIPTION_TIMEOUT.toMillis());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -10,8 +10,8 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import java.time.Duration;
 import java.util.function.Supplier;
 
@@ -21,21 +21,21 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   public static final Duration SUBSCRIPTION_CHECK_INTERVAL = Duration.ofSeconds(30);
 
   private final SubscriptionCommandSender subscriptionCommandSender;
-  private final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory;
+  private final Supplier<ScheduledTaskState> scheduledTaskStateFactory;
   private final MutablePendingMessageSubscriptionState pendingState;
   private final int messagesTtlCheckerBatchLimit;
   private final Duration messagesTtlCheckerInterval;
   private final boolean enableMessageTtlCheckerAsync;
 
   public MessageObserver(
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final MutablePendingMessageSubscriptionState pendingState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Duration messagesTtlCheckerInterval,
       final int messagesTtlCheckerBatchLimit,
       final boolean enableMessageTtlCheckerAsync) {
     this.subscriptionCommandSender = subscriptionCommandSender;
-    this.scheduledTaskDbStateFactory = scheduledTaskDbStateFactory;
+    this.scheduledTaskStateFactory = scheduledTaskStateFactory;
     this.pendingState = pendingState;
     this.messagesTtlCheckerInterval = messagesTtlCheckerInterval;
     this.messagesTtlCheckerBatchLimit = messagesTtlCheckerBatchLimit;
@@ -50,7 +50,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
 
   private void scheduleMessageTtlChecker(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
-    final var messageState = scheduledTaskDbStateFactory.get().getMessageState();
+    final var messageState = scheduledTaskStateFactory.get().getMessageState();
     final var timeToLiveChecker =
         new MessageTimeToLiveChecker(
             messagesTtlCheckerInterval,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -10,9 +10,10 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
-import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import java.time.Duration;
+import java.util.function.Supplier;
 
 public final class MessageObserver implements StreamProcessorLifecycleAware {
 
@@ -20,21 +21,21 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   public static final Duration SUBSCRIPTION_CHECK_INTERVAL = Duration.ofSeconds(30);
 
   private final SubscriptionCommandSender subscriptionCommandSender;
-  private final MessageState messageState;
+  private final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory;
   private final MutablePendingMessageSubscriptionState pendingState;
   private final int messagesTtlCheckerBatchLimit;
   private final Duration messagesTtlCheckerInterval;
   private final boolean enableMessageTtlCheckerAsync;
 
   public MessageObserver(
-      final MessageState messageState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final MutablePendingMessageSubscriptionState pendingState,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Duration messagesTtlCheckerInterval,
       final int messagesTtlCheckerBatchLimit,
       final boolean enableMessageTtlCheckerAsync) {
     this.subscriptionCommandSender = subscriptionCommandSender;
-    this.messageState = messageState;
+    this.scheduledTaskDbStateFactory = scheduledTaskDbStateFactory;
     this.pendingState = pendingState;
     this.messagesTtlCheckerInterval = messagesTtlCheckerInterval;
     this.messagesTtlCheckerBatchLimit = messagesTtlCheckerBatchLimit;
@@ -49,6 +50,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
 
   private void scheduleMessageTtlChecker(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
+    final var messageState = scheduledTaskDbStateFactory.get().getMessageState();
     final var timeToLiveChecker =
         new MessageTimeToLiveChecker(
             messagesTtlCheckerInterval,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import java.util.function.Supplier;
 
 public interface TypedRecordProcessorContext {
 
@@ -26,7 +27,7 @@ public interface TypedRecordProcessorContext {
 
   InterPartitionCommandSender getPartitionCommandSender();
 
-  ScheduledTaskDbState getScheduledTaskDbState();
+  Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory();
 
   EngineConfiguration getConfig();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -27,6 +27,7 @@ public interface TypedRecordProcessorContext {
 
   InterPartitionCommandSender getPartitionCommandSender();
 
+  /** Returns a state factory, where each created state has a separate transaction context. */
   Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory();
 
   EngineConfiguration getConfig();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.function.Supplier;
 
@@ -28,7 +28,7 @@ public interface TypedRecordProcessorContext {
   InterPartitionCommandSender getPartitionCommandSender();
 
   /** Returns a state factory, where each created state has a separate transaction context. */
-  Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory();
+  Supplier<ScheduledTaskState> getScheduledTaskStateFactory();
 
   EngineConfiguration getConfig();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -14,13 +14,14 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import java.util.function.Supplier;
 
 public class TypedRecordProcessorContextImpl implements TypedRecordProcessorContext {
 
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
   private final ProcessingDbState processingState;
-  private final ScheduledTaskDbState scheduledTaskDbState;
+  private final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
   private final EngineConfiguration config;
@@ -29,14 +30,14 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
       final int partitionId,
       final ProcessingScheduleService scheduleService,
       final ProcessingDbState processingState,
-      final ScheduledTaskDbState scheduledTaskDbState,
+      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
       final Writers writers,
       final InterPartitionCommandSender partitionCommandSender,
       final EngineConfiguration config) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.processingState = processingState;
-    this.scheduledTaskDbState = scheduledTaskDbState;
+    this.scheduledTaskDbStateFactory = scheduledTaskDbStateFactory;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
     this.config = config;
@@ -68,8 +69,8 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   }
 
   @Override
-  public ScheduledTaskDbState getScheduledTaskDbState() {
-    return scheduledTaskDbState;
+  public Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory() {
+    return scheduledTaskDbStateFactory;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
@@ -21,7 +22,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
   private final ProcessingDbState processingState;
-  private final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory;
+  private final ZeebeDb zeebeDb;
   private final Writers writers;
   private final InterPartitionCommandSender partitionCommandSender;
   private final EngineConfiguration config;
@@ -30,14 +31,14 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
       final int partitionId,
       final ProcessingScheduleService scheduleService,
       final ProcessingDbState processingState,
-      final Supplier<ScheduledTaskDbState> scheduledTaskDbStateFactory,
+      final ZeebeDb zeebeDb,
       final Writers writers,
       final InterPartitionCommandSender partitionCommandSender,
       final EngineConfiguration config) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.processingState = processingState;
-    this.scheduledTaskDbStateFactory = scheduledTaskDbStateFactory;
+    this.zeebeDb = zeebeDb;
     this.writers = writers;
     this.partitionCommandSender = partitionCommandSender;
     this.config = config;
@@ -70,7 +71,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
 
   @Override
   public Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory() {
-    return scheduledTaskDbStateFactory;
+    return () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.function.Supplier;
 
@@ -70,7 +71,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   }
 
   @Override
-  public Supplier<ScheduledTaskDbState> getScheduledTaskDbStateFactory() {
+  public Supplier<ScheduledTaskState> getScheduledTaskStateFactory() {
     return () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext());
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -10,12 +10,13 @@ package io.camunda.zeebe.engine.state;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.instance.DbTimerInstanceState;
 import io.camunda.zeebe.engine.state.message.DbMessageState;
 
 /** Contains read-only state that can be accessed safely by scheduled tasks. */
-public final class ScheduledTaskDbState {
+public final class ScheduledTaskDbState implements ScheduledTaskState {
   private final MessageState messageState;
   private final TimerInstanceState timerInstanceState;
 
@@ -25,10 +26,12 @@ public final class ScheduledTaskDbState {
     timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
   }
 
+  @Override
   public MessageState getMessageState() {
     return messageState;
   }
 
+  @Override
   public TimerInstanceState getTimerState() {
     return timerInstanceState;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+public interface ScheduledTaskState {
+
+  MessageState getMessageState();
+
+  TimerInstanceState getTimerState();
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -64,7 +64,7 @@ public final class MessageStreamProcessorTest {
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
           final var processingState = processingContext.getProcessingState();
-          final var scheduledTaskDbState = processingContext.getScheduledTaskDbState();
+          final var scheduledTaskDbState = processingContext.getScheduledTaskDbStateFactory();
           MessageEventProcessors.addMessageProcessors(
               mock(BpmnBehaviors.class),
               typedRecordProcessors,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -64,12 +64,12 @@ public final class MessageStreamProcessorTest {
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
           final var processingState = processingContext.getProcessingState();
-          final var scheduledTaskDbState = processingContext.getScheduledTaskDbStateFactory();
+          final var scheduledTaskState = processingContext.getScheduledTaskStateFactory();
           MessageEventProcessors.addMessageProcessors(
               mock(BpmnBehaviors.class),
               typedRecordProcessors,
               processingState,
-              scheduledTaskDbState,
+              scheduledTaskState,
               spySubscriptionCommandSender,
               processingContext.getWriters(),
               DEFAULT_ENGINE_CONFIGURATION,


### PR DESCRIPTION
## Description

<!-- Link to the PR that is back ported -->

Manual backport of #13208

Conflicts are described in each commit message. But the gist is that the CommandRedistributor is not available in 8.1, which also accesses the ScheduledTaskState in #13208.

In addition, be3917d8d4379a0d304556fa0a72224b265ed0bc and 77ddf473f0d366062d4816be0a465fe664d6419f are left out because these were especially hard to resolve (EventAppliers is still created through some factory in 8.1) and these changes are not mandatory for the bugfix.

## Related issues

<!-- Link to the related issues of the origin PR -->

relates to #13164
