### PR TITLE
[Backport stable/8.0] Invalidate process cache on deployment rejection

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -101,17 +101,17 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     if (accepted) {
       final long key = keyGenerator.nextKey();
 
-    try {
-      createTimerIfTimerStartEvent(command, streamWriter, sideEffects);
-    } catch (final RuntimeException e) {
-      // Make sure the cache does not contain any leftovers from this run (by hard resetting)
-      processState.clearCache();
+      try {
+        createTimerIfTimerStartEvent(command, streamWriter, sideEffects);
+      } catch (final RuntimeException e) {
+        // Make sure the cache does not contain any leftovers from this run (by hard resetting)
+        processState.clearCache();
 
-      final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
-      responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
-      streamWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
-      return;
-    }
+        final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
+        responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
+        streamWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
+        return;
+      }
 
       responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -101,14 +101,17 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     if (accepted) {
       final long key = keyGenerator.nextKey();
 
-      try {
-        createTimerIfTimerStartEvent(command, streamWriter, sideEffects);
-      } catch (final RuntimeException e) {
-        final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
-        responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
-        streamWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
-        return;
-      }
+    try {
+      createTimerIfTimerStartEvent(command, streamWriter, sideEffects);
+    } catch (final RuntimeException e) {
+      // Make sure the cache does not contain any leftovers from this run (by hard resetting)
+      processState.clearCache();
+
+      final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
+      responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
+      streamWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
+      return;
+    }
 
       responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
 
@@ -119,6 +122,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
           deploymentEvent, stateWriter);
 
     } else {
+      // Make sure the cache does not contain any leftovers from this run (by hard resetting)
+      processState.clearCache();
       responseWriter.writeRejectionOnCommand(
           command,
           deploymentTransformer.getRejectionType(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -313,6 +313,15 @@ public final class DbProcessState implements MutableProcessState {
     return element;
   }
 
+  @Override
+  public void clearCache() {
+    processesByKey.clear();
+    processesByProcessIdAndVersion.clear();
+
+    // On 8.0, the version manager is not a cache, but it is a cache in 8.1+
+    // versionManager.clear();
+  }
+
   private DeployedProcess lookupProcessByIdAndPersistedVersion(final long latestVersion) {
     processVersion.wrapLong(latestVersion);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -30,4 +30,7 @@ public interface ProcessState {
 
   <T extends ExecutableFlowElement> T getFlowElement(
       long processDefinitionKey, DirectBuffer elementId, Class<T> elementType);
+
+  /** TODO: Remove the cache entirely from the immutable state */
+  void clearCache();
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -252,4 +252,37 @@ public class DeploymentRejectionTest {
             tuple(DeploymentIntent.CREATED, RecordType.EVENT),
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
+
+  /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
+  @Test
+  public void shouldNotCacheProcessesWhenDeploymentRejected() {
+    // given
+    final BpmnModelInstance invalidProcess =
+        Bpmn.createExecutableProcess("too_large_process")
+            .startEvent()
+            .documentation("x".repeat((int) ByteValue.ofMegabytes(3)))
+            .done();
+    final BpmnModelInstance validProcess =
+        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
+
+    // when
+    ENGINE
+        .deployment()
+        .withXmlResource(invalidProcess)
+        .withXmlResource(validProcess)
+        .expectRejection()
+        .deploy();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getRecordType() == RecordType.COMMAND_REJECTION)
+                .collect(Collectors.toList()))
+        .extracting(Record::getIntent, Record::getRecordType)
+        .doesNotContain(
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT));
+
+    ENGINE.processInstance().ofBpmnProcessId("valid_process").expectRejection().create();
+  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -255,7 +255,7 @@ public class DeploymentRejectionTest {
 
   /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
   @Test
-  public void shouldNotCacheProcessesWhenDeploymentRejected() {
+  public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =
         Bpmn.createExecutableProcess("too_large_process")

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -260,6 +260,7 @@ public class DeploymentRejectionTest {
     final BpmnModelInstance invalidProcess =
         Bpmn.createExecutableProcess("too_large_process")
             .startEvent()
+            // In order to cause BATCH SIZE EXCEEDING we add a big comment
             .documentation("x".repeat((int) ByteValue.ofMegabytes(3)))
             .done();
     final BpmnModelInstance validProcess =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -263,7 +263,7 @@ public class DeploymentRejectionTest {
             .documentation("x".repeat((int) ByteValue.ofMegabytes(3)))
             .done();
     final BpmnModelInstance validProcess =
-        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
+        Bpmn.createExecutableProcess("valid_process").startEvent().userTask().endEvent().done();
 
     // when
     ENGINE

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
@@ -253,8 +254,7 @@ public class DeploymentRejectionTest {
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 
-  /** Regression test against https://github.com/camunda/zeebe/issues/13254 */
-  @Test
+  @RegressionTest("https://github.com/camunda/zeebe/issues/13254")
   public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
-import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
@@ -254,7 +253,7 @@ public class DeploymentRejectionTest {
             tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
   }
 
-  @RegressionTest("https://github.com/camunda/zeebe/issues/13254")
+  @Test // Regression of https://github.com/camunda/zeebe/issues/13254
   public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
     // given
     final BpmnModelInstance invalidProcess =


### PR DESCRIPTION
## Description

<!-- Link to the PR that is back ported -->

Backport of 
- #13256

There was a conflict in 05d8e36fb474812dd305aaddf6390ed7e74b5815, see commit message for details.

Additionally, I had to make some adjustments:
- cherry-pick the ability to use `.expectRejection()`
- avoid using Undefined Task in a test case (not supported in this version)

## Related issues

<!-- Link to the related issues of the origin PR -->

relates to #13254
