### PR TITLE
Reset the diskSpaceAvailable flag correctly

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -440,7 +440,7 @@ public final class ZeebePartition extends Actor
     actor.call(
         () -> {
           context.setDiskSpaceAvailable(true);
-          zeebePartitionHealth.setDiskSpaceAvailable(false);
+          zeebePartitionHealth.setDiskSpaceAvailable(true);
           if (context.getStreamProcessor() != null && context.shouldProcess()) {
             LOG.info("Disk space usage is below threshold. Resuming stream processor.");
             context.getStreamProcessor().resumeProcessing();

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -43,6 +43,7 @@ import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 public class ZeebePartitionTest {
@@ -349,6 +350,69 @@ public class ZeebePartitionTest {
 
     // then
     Awaitility.await().until(closeFuture::isDone);
+  }
+
+  @Test
+  public void shouldReportUnhealthyPerDefault() {
+    // given
+    final var captor = ArgumentCaptor.forClass(ZeebePartitionHealth.class);
+    schedulerRule.submitActor(partition);
+    partition.onNewRole(Role.LEADER, 1);
+    schedulerRule.workUntilDone();
+
+    // when
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(healthMonitor).registerComponent(any(), captor.capture());
+
+    final var zeebePartitionHealth = captor.getValue();
+    final HealthReport healthReport = zeebePartitionHealth.getHealthReport();
+    assertThat(healthReport.getStatus()).isEqualTo(HealthStatus.UNHEALTHY);
+    assertThat(healthReport.getIssue().message()).contains("Initial state");
+  }
+
+  @Test
+  public void shouldReportUnhealthyWhenNoDiskAvailable() {
+    // given
+    final var captor = ArgumentCaptor.forClass(ZeebePartitionHealth.class);
+    schedulerRule.submitActor(partition);
+    partition.onNewRole(Role.LEADER, 1);
+    schedulerRule.workUntilDone();
+
+    // when
+    partition.onDiskSpaceNotAvailable();
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(healthMonitor).registerComponent(any(), captor.capture());
+
+    final var zeebePartitionHealth = captor.getValue();
+    final HealthReport healthReport = zeebePartitionHealth.getHealthReport();
+    assertThat(healthReport.getStatus()).isEqualTo(HealthStatus.UNHEALTHY);
+    assertThat(healthReport.getIssue().message()).contains("Not enough disk space available");
+  }
+
+  @Test
+  public void shouldReportHealthyWhenDiskIsAvailableAgain() {
+    // given
+    final var captor = ArgumentCaptor.forClass(ZeebePartitionHealth.class);
+    schedulerRule.submitActor(partition);
+    partition.onNewRole(Role.LEADER, 1);
+    partition.onDiskSpaceNotAvailable();
+    schedulerRule.workUntilDone();
+
+    // when
+    partition.onDiskSpaceAvailable();
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(healthMonitor).registerComponent(any(), captor.capture());
+
+    final var zeebePartitionHealth = captor.getValue();
+    final HealthReport healthReport = zeebePartitionHealth.getHealthReport();
+    assertThat(healthReport.getStatus()).isEqualTo(HealthStatus.HEALTHY);
+    assertThat(healthReport.getIssue()).isNull();
   }
 
   private static class NoopStartupStep implements PartitionStartupStep {


### PR DESCRIPTION
## Description

The flag was set incorrectly in the ZeebePartition. IMHO it shows again that we should try to avoid such, and instead have specific methods which set these flags/values, but I deferred this refactoring to keep the changes small.

_Example follow up refactoring:_

```java

  zeebePartitionHealth.setDiskSpaceAvailable(true);

  // could be:
  zeebePartitionHealth.notifyForDiskSpaceAvailable(); or zeebePartitionHealth.diskSpaceAvailable(); 
  // and
  zeebePartitionHealth.notifyForDiskSpaceUnavailable(); or zeebePartitionHealth.diskSpaceUnavailable();
```

Of course, we could still run into the issue that only one method is called, but we would detect it more easily if one method is not used (with IDE support).

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/6232

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
