### PR TITLE
Invalidate process cache on deployment rejection

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -96,6 +96,9 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     try {
       createTimerIfTimerStartEvent(command);
     } catch (final RuntimeException e) {
+      // Make sure the cache does not contain any leftovers from this run (by hard resetting)
+      processState.clearCache();
+
       final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
       responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
       rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
@@ -116,6 +119,9 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   @Override
   public ProcessingError tryHandleError(
       final TypedRecord<DeploymentRecord> command, final Throwable error) {
+    // Make sure the cache does not contain any leftovers from this run (by hard resetting)
+    processState.clearCache();
+
     if (error instanceof ResourceTransformationFailedException exception) {
       rejectionWriter.appendRejection(
           command, RejectionType.INVALID_ARGUMENT, exception.getMessage());

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -302,6 +302,13 @@ public final class DbProcessState implements MutableProcessState {
     return element;
   }
 
+  @Override
+  public void clearCache() {
+    processesByKey.clear();
+    processesByProcessIdAndVersion.clear();
+    versionManager.clear();
+  }
+
   private DeployedProcess lookupProcessByIdAndPersistedVersion(final long latestVersion) {
     processVersion.wrapLong(latestVersion);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -69,4 +69,8 @@ public final class ProcessVersionManager {
     }
     return currentValue;
   }
+
+  public void clear() {
+    versionCache.clear();
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -30,4 +30,7 @@ public interface ProcessState {
 
   <T extends ExecutableFlowElement> T getFlowElement(
       long processDefinitionKey, DirectBuffer elementId, Class<T> elementType);
+
+  /** TODO: Remove the cache entirely from the immutable state */
+  void clearCache();
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -302,6 +302,7 @@ public class DeploymentRejectionTest {
     final BpmnModelInstance invalidProcess =
         Bpmn.createExecutableProcess("too_large_process")
             .startEvent()
+            // In order to cause BATCH SIZE EXCEEDING we add a big comment
             .documentation("x".repeat((int) ByteValue.ofMegabytes(3)))
             .done();
     final BpmnModelInstance validProcess =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -297,7 +297,7 @@ public class DeploymentRejectionTest {
 
   /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
   @Test
-  public void shouldNotCacheProcessesWhenDeploymentRejected() {
+  public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =
         Bpmn.createExecutableProcess("too_large_process")

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
-import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
@@ -296,7 +295,7 @@ public class DeploymentRejectionTest {
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 
-  @RegressionTest("https://github.com/camunda/zeebe/issues/13254")
+  @Test // Regression of https://github.com/camunda/zeebe/issues/13254
   public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -294,4 +294,37 @@ public class DeploymentRejectionTest {
             tuple(DeploymentIntent.CREATED, RecordType.EVENT),
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
+
+  /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
+  @Test
+  public void shouldNotCacheProcessesWhenDeploymentRejected() {
+    // given
+    final BpmnModelInstance invalidProcess =
+        Bpmn.createExecutableProcess("too_large_process")
+            .startEvent()
+            .documentation("x".repeat((int) ByteValue.ofMegabytes(3)))
+            .done();
+    final BpmnModelInstance validProcess =
+        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
+
+    // when
+    ENGINE
+        .deployment()
+        .withXmlResource(invalidProcess)
+        .withXmlResource(validProcess)
+        .expectRejection()
+        .deploy();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getRecordType() == RecordType.COMMAND_REJECTION)
+                .collect(Collectors.toList()))
+        .extracting(Record::getIntent, Record::getRecordType)
+        .doesNotContain(
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT));
+
+    ENGINE.processInstance().ofBpmnProcessId("valid_process").expectRejection().create();
+  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
@@ -295,8 +296,7 @@ public class DeploymentRejectionTest {
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 
-  /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
-  @Test
+  @RegressionTest("https://github.com/camunda/zeebe/issues/13254")
   public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This resolves a critical bug where process instances can be created for processes from rejected deployments. This could lead to unrecoverable partitions.

The problem was that a cache is build up for each of the processes during the processing of the `Deployment:CREATE` command, but this cache was not invalidated when that command is rejected.

This solution only provides a quick fix by completely clearing the cache, which comes at some performance loss when deployments are rejected.

In a future iteration, we'll need to investigate other solutions for the long term. We should also remove the cache entirely from any operations in the immutable ProcessState.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13254

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
