### PR TITLE
[Backport stable/8.0] Deployment payload size regression tests

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBpmnModelElementBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBpmnModelElementBuilder.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelException;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.instance.Documentation;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
@@ -88,5 +89,12 @@ public abstract class AbstractBpmnModelElementBuilder<
 
   public E getElement() {
     return element;
+  }
+
+  public AbstractBpmnModelElementBuilder<B, E> documentation(final String content) {
+    final Documentation documentation = modelInstance.newInstance(Documentation.class);
+    documentation.setTextContent(content);
+    element.addChildElement(documentation);
+    return this;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -218,7 +218,7 @@ public class DeploymentRejectionTest {
 
     // then
     Assertions.assertThat(deploymentRejection)
-        .hasRejectionType(RejectionType.EXCEEDED_BATCH_RECORD_SIZE)
+        .hasRejectionType(RejectionType.PROCESSING_ERROR)
         .hasRejectionReason("");
   }
 
@@ -273,7 +273,7 @@ public class DeploymentRejectionTest {
     final BpmnModelInstance invalidProcess =
         Bpmn.createExecutableProcess("invalid_process_without_start_event").done();
     final BpmnModelInstance validProcess =
-        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
+        Bpmn.createExecutableProcess("valid_process").startEvent().userTask().endEvent().done();
 
     // when
     ENGINE

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
 import java.util.stream.Collectors;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -267,6 +268,7 @@ public class DeploymentRejectionTest {
         .contains("Must contain at least one executable process");
   }
 
+  @Ignore("8.0 Does not have a fix for https://github.com/camunda/zeebe/issues/5723")
   @Test
   public void shouldDoAtomicDeployments() {
     // given

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -202,6 +202,7 @@ public class DeploymentRejectionTest {
                 """);
   }
 
+  @Ignore("8.0 Does not have a fix for https://github.com/camunda/zeebe/issues/9946")
   @Test
   public void shouldRejectDeploymentIfResourceIsTooLarge() {
     // when

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -248,26 +248,6 @@ public class DeploymentRejectionTest {
         .contains("bpmndi:BPMNPlane");
   }
 
-  // https://github.com/camunda/zeebe/issues/9542
-  @Test
-  public void shouldRejectDeploymentIfNoExecutableProcess() {
-    // given
-    final String resource = "/processes/non-executable-process-single.bpmn";
-
-    // when
-    final Record<DeploymentRecordValue> deploymentRejection =
-        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
-
-    // then
-    Assertions.assertThat(deploymentRejection)
-        .hasRecordType(RecordType.COMMAND_REJECTION)
-        .hasIntent(DeploymentIntent.CREATE)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
-
-    assertThat(deploymentRejection.getRejectionReason())
-        .contains("Must contain at least one executable process");
-  }
-
   @Ignore("8.0 Does not have a fix for https://github.com/camunda/zeebe/issues/5723")
   @Test
   public void shouldDoAtomicDeployments() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -224,31 +224,6 @@ public class DeploymentRejectionTest {
         .hasRejectionReason("");
   }
 
-  // https://github.com/camunda/zeebe/issues/8026
-  @Test
-  public void shouldRejectDeploymentOfSAXException() {
-    // given
-    final String resource = "/processes/saxexception-error-8026.bpmn";
-
-    // when
-    final Record<DeploymentRecordValue> deploymentRejection =
-        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
-
-    // then
-    Assertions.assertThat(deploymentRejection)
-        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
-        .hasRecordType(RecordType.COMMAND_REJECTION)
-        .hasIntent(DeploymentIntent.CREATE)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
-
-    assertThat(deploymentRejection.getRejectionReason())
-        .describedAs("rejection should contain enough detail rejection reason")
-        .contains("saxexception-error-8026.bpmn")
-        .contains("cvc-complex-type.3.2.2")
-        .contains("stroke")
-        .contains("bpmndi:BPMNPlane");
-  }
-
   @Ignore("8.0 Does not have a fix for https://github.com/camunda/zeebe/issues/5723")
   @Test
   public void shouldDoAtomicDeployments() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.ByteValue;
+import java.util.stream.Collectors;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DeploymentRejectionTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectDeploymentIfUsedInvalidMessage() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess().startEvent().intermediateCatchEvent("invalidMessage").done();
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment.getRecordType())
+        .isEqualTo(RecordType.COMMAND_REJECTION);
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfNotValidDesignTimeAspect() {
+    // given
+    final String resource = "/processes/invalid_process.bpmn";
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("ERROR: Must have at least one start event");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfNotValidRuntimeAspect() {
+    // given
+    final String resource = "/processes/invalid_process_condition.bpmn";
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("Element: flow2 > conditionExpression")
+        .contains("ERROR: failed to parse expression");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfOneResourceIsNotValid() {
+    // given
+    final String resource1 = "/processes/invalid_process.bpmn";
+    final String resource2 = "/processes/collaboration.bpmn";
+
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE
+            .deployment()
+            .withXmlClasspathResource(resource1)
+            .withXmlClasspathResource(resource2)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfNoResources() {
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfNotParsable() {
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource("not a process".getBytes(UTF_8))
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldRejectDeploymentWithDuplicateResources() {
+    // given
+    final BpmnModelInstance definition1 =
+        Bpmn.createExecutableProcess("process1").startEvent().done();
+    final BpmnModelInstance definition2 =
+        Bpmn.createExecutableProcess("process2").startEvent().done();
+    final BpmnModelInstance definition3 =
+        Bpmn.createExecutableProcess("process2")
+            .startEvent()
+            .serviceTask("task", (t) -> t.zeebeJobType("j").zeebeTaskHeader("k", "v"))
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        ENGINE
+            .deployment()
+            .withXmlResource("p1.bpmn", definition1)
+            .withXmlResource("p2.bpmn", definition2)
+            .withXmlResource("p3.bpmn", definition3)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to deploy new resources, but encountered the following errors:\n"
+                + "Duplicated process id in resources 'p2.bpmn' and 'p3.bpmn'");
+  }
+
+  @Test
+  public void shouldRejectDeploymentWithInvalidTimerStartEventExpression() {
+    // given
+    final BpmnModelInstance definition =
+        Bpmn.createExecutableProcess("process1")
+            .startEvent("start-event-1")
+            .timerWithCycleExpression("INVALID_CYCLE_EXPRESSION")
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        ENGINE.deployment().withXmlResource("p1.bpmn", definition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+                Expected to deploy new resources, but encountered the following errors:
+                'p1.bpmn': - Element: start-event-1
+                    - ERROR: Invalid timer cycle expression (failed to evaluate expression 'INVALID_CYCLE_EXPRESSION': no variable found for name 'INVALID_CYCLE_EXPRESSION')
+                """);
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfResourceIsTooLarge() {
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("PROCESS")
+                    .startEvent()
+                    .documentation(
+                        "x".repeat((int) (ByteValue.ofMegabytes(4) - ByteValue.ofKilobytes(2))))
+                    .done())
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasRejectionType(RejectionType.EXCEEDED_BATCH_RECORD_SIZE)
+        .hasRejectionReason("");
+  }
+
+  // https://github.com/camunda/zeebe/issues/8026
+  @Test
+  public void shouldRejectDeploymentOfSAXException() {
+    // given
+    final String resource = "/processes/saxexception-error-8026.bpmn";
+
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentRejection.getRejectionReason())
+        .describedAs("rejection should contain enough detail rejection reason")
+        .contains("saxexception-error-8026.bpmn")
+        .contains("cvc-complex-type.3.2.2")
+        .contains("stroke")
+        .contains("bpmndi:BPMNPlane");
+  }
+
+  // https://github.com/camunda/zeebe/issues/9542
+  @Test
+  public void shouldRejectDeploymentIfNoExecutableProcess() {
+    // given
+    final String resource = "/processes/non-executable-process-single.bpmn";
+
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentRejection.getRejectionReason())
+        .contains("Must contain at least one executable process");
+  }
+
+  @Test
+  public void shouldDoAtomicDeployments() {
+    // given
+    final BpmnModelInstance invalidProcess =
+        Bpmn.createExecutableProcess("invalid_process_without_start_event").done();
+    final BpmnModelInstance validProcess =
+        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
+
+    // when
+    ENGINE
+        .deployment()
+        .withXmlResource(invalidProcess)
+        .withXmlResource(validProcess)
+        .expectRejection()
+        .deploy();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getRecordType() == RecordType.COMMAND_REJECTION)
+                .collect(Collectors.toList()))
+        .extracting(Record::getIntent, Record::getRecordType)
+        .doesNotContain(
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.util.ByteValue;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -134,6 +135,7 @@ public final class CreateDeploymentTest {
         .hasMessageContaining("Must have exactly one 'zeebe:taskDefinition' extension element");
   }
 
+  @Ignore("Bug not fixed on 8.0 https://github.com/camunda/zeebe/issues/9946")
   @Test
   public void shouldRejectDeployIfResourceIsTooLarge() {
     // when

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateLargeDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateLargeDeploymentTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.util.ByteValue;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.springframework.util.unit.DataSize;
+
+public final class CreateLargeDeploymentTest {
+
+  private static final int MAX_MSG_SIZE_MB = 1;
+  private static final EmbeddedBrokerRule BROKER_RULE =
+      new EmbeddedBrokerRule(
+          b -> b.getNetwork().setMaxMessageSize(DataSize.ofMegabytes(MAX_MSG_SIZE_MB)));
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  // Regression "https://github.com/camunda/zeebe/issues/12591")
+  @Test
+  public void shouldRejectDeployIfResourceIsTooLarge() {
+    // when
+    final var deployLargeProcess =
+        CLIENT_RULE
+            .getClient()
+            .newDeployResourceCommand()
+            .addProcessModel(
+                Bpmn.createExecutableProcess("PROCESS")
+                    .startEvent()
+                    .documentation("x".repeat((int) ByteValue.ofMegabytes(MAX_MSG_SIZE_MB)))
+                    .done(),
+                "too_large_process.bpmn")
+            .send();
+
+    // then
+    assertThatThrownBy(deployLargeProcess::join)
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("Request size is above configured maxMessageSize.");
+
+    // then - can deploy another process
+    final var deployedValidProcess =
+        CLIENT_RULE
+            .getClient()
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("processes/one-task-process.bpmn")
+            .send()
+            .join();
+    assertThat(deployedValidProcess.getProcesses()).hasSize(1);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateLargeDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateLargeDeploymentTest.java
@@ -54,7 +54,8 @@ public final class CreateLargeDeploymentTest {
     // then
     assertThatThrownBy(deployLargeProcess::join)
         .isInstanceOf(ClientException.class)
-        .hasMessageContaining("Request size is above configured maxMessageSize.");
+        .hasMessageContaining(
+            "Unexpected error occurred between gateway and broker (code: INTERNAL_ERROR)");
 
     // then - can deploy another process
     final var deployedValidProcess =


### PR DESCRIPTION
## Description

<!-- Link to the PR that is back ported -->

Backport of 
- #13239 

There were conflicts, please see the commit messages.

This backport misses the commit bdcb0d9d0a1b59693c3a3d200a1acda14b7adb9d because the file `too_large_process.bpmn` did not exist on this branch.

I also had to ignore / remove some test cases because the related bug was not fixed / feature was not implemented on this branch.

And I had to adjust a test case for this specific branch.

## Related issues

<!-- Link to the related issues of the origin PR -->

relates to https://github.com/camunda/zeebe/issues/13233