### PR TITLE
[Backport 8.1]: Mark command as processed even on processing error 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -454,6 +454,10 @@ public final class ProcessingStateMachine {
                       .valueWriter(entry.recordValue())
                       .done());
           pendingResponses = currentProcessingResult.getProcessingResponse().stream().toList();
+          // we need to mark the command as processed, even if the processing failed
+          // otherwise we might replay the events, which have been written during
+          // #onProcessingError again on restart
+          lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
         });
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessorReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessorReplayTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+import io.camunda.zeebe.engine.api.RecordProcessor;
+import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.engine.util.StreamPlatform;
+import io.camunda.zeebe.engine.util.StreamPlatformExtension;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.verification.VerificationWithTimeout;
+
+@ExtendWith(StreamPlatformExtension.class)
+final class MigratedStreamProcessorReplayTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  @SuppressWarnings("unused") // injected by the extension
+  private StreamPlatform streamPlatform;
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
+  public void shouldNotApplyErrorEventOnReplay() throws Exception {
+    // given
+    final var processorWhichFails = setupProcessorWhichFailsOnProcessing();
+    setupOnErrorReactionForProcessor(processorWhichFails);
+
+    streamPlatform.startStreamProcessor();
+    // commands to process -> which should fail
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+
+    // await that two commands are failed and processed, to make sure error event has been committed
+    verify(processorWhichFails, TIMEOUT.times(2)).onProcessingError(any(), any(), any());
+    // the snapshot should contain last processed position
+    streamPlatform.snapshot();
+    streamPlatform.closeStreamProcessor();
+    streamPlatform.resetMockInvocations();
+
+    // when
+    streamPlatform.startStreamProcessor();
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verifyProcessingErrorLifecycle(processorWhichFails);
+    // we shouldn't replay any events - due to snapshot
+    // we shouldn't replay any events - due to snapshot
+    verify(processorWhichFails, never()).replay(any());
+  }
+
+  private static void verifyProcessingErrorLifecycle(final RecordProcessor processorWhichFails) {
+    final var inOrder = inOrder(processorWhichFails);
+    inOrder.verify(processorWhichFails, TIMEOUT).init(any());
+    inOrder.verify(processorWhichFails, TIMEOUT).accepts(ValueType.PROCESS_INSTANCE);
+    inOrder.verify(processorWhichFails, TIMEOUT).process(any(), any());
+    inOrder.verify(processorWhichFails, TIMEOUT).onProcessingError(any(), any(), any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private RecordProcessor setupProcessorWhichFailsOnProcessing() {
+    final var processorWhichFails = streamPlatform.getDefaultMockedRecordProcessor();
+    doThrow(new RuntimeException("processing error"))
+        .when(processorWhichFails)
+        .process(any(), any());
+    return processorWhichFails;
+  }
+
+  private static void setupOnErrorReactionForProcessor(final RecordProcessor processorWhichFails) {
+    doAnswer(
+            invocationOnMock -> {
+              // writing error event on failure
+              final var builder = (ProcessingResultBuilder) invocationOnMock.getArgument(2);
+              final RecordMetadata recordMetadata = new RecordMetadata();
+              recordMetadata
+                  .valueType(ValueType.ERROR)
+                  .intent(ErrorIntent.CREATED)
+                  .recordType(RecordType.EVENT);
+              builder.appendRecord(
+                  6,
+                  RecordType.EVENT,
+                  ErrorIntent.CREATED,
+                  RejectionType.NULL_VAL,
+                  "",
+                  Records.processInstance(6));
+              return builder.build();
+            })
+        .when(processorWhichFails)
+        .onProcessingError(
+            any(Throwable.class), any(TypedRecord.class), any(ProcessingResultBuilder.class));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessorReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessorReplayTest.java
@@ -71,7 +71,6 @@ final class MigratedStreamProcessorReplayTest {
     // then
     verifyProcessingErrorLifecycle(processorWhichFails);
     // we shouldn't replay any events - due to snapshot
-    // we shouldn't replay any events - due to snapshot
     verify(processorWhichFails, never()).replay(any());
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessorReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessorReplayTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.verification.VerificationWithTimeout;
 
@@ -55,6 +56,8 @@ final class MigratedStreamProcessorReplayTest {
 
     // await that two commands are failed and processed, to make sure error event has been committed
     verify(processorWhichFails, TIMEOUT.times(2)).onProcessingError(any(), any(), any());
+    Awaitility.await("last processed position is updated")
+        .until(() -> streamPlatform.getLastSuccessfulProcessedRecordPosition(), pos -> pos >= 2);
     // the snapshot should contain last processed position
     streamPlatform.snapshot();
     streamPlatform.closeStreamProcessor();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessorReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessorReplayTest.java
@@ -43,7 +43,7 @@ final class MigratedStreamProcessorReplayTest {
   private StreamPlatform streamPlatform;
 
   @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
-  public void shouldNotApplyErrorEventOnReplay() throws Exception {
+  public void shouldNotReplayErrorEventAppliedInSnapshot() throws Exception {
     // given
     final var processorWhichFails = setupProcessorWhichFailsOnProcessing();
     setupOnErrorReactionForProcessor(processorWhichFails);

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.streamprocessor.StreamProcessorContext;
 import io.camunda.zeebe.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.streamprocessor.StreamProcessorMode;
+import io.camunda.zeebe.streamprocessor.state.DbLastProcessedPositionState;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.IOException;
@@ -272,6 +273,10 @@ public final class StreamPlatform {
     LOG.info("Snapshot database for processor {}", processorContext.streamProcessor.getName());
   }
 
+  public long getLastSuccessfulProcessedRecordPosition() {
+    return processorContext.getLastSuccessfulProcessedRecordPosition();
+  }
+
   public RecordProcessor getDefaultMockedRecordProcessor() {
     return defaultMockedRecordProcessor;
   }
@@ -330,6 +335,11 @@ public final class StreamPlatform {
 
     public void snapshot() {
       zeebeDb.createSnapshot(snapshotPath.toFile());
+    }
+
+    public Long getLastSuccessfulProcessedRecordPosition() {
+      return new DbLastProcessedPositionState(zeebeDb, zeebeDb.createContext())
+          .getLastSuccessfulProcessedRecordPosition();
     }
 
     @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -52,6 +52,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 
 public final class StreamPlatform {
@@ -111,6 +112,14 @@ public final class StreamPlatform {
     closeables.add(() -> recordProcessors.clear());
     mockProcessorLifecycleAware = mock(StreamProcessorLifecycleAware.class);
     mockStreamProcessorListener = mock(StreamProcessorListener.class);
+  }
+
+  public void resetMockInvocations() {
+    Mockito.clearInvocations(
+        mockCommandResponseWriter,
+        mockProcessorLifecycleAware,
+        mockStreamProcessorListener,
+        defaultMockedRecordProcessor);
   }
 
   public CommandResponseWriter getMockCommandResponseWriter() {

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -54,6 +54,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import java.time.Duration;
 import java.util.List;
@@ -61,6 +62,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -165,6 +167,26 @@ public final class StreamProcessorTest {
         .verify(defaultRecordProcessor, TIMEOUT)
         .onProcessingError(eq(processingError), any(), any());
     inOrder.verifyNoMoreInteractions();
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
+  public void shouldUpdateLastProcessPositionEvenWhenProcessingFails() {
+    // given
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    final var processingError = new RuntimeException("processing error");
+    doThrow(processingError).when(defaultRecordProcessor).process(any(), any());
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.event()
+            .processInstance(ELEMENT_ACTIVATING, Records.processInstance(1))
+            .causedBy(0));
+
+    // then
+    Awaitility.await("last processed position is updated")
+        .until(() -> streamPlatform.getLastSuccessfulProcessedRecordPosition(), pos -> pos >= 1);
   }
 
   @Test


### PR DESCRIPTION
## Description

Backports #13206 

Backporting was not that easy, since the module split was done on 8.2 and several classes have been moved etc.

For simplicity I created a separate Test file for the regression test, which already uses the StreamPlatform. Before the StreamProcessorReplayTest used the StreamProcessorRule which is a bit limited.

Furthemore I had to do some more additions to the StreamPlatform to be able to run our test.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/13101

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
