### PR TITLE
[Backport stable/8.1] Invalidate process cache on deployment rejection

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -94,6 +94,9 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     try {
       createTimerIfTimerStartEvent(command);
     } catch (final RuntimeException e) {
+      // Make sure the cache does not contain any leftovers from this run (by hard resetting)
+      processState.clearCache();
+
       final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
       responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
       rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
@@ -114,6 +117,9 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   @Override
   public ProcessingError tryHandleError(
       final TypedRecord<DeploymentRecord> command, final Throwable error) {
+    // Make sure the cache does not contain any leftovers from this run (by hard resetting)
+    processState.clearCache();
+
     if (error instanceof ResourceTransformationFailedException exception) {
       rejectionWriter.appendRejection(
           command, RejectionType.INVALID_ARGUMENT, exception.getMessage());

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -310,6 +310,13 @@ public final class DbProcessState implements MutableProcessState {
     return element;
   }
 
+  @Override
+  public void clearCache() {
+    processesByKey.clear();
+    processesByProcessIdAndVersion.clear();
+    versionManager.clear();
+  }
+
   private DeployedProcess lookupProcessByIdAndPersistedVersion(final long latestVersion) {
     processVersion.wrapLong(latestVersion);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -70,4 +70,8 @@ public final class ProcessVersionManager {
     }
     return currentValue;
   }
+
+  public void clear() {
+    versionCache.clear();
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -30,4 +30,7 @@ public interface ProcessState {
 
   <T extends ExecutableFlowElement> T getFlowElement(
       long processDefinitionKey, DirectBuffer elementId, Class<T> elementType);
+
+  /** TODO: Remove the cache entirely from the immutable state */
+  void clearCache();
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -269,7 +269,7 @@ public class DeploymentRejectionTest {
             .documentation("x".repeat((int) ByteValue.ofMegabytes(3)))
             .done();
     final BpmnModelInstance validProcess =
-        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
+        Bpmn.createExecutableProcess("valid_process").startEvent().userTask().endEvent().done();
 
     // when
     ENGINE

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -258,4 +258,37 @@ public class DeploymentRejectionTest {
             tuple(DeploymentIntent.CREATED, RecordType.EVENT),
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
+
+  /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
+  @Test
+  public void shouldNotCacheProcessesWhenDeploymentRejected() {
+    // given
+    final BpmnModelInstance invalidProcess =
+        Bpmn.createExecutableProcess("too_large_process")
+            .startEvent()
+            .documentation("x".repeat((int) ByteValue.ofMegabytes(3)))
+            .done();
+    final BpmnModelInstance validProcess =
+        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
+
+    // when
+    ENGINE
+        .deployment()
+        .withXmlResource(invalidProcess)
+        .withXmlResource(validProcess)
+        .expectRejection()
+        .deploy();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getRecordType() == RecordType.COMMAND_REJECTION)
+                .collect(Collectors.toList()))
+        .extracting(Record::getIntent, Record::getRecordType)
+        .doesNotContain(
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT));
+
+    ENGINE.processInstance().ofBpmnProcessId("valid_process").expectRejection().create();
+  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -266,6 +266,7 @@ public class DeploymentRejectionTest {
     final BpmnModelInstance invalidProcess =
         Bpmn.createExecutableProcess("too_large_process")
             .startEvent()
+            // In order to cause BATCH SIZE EXCEEDING we add a big comment
             .documentation("x".repeat((int) ByteValue.ofMegabytes(3)))
             .done();
     final BpmnModelInstance validProcess =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
-import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
@@ -260,7 +259,7 @@ public class DeploymentRejectionTest {
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 
-  @RegressionTest("https://github.com/camunda/zeebe/issues/13254")
+  @Test // Regression of https://github.com/camunda/zeebe/issues/13254
   public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -261,7 +261,7 @@ public class DeploymentRejectionTest {
 
   /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
   @Test
-  public void shouldNotCacheProcessesWhenDeploymentRejected() {
+  public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =
         Bpmn.createExecutableProcess("too_large_process")

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
@@ -259,8 +260,7 @@ public class DeploymentRejectionTest {
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 
-  /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
-  @Test
+  @RegressionTest("https://github.com/camunda/zeebe/issues/13254")
   public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =


### PR DESCRIPTION
# Description
Backport of #13256 to `stable/8.1`.

relates to #13254

@korthout: I had to rebase and added 34d18c5