### PR TITLE
Publish message via send task

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -101,7 +101,8 @@ public final class EngineProcessors {
             timerChecker,
             jobStreamer,
             jobMetrics,
-            decisionBehavior);
+            decisionBehavior,
+            interPartitionCommandSender);
 
     final var commandDistributionBehavior =
         new CommandDistributionBehavior(
@@ -173,7 +174,8 @@ public final class EngineProcessors {
       final DueDateTimerChecker timerChecker,
       final JobStreamer jobStreamer,
       final JobMetrics jobMetrics,
-      final DecisionBehavior decisionBehavior) {
+      final DecisionBehavior decisionBehavior,
+      final InterPartitionCommandSender interPartitionCommandSender) {
     return new BpmnBehaviorsImpl(
         processingState,
         writers,
@@ -182,7 +184,8 @@ public final class EngineProcessors {
         subscriptionCommandSender,
         partitionsCount,
         timerChecker,
-        jobStreamer);
+        jobStreamer,
+        interPartitionCommandSender);
   }
 
   private static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.processing.bpmn.task.JobWorkerTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ManualTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ReceiveTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ScriptTaskProcessor;
+import io.camunda.zeebe.engine.processing.bpmn.task.SendTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.UndefinedTaskProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -53,8 +54,7 @@ public final class BpmnElementProcessors {
         BpmnElementType.SCRIPT_TASK,
         new ScriptTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
     processors.put(
-        BpmnElementType.SEND_TASK,
-        new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
+        BpmnElementType.SEND_TASK, new SendTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
     processors.put(
         BpmnElementType.USER_TASK,
         new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -51,4 +51,6 @@ public interface BpmnBehaviors {
   ElementActivationBehavior elementActivationBehavior();
 
   BpmnJobActivationBehavior jobActivationBehavior();
+
+  BpmnMessageBehavior messageBehavior();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.processing.variable.VariableStateEvaluationContextLookup;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 
 public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
@@ -54,7 +55,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final SubscriptionCommandSender subscriptionCommandSender,
       final int partitionsCount,
       final DueDateTimerChecker timerChecker,
-      final JobStreamer jobStreamer) {
+      final JobStreamer jobStreamer,
+      final InterPartitionCommandSender interPartitionCommandSender) {
     expressionBehavior =
         new ExpressionProcessor(
             ExpressionLanguageFactory.createExpressionLanguage(),
@@ -163,7 +165,9 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getKeyGenerator(),
             processingState.getVariableState(),
             writers,
-            expressionBehavior);
+            expressionBehavior,
+            partitionsCount,
+            interPartitionCommandSender);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -44,6 +44,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final ElementActivationBehavior elementActivationBehavior;
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final BpmnSignalBehavior signalBehavior;
+  private final BpmnMessageBehavior messageBehavior;
 
   public BpmnBehaviorsImpl(
       final MutableProcessingState processingState,
@@ -156,6 +157,13 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getVariableState(),
             writers,
             expressionBehavior);
+
+    messageBehavior =
+        new BpmnMessageBehavior(
+            processingState.getKeyGenerator(),
+            processingState.getVariableState(),
+            writers,
+            expressionBehavior);
   }
 
   @Override
@@ -246,5 +254,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public BpmnJobActivationBehavior jobActivationBehavior() {
     return jobActivationBehavior;
+  }
+
+  @Override
+  public BpmnMessageBehavior messageBehavior() {
+    return messageBehavior;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnMessageBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnMessageBehavior.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExectuablePublishMessage;
+import io.camunda.zeebe.engine.processing.deployment.model.element.PublishMessageProperties;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+import java.time.Duration;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
+
+public class BpmnMessageBehavior {
+
+  private static final Duration DEFAULT_MSG_TTL = Duration.ofHours(1);
+
+  private final MessageRecord messageRecord =
+      new MessageRecord().setVariables(DocumentValue.EMPTY_DOCUMENT);
+  private final KeyGenerator keyGenerator;
+  private final VariableState variableState;
+  private final TypedCommandWriter commandWriter;
+  private final ExpressionProcessor expressionBehavior;
+
+  public BpmnMessageBehavior(
+      final KeyGenerator keyGenerator,
+      final VariableState variableState,
+      final Writers writers,
+      final ExpressionProcessor expressionBehavior) {
+    this.keyGenerator = keyGenerator;
+    this.expressionBehavior = expressionBehavior;
+    this.variableState = variableState;
+    commandWriter = writers.command();
+  }
+
+  public Either<Failure, ?> publishMessage(
+      final ExectuablePublishMessage publishMessage, final BpmnElementContext context) {
+
+    final var variables =
+        variableState.getVariablesLocalAsDocument(context.getElementInstanceKey());
+
+    final var publishMessageProps = publishMessage.getPublishMessageProperties();
+    return evaluateMessageExpressions(publishMessageProps, context.getElementInstanceKey())
+        .map(
+            properties -> {
+              writeMessagePublishCommand(properties, variables);
+              return null;
+            });
+  }
+
+  private Either<Failure, MessageProperties> evaluateMessageExpressions(
+      final PublishMessageProperties publishMessageProps, final long scopeKey) {
+    return Either.<Failure, MessageProperties>right(new MessageProperties())
+        .flatMap(p -> evalMessageNameExp(publishMessageProps, scopeKey).map(p::messageName))
+        .flatMap(p -> evalMessageIdExp(publishMessageProps, scopeKey).map(p::messageId))
+        .flatMap(p -> evalCorrelationKeyExp(publishMessageProps, scopeKey).map(p::correlationKey))
+        .flatMap(p -> evalTimeToLiveExp(publishMessageProps, scopeKey).map(p::timeToLive));
+  }
+
+  private Either<Failure, String> evalMessageNameExp(
+      final PublishMessageProperties publishMessageProps, final long scopeKey) {
+    return expressionBehavior.evaluateStringExpression(
+        publishMessageProps.getMessageName(), scopeKey);
+  }
+
+  private Either<Failure, String> evalMessageIdExp(
+      final PublishMessageProperties publishMessageProps, final long scopeKey) {
+    final Expression messageId = publishMessageProps.getMessageId();
+    if (messageId == null) {
+      return Either.right(null);
+    }
+    return expressionBehavior.evaluateStringExpression(
+        publishMessageProps.getMessageId(), scopeKey);
+  }
+
+  private Either<Failure, String> evalCorrelationKeyExp(
+      final PublishMessageProperties publishMessageProps, final long scopeKey) {
+    return expressionBehavior.evaluateMessageCorrelationKeyExpression(
+        publishMessageProps.getCorrelationKey(), scopeKey);
+  }
+
+  private Either<Failure, Long> evalTimeToLiveExp(
+      final PublishMessageProperties publishMessageProps, final long scopeKey) {
+    final Expression timeToLive = publishMessageProps.getTimeToLive();
+    if (timeToLive == null) {
+      return Either.right(null);
+    }
+
+    return expressionBehavior
+        .evaluateIntervalExpression(timeToLive, scopeKey)
+        .map(
+            interval -> {
+              final var currentTimeMillis = ActorClock.currentTimeMillis();
+              return interval.toEpochMilli(currentTimeMillis) - currentTimeMillis;
+            });
+  }
+
+  private void writeMessagePublishCommand(
+      final MessageProperties properties, final DirectBuffer variables) {
+
+    messageRecord.reset();
+    messageRecord.setName(properties.getMessageName());
+    messageRecord.setCorrelationKey(properties.getCorrelationKey());
+    messageRecord.setVariables(variables);
+    Optional.ofNullable(properties.getMessageId()).ifPresent(messageRecord::setMessageId);
+
+    final var timeToLive =
+        Optional.ofNullable(properties.getTimeToLive()).orElse(DEFAULT_MSG_TTL.toMillis());
+    messageRecord.setTimeToLive(timeToLive);
+
+    final var key = keyGenerator.nextKey();
+    commandWriter.appendFollowUpCommand(key, MessageIntent.PUBLISH, messageRecord);
+  }
+
+  private static final class MessageProperties {
+
+    private String messageName;
+    private String messageId;
+    private String correlationKey;
+    private Long timeToLive;
+
+    public MessageProperties messageName(final String messageName) {
+      this.messageName = messageName;
+      return this;
+    }
+
+    public String getMessageName() {
+      return messageName;
+    }
+
+    public MessageProperties messageId(final String messageId) {
+      this.messageId = messageId;
+      return this;
+    }
+
+    public String getMessageId() {
+      return messageId;
+    }
+
+    public MessageProperties correlationKey(final String correlationKey) {
+      this.correlationKey = correlationKey;
+      return this;
+    }
+
+    public String getCorrelationKey() {
+      return correlationKey;
+    }
+
+    public MessageProperties timeToLive(final Long timeToLive) {
+      this.timeToLive = timeToLive;
+      return this;
+    }
+
+    public Long getTimeToLive() {
+      return timeToLive;
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/SendTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/SendTaskProcessor.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.task;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnMessageBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSendTask;
+
+public final class SendTaskProcessor implements BpmnElementProcessor<ExecutableSendTask> {
+
+  private final SendTaskBehavior publishMessageBehavior;
+  private final SendTaskBehavior jobWorkerTaskBehavior;
+
+  public SendTaskProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    publishMessageBehavior = new PublishMessageBehavior(bpmnBehaviors, stateTransitionBehavior);
+    jobWorkerTaskBehavior = new JobWorkerTaskBehavior(bpmnBehaviors, stateTransitionBehavior);
+  }
+
+  @Override
+  public Class<ExecutableSendTask> getType() {
+    return ExecutableSendTask.class;
+  }
+
+  @Override
+  public void onActivate(final ExecutableSendTask element, final BpmnElementContext context) {
+    eventBehaviorOf(element, context).onActivate(element, context);
+  }
+
+  @Override
+  public void onComplete(final ExecutableSendTask element, final BpmnElementContext context) {
+    eventBehaviorOf(element, context).onComplete(element, context);
+  }
+
+  @Override
+  public void onTerminate(final ExecutableSendTask element, final BpmnElementContext context) {
+    eventBehaviorOf(element, context).onTerminate(element, context);
+  }
+
+  private SendTaskBehavior eventBehaviorOf(
+      final ExecutableSendTask element, final BpmnElementContext context) {
+    if (element.getPublishMessageProperties() != null) {
+      return publishMessageBehavior;
+    } else if (element.getJobWorkerProperties() != null) {
+      return jobWorkerTaskBehavior;
+    } else {
+      throw new BpmnProcessingException(
+          context, "Expected to process send task, but could not determine processing behavior");
+    }
+  }
+
+  private static final class PublishMessageBehavior implements SendTaskBehavior {
+
+    private final BpmnMessageBehavior messageBehavior;
+    private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
+    private final BpmnIncidentBehavior incidentBehavior;
+    private final BpmnStateTransitionBehavior stateTransitionBehavior;
+    private final BpmnVariableMappingBehavior variableMappingBehavior;
+    private final BpmnStateBehavior stateBehavior;
+
+    public PublishMessageBehavior(
+        final BpmnBehaviors bpmnBehaviors,
+        final BpmnStateTransitionBehavior stateTransitionBehavior) {
+      messageBehavior = bpmnBehaviors.messageBehavior();
+      eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
+      incidentBehavior = bpmnBehaviors.incidentBehavior();
+      this.stateTransitionBehavior = stateTransitionBehavior;
+      variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
+      stateBehavior = bpmnBehaviors.stateBehavior();
+    }
+
+    @Override
+    public void onActivate(final ExecutableSendTask element, final BpmnElementContext context) {
+      variableMappingBehavior
+          .applyInputMappings(context, element)
+          .flatMap(ok -> messageBehavior.publishMessage(element, context))
+          .ifRightOrLeft(
+              ok -> {
+                final var activated = stateTransitionBehavior.transitionToActivated(context);
+                stateTransitionBehavior.completeElement(activated);
+              },
+              failure -> incidentBehavior.createIncident(failure, context));
+    }
+
+    @Override
+    public void onComplete(final ExecutableSendTask element, final BpmnElementContext context) {
+      variableMappingBehavior
+          .applyOutputMappings(context, element)
+          .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, context))
+          .ifRightOrLeft(
+              completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
+              failure -> incidentBehavior.createIncident(failure, context));
+    }
+
+    @Override
+    public void onTerminate(final ExecutableSendTask element, final BpmnElementContext context) {
+      final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
+
+      incidentBehavior.resolveIncidents(context);
+
+      eventSubscriptionBehavior
+          .findEventTrigger(context)
+          .filter(eventTrigger -> flowScopeInstance.isActive())
+          .filter(eventTrigger -> !flowScopeInstance.isInterrupted())
+          .ifPresentOrElse(
+              eventTrigger -> {
+                final var terminated = stateTransitionBehavior.transitionToTerminated(context);
+                eventSubscriptionBehavior.activateTriggeredEvent(
+                    context.getElementInstanceKey(),
+                    terminated.getFlowScopeKey(),
+                    eventTrigger,
+                    terminated);
+              },
+              () -> {
+                final var terminated = stateTransitionBehavior.transitionToTerminated(context);
+                stateTransitionBehavior.onElementTerminated(element, terminated);
+              });
+    }
+  }
+
+  private static final class JobWorkerTaskBehavior implements SendTaskBehavior {
+
+    private final JobWorkerTaskProcessor delegate;
+
+    public JobWorkerTaskBehavior(
+        final BpmnBehaviors bpmnBehaviors,
+        final BpmnStateTransitionBehavior stateTransitionBehavior) {
+      delegate = new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior);
+    }
+
+    @Override
+    public void onActivate(final ExecutableSendTask element, final BpmnElementContext activating) {
+      delegate.onActivate(element, activating);
+    }
+
+    @Override
+    public void onComplete(final ExecutableSendTask element, final BpmnElementContext completing) {
+      delegate.onComplete(element, completing);
+    }
+
+    @Override
+    public void onTerminate(
+        final ExecutableSendTask element, final BpmnElementContext terminating) {
+      delegate.onTerminate(element, terminating);
+    }
+  }
+
+  /** Extract different behaviors depending on the type of task. */
+  private interface SendTaskBehavior {
+
+    void onActivate(ExecutableSendTask element, BpmnElementContext activating);
+
+    void onComplete(ExecutableSendTask element, BpmnElementContext completing);
+
+    void onTerminate(ExecutableSendTask element, BpmnElementContext terminating);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExectuablePublishMessage.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExectuablePublishMessage.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+/** A representation of an element that publishes a message. For example, a message throw event. */
+public interface ExectuablePublishMessage extends ExecutableFlowElement {
+
+  PublishMessageProperties getPublishMessageProperties();
+
+  void setPublishMessageProperties(PublishMessageProperties publishMessageProperties);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableSendTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableSendTask.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+public class ExecutableSendTask extends ExecutableJobWorkerTask
+    implements ExectuablePublishMessage {
+
+  private PublishMessageProperties publishMessageProperties;
+
+  public ExecutableSendTask(final String id) {
+    super(id);
+  }
+
+  @Override
+  public PublishMessageProperties getPublishMessageProperties() {
+    return publishMessageProperties;
+  }
+
+  @Override
+  public void setPublishMessageProperties(final PublishMessageProperties publishMessageProperties) {
+    this.publishMessageProperties = publishMessageProperties;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/PublishMessageProperties.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/PublishMessageProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import io.camunda.zeebe.el.Expression;
+
+/**
+ * The properties of an element that publishes a message. For example, a throw message event,
+ * message end event or send task.
+ */
+public class PublishMessageProperties {
+  private Expression messageName;
+  private Expression messageId;
+  private Expression correlationKey;
+  private Expression timeToLive;
+
+  public Expression getMessageName() {
+    return messageName;
+  }
+
+  public void setMessageName(final Expression messageName) {
+    this.messageName = messageName;
+  }
+
+  public Expression getMessageId() {
+    return messageId;
+  }
+
+  public void setMessageId(final Expression messageId) {
+    this.messageId = messageId;
+  }
+
+  public Expression getCorrelationKey() {
+    return correlationKey;
+  }
+
+  public void setCorrelationKey(final Expression correlationKey) {
+    this.correlationKey = correlationKey;
+  }
+
+  public Expression getTimeToLive() {
+    return timeToLive;
+  }
+
+  public void setTimeToLive(final Expression timeToLive) {
+    this.timeToLive = timeToLive;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformer.MultiInst
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ProcessTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ReceiveTaskTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ScriptTaskTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.SendTaskTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.SequenceFlowTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.SignalTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.StartEventTransformer;
@@ -91,6 +92,7 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new SequenceFlowTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());
     step2Visitor.registerHandler(new UserTaskTransformer(expressionLanguage));
+    step2Visitor.registerHandler(new SendTaskTransformer());
 
     step3Visitor = new TransformationVisitor();
     step3Visitor.registerHandler(new ContextProcessTransformer());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJob
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableReceiveTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableScriptTask;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSendTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
@@ -84,7 +85,7 @@ public final class FlowElementInstantiationTransformer
     ELEMENT_FACTORIES.put(ParallelGateway.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(ReceiveTask.class, ExecutableReceiveTask::new);
     ELEMENT_FACTORIES.put(ScriptTask.class, ExecutableScriptTask::new);
-    ELEMENT_FACTORIES.put(SendTask.class, ExecutableJobWorkerTask::new);
+    ELEMENT_FACTORIES.put(SendTask.class, ExecutableSendTask::new);
     ELEMENT_FACTORIES.put(SequenceFlow.class, ExecutableSequenceFlow::new);
     ELEMENT_FACTORIES.put(ServiceTask.class, ExecutableJobWorkerTask::new);
     ELEMENT_FACTORIES.put(StartEvent.class, ExecutableStartEvent::new);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/SendTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/SendTaskTransformer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSendTask;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.PublishMessageTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskDefinitionTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskHeadersTransformer;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+
+public class SendTaskTransformer implements ModelElementTransformer<SendTask> {
+
+  private final TaskDefinitionTransformer taskDefinitionTransformer =
+      new TaskDefinitionTransformer();
+  private final TaskHeadersTransformer taskHeadersTransformer = new TaskHeadersTransformer();
+  private final PublishMessageTransformer publishMessageTransformer =
+      new PublishMessageTransformer();
+
+  @Override
+  public Class<SendTask> getType() {
+    return SendTask.class;
+  }
+
+  @Override
+  public void transform(final SendTask element, final TransformContext context) {
+    final ExecutableProcess process = context.getCurrentProcess();
+    final var executableTask = process.getElementById(element.getId(), ExecutableSendTask.class);
+
+    final var taskDefinition = element.getSingleExtensionElement(ZeebeTaskDefinition.class);
+    taskDefinitionTransformer.transform(executableTask, context, taskDefinition);
+
+    final var taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+    taskHeadersTransformer.transform(executableTask, taskHeaders, element);
+
+    final var publishMessage = element.getSingleExtensionElement(ZeebePublishMessage.class);
+    publishMessageTransformer.transform(
+        executableTask, context, element.getMessage(), publishMessage);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/PublishMessageTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/PublishMessageTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExectuablePublishMessage;
+import io.camunda.zeebe.engine.processing.deployment.model.element.PublishMessageProperties;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.model.bpmn.instance.Message;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
+import java.util.Optional;
+
+public final class PublishMessageTransformer {
+
+  public void transform(
+      final ExectuablePublishMessage executableElement,
+      final TransformContext context,
+      final Message message,
+      final ZeebePublishMessage publishMessage) {
+
+    if (publishMessage == null) {
+      return;
+    }
+
+    final var publishMessageProperties =
+        Optional.ofNullable(executableElement.getPublishMessageProperties())
+            .orElse(new PublishMessageProperties());
+    executableElement.setPublishMessageProperties(publishMessageProperties);
+
+    final var expressionLanguage = context.getExpressionLanguage();
+
+    final var messageNameExpression = expressionLanguage.parseExpression(message.getName());
+    publishMessageProperties.setMessageName(messageNameExpression);
+
+    final var correlationKeyExpression =
+        expressionLanguage.parseExpression(publishMessage.getCorrelationKey());
+    publishMessageProperties.setCorrelationKey(correlationKeyExpression);
+
+    final var messageId = publishMessage.getMessageId();
+    if (messageId != null) {
+      final var messageIdExpression = expressionLanguage.parseExpression(messageId);
+      publishMessageProperties.setMessageId(messageIdExpression);
+    }
+
+    final var timeToLive = publishMessage.getTimeToLive();
+    if (timeToLive != null) {
+      final var timeToLiveExpression = expressionLanguage.parseExpression(timeToLive);
+      publishMessageProperties.setTimeToLive(timeToLiveExpression);
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/SendTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/SendTaskTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.SendTaskBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class SendTaskTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String MESSAGE_NAME = "message";
+  private static final String MESSAGE_ID = "messageId";
+  private static final String CORRELATION_KEY = "correlationKey";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance processWithSendTask(final Consumer<SendTaskBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID).startEvent().sendTask(TASK_ID, modifier).done();
+  }
+
+  @Test
+  public void shouldActivateTask() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                t -> t.message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_KEY))))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SEND_TASK)
+                .limit(3))
+        .extracting(Record::getRecordType, Record::getIntent)
+        .containsSequence(
+            tuple(RecordType.COMMAND, ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(RecordType.EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(RecordType.EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+
+    final Record<ProcessInstanceRecordValue> taskActivating =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.SEND_TASK)
+            .getFirst();
+
+    assertThat(taskActivating.getValue())
+        .hasElementId(TASK_ID)
+        .hasBpmnElementType(BpmnElementType.SEND_TASK)
+        .hasFlowScopeKey(processInstanceKey)
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasProcessInstanceKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCompleteTask() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                t -> t.message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_KEY))))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.SEND_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.SEND_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldPublishMessage() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                t ->
+                    t.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeCorrelationKey(CORRELATION_KEY)
+                                .zeebeMessageId(MESSAGE_ID)
+                                .zeebeTimeToLive("PT10S"))))
+        .deploy();
+
+    // when
+    ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(MESSAGE_NAME)
+                .withCorrelationKey(CORRELATION_KEY)
+                .withMessageId(MESSAGE_ID)
+                .withTimeToLive(10_000L)
+                .limit(1))
+        .hasSize(1);
+  }
+
+  @Test
+  public void shouldPublishMessageWithMessageNameExpression() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                t ->
+                    t.message(
+                        m ->
+                            m.nameExpression("= name")
+                                .zeebeCorrelationKey(CORRELATION_KEY)
+                                .zeebeMessageId(MESSAGE_ID)
+                                .zeebeTimeToLive("PT10S"))))
+        .deploy();
+
+    // when
+    ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("name", "foo").create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName("foo")
+                .withCorrelationKey(CORRELATION_KEY)
+                .withMessageId(MESSAGE_ID)
+                .withTimeToLive(10_000L)
+                .limit(1))
+        .hasSize(1);
+  }
+
+  @Test
+  public void shouldPublishMessageWithMessageCorrelationKeyExpression() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                t ->
+                    t.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeCorrelationKey("= correlationKey")
+                                .zeebeMessageId(MESSAGE_ID)
+                                .zeebeTimeToLive("PT10S"))))
+        .deploy();
+
+    // when
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withVariable("correlationKey", "foo")
+        .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(MESSAGE_NAME)
+                .withCorrelationKey("foo")
+                .withMessageId(MESSAGE_ID)
+                .withTimeToLive(10_000L)
+                .limit(1))
+        .hasSize(1);
+  }
+
+  @Test
+  public void shouldPublishMessageWithMessageIdExpression() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                t ->
+                    t.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeCorrelationKey(CORRELATION_KEY)
+                                .zeebeMessageId("= messageId")
+                                .zeebeTimeToLive("PT10S"))))
+        .deploy();
+
+    // when
+    ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("messageId", "foo").create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(MESSAGE_NAME)
+                .withCorrelationKey(CORRELATION_KEY)
+                .withMessageId("foo")
+                .withTimeToLive(10_000L)
+                .limit(1))
+        .hasSize(1);
+  }
+
+  @Test
+  public void shouldPublishMessageWithMessageTimeToLiveExpression() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                t ->
+                    t.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeCorrelationKey(CORRELATION_KEY)
+                                .zeebeMessageId(MESSAGE_ID)
+                                .zeebeTimeToLive("= timeToLive"))))
+        .deploy();
+
+    // when
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withVariable("timeToLive", "PT10S")
+        .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(MESSAGE_NAME)
+                .withCorrelationKey(CORRELATION_KEY)
+                .withMessageId(MESSAGE_ID)
+                .withTimeToLive(10_000L)
+                .limit(1))
+        .hasSize(1);
+  }
+
+  @Test
+  public void shouldTriggerMessageCatchEvent() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                t ->
+                    t.message(
+                            m ->
+                                m.name(MESSAGE_NAME).zeebeCorrelationKeyExpression(CORRELATION_KEY))
+                        .intermediateCatchEvent(
+                            "catch",
+                            b ->
+                                b.message(
+                                    m ->
+                                        m.name(MESSAGE_NAME)
+                                            .zeebeCorrelationKeyExpression(CORRELATION_KEY)))
+                        .endEvent()))
+        .deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("correlationKey", "foo")
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.SEND_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                BpmnElementType.INTERMEDIATE_CATCH_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/SendTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/SendTaskIncidentTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.SendTaskBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValueAssert;
+import io.camunda.zeebe.test.util.collection.Maps;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SendTaskIncidentTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ELEMENT_ID = "task";
+  private static final String MESSAGE_NAME = "message";
+  private static final String MESSAGE_ID = "messageId";
+  private static final String CORRELATION_KEY = "correlationKey";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private BpmnModelInstance processWithSendTask(final Consumer<SendTaskBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .sendTask(TASK_ELEMENT_ID, modifier)
+        .endEvent()
+        .done();
+  }
+
+  private IncidentRecordValueAssert assertIncidentCreated(
+      final long processInstanceKey, final long elementInstanceKey) {
+    final var incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    return Assertions.assertThat(incidentRecord.getValue())
+        .hasElementId(TASK_ELEMENT_ID)
+        .hasElementInstanceKey(elementInstanceKey)
+        .hasJobKey(-1L)
+        .hasVariableScopeKey(elementInstanceKey);
+  }
+
+  @Test
+  public void shouldCreateIncidentIfMessageNameExpressionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                s ->
+                    s.message(
+                        m -> m.nameExpression("MISSING_VAR").zeebeCorrelationKey(CORRELATION_KEY))))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var sendTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.SEND_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, sendTaskActivating.getKey())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "failed to evaluate expression 'MISSING_VAR': no variable found for name 'MISSING_VAR'");
+  }
+
+  @Test
+  public void shouldResolveIncidentAfterMessageNameExpressionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                s ->
+                    s.message(
+                        m -> m.nameExpression("MISSING_VAR").zeebeCorrelationKey(CORRELATION_KEY))))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+
+    // ... update state to resolve issue
+    ENGINE
+        .variables()
+        .ofScope(incidentCreated.getValue().getElementInstanceKey())
+        .withDocument(Maps.of(entry("MISSING_VAR", MESSAGE_NAME)))
+        .update();
+
+    // ... resolve incident
+    final var incidentResolved =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentCreated.getKey())
+            .resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(MESSAGE_NAME)
+                .withCorrelationKey(CORRELATION_KEY)
+                .limit(1))
+        .hasSize(1);
+
+    assertThat(incidentResolved.getKey()).isEqualTo(incidentCreated.getKey());
+  }
+
+  @Test
+  public void shouldCreateIncidentIfMessageIdExpressionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                s ->
+                    s.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeMessageIdExpression("MISSING_VAR")
+                                .zeebeCorrelationKey(CORRELATION_KEY))))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var sendTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.SEND_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, sendTaskActivating.getKey())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "failed to evaluate expression 'MISSING_VAR': no variable found for name 'MISSING_VAR'");
+  }
+
+  @Test
+  public void shouldResolveIncidentAfterMessageIdExpressionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                s ->
+                    s.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeMessageIdExpression("MISSING_VAR")
+                                .zeebeCorrelationKey(CORRELATION_KEY))))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+
+    // ... update state to resolve issue
+    ENGINE
+        .variables()
+        .ofScope(incidentCreated.getValue().getElementInstanceKey())
+        .withDocument(Maps.of(entry("MISSING_VAR", MESSAGE_ID)))
+        .update();
+
+    // ... resolve incident
+    final var incidentResolved =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentCreated.getKey())
+            .resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(MESSAGE_NAME)
+                .withCorrelationKey(CORRELATION_KEY)
+                .withMessageId(MESSAGE_ID)
+                .limit(1))
+        .hasSize(1);
+
+    assertThat(incidentResolved.getKey()).isEqualTo(incidentCreated.getKey());
+  }
+
+  @Test
+  public void shouldCreateIncidentIfMessageCorrelationKeyExpressionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                s ->
+                    s.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeMessageId(MESSAGE_ID)
+                                .zeebeCorrelationKeyExpression("MISSING_VAR"))))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var sendTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.SEND_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, sendTaskActivating.getKey())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "failed to evaluate expression 'MISSING_VAR': no variable found for name 'MISSING_VAR'");
+  }
+
+  @Test
+  public void shouldResolveIncidentAfterMessageCorrelationKeyExpressionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                s ->
+                    s.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeMessageId(MESSAGE_ID)
+                                .zeebeCorrelationKeyExpression("MISSING_VAR"))))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+
+    // ... update state to resolve issue
+    ENGINE
+        .variables()
+        .ofScope(incidentCreated.getValue().getElementInstanceKey())
+        .withDocument(Maps.of(entry("MISSING_VAR", CORRELATION_KEY)))
+        .update();
+
+    // ... resolve incident
+    final var incidentResolved =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentCreated.getKey())
+            .resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(MESSAGE_NAME)
+                .withCorrelationKey(CORRELATION_KEY)
+                .withMessageId(MESSAGE_ID)
+                .limit(1))
+        .hasSize(1);
+
+    assertThat(incidentResolved.getKey()).isEqualTo(incidentCreated.getKey());
+  }
+
+  @Test
+  public void shouldCreateIncidentIfMessageTimeToLiveExpressionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                s ->
+                    s.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeMessageId(MESSAGE_ID)
+                                .zeebeCorrelationKey(CORRELATION_KEY)
+                                .zeebeTimeToLiveExpression("MISSING_VAR"))))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var sendTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.SEND_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, sendTaskActivating.getKey())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "failed to evaluate expression 'MISSING_VAR': no variable found for name 'MISSING_VAR'");
+  }
+
+  @Test
+  public void shouldResolveIncidentAfterMessageTimeToLiveExpressionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithSendTask(
+                s ->
+                    s.message(
+                        m ->
+                            m.name(MESSAGE_NAME)
+                                .zeebeMessageId(MESSAGE_ID)
+                                .zeebeCorrelationKey(CORRELATION_KEY)
+                                .zeebeTimeToLiveExpression("MISSING_VAR"))))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+
+    // ... update state to resolve issue
+    ENGINE
+        .variables()
+        .ofScope(incidentCreated.getValue().getElementInstanceKey())
+        .withDocument(Maps.of(entry("MISSING_VAR", "PT10S")))
+        .update();
+
+    // ... resolve incident
+    final var incidentResolved =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentCreated.getKey())
+            .resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                .withName(MESSAGE_NAME)
+                .withCorrelationKey(CORRELATION_KEY)
+                .withMessageId(MESSAGE_ID)
+                .withTimeToLive(10_000L)
+                .limit(1))
+        .hasSize(1);
+
+    assertThat(incidentResolved.getKey()).isEqualTo(incidentCreated.getKey());
+  }
+}


### PR DESCRIPTION
## Description
As a user, I can publish a message via `Send Task`.

## Related issues
closes #13398

## Definition of Done


Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
