### PR TITLE
[Backport stable/8.0] Switch to software.xdev.saveactions IDEA plugin

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalDependencies">
-    <plugin id="com.dubreuia" />
+    <plugin id="software.xdev.saveactions" />
     <plugin id="google-java-format" />
   </component>
 </project>


### PR DESCRIPTION
## Description

<!-- Link to the PR that is back ported -->

Backport of 
- #13326

Tiny conflict because the google-java-format plugin was using a different version.
