### PR TITLE
Insert process instance keys into `PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY` ColumnFamily

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -48,4 +48,14 @@ public interface ElementInstanceState {
    * @return the number of taken sequence flows of the given gateway
    */
   int getNumberOfTakenSequenceFlows(final long flowScopeKey, final DirectBuffer gatewayElementId);
+
+  /**
+   * Returns a list of process instance keys that belong to a specific process definition.
+   *
+   * <p>Caution: This will also return the keys of banned process instances!
+   *
+   * @param processDefinitionKey the key of the process definition
+   * @return a list of process instance keys
+   */
+  List<Long> getProcessInstanceKeysByDefinitionKey(final long processDefinitionKey);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -191,6 +192,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     elementInstanceColumnFamily.insert(elementInstanceKey, instance);
     parentChildColumnFamily.insert(parentChildKey, DbNil.INSTANCE);
     variableState.createScope(elementInstanceKey.getValue(), parentKey.inner().getValue());
+
+    final var recordValue = instance.getValue();
+    if (recordValue.getBpmnElementType() == BpmnElementType.PROCESS) {
+      processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
+      processInstanceKeyByProcessDefinitionKeyColumnFamily.insert(
+          processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
+    }
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -171,6 +171,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     awaitProcessInstanceResultMetadataColumnFamily.deleteIfExists(elementInstanceKey);
     removeNumberOfTakenSequenceFlows(key);
 
+    final var recordValue = instance.getValue();
+    if (recordValue.getBpmnElementType() == BpmnElementType.PROCESS) {
+      processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
+      processInstanceKeyByProcessDefinitionKeyColumnFamily.deleteExisting(
+          processInstanceKeyByProcessDefinitionKey);
+    }
+
     if (parent > 0) {
       elementInstanceKey.wrapLong(parent);
       final var parentInstance = elementInstanceColumnFamily.get(elementInstanceKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -327,6 +327,20 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     return count.get();
   }
 
+  @Override
+  public List<Long> getProcessInstanceKeysByDefinitionKey(final long processDefinitionKey) {
+    final List<Long> processInstanceKeys = new ArrayList<>();
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+
+    processInstanceKeyByProcessDefinitionKeyColumnFamily.whileEqualPrefix(
+        this.processDefinitionKey,
+        (key, value) -> {
+          final DbLong processInstanceKey = key.second();
+          processInstanceKeys.add(processInstanceKey.getValue());
+        });
+    return processInstanceKeys;
+  }
+
   private ElementInstance copyElementInstance(final ElementInstance elementInstance) {
     if (elementInstance != null) {
       final byte[] bytes = new byte[elementInstance.getLength()];

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -377,12 +377,34 @@ public final class ElementInstanceStateTest {
   }
 
   @Test
+  public void shouldRemoveProcessInstanceByProcessDefinitionKeyOnRemoval() {
+    // given
+    final var processDefinitionKey = 100L;
+    final var processInstanceRecord =
+        createProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setProcessDefinitionKey(processDefinitionKey);
+    final var processInstanceKey = 101L;
+    elementInstanceState.newInstance(
+        processInstanceKey, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    elementInstanceState.removeInstance(processInstanceKey);
+    final List<Long> processInstanceKeys =
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
+
+    // then
+    Assertions.assertThat(processInstanceKeys).isEmpty();
+  }
+
+  @Test
   public void shouldNotLeakMemoryOnRemoval() {
     // given
     final int parent = 100;
     final int child = 101;
 
-    final ProcessInstanceRecord processInstanceRecord = createProcessInstanceRecord();
+    final ProcessInstanceRecord processInstanceRecord =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
     final ElementInstance parentInstance =
         elementInstanceState.newInstance(
             parent, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -282,6 +282,101 @@ public final class ElementInstanceStateTest {
   }
 
   @Test
+  public void shouldInsertProcessInstanceKeyByProcessDefinitionKey() {
+    // given
+    final var processInstanceRecord =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+    final var processInstanceKey = 100L;
+    elementInstanceState.newInstance(
+        processInstanceKey, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    final List<Long> processInstanceKeys =
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(
+            processInstanceRecord.getProcessDefinitionKey());
+
+    // then
+    Assertions.assertThat(processInstanceKeys).hasSize(1);
+    assertThat(processInstanceKeys).containsOnly(processInstanceKey);
+  }
+
+  @Test
+  public void shouldInsertMultipleProcessInstanceKeyByProcessDefinitionKey() {
+    // given
+    final var processDefinitionKey = 100L;
+    final var processInstanceRecord1 =
+        createProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setProcessDefinitionKey(processDefinitionKey);
+    final var processInstanceRecord2 =
+        createProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setProcessDefinitionKey(processDefinitionKey);
+    final var processInstanceKey1 = 101L;
+    final var processInstanceKey2 = 102L;
+    elementInstanceState.newInstance(
+        processInstanceKey1, processInstanceRecord1, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    elementInstanceState.newInstance(
+        processInstanceKey2, processInstanceRecord2, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    final List<Long> processInstanceKeys =
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
+
+    // then
+    Assertions.assertThat(processInstanceKeys).hasSize(2);
+    assertThat(processInstanceKeys).containsOnly(processInstanceKey1, processInstanceKey2);
+  }
+
+  @Test
+  public void shouldOnlyReturnProcessInstanceKeyBelongingToProcessDefinition() {
+    // given
+    final var processDefinitionKey = 100L;
+    final var processInstanceRecord1 =
+        createProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setProcessDefinitionKey(processDefinitionKey);
+    final var processInstanceRecord2 =
+        createProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setProcessDefinitionKey(101L);
+    final var processInstanceKey1 = 102L;
+    final var processInstanceKey2 = 103L;
+    elementInstanceState.newInstance(
+        processInstanceKey1, processInstanceRecord1, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    elementInstanceState.newInstance(
+        processInstanceKey2, processInstanceRecord2, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    final List<Long> processInstanceKeys =
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
+
+    // then
+    Assertions.assertThat(processInstanceKeys).hasSize(1);
+    assertThat(processInstanceKeys).containsOnly(processInstanceKey1);
+  }
+
+  @Test
+  public void shouldOnlyReturnEmptyListWhenNoProcessInstanceForProcessDefinitionKeyExist() {
+    // given
+    final var processDefinitionKey = 100L;
+    final var processInstanceRecord =
+        createProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setProcessDefinitionKey(101L);
+    final var processInstanceKey = 102L;
+    elementInstanceState.newInstance(
+        processInstanceKey, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    final List<Long> processInstanceKeys =
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
+
+    // then
+    Assertions.assertThat(processInstanceKeys).isEmpty();
+  }
+
+  @Test
   public void shouldNotLeakMemoryOnRemoval() {
     // given
     final int parent = 100;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR makes it so we can insert data into the ColumnFamily. The ColumnFamily keeps track of the process instances that are running for a specific process definition key. This will allow us to later determine which process instances we need to terminate when deleting a process definition.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13341 
closes #13342 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
