### PR TITLE
ci: adjust e2e test load

### DIFF
--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -90,8 +90,8 @@ jobs:
         \"testParams\":
         {
         \"maxTestDuration\": \"${{ inputs.maxTestDuration || 'P5D' }}\",
-        \"starter\": [ {\"rate\": 30, \"processId\": \"one-task-one-timer\" },
-                       {\"rate\": 20, \"processId\": \"ping-pong-message\" } ],
+        \"starter\": [ {\"rate\": 20, \"processId\": \"one-task-one-timer\" },
+                       {\"rate\": 10, \"processId\": \"ping-pong-message\" } ],
         \"verifier\" : { \"maxInstanceDuration\" : \"${{ inputs.maxInstanceDuration }}\" },
         \"fault\": ${{ inputs.fault || 'null' }}
         }


### PR DESCRIPTION
## Description

Likely we overloaded our cluster with to processed instances, tasks etc. The goal of the e2e is test is more correctness which is why we decreasing the load.