### PR TITLE
[Backport stable/8.1] refactor: stabilize container based tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,14 @@ jobs:
             maven-build-threads: 1
             maven-test-fork-count: 10
             tcc-enabled: 'true'
-            tcc-concurrency: 3
+            tcc-concurrency: 4
           - group: qa-update
             name: "QA Update Tests"
             maven-modules: "qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
             tcc-enabled: 'true'
-            tcc-concurrency: 2
+            tcc-concurrency: 3
     env:
       TC_CLOUD_LOGS_VERBOSE: true
       TC_CLOUD_TOKEN: ${{ matrix.tcc-enabled == 'true' && secrets.TC_CLOUD_TOKEN || '' }}
@@ -78,7 +78,7 @@ jobs:
         run: |
           curl -L -o agent https://app.testcontainers.cloud/download/testcontainers-cloud-agent_linux_x86-64
           chmod +x agent
-          ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' &
+          ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' --terminate > .testcontainers-agent.log 2>&1 &
           ./agent wait
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
@@ -93,6 +93,9 @@ jobs:
           -pl ${{ matrix.maven-modules }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Terminate TCC session
+        if: env.TC_CLOUD_TOKEN != ''
+        run: ./agent terminate
       - name: Duplicate Test Check
         uses: ./.github/actions/check-duplicate-tests
         with:


### PR DESCRIPTION
## Description

Stabilize start up time of container based tests by increasing the concurrency. To keep the minutes down as well, add the new experimental `--terminate` flag, which will force stop all leased VMs as soon as the agent is stopped.

We could let the agent keep running until the job exits, but just to be on the safe side, we'll manually stop it to do a graceful shutdown.

(cherry picked from commit f1539e1780047df02b7281bc1acd966fa7ffcf45)

## Related issues

backports #13278 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
