### PR TITLE
Introduce `ResourceDeletion DELETING` intent

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -56,8 +56,9 @@ public class ResourceDeletionProcessor
     tryDeleteResources(command);
 
     final long eventKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETING, value);
+    responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETING, value, command);
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
-    responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETED, value, command);
 
     commandDistributionBehavior.distributeCommand(eventKey, command);
   }
@@ -66,6 +67,7 @@ public class ResourceDeletionProcessor
   public void processDistributedCommand(final TypedRecord<ResourceDeletionRecord> command) {
     final var value = command.getValue();
     tryDeleteResources(command);
+    stateWriter.appendFollowUpEvent(command.getKey(), ResourceDeletionIntent.DELETING, value);
     stateWriter.appendFollowUpEvent(command.getKey(), ResourceDeletionIntent.DELETED, value);
     commandDistributionBehavior.acknowledgeCommand(command.getKey(), command);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -215,7 +215,9 @@ public class ResourceDeletionTest {
         .describedAs("Expect resource to be deleted")
         .extracting(Record::getIntent, r -> r.getValue().getResourceKey())
         .containsOnly(
-            tuple(ResourceDeletionIntent.DELETE, key), tuple(ResourceDeletionIntent.DELETED, key));
+            tuple(ResourceDeletionIntent.DELETE, key),
+            tuple(ResourceDeletionIntent.DELETING, key),
+            tuple(ResourceDeletionIntent.DELETED, key));
   }
 
   private void verifyDecisionRequirementsIsDeleted(final long key) {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceDeletionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceDeletionIntent.java
@@ -17,7 +17,8 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public enum ResourceDeletionIntent implements Intent {
   DELETE(0),
-  DELETED(1);
+  DELETING(1),
+  DELETED(2);
 
   private final short value;
 
@@ -39,6 +40,8 @@ public enum ResourceDeletionIntent implements Intent {
       case 0:
         return DELETE;
       case 1:
+        return DELETING;
+      case 2:
         return DELETED;
       default:
         return Intent.UNKNOWN;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Resource deletion for BPMN will be asynchronous. This is because running instances need the time to be terminated or completed. This means for BPMN we can't write the `DELETED` event immediately in the `ResourceDeletionProcessor`. Instead it will write a `DELETING` event and send use this for the response to the client.

As we'd like to keep DMN and BPMN aligned we must also write the `DELETING` event for DMN resources. To fully align it we also use this `DELETING` for the response to the client.
However, there is one big difference. DMN resource deletion doesn't have to happen asynchronously. We can remove the resource immediately when we receive the command, as we don't have the problem of running DMN instances. This is why after we've written the `DELETING` response we still write a `DELETED` event as follow-up.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13335 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
