### PR TITLE
[Backport stable/8.0] Prevent StackOverFlowError during termination of children

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.function.Function;
 
 public final class BpmnStateTransitionBehavior {
-
   private static final String ALREADY_MIGRATED_ERROR_MSG =
       "The Processor for the element type %s is already migrated no need to call %s again this is already done in the BpmnStreamProcessor for you. Happy to help :) ";
   private static final String NO_PROCESS_FOUND_MESSAGE =
@@ -381,7 +380,19 @@ public final class BpmnStateTransitionBehavior {
         element,
         childContext,
         (containerProcessor, containerScope, containerContext) -> {
-          containerProcessor.onChildTerminated(containerScope, containerContext, childContext);
+          try {
+            containerProcessor.onChildTerminated(containerScope, containerContext, childContext);
+          } catch (final StackOverflowError stackOverFlow) {
+            // This is a dirty quick "fix" for https://github.com/camunda/zeebe/issues/8955
+            // It's done so a cluster doesn't die when a user encounters this.
+            final var message =
+                String.format(
+                    """
+                    Process instance `%d` has too many nested child instances and could not be terminated. \
+                    The deepest nested child instance has been banned as a result.""",
+                    containerContext.getProcessInstanceKey());
+            throw new ChildTerminationStackOverflowException(message);
+          }
           return Either.right(null);
         });
   }
@@ -473,6 +484,13 @@ public final class BpmnStateTransitionBehavior {
             child ->
                 terminateElement(context.copy(child.getKey(), child.getValue(), child.getState())),
             () -> containerProcessor.onChildTerminated(element, context, null));
+  }
+
+  private static final class ChildTerminationStackOverflowException extends RuntimeException {
+
+    public ChildTerminationStackOverflowException(final String message) {
+      super(message);
+    }
   }
 
   @FunctionalInterface

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceBanTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceBanTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public final class CancelProcessInstanceBanTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test // Regression of https://github.com/camunda/zeebe/issues/8955
+  public void shouldBanInstanceWhenTerminatingInstanceWithALotOfNestedChildInstances() {
+    // given
+    final var amountOfNestedChildInstances = 1000;
+    final var processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .exclusiveGateway()
+                .defaultFlow()
+                .userTask()
+                .endEvent()
+                .moveToLastGateway()
+                .conditionExpression("count < " + amountOfNestedChildInstances)
+                .intermediateThrowEvent("preventStraightThroughLoop")
+                .callActivity(
+                    "callActivity",
+                    c -> c.zeebeProcessId(processId).zeebeInputExpression("count + 1", "count"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVariable("count", 0).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementType(BpmnElementType.USER_TASK)
+        .getFirst();
+
+    // when
+    final var errorRecordValue =
+        ENGINE.processInstance().withInstanceKey(processInstanceKey).cancelWithError();
+
+    // then
+    Assertions.assertThat(errorRecordValue.getValue().getStacktrace())
+        .contains("ChildTerminationStackOverflowException");
+    Assertions.assertThat(errorRecordValue.getValue().getExceptionMessage())
+        .contains(
+            "Process instance",
+            """
+            has too many nested child instances and could not be terminated. The deepest nested \
+            child instance has been banned as a result.""");
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ErrorRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ErrorRecordStream.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
+import java.util.stream.Stream;
+
+public class ErrorRecordStream extends ExporterRecordStream<ErrorRecordValue, ErrorRecordStream> {
+
+  public ErrorRecordStream(final Stream<Record<ErrorRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ErrorRecordStream supply(final Stream<Record<ErrorRecordValue>> wrappedStream) {
+    return new ErrorRecordStream(wrappedStream);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -261,6 +262,10 @@ public final class RecordingExporter implements Exporter {
   public static DecisionEvaluationRecordStream decisionEvaluationRecords() {
     return new DecisionEvaluationRecordStream(
         records(ValueType.DECISION_EVALUATION, DecisionEvaluationRecordValue.class));
+  }
+
+  public static ErrorRecordStream errorRecords() {
+    return new ErrorRecordStream(records(ValueType.ERROR, ErrorRecordValue.class));
   }
 
   public static class RecordIterator implements Iterator<Record<?>> {


### PR DESCRIPTION
# Description
Backport of #13258 to `stable/8.0`.

relates to #8955