### PR TITLE
Log node member ID via the scheduler name as part of actor logging context

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -54,7 +54,7 @@ public final class BackupService extends Actor implements BackupManager {
     this.isSegmentsFile = isSegmentsFile;
     metrics = new BackupManagerMetrics(partitionId);
     internalBackupManager = new BackupServiceImpl(backupStore);
-    actorName = buildActorName(nodeId, "BackupService", partitionId);
+    actorName = buildActorName("BackupService", partitionId);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -206,7 +206,7 @@ public final class Broker implements AutoCloseable {
 
     @Override
     public String getName() {
-      return buildActorName(nodeId, "Startup");
+      return "Startup";
     }
 
     private ActorFuture<BrokerContext> start() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
@@ -44,8 +44,7 @@ final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
     final var schedulingService = brokerStartupContext.getActorSchedulingService();
     final var messagingService = brokerStartupContext.getApiMessagingService();
 
-    final var atomixServerTransport =
-        new AtomixServerTransport(messagingService);
+    final var atomixServerTransport = new AtomixServerTransport(messagingService);
 
     concurrencyControl.runOnCompletion(
         schedulingService.submitActor(atomixServerTransport),

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
@@ -45,7 +45,7 @@ final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
     final var messagingService = brokerStartupContext.getApiMessagingService();
 
     final var atomixServerTransport =
-        new AtomixServerTransport(brokerInfo.getNodeId(), messagingService);
+        new AtomixServerTransport(messagingService);
 
     concurrencyControl.runOnCompletion(
         schedulingService.submitActor(atomixServerTransport),

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -36,8 +36,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
       final ActorFuture<BrokerStartupContext> startupFuture) {
     final var clusterServices = brokerStartupContext.getClusterServices();
     final var errorHandlerService =
-        new RemoteJobStreamErrorHandlerService(
-            new YieldingJobStreamErrorHandler(), brokerStartupContext.getBrokerInfo().getNodeId());
+        new RemoteJobStreamErrorHandlerService(new YieldingJobStreamErrorHandler());
 
     final var scheduler = brokerStartupContext.getActorSchedulingService();
     final RemoteStreamService<JobActivationProperties, ActivatedJob> remoteStreamService =

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerService.java
@@ -27,8 +27,7 @@ public final class RemoteJobStreamErrorHandlerService extends Actor
   private final RemoteJobStreamErrorHandler delegate;
   private final String name;
 
-  public RemoteJobStreamErrorHandlerService(
-      final JobStreamErrorHandler errorHandler) {
+  public RemoteJobStreamErrorHandlerService(final JobStreamErrorHandler errorHandler) {
     delegate = new RemoteJobStreamErrorHandler(errorHandler);
     name = "RemoteJobStreamErrorHandler";
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerService.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.jobstream;
 
-import static io.camunda.zeebe.scheduler.Actor.buildActorName;
-
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
@@ -30,9 +28,9 @@ public final class RemoteJobStreamErrorHandlerService extends Actor
   private final String name;
 
   public RemoteJobStreamErrorHandlerService(
-      final JobStreamErrorHandler errorHandler, final int nodeId) {
+      final JobStreamErrorHandler errorHandler) {
     delegate = new RemoteJobStreamErrorHandler(errorHandler);
-    name = buildActorName(nodeId, "RemoteJobStreamErrorHandler");
+    name = "RemoteJobStreamErrorHandler";
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/LogDeletionService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/LogDeletionService.java
@@ -22,13 +22,12 @@ public final class LogDeletionService extends Actor implements PersistedSnapshot
   private final int partitionId;
 
   public LogDeletionService(
-      final int nodeId,
       final int partitionId,
       final LogCompactor logCompactor,
       final PersistedSnapshotStore persistedSnapshotStore) {
     this.persistedSnapshotStore = persistedSnapshotStore;
     this.logCompactor = logCompactor;
-    actorName = buildActorName(nodeId, "DeletionService", partitionId);
+    actorName = buildActorName("DeletionService", partitionId);
     this.partitionId = partitionId;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -44,7 +44,7 @@ public final class TopologyManagerImpl extends Actor
     this.membershipService = membershipService;
     this.localBroker = localBroker;
 
-    actorName = buildActorName(localBroker.getNodeId(), "TopologyManager");
+    actorName = "TopologyManager";
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -94,7 +94,6 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
 
   private static final String PARTITION_COMPONENT_NAME_FORMAT = "Partition-%d";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
-  private final String actorName;
   private Map<Integer, Boolean> partitionInstallStatus;
   /* set to true when all partitions are installed. Once set to true, it is never
   changed. */
@@ -104,7 +103,6 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   private final MemberId nodeId;
 
   public BrokerHealthCheckService(final BrokerInfo localBroker) {
-    actorName = buildActorName(localBroker.getNodeId(), "HealthCheckService");
     nodeId = MemberId.from(String.valueOf(localBroker.getNodeId()));
     healthMonitor = new CriticalComponentsHealthMonitor("Broker-" + nodeId, actor, LOG);
   }
@@ -181,7 +179,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
 
   @Override
   public String getName() {
-    return actorName;
+    return "HealthCheckService";
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -76,9 +76,7 @@ public final class ZeebePartition extends Actor
 
     transition.setConcurrencyControl(actor);
 
-    actorName =
-        buildActorName(
-            "ZeebePartition", transitionContext.getPartitionId());
+    actorName = buildActorName("ZeebePartition", transitionContext.getPartitionId());
     transitionContext.setComponentHealthMonitor(
         new CriticalComponentsHealthMonitor(
             "Partition-" + transitionContext.getPartitionId(), actor, LOG));

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -78,7 +78,7 @@ public final class ZeebePartition extends Actor
 
     actorName =
         buildActorName(
-            transitionContext.getNodeId(), "ZeebePartition", transitionContext.getPartitionId());
+            "ZeebePartition", transitionContext.getPartitionId());
     transitionContext.setComponentHealthMonitor(
         new CriticalComponentsHealthMonitor(
             "Partition-" + transitionContext.getPartitionId(), actor, LOG));

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -68,7 +68,6 @@ public final class AsyncSnapshotDirector extends Actor
   private long commitPosition;
 
   private AsyncSnapshotDirector(
-      final int nodeId,
       final int partitionId,
       final StreamProcessor streamProcessor,
       final StateController stateController,
@@ -80,7 +79,7 @@ public final class AsyncSnapshotDirector extends Actor
     processorName = streamProcessor.getName();
     this.snapshotRate = snapshotRate;
     this.partitionId = partitionId;
-    actorName = buildActorName(nodeId, "SnapshotDirector", this.partitionId);
+    actorName = buildActorName("SnapshotDirector", this.partitionId);
     this.streamProcessorMode = streamProcessorMode;
     this.flushLog = flushLog;
   }
@@ -148,7 +147,6 @@ public final class AsyncSnapshotDirector extends Actor
       final Duration snapshotRate,
       final Callable<CompletableFuture<Void>> flushLog) {
     return new AsyncSnapshotDirector(
-        nodeId,
         partitionId,
         streamProcessor,
         stateController,
@@ -176,7 +174,6 @@ public final class AsyncSnapshotDirector extends Actor
       final Duration snapshotRate,
       final Callable<CompletableFuture<Void>> flushLog) {
     return new AsyncSnapshotDirector(
-        nodeId,
         partitionId,
         streamProcessor,
         stateController,

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -87,7 +87,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
     final ExporterDirectorContext exporterCtx =
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)
-            .name(Actor.buildActorName(context.getNodeId(), "Exporter", context.getPartitionId()))
+            .name(Actor.buildActorName("Exporter", context.getPartitionId()))
             .logStream(context.getLogStream())
             .zeebeDb(context.getZeebeDb())
             .partitionMessagingService(context.getMessagingService())

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
@@ -99,10 +99,7 @@ public final class InterPartitionCommandServiceStep implements PartitionTransiti
               }
               final var receiver =
                   new InterPartitionCommandReceiverActor(
-                      context.getNodeId(),
-                      context.getPartitionId(),
-                      context.getClusterCommunicationService(),
-                      writer);
+                      context.getPartitionId(), context.getClusterCommunicationService(), writer);
               context.getActorSchedulingService().submitActor(receiver);
               context.setPartitionCommandReceiver(receiver);
               context.getCheckpointProcessor().addCheckpointListener(receiver);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStartupStep.java
@@ -30,7 +30,6 @@ public class LogDeletionPartitionStartupStep implements PartitionStartupStep {
         new AtomixLogCompactor(partitionStartupContext.getRaftPartition().getServer());
     final LogDeletionService deletionService =
         new LogDeletionService(
-            partitionStartupContext.getNodeId(),
             partitionStartupContext.getPartitionId(),
             logCompactor,
             partitionStartupContext.getPersistedSnapshotStore());

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -38,7 +38,6 @@ public final class CommandApiServiceImpl extends Actor
   private final CommandApiRequestHandler commandHandler;
   private final QueryApiRequestHandler queryHandler;
   private final IntHashSet leadPartitions = new IntHashSet();
-  private final String actorName;
   private final ActorSchedulingService scheduler;
 
   public CommandApiServiceImpl(
@@ -51,13 +50,12 @@ public final class CommandApiServiceImpl extends Actor
     this.limiter = limiter;
     this.scheduler = scheduler;
     commandHandler = new CommandApiRequestHandler();
-    queryHandler = new QueryApiRequestHandler(queryApiCfg, localBroker.getNodeId());
-    actorName = buildActorName(localBroker.getNodeId(), "CommandApiService");
+    queryHandler = new QueryApiRequestHandler(queryApiCfg);
   }
 
   @Override
   public String getName() {
-    return actorName;
+    return "CommandApiService";
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
@@ -35,14 +35,13 @@ public final class InterPartitionCommandReceiverActor extends Actor
   private final InterPartitionCommandReceiverImpl receiver;
 
   public InterPartitionCommandReceiverActor(
-      final int nodeId,
       final int partitionId,
       final ClusterCommunicationService communicationService,
       final LogStreamWriter logStreamWriter) {
     this.partitionId = partitionId;
     this.communicationService = communicationService;
     receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
-    actorName = buildActorName(nodeId, getClass().getSimpleName(), partitionId);
+    actorName = buildActorName(getClass().getSimpleName(), partitionId);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
@@ -42,10 +42,10 @@ public final class QueryApiRequestHandler
   private final QueryApiCfg config;
   private final String actorName;
 
-  public QueryApiRequestHandler(final QueryApiCfg config, final int nodeId) {
+  public QueryApiRequestHandler(final QueryApiCfg config) {
     super(QueryRequestReader::new, QueryResponseWriter::new);
     this.config = config;
-    actorName = buildActorName(nodeId, "QueryApi");
+    actorName = "QueryApi";
   }
 
   @Override

--- a/broker/src/main/resources/log4j2.xml
+++ b/broker/src/main/resources/log4j2.xml
@@ -4,7 +4,7 @@
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout
-        pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
+        pattern="%d{HH:mm:ss.SSS} [%X{actor-scheduler}] [%t] [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/logstreams/LogDeletionServiceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/logstreams/LogDeletionServiceTest.java
@@ -37,7 +37,7 @@ class LogDeletionServiceTest {
     snapshotStore = mock(PersistedSnapshotStore.class);
     compactor = mock(LogCompactor.class);
 
-    service = new LogDeletionService(1, 1, compactor, snapshotStore);
+    service = new LogDeletionService(1, compactor, snapshotStore);
     actorScheduler.submitActor(service).join();
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -64,7 +64,6 @@ public final class StateControllerImplTest {
     store =
         new FileBasedSnapshotStore(
             1,
-            1,
             new SnapshotMetrics("partition-1"),
             tempFolderRule.newFolder("snapshots").toPath(),
             tempFolderRule.newFolder("pending").toPath());

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandlerTest.java
@@ -318,7 +318,7 @@ final class QueryApiRequestHandlerTest {
   private QueryApiRequestHandler createQueryApiRequestHandler(final boolean enabled) {
     final var config = new QueryApiCfg();
     config.setEnabled(enabled);
-    final var requestHandler = new QueryApiRequestHandler(config, 0);
+    final var requestHandler = new QueryApiRequestHandler(config);
     scheduler.submitActor(requestHandler);
 
     return requestHandler;

--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -3,7 +3,7 @@
 
   <Properties>
     <Property name="log.path">${sys:app.home}/logs</Property>
-    <Property name="log.pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level
+    <Property name="log.pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-scheduler}] [%t] [%X{actor-name}] %-5level
       %logger{36} - %msg%n
     </Property>
     <Property name="log.stackdriver.serviceName">${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-}

--- a/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerComponent.java
@@ -34,7 +34,7 @@ public final class ActorSchedulerComponent {
     return ActorScheduler.newActorScheduler()
         .setCpuBoundActorThreadCount(config.getThreads().getManagementThreads())
         .setIoBoundActorThreadCount(0)
-        .setSchedulerName("gateway-scheduler")
+        .setSchedulerName("Gateway-%s".formatted(config.getCluster().getMemberId()))
         .setActorClock(clockConfiguration.getClock().orElse(null))
         .build();
   }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -64,7 +64,7 @@ public final class LogStreamImpl extends Actor
 
     this.partitionId = partitionId;
     this.nodeId = nodeId;
-    actorName = buildActorName(nodeId, "LogStream", partitionId);
+    actorName = buildActorName("LogStream", partitionId);
 
     this.maxFragmentSize = maxFragmentSize;
     this.logStorage = logStorage;
@@ -306,7 +306,7 @@ public final class LogStreamImpl extends Actor
   private ActorFuture<Void> createAndScheduleLogStorageAppender(final Sequencer sequencer) {
     appender =
         new LogStorageAppender(
-            buildActorName(nodeId, "LogAppender", partitionId), partitionId, logStorage, sequencer);
+            buildActorName("LogAppender", partitionId), partitionId, logStorage, sequencer);
     return actorSchedulingService.submitActor(appender);
   }
 

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -40,7 +40,7 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
   }
 
   public String getName() {
-    return getClass().getName();
+    return getClass().getSimpleName();
   }
 
   /**
@@ -102,12 +102,8 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
     return actor.close();
   }
 
-  public static String buildActorName(final int nodeId, final String name) {
-    return String.format("Broker-%d-%s", nodeId, name);
-  }
-
-  public static String buildActorName(final int nodeId, final String name, final int partitionId) {
-    return String.format("Broker-%d-%s-%d", nodeId, name, partitionId);
+  public static String buildActorName(final String name, final int partitionId) {
+    return "%s-%d".formatted(name, partitionId);
   }
 
   /** Invoked when a task throws and the actor phase is not 'STARTING' and 'CLOSING'. */

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -105,8 +105,6 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
     boolean resubmit = false;
 
     final var actorName = properties.getOrDefault("actor-name", "");
-    final var scopedActorName = "%s-%s".formatted(actorThreadGroup.getSchedulerName(), actorName);
-
     try (final var ignored = MDC.putCloseable("actor-name", actorName)) {
       resubmit = currentTask.execute(this);
     } catch (final Throwable e) {

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -98,17 +98,21 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   private void executeCurrentTask() {
     final var properties = currentTask.getActor().getContext();
     MDC.setContextMap(properties);
+    MDC.put("actor-scheduler", actorThreadGroup.getSchedulerName());
+
     idleStrategy.onTaskExecuted();
 
     boolean resubmit = false;
 
-    try {
+    final var actorName = properties.getOrDefault("actor-name", "");
+    final var scopedActorName = "%s-%s".formatted(actorThreadGroup.getSchedulerName(), actorName);
+
+    try (final var ignored = MDC.putCloseable("actor-name", actorName)) {
       resubmit = currentTask.execute(this);
     } catch (final Throwable e) {
       FATAL_ERROR_HANDLER.handleError(e);
       LOG.error("Unexpected error occurred in task {}", currentTask, e);
     } finally {
-      MDC.remove("actor-name");
       clock.update();
     }
 

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java
@@ -21,11 +21,16 @@ public abstract class ActorThreadGroup {
   protected final ActorThread[] threads;
   protected final WorkStealingGroup tasks;
   protected final int numOfThreads;
+  private final String schedulerName;
 
   public ActorThreadGroup(
-      final String groupName, final int numOfThreads, final ActorSchedulerBuilder builder) {
+      final String groupName,
+      final int numOfThreads,
+      final ActorSchedulerBuilder builder,
+      final String schedulerName) {
     this.groupName = groupName;
     this.numOfThreads = numOfThreads;
+    this.schedulerName = schedulerName;
 
     tasks = new WorkStealingGroup(numOfThreads);
 
@@ -64,6 +69,10 @@ public abstract class ActorThreadGroup {
     for (final ActorThread actorThread : threads) {
       actorThread.start();
     }
+  }
+
+  public String getSchedulerName() {
+    return schedulerName;
   }
 
   public CompletableFuture<Void> closeAsync() {

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/CpuThreadGroup.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/CpuThreadGroup.java
@@ -13,9 +13,6 @@ import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
 public final class CpuThreadGroup extends ActorThreadGroup {
 
   public CpuThreadGroup(final ActorSchedulerBuilder builder) {
-    super(
-        String.format("%s-%s", builder.getSchedulerName(), "zb-actors"),
-        builder.getCpuBoundActorThreadCount(),
-        builder);
+    super("zb-actors", builder.getCpuBoundActorThreadCount(), builder, builder.getSchedulerName());
   }
 }

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/IoThreadGroup.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/IoThreadGroup.java
@@ -13,8 +13,6 @@ public final class IoThreadGroup extends ActorThreadGroup {
 
   public IoThreadGroup(final ActorSchedulerBuilder builder) {
     super(
-        String.format("%s-%s", builder.getSchedulerName(), "zb-fs-workers"),
-        builder.getIoBoundActorThreadCount(),
-        builder);
+        "zb-fs-workers", builder.getIoBoundActorThreadCount(), builder, builder.getSchedulerName());
   }
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -82,7 +82,6 @@ public final class FileBasedSnapshotStore extends Actor
   private final int partitionId;
 
   public FileBasedSnapshotStore(
-      final int nodeId,
       final int partitionId,
       final SnapshotMetrics snapshotMetrics,
       final Path snapshotsDirectory,
@@ -93,7 +92,7 @@ public final class FileBasedSnapshotStore extends Actor
     receivingSnapshotStartCount = new AtomicLong();
 
     listeners = new CopyOnWriteArraySet<>();
-    actorName = buildActorName(nodeId, "SnapshotStore", partitionId);
+    actorName = buildActorName("SnapshotStore", partitionId);
     this.partitionId = partitionId;
   }
 

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
@@ -64,7 +64,6 @@ public final class FileBasedSnapshotStoreFactory implements ReceivableSnapshotSt
     }
 
     return new FileBasedSnapshotStore(
-        nodeId,
         partitionId,
         new SnapshotMetrics(Integer.toString(partitionId)),
         snapshotDirectory,

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -381,7 +381,6 @@ public class FileBasedReceivedSnapshotTest {
       final int nodeId, final Path snapshotDir, final Path pendingDir) throws IOException {
     final var store =
         new FileBasedSnapshotStore(
-            nodeId,
             PARTITION_ID,
             new SnapshotMetrics(nodeId + "-" + PARTITION_ID),
             snapshotDir,

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -392,7 +392,7 @@ public class FileBasedSnapshotStoreTest {
   private FileBasedSnapshotStore createStore(final Path snapshotDir, final Path pendingDir)
       throws IOException {
     final var store =
-        new FileBasedSnapshotStore(1, 1, new SnapshotMetrics(1 + "-" + 1), snapshotDir, pendingDir);
+        new FileBasedSnapshotStore(1, new SnapshotMetrics(1 + "-" + 1), snapshotDir, pendingDir);
     FileUtil.ensureDirectoryExists(snapshotDir);
     FileUtil.ensureDirectoryExists(pendingSnapshotsDir);
     scheduler.submitActor(store).join();

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -375,7 +375,7 @@ public class FileBasedTransientSnapshotTest {
   private FileBasedSnapshotStore createStore(final Path snapshotDir, final Path pendingDir)
       throws IOException {
     final var store =
-        new FileBasedSnapshotStore(1, 1, new SnapshotMetrics("1-1"), snapshotDir, pendingDir);
+        new FileBasedSnapshotStore(1, new SnapshotMetrics("1-1"), snapshotDir, pendingDir);
 
     FileUtil.ensureDirectoryExists(snapshotDir);
     FileUtil.ensureDirectoryExists(pendingDir);

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -172,8 +172,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               streamProcessorContext::getStreamProcessorPhase, // this is volatile
               () -> false, // we will just stop the actor in this case, no need to provide this
               logStream::newLogStreamWriter);
-      asyncActor =
-          new AsyncProcessingScheduleServiceActor(asyncScheduleService, partitionId);
+      asyncActor = new AsyncProcessingScheduleServiceActor(asyncScheduleService, partitionId);
       final var extendedProcessingScheduleService =
           new ExtendedProcessingScheduleServiceImpl(
               processorActorService, asyncScheduleService, asyncActor.getActorControl());
@@ -574,8 +573,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     private final int partitionId;
 
     public AsyncProcessingScheduleServiceActor(
-        final ProcessingScheduleServiceImpl scheduleService,
-        final int partitionId) {
+        final ProcessingScheduleServiceImpl scheduleService, final int partitionId) {
       this.scheduleService = scheduleService;
       asyncScheduleActorName = buildActorName("AsyncProcessingScheduleActor", partitionId);
       this.partitionId = partitionId;

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -126,7 +126,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     logStream = streamProcessorContext.getLogStream();
     partitionId = logStream.getPartitionId();
     nodeId = processorBuilder.getNodeId();
-    actorName = buildActorName(nodeId, "StreamProcessor", partitionId);
+    actorName = buildActorName("StreamProcessor", partitionId);
     metrics = new StreamProcessorMetrics(partitionId);
     recordProcessors.addAll(processorBuilder.getRecordProcessors());
   }
@@ -173,7 +173,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               () -> false, // we will just stop the actor in this case, no need to provide this
               logStream::newLogStreamWriter);
       asyncActor =
-          new AsyncProcessingScheduleServiceActor(asyncScheduleService, nodeId, partitionId);
+          new AsyncProcessingScheduleServiceActor(asyncScheduleService, partitionId);
       final var extendedProcessingScheduleService =
           new ExtendedProcessingScheduleServiceImpl(
               processorActorService, asyncScheduleService, asyncActor.getActorControl());
@@ -575,10 +575,9 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
     public AsyncProcessingScheduleServiceActor(
         final ProcessingScheduleServiceImpl scheduleService,
-        final int nodeId,
         final int partitionId) {
       this.scheduleService = scheduleService;
-      asyncScheduleActorName = buildActorName(nodeId, "AsyncProcessingScheduleActor", partitionId);
+      asyncScheduleActorName = buildActorName("AsyncProcessingScheduleActor", partitionId);
       this.partitionId = partitionId;
     }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -37,7 +37,7 @@ public final class TransportFactory {
 
   public ServerTransport createServerTransport(
       final int nodeId, final MessagingService messagingService) {
-    final var atomixServerTransport = new AtomixServerTransport(nodeId, messagingService);
+    final var atomixServerTransport = new AtomixServerTransport(messagingService);
     actorSchedulingService.submitActor(atomixServerTransport);
     return atomixServerTransport;
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -33,18 +33,16 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
       partitionsRequestMap;
   private final AtomicLong requestCount;
   private final MessagingService messagingService;
-  private final String actorName;
 
-  public AtomixServerTransport(final int nodeId, final MessagingService messagingService) {
+  public AtomixServerTransport(final MessagingService messagingService) {
     this.messagingService = messagingService;
     partitionsRequestMap = new Int2ObjectHashMap<>();
     requestCount = new AtomicLong(0);
-    actorName = buildActorName(nodeId, "ServerTransport");
   }
 
   @Override
   public String getName() {
-    return actorName;
+    return "ServerTransport";
   }
 
   @Override

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamEndpoint.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamEndpoint.java
@@ -29,10 +29,6 @@ public final class RemoteStreamEndpoint<M extends BufferReader> extends Actor {
     this.requestHandler = requestHandler;
   }
 
-  public void removeAll(final MemberId member) {
-    actor.run(() -> requestHandler.removeAll(member));
-  }
-
   @Override
   protected void onActorStarting() {
     transport.replyTo(
@@ -61,6 +57,10 @@ public final class RemoteStreamEndpoint<M extends BufferReader> extends Actor {
     transport.unsubscribe(StreamTopics.REMOVE.topic());
     transport.unsubscribe(StreamTopics.REMOVE_ALL.topic());
     requestHandler.close();
+  }
+
+  public void removeAll(final MemberId member) {
+    actor.run(() -> requestHandler.removeAll(member));
   }
 
   private byte[] onAdd(final MemberId sender, final AddStreamRequest request) {


### PR DESCRIPTION
## Description

This PR removes the need to pass around the node ID to all actor names, and instead leverages the fact that the scheduler name already contains it. The scheduler's name is now part of the actor's logging context, and displayed in either the logging pattern, or as its own field in the JSON logging context.

Additionally, the node ID is removed everywhere from the actor names, as it's now redundant.

This closes the job push relevant issue, as it now has all the information it needed.

Logs now look like this when using the normal console appender:

```
19:24:49.843 [Broker-0] [zb-actors-1] [ZeebePartition-2] INFO  io.camunda.zeebe.broker.system - Shutdown RocksDB metric timer
19:24:49.844 [Broker-0] [zb-actors-1] [ZeebePartition-2] INFO  io.camunda.zeebe.broker.system - Shutdown LogDeletionService
19:24:49.885 [Broker-0] [zb-fs-workers-0] [SnapshotStore-2] DEBUG io.camunda.zeebe.logstreams.snapshot - Closed database from '/home/nicolas/tmp/data/raft-partition/partitions/2/runtime'.
19:24:49.888 [Broker-0] [zb-fs-workers-1] [SnapshotStore-1] DEBUG io.camunda.zeebe.logstreams.snapshot - Closed database from '/home/nicolas/tmp/data/raft-partition/partitions/1/runtime'.
19:24:49.910 [] [raft-server-0-raft-partition-partition-2] [] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=12, index=820387}
19:24:49.910 [] [raft-server-0-raft-partition-partition-1] [] DEBUG io.camunda.zeebe.journal.file.SegmentsManager - Closing segment: Segment{id=12, index=822412}
19:24:49.921 [Broker-0] [zb-actors-1] [Startup] INFO  io.camunda.zeebe.broker.system - Shutdown Embedded Gateway
```

Otherwise, it's simply a field called `actor-scheduler` under the JSON context.

## Related issues

closes #13281 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
