### PR TITLE
feat: expire messages in TTL checker in batches

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistribut
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
@@ -44,6 +45,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.JOB, JobRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE, ProcessInstanceRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MESSAGE, MessageRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.MESSAGE_BATCH, MessageBatchRecord::new);
     RECORDS_BY_TYPE.put(ValueType.JOB_BATCH, JobBatchRecord::new);
     RECORDS_BY_TYPE.put(ValueType.INCIDENT, IncidentRecord::new);
     RECORDS_BY_TYPE.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord::new);

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -725,6 +725,7 @@
         #     job: true
         #     jobBatch: false
         #     message: true
+        #     messageBatch: false
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true
@@ -795,6 +796,7 @@
         #     job: true
         #     jobBatch: false
         #     message: true
+        #     messageBatch: false
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -635,6 +635,7 @@
         #     job: true
         #     jobBatch: false
         #     message: true
+        #     messageBatch: false
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true
@@ -705,6 +706,7 @@
         #     job: true
         #     jobBatch: false
         #     message: true
+        #     messageBatch: false
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -45,7 +45,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.PROCESS_INSTANCE_BATCH);
+      EnumSet.range(ValueType.JOB, ValueType.MESSAGE_BATCH);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public final class MessageBatchExpireProcessor implements TypedRecordProcessor<MessageBatchRecord> {
+
+  private final StateWriter stateWriter;
+
+  private final MessageRecord emptyDeleteMessageCommand =
+      new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
+
+  public MessageBatchExpireProcessor(final StateWriter stateWriter) {
+    this.stateWriter = stateWriter;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<MessageBatchRecord> record) {
+    record
+        .getValue()
+        .getMessageKeys()
+        .forEach(
+            messageKey ->
+                stateWriter.appendFollowUpEvent(
+                    messageKey, MessageIntent.EXPIRED, emptyDeleteMessageCommand));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -42,10 +42,9 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
       } catch (final ExceededBatchRecordSizeException exceededBatchRecordSizeException) {
         LOG.warn(
             "Expected to expire messages in a batch, but exceeded the resulting batch size after expiring {} out of {} messages. "
-                + "Try using a lower Message TTL Checker's batch limit. (maxCommandsInBatch: {})",
+                + "Try using a lower Message TTL Checker's batch limit.",
             expiredMessagesCount,
-            totalMessagesCount,
-            exceededBatchRecordSizeException);
+            totalMessagesCount);
         break;
       }
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -63,6 +64,10 @@ public final class MessageEventProcessors {
                 processState,
                 bpmnBehaviors.eventTriggerBehavior(),
                 bpmnBehaviors.stateBehavior()))
