### PR TITLE
Group by container and service

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -4694,9 +4694,9 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum by (pod, container, service) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", container!~\"\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
               "interval": "",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{pod}}:{{container}} {{service}}",
               "range": true,
               "refId": "A"
             }
@@ -16230,6 +16230,6 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 10,
+  "version": 11,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description

Our CPU metric panel always reported wrong results, it showed results like 4 CPU are used for a Zeebe container, where actually the limits are at ~1. This PR resolves this issue. See relates [slack thread](https://camunda.slack.com/archives/C037RS2JHB8/p1688641310918929)

It looks like in our current set up we scrape the metrics twice which results in wrong results. Furthermore, metrics can be reported twice for empty container and actual container.
![service](https://github.com/camunda/zeebe/assets/2758593/ace5160c-d5df-46cb-9d67-a281177514f7)

We exclude the empty container name, and group now by service, container, and pod to see correct results.

Elasticsearch seems to contain two containers in our SaaS environment which is the reason why we want to see the container here as well.

![container](https://github.com/camunda/zeebe/assets/2758593/399b665e-30b7-49df-9029-86fcb9514696)


We need to investigate where the second metric comes from, and who scrapes it. I was not able to pinpoint this yet, but in order to resolve the CPU issue for now I made the changes and the output a bit more verbose.

<!-- Please explain the changes you made here. -->

