### PR TITLE
Prevent StackOverFlowError during termination of children

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.function.Function;
 
 public final class BpmnStateTransitionBehavior {
-
   private static final String ALREADY_MIGRATED_ERROR_MSG =
       "The Processor for the element type %s is already migrated no need to call %s again this is already done in the BpmnStreamProcessor for you. Happy to help :) ";
   private static final String NO_PROCESS_FOUND_MESSAGE =
@@ -421,7 +420,19 @@ public final class BpmnStateTransitionBehavior {
         element,
         childContext,
         (containerProcessor, containerScope, containerContext) -> {
-          containerProcessor.onChildTerminated(containerScope, containerContext, childContext);
+          try {
+            containerProcessor.onChildTerminated(containerScope, containerContext, childContext);
+          } catch (final StackOverflowError stackOverFlow) {
+            // This is a dirty quick "fix" for https://github.com/camunda/zeebe/issues/8955
+            // It's done so a cluster doesn't die when a user encounters this.
+            final var message =
+                String.format(
+                    """
+                    Process instance `%d` has too many nested child instances and could not be terminated. \
+                    The deepest nested child instance has been banned as a result.""",
+                    containerContext.getProcessInstanceKey());
+            throw new ChildTerminationStackOverflowException(message);
+          }
           return Either.right(null);
         });
   }
@@ -513,6 +524,13 @@ public final class BpmnStateTransitionBehavior {
             child ->
                 terminateElement(context.copy(child.getKey(), child.getValue(), child.getState())),
             () -> containerProcessor.onChildTerminated(element, context, null));
+  }
+
+  private static final class ChildTerminationStackOverflowException extends RuntimeException {
+
+    public ChildTerminationStackOverflowException(final String message) {
+      super(message);
+    }
   }
 
   @FunctionalInterface

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceBanTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceBanTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public final class CancelProcessInstanceBanTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test // Regression of https://github.com/camunda/zeebe/issues/8955
+  public void shouldBanInstanceWhenTerminatingInstanceWithALotOfNestedChildInstances() {
+    // given
+    final var amountOfNestedChildInstances = 1000;
+    final var processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .exclusiveGateway()
+                .defaultFlow()
+                .userTask()
+                .endEvent()
+                .moveToLastGateway()
+                .conditionExpression("count < " + amountOfNestedChildInstances)
+                .intermediateThrowEvent("preventStraightThroughLoop")
+                .callActivity(
+                    "callActivity",
+                    c -> c.zeebeProcessId(processId).zeebeInputExpression("count + 1", "count"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVariable("count", 0).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementType(BpmnElementType.USER_TASK)
+        .getFirst();
+
+    // when
+    final var errorRecordValue =
+        ENGINE.processInstance().withInstanceKey(processInstanceKey).cancelWithError();
+
+    // then
+    Assertions.assertThat(errorRecordValue.getValue().getStacktrace())
+        .contains("ChildTerminationStackOverflowException");
+    Assertions.assertThat(errorRecordValue.getValue().getExceptionMessage())
+        .contains(
+            "Process instance",
+            """
+            has too many nested child instances and could not be terminated. The deepest nested \
+            child instance has been banned as a result.""");
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -19,9 +19,11 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
@@ -193,6 +195,10 @@ public final class ProcessInstanceClient {
                 .withProcessInstanceKey(processInstanceKey)
                 .getFirst();
 
+    public static final Function<Long, Record<ErrorRecordValue>> ERROR_EXPECTATION =
+        (processInstanceKey) ->
+            RecordingExporter.errorRecords().withIntent(ErrorIntent.CREATED).getFirst();
+
     private static final int DEFAULT_PARTITION = -1;
     private final CommandWriter writer;
     private final long processInstanceKey;
@@ -216,6 +222,16 @@ public final class ProcessInstanceClient {
     }
 
     public Record<ProcessInstanceRecordValue> cancel() {
+      writeCancelCommand();
+      return expectation.apply(processInstanceKey);
+    }
+
+    public Record<ErrorRecordValue> cancelWithError() {
+      writeCancelCommand();
+      return ERROR_EXPECTATION.apply(processInstanceKey);
+    }
+
+    private void writeCancelCommand() {
       if (partition == DEFAULT_PARTITION) {
         partition =
             RecordingExporter.processInstanceRecords()
@@ -229,8 +245,6 @@ public final class ProcessInstanceClient {
           processInstanceKey,
           ProcessInstanceIntent.CANCEL,
           new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey));
-
-      return expectation.apply(processInstanceKey);
     }
 
     public ProcessInstanceModificationClient modification() {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ErrorRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ErrorRecordStream.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
+import java.util.stream.Stream;
+
+public class ErrorRecordStream extends ExporterRecordStream<ErrorRecordValue, ErrorRecordStream> {
+
+  public ErrorRecordStream(final Stream<Record<ErrorRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ErrorRecordStream supply(final Stream<Record<ErrorRecordValue>> wrappedStream) {
+    return new ErrorRecordStream(wrappedStream);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -355,6 +356,10 @@ public final class RecordingExporter implements Exporter {
   public static ResourceDeletionRecordStream resourceDeletionRecords(
       final ResourceDeletionIntent intent) {
     return resourceDeletionRecords().withIntent(intent);
+  }
+
+  public static ErrorRecordStream errorRecords() {
+    return new ErrorRecordStream(records(ValueType.ERROR, ErrorRecordValue.class));
   }
 
   public static class AwaitingRecordIterator implements Iterator<Record<?>> {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When terminating a child instance we bubble up to the flowscope to let it know the child has been terminated. This flow scope can then check if it can also terminate itself. If there is a lot of nested children (usually due to a modelling error)  this bubbling up could cause a `StackOverFlowError`. Currently this would break a partition and put the cluster in an unrecoverable state.

This commit catches the SO and turns it into a RuntimeException. The Engine can handle this and will consider this to be an `UNEXPECTED_ERROR`. As a result the process instance is banned.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Dirty fix for #8955 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