+        .onCommand(
+            ValueType.MESSAGE_BATCH,
+            MessageBatchIntent.EXPIRE,
+            new MessageBatchExpireProcessor(writers.state()))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/ExpireMessageTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/ExpireMessageTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.PublishMessageClient;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ExpireMessageTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private PublishMessageClient messageClient;
+
+  @Before
+  public void init() {
+    messageClient =
+        ENGINE_RULE
+            .message()
+            .withCorrelationKey("order-123")
+            .withName("order canceled")
+            .withTimeToLive(1_000L);
+  }
+
+  @Test
+  public void shouldExpireMessageAfterTTL() {
+    // given
+    final long timeToLive = 100;
+
+    // when
+    final Record<MessageRecordValue> publishedRecord =
+        messageClient.withTimeToLive(timeToLive).publish();
+
+    final Record<MessageRecordValue> secondPublishedRecord =
+        messageClient.withTimeToLive(timeToLive).withName("order shipped").publish();
+
+    final var publishedMessageKeys =
+        List.of(publishedRecord.getKey(), secondPublishedRecord.getKey());
+
+    ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
+
+    // then
+    final Record<MessageBatchRecordValue> expireBatchMessageCommand =
+        RecordingExporter.messageBatchRecords().withIntent(MessageBatchIntent.EXPIRE).getFirst();
+
+    Assertions.assertThat(expireBatchMessageCommand.getValue())
+        .hasMessageKeys(publishedMessageKeys);
+
+    final List<Long> listOfExpiredMessageKeys =
+        RecordingExporter.messageRecords()
+            .withIntent(MessageIntent.EXPIRED)
+            .flatMapToLong(v -> LongStream.of(v.getKey()))
+            .boxed()
+            .collect(Collectors.toList());
+
+    assertThat(listOfExpiredMessageKeys).isEqualTo(publishedMessageKeys);
+  }
+
+  @Test
+  public void shouldExpireMessageImmediatelyWithZeroTTL() {
+    // given
+    final long timeToLive = 0L;
+
+    // when
+    final Record<MessageRecordValue> publishedRecord =
+        messageClient.withTimeToLive(timeToLive).publish();
+
+    // then
+    final Record<MessageRecordValue> deletedEvent =
+        RecordingExporter.messageRecords()
+            .withIntent(MessageIntent.EXPIRED)
+            .withRecordKey(publishedRecord.getKey())
+            .getFirst();
+
+    Assertions.assertThat(deletedEvent.getValue())
+        .hasName("order canceled")
+        .hasCorrelationKey("order-123")
+        .hasTimeToLive(0L)
+        .hasMessageId("");
+  }
+
+  // regression test for https://github.com/camunda/zeebe/issues/5420
+  @Test
+  public void shouldHaveNoSourceRecordPositionOnExpire() {
+    // given
+    final long timeToLive = 50L;
+
+    // when
+    final Record<MessageRecordValue> publishedRecord =
+        messageClient.withTimeToLive(timeToLive).publish();
+    ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
+
+    // then
+    final Record<MessageBatchRecordValue> deleteCommand =
+        RecordingExporter.messageBatchRecords()
+            .withIntent(MessageBatchIntent.EXPIRE)
+            .hasMessageKey(publishedRecord.getKey())
+            .getFirst();
+
+    // then
+    assertThat(deleteCommand.getSourceRecordPosition()).isLessThan(0);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
@@ -45,9 +45,12 @@ public final class MessageBatchExpireProcessorTest {
 
     doNothing().when(stateWriter).appendFollowUpEvent(eq(1L), any(), any());
     doNothing().when(stateWriter).appendFollowUpEvent(eq(2L), any(), any());
-    doThrow(new ExceededBatchRecordSizeException(mock(RecordBatchEntry.class), 10, 1, 1))
+
+    final var exceededBatchRecordSizeException =
+        new ExceededBatchRecordSizeException(mock(RecordBatchEntry.class), 10, 1, 1);
+    doThrow(exceededBatchRecordSizeException)
         .when(stateWriter)
-        .appendFollowUpEvent(eq(3l), any(), any());
+        .appendFollowUpEvent(eq(3L), any(), any());
 
     // when
     messageBatchExpireProcessor.processRecord(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
+import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
+import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
+import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public final class MessageBatchExpireProcessorTest {
+
+  private final StateWriter stateWriter = Mockito.mock(StateWriter.class);
+  final MessageBatchExpireProcessor messageBatchExpireProcessor =
+      new MessageBatchExpireProcessor(stateWriter);
+
+  @Test
+  public void shouldStopProcessingWhenExceedingBatchLimit() {
+
+    // given
+    final var messageBatchRecord =
+        new MessageBatchRecord()
+            .addMessageKey(1)
+            .addMessageKey(2)
+            .addMessageKey(3)
+            .addMessageKey(4);
+
+    doNothing().when(stateWriter).appendFollowUpEvent(eq(1L), any(), any());
+    doNothing().when(stateWriter).appendFollowUpEvent(eq(2L), any(), any());
+    doThrow(new ExceededBatchRecordSizeException(mock(RecordBatchEntry.class), 10, 1, 1))
+        .when(stateWriter)
+        .appendFollowUpEvent(eq(3l), any(), any());
+
+    // when
+    messageBatchExpireProcessor.processRecord(
+        new UnwrittenRecord(-1, 1, messageBatchRecord, new RecordMetadata()));
+
+    // then
+    verify(stateWriter, times(3)).appendFollowUpEvent(anyLong(), any(), any());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.message;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.client.PublishMessageClient;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -18,15 +17,9 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
-import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
-import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -175,84 +168,5 @@ public final class PublishMessageTest {
     // then
     assertThat(rejectedCommand.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
     assertThat(rejectedCommand.getRejectionType()).isEqualTo(RejectionType.ALREADY_EXISTS);
-  }
-
-  @Test
-  public void shouldExpireMessageAfterTTL() {
-    // given
-    final long timeToLive = 100;
-
-    // when
-    final Record<MessageRecordValue> publishedRecord =
-        messageClient.withTimeToLive(timeToLive).publish();
-
-    final Record<MessageRecordValue> secondPublishedRecord =
-        messageClient.withTimeToLive(timeToLive).withName("order shipped").publish();
-
-    final var publishedMessageKeys =
-        List.of(publishedRecord.getKey(), secondPublishedRecord.getKey());
-
-    ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
-
-    // then
-    final Record<MessageBatchRecordValue> expireBatchMessageCommand =
-        RecordingExporter.messageBatchRecords().withIntent(MessageBatchIntent.EXPIRE).getFirst();
-
-    Assertions.assertThat(expireBatchMessageCommand.getValue())
-        .hasMessageKeys(publishedMessageKeys);
-
-    final List<Long> listOfExpiredMessageKeys =
-        RecordingExporter.messageRecords()
-            .withIntent(MessageIntent.EXPIRED)
-            .flatMapToLong(v -> LongStream.of(v.getKey()))
-            .boxed()
-            .collect(Collectors.toList());
-
-    assertThat(listOfExpiredMessageKeys).isEqualTo(publishedMessageKeys);
-  }
-
-  @Test
-  public void shouldExpireMessageImmediatelyWithZeroTTL() {
-    // given
-    final long timeToLive = 0L;
-
-    // when
-    final Record<MessageRecordValue> publishedRecord =
-        messageClient.withTimeToLive(timeToLive).publish();
-
-    // then
-    final Record<MessageRecordValue> deletedEvent =
-        RecordingExporter.messageRecords()
-            .withIntent(MessageIntent.EXPIRED)
-            .withRecordKey(publishedRecord.getKey())
-            .getFirst();
-
-    Assertions.assertThat(deletedEvent.getValue())
-        .hasName("order canceled")
-        .hasCorrelationKey("order-123")
-        .hasTimeToLive(0L)
-        .hasMessageId("");
-  }
-
-  // regression test for https://github.com/camunda/zeebe/issues/5420
-  @Test
-  public void shouldHaveNoSourceRecordPositionOnExpire() {
-    // given
-    final long timeToLive = 50L;
-
-    // when
-    final Record<MessageRecordValue> publishedRecord =
-        messageClient.withTimeToLive(timeToLive).publish();
-    ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
-
-    // then
-    final Record<MessageBatchRecordValue> deleteCommand =
-        RecordingExporter.messageBatchRecords()
-            .withIntent(MessageBatchIntent.EXPIRE)
-            .hasMessageKey(publishedRecord.getKey())
-            .getFirst();
-
-    // then
-    assertThat(deleteCommand.getSourceRecordPosition()).isLessThan(0);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/PublishMessageTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.assertj.core.api.Assertions.fail;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -210,8 +209,6 @@ public final class PublishMessageTest {
             .collect(Collectors.toList());
 
     assertThat(listOfExpiredMessageKeys).isEqualTo(publishedMessageKeys);
-
-    fail("ddd");
   }
 
   @Test
@@ -249,10 +246,10 @@ public final class PublishMessageTest {
     ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
 
     // then
-    final Record<MessageRecordValue> deleteCommand =
-        RecordingExporter.messageRecords()
-            .withIntent(MessageIntent.EXPIRE)
-            .withRecordKey(publishedRecord.getKey())
+    final Record<MessageBatchRecordValue> deleteCommand =
+        RecordingExporter.messageBatchRecords()
+            .withIntent(MessageBatchIntent.EXPIRE)
+            .hasMessageKey(publishedRecord.getKey())
             .getFirst();
 
     // then

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -111,6 +112,11 @@ public final class BanInstanceTest {
       {ValueType.MESSAGE, MessageIntent.PUBLISHED, false},
       {ValueType.MESSAGE, MessageIntent.EXPIRE, false},
       {ValueType.MESSAGE, MessageIntent.EXPIRED, false},
+
+      ////////////////////////////////////////
+      ////////////// MESSAGE BATCH ///////////////
+      ////////////////////////////////////////
+      {ValueType.MESSAGE_BATCH, MessageBatchIntent.EXPIRE, false},
 
       ////////////////////////////////////////
       ////////// MSG START EVENT SUB /////////

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -219,6 +219,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.message) {
         createValueIndexTemplate(ValueType.MESSAGE);
       }
+      if (index.messageBatch) {
+        createValueIndexTemplate(ValueType.MESSAGE_BATCH);
+      }
       if (index.messageSubscription) {
         createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION);
       }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -74,6 +74,8 @@ public class ElasticsearchExporterConfiguration {
         return index.jobBatch;
       case MESSAGE:
         return index.message;
+      case MESSAGE_BATCH:
+        return index.messageBatch;
       case MESSAGE_SUBSCRIPTION:
         return index.messageSubscription;
       case VARIABLE:
@@ -156,6 +158,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean job = true;
     public boolean jobBatch = false;
     public boolean message = true;
+    public boolean messageBatch = false;
     public boolean messageSubscription = true;
     public boolean process = true;
     public boolean processInstance = true;
@@ -229,6 +232,8 @@ public class ElasticsearchExporterConfiguration {
           + jobBatch
           + ", message="
           + message
+          + ", messageBatch="
+          + messageBatch
           + ", messageSubscription="
           + messageSubscription
           + ", process="

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-batch-template.json
@@ -1,0 +1,30 @@
+{
+  "index_patterns": [
+    "zeebe-record_message-batch_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-message-batch": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "messageKeys": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -55,6 +55,7 @@ final class TestSupport {
       case PROCESS_INSTANCE_BATCH -> config.processInstanceBatch = value;
       case INCIDENT -> config.incident = value;
       case MESSAGE -> config.message = value;
+      case MESSAGE_BATCH -> config.messageBatch = value;
       case MESSAGE_SUBSCRIPTION -> config.messageSubscription = value;
       case PROCESS_MESSAGE_SUBSCRIPTION -> config.processMessageSubscription = value;
       case JOB_BATCH -> config.jobBatch = value;

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -213,6 +213,9 @@ public class OpensearchExporter implements Exporter {
       if (index.message) {
         createValueIndexTemplate(ValueType.MESSAGE);
       }
+      if (index.messageBatch) {
+        createValueIndexTemplate(ValueType.MESSAGE_BATCH);
+      }
       if (index.messageSubscription) {
         createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION);
       }

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -70,6 +70,8 @@ public class OpensearchExporterConfiguration {
         return index.jobBatch;
       case MESSAGE:
         return index.message;
+      case MESSAGE_BATCH:
+        return index.messageBatch;
       case MESSAGE_SUBSCRIPTION:
         return index.messageSubscription;
       case VARIABLE:
@@ -152,6 +154,7 @@ public class OpensearchExporterConfiguration {
     public boolean job = true;
     public boolean jobBatch = false;
     public boolean message = true;
+    public boolean messageBatch = false;
     public boolean messageSubscription = true;
     public boolean process = true;
     public boolean processInstance = true;
@@ -219,6 +222,8 @@ public class OpensearchExporterConfiguration {
           + job
           + ", message="
           + message
+          + ", messageBatch="
+          + messageBatch
           + ", messageSubscription="
           + messageSubscription
           + ", variable="

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-batch-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-batch-template.json
@@ -1,0 +1,30 @@
+{
+  "index_patterns": [
+    "zeebe-record_job-batch_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-job-batch": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "messageKeys": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -54,6 +54,7 @@ final class TestSupport {
       case PROCESS_INSTANCE_BATCH -> config.processInstanceBatch = value;
       case INCIDENT -> config.incident = value;
       case MESSAGE -> config.message = value;
+      case MESSAGE_BATCH -> config.messageBatch = value;
       case MESSAGE_SUBSCRIPTION -> config.messageSubscription = value;
       case PROCESS_MESSAGE_SUBSCRIPTION -> config.processMessageSubscription = value;
       case JOB_BATCH -> config.jobBatch = value;

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.message;
+
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public final class MessageBatchRecord extends UnifiedRecordValue
+    implements MessageBatchRecordValue {
+
+  private final ArrayProperty<LongValue> messageKeysProp =
+      new ArrayProperty<>("messageKeys", new LongValue());
+
+  public MessageBatchRecord() {
+    declareProperty(messageKeysProp);
+  }
+
+  public ValueArray<LongValue> messageKeys() {
+    return messageKeysProp;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return messageKeysProp.isEmpty();
+  }
+
+  public MessageBatchRecord addMessageKey(final long key) {
+    messageKeys().add().setValue(key);
+    return this;
+  }
+
+  @Override
+  public List<Long> getMessageKeys() {
+    return StreamSupport.stream(messageKeysProp.spliterator(), false)
+        .map(LongValue::getValue)
+        .collect(Collectors.toList());
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -63,6 +64,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -546,6 +548,34 @@ final class JsonSerializableToJsonTest {
                   .setName(messageName);
             },
         "{'timeToLive':12,'correlationKey':'test-key','variables':{},'messageId':'','name':'test-message','deadline':-1}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// MessageBatchRecord
+      // /////////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "MessageBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final List<Long> messageKeys = List.of(123L, 456L);
+
+              return new MessageBatchRecord()
+                  .addMessageKey(messageKeys.get(0))
+                  .addMessageKey(messageKeys.get(1));
+            },
+        "{'messageKeys':[123,456]}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty MessageBatchRecord
+      // ///////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty MessageBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              return new MessageBatchRecord();
+            },
+        "{'messageKeys':[]}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -54,6 +55,7 @@ import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -147,6 +149,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.JOB_BATCH, new Mapping<>(JobBatchRecordValue.class, JobBatchIntent.class));
     mapping.put(ValueType.MESSAGE, new Mapping<>(MessageRecordValue.class, MessageIntent.class));
+    mapping.put(
+        ValueType.MESSAGE_BATCH,
+        new Mapping<>(MessageBatchRecordValue.class, MessageBatchIntent.class));
     mapping.put(
         ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
         new Mapping<>(

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -29,6 +29,7 @@ public interface Intent {
           JobIntent.class,
           ProcessInstanceIntent.class,
           MessageIntent.class,
+          MessageBatchIntent.class,
           MessageSubscriptionIntent.class,
           ProcessMessageSubscriptionIntent.class,
           JobBatchIntent.class,
@@ -59,15 +60,6 @@ public interface Intent {
 
   String name();
 
-  enum UnknownIntent implements Intent {
-    UNKNOWN;
-
-    @Override
-    public short value() {
-      return NULL_VAL;
-    }
-  }
-
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   static Intent fromProtocolValue(final ValueType valueType, final short intent) {
     switch (valueType) {
@@ -81,6 +73,8 @@ public interface Intent {
         return ProcessInstanceIntent.from(intent);
       case MESSAGE:
         return MessageIntent.from(intent);
+      case MESSAGE_BATCH:
+        return MessageBatchIntent.from(intent);
       case MESSAGE_SUBSCRIPTION:
         return MessageSubscriptionIntent.from(intent);
       case MESSAGE_START_EVENT_SUBSCRIPTION:
@@ -152,6 +146,8 @@ public interface Intent {
         return ProcessInstanceIntent.valueOf(intent);
       case MESSAGE:
         return MessageIntent.valueOf(intent);
+      case MESSAGE_BATCH:
+        return MessageBatchIntent.valueOf(intent);
       case MESSAGE_SUBSCRIPTION:
         return MessageSubscriptionIntent.valueOf(intent);
       case MESSAGE_START_EVENT_SUBSCRIPTION:
@@ -210,5 +206,14 @@ public interface Intent {
         .mapToInt(clazz -> clazz.getEnumConstants().length)
         .max()
         .getAsInt();
+  }
+
+  enum UnknownIntent implements Intent {
+    UNKNOWN;
+
+    @Override
+    public short value() {
+      return NULL_VAL;
+    }
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageBatchIntent.java
@@ -16,8 +16,7 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum MessageBatchIntent implements Intent {
-  EXPIRE((short) 0),
-  EXPIRED((short) 1);
+  EXPIRE((short) 0);
   private final short value;
 
   MessageBatchIntent(final short value) {
@@ -33,8 +32,6 @@ public enum MessageBatchIntent implements Intent {
     switch (value) {
       case 0:
         return EXPIRE;
-      case 1:
-        return EXPIRED;
       default:
         return Intent.UNKNOWN;
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageBatchIntent.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum MessageBatchIntent implements Intent {
+  EXPIRE((short) 0),
+  EXPIRED((short) 1);
+  private final short value;
+
+  MessageBatchIntent(final short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return EXPIRE;
+      case 1:
+        return EXPIRED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageBatchRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageBatchRecordValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+import org.immutables.value.Value;
+
+/**
+ * Represents a message event or command.
+ *
+ * <p>See {@link io.camunda.zeebe.protocol.record.intent.MessageBatchIntent} for intents.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableMessageBatchRecordValue.Builder.class)
+public interface MessageBatchRecordValue extends RecordValue {
+
+  /**
+   * @return list of the keys from the messages assigned to this batch
+   */
+  List<Long> getMessageKeys();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -49,6 +49,7 @@
       <validValue name="RESOURCE_DELETION">32</validValue>
       <validValue name="COMMAND_DISTRIBUTION">33</validValue>
       <validValue name="PROCESS_INSTANCE_BATCH">34</validValue>
+      <validValue name="MESSAGE_BATCH">35</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
@@ -22,6 +22,11 @@ public interface TaskResultBuilder {
    */
   boolean appendCommandRecord(final long key, final Intent intent, final UnifiedRecordValue value);
 
+  /**
+   * Appends a record to the result without a key
+   *
+   * @return returns true if the record still fits into the result, false otherwise
+   */
   default boolean appendCommandRecord(final Intent intent, final UnifiedRecordValue value) {
     return appendCommandRecord(NULL_KEY, intent, value);
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
@@ -13,12 +13,18 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 /** Here the interface is just a suggestion. Can be whatever PDT team thinks is best to work with */
 public interface TaskResultBuilder {
 
+  long NULL_KEY = -1;
+
   /**
    * Appends a record to the result
    *
    * @return returns true if the record still fits into the result, false otherwise
    */
   boolean appendCommandRecord(final long key, final Intent intent, final UnifiedRecordValue value);
+
+  default boolean appendCommandRecord(final Intent intent, final UnifiedRecordValue value) {
+    return appendCommandRecord(NULL_KEY, intent, value);
+  }
 
   TaskResult build();
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -56,6 +57,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.PROCESS_INSTANCE, ProcessInstanceRecord.class);
     registry.put(ValueType.INCIDENT, IncidentRecord.class);
     registry.put(ValueType.MESSAGE, MessageRecord.class);
+    registry.put(ValueType.MESSAGE_BATCH, MessageBatchRecord.class);
     registry.put(ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionRecord.class);
     registry.put(
         ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, MessageStartEventSubscriptionRecord.class);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -119,6 +120,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.JOB, this::summarizeJob);
     valueLoggers.put(ValueType.JOB_BATCH, this::summarizeJobBatch);
     valueLoggers.put(ValueType.MESSAGE, this::summarizeMessage);
+    valueLoggers.put(ValueType.MESSAGE_BATCH, this::summarizeMessageBatch);
     valueLoggers.put(
         ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, this::summarizeMessageStartEventSubscription);
     valueLoggers.put(ValueType.MESSAGE_SUBSCRIPTION, this::summarizeMessageSubscription);
@@ -475,6 +477,20 @@ public class CompactRecordLogger {
     }
 
     result.append(summarizeVariables(value.getVariables()));
+
+    return result.toString();
+  }
+
+  private String summarizeMessageBatch(final Record<?> record) {
+    final var value = (MessageBatchRecordValue) record.getValue();
+
+    final var result =
+        new StringBuilder()
+            .append("\"")
+            .append("messageKeys:")
+            .append("\" ")
+            .append(value.getMessageKeys())
+            .append("\"");
 
     return result.toString();
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageBatchRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageBatchRecordStream.java
@@ -23,4 +23,8 @@ public final class MessageBatchRecordStream
       final Stream<Record<MessageBatchRecordValue>> wrappedStream) {
     return new MessageBatchRecordStream(wrappedStream);
   }
+
+  public MessageBatchRecordStream hasMessageKey(final long messageKey) {
+    return valueFilter(v -> v.getMessageKeys().contains(messageKey));
+  }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageBatchRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageBatchRecordStream.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
+import java.util.stream.Stream;
+
+public final class MessageBatchRecordStream
+    extends ExporterRecordStream<MessageBatchRecordValue, MessageBatchRecordStream> {
+
+  public MessageBatchRecordStream(final Stream<Record<MessageBatchRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected MessageBatchRecordStream supply(
+      final Stream<Record<MessageBatchRecordValue>> wrappedStream) {
+    return new MessageBatchRecordStream(wrappedStream);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -40,6 +41,7 @@ import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -239,6 +241,19 @@ public final class RecordingExporter implements Exporter {
 
   public static MessageRecordStream messageRecords(final MessageIntent intent) {
     return messageRecords().withIntent(intent);
+  }
+
+  public static MessageBatchRecordStream messageBatchRecords() {
+    return new MessageBatchRecordStream(
+        records(ValueType.MESSAGE_BATCH, MessageBatchRecordValue.class));
+  }
+
+  public static MessageBatchRecordStream messageBatchRecords(final MessageIntent intent) {
+    return messageBatchRecords().withIntent(intent);
+  }
+
+  public static MessageBatchRecordStream messageBatchRecords(final MessageBatchIntent intent) {
+    return messageBatchRecords().withIntent(intent);
   }
 
   public static ProcessInstanceRecordStream processInstanceRecords() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

To further improve the performance of message expiration, the Message TTL Checker writes a single `MessageBatch:EXPIRE` command (instead of individual `Message:EXPIRE` commands) to expire a batch of messages simultaneously. 

## Related issues

<!-- Which issues are closed by this PR or are related -->
related: #11591
closes: #11953
