### PR TITLE
fix(engine): don't mutate state when checking for job backoffs

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -122,9 +122,7 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void recurAfterBackoff(final long key, final JobRecord record) {
     updateJob(key, record, State.ACTIVATABLE);
-    jobKey.wrapLong(key);
-    backoffKey.wrapLong(record.getRecurringTime());
-    backoffColumnFamily.deleteExisting(backoffJobKey);
+    removeJobBackoff(key, record.getRecurringTime());
   }
 
   @Override
@@ -178,9 +176,7 @@ public final class DbJobState implements JobState, MutableJobState {
   public void fail(final long key, final JobRecord updatedValue) {
     if (updatedValue.getRetries() > 0) {
       if (updatedValue.getRetryBackoff() > 0) {
-        jobKey.wrapLong(key);
-        backoffKey.wrapLong(updatedValue.getRecurringTime());
-        backoffColumnFamily.insert(backoffJobKey, DbNil.INSTANCE);
+        addJobBackoff(key, updatedValue.getRecurringTime());
         updateJob(key, updatedValue, State.FAILED);
       } else {
         updateJob(key, updatedValue, State.ACTIVATABLE);
@@ -392,6 +388,22 @@ public final class DbJobState implements JobState, MutableJobState {
       jobKey.wrapLong(job);
       deadlineKey.wrapLong(deadline);
       deadlinesColumnFamily.deleteIfExists(deadlineJobKey);
+    }
+  }
+
+  private void addJobBackoff(final long job, final long backoff) {
+    if (backoff > 0) {
+      jobKey.wrapLong(job);
+      backoffKey.wrapLong(backoff);
+      backoffColumnFamily.insert(backoffJobKey, DbNil.INSTANCE);
+    }
+  }
+
+  private void removeJobBackoff(final long job, final long backoff) {
+    if (backoff > 0) {
+      jobKey.wrapLong(job);
+      backoffKey.wrapLong(backoff);
+      backoffColumnFamily.deleteIfExists(backoffJobKey);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -170,6 +170,7 @@ public final class DbJobState implements JobState, MutableJobState {
     makeJobNotActivatable(type);
 
     removeJobDeadline(key, record.getDeadline());
+    removeJobBackoff(key, record.getRecurringTime());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -312,7 +312,8 @@ public final class DbJobState implements JobState, MutableJobState {
           boolean consumed = false;
           if (deadline <= timestamp) {
             final long jobKey = key.second().inner().getValue();
-            consumed = visitJob(jobKey, callback, () -> backoffColumnFamily.deleteExisting(key));
+            consumed = visitJob(jobKey, callback, () -> {
+            });
           }
           if (!consumed) {
             nextBackOffDueDate = deadline;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -249,7 +249,7 @@ public final class DbJobState implements JobState, MutableJobState {
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().inner().getValue();
-            return visitJob(jobKey1, callback, () -> {});
+            return visitJob(jobKey1, callback);
           }
           return false;
         });
@@ -288,8 +288,7 @@ public final class DbJobState implements JobState, MutableJobState {
         jobTypeKey,
         ((compositeKey, zbNil) -> {
           final long jobKey = compositeKey.second().inner().getValue();
-          // TODO #6521 reconsider race condition and whether or not the cleanup task is needed
-          return visitJob(jobKey, callback::apply, () -> {});
+          return visitJob(jobKey, callback::apply);
         }));
   }
 
@@ -309,8 +308,7 @@ public final class DbJobState implements JobState, MutableJobState {
           boolean consumed = false;
           if (deadline <= timestamp) {
             final long jobKey = key.second().inner().getValue();
-            consumed = visitJob(jobKey, callback, () -> {
-            });
+            consumed = visitJob(jobKey, callback);
           }
           if (!consumed) {
             nextBackOffDueDate = deadline;
@@ -320,14 +318,10 @@ public final class DbJobState implements JobState, MutableJobState {
     return nextBackOffDueDate;
   }
 
-  boolean visitJob(
-      final long jobKey,
-      final BiPredicate<Long, JobRecord> callback,
-      final Runnable cleanupRunnable) {
+  boolean visitJob(final long jobKey, final BiPredicate<Long, JobRecord> callback) {
     final JobRecord job = getJob(jobKey);
     if (job == null) {
       LOG.error("Expected to find job with key {}, but no job found", jobKey);
-      cleanupRunnable.run();
       return true; // we want to continue with the iteration
     }
     return callback.test(jobKey, job);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -347,8 +347,13 @@ public final class JobStateTest {
   public void shouldFailJobWithRetriesAndBackOff() {
     // given
     final long key = 1L;
+    final long now = 0;
     final var retryBackoff = 100;
-    final JobRecord jobRecord = newJobRecord().setRetries(1).setRetryBackoff(retryBackoff);
+    final JobRecord jobRecord =
+        newJobRecord()
+            .setRetries(1)
+            .setRetryBackoff(retryBackoff)
+            .setRecurringTime(now + retryBackoff);
 
     // when
     jobState.create(key, jobRecord);
@@ -361,7 +366,7 @@ public final class JobStateTest {
     assertJobRecordIsEqualTo(jobState.getJob(key), jobRecord);
     refuteListedAsActivatable(key, jobRecord.getTypeBuffer());
     refuteListedAsTimedOut(key, jobRecord.getDeadline() + 1);
-    assertListedAsBackOff(key, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    assertListedAsBackOff(key, jobRecord.getRecurringTime() + 1);
   }
 
   @Test
@@ -408,8 +413,13 @@ public final class JobStateTest {
   public void shouldRetryJobAfterRecurredAndHasRetries() {
     // given
     final long jobKey = 1L;
+    final long now = 0;
     final long retryBackoff = Duration.ofDays(1).toMillis();
-    final JobRecord jobRecord = newJobRecord().setRetries(1).setRetryBackoff(retryBackoff);
+    final JobRecord jobRecord =
+        newJobRecord()
+            .setRetries(1)
+            .setRetryBackoff(retryBackoff)
+            .setRecurringTime(now + retryBackoff);
 
     // when
     jobState.create(jobKey, jobRecord);
@@ -417,12 +427,12 @@ public final class JobStateTest {
     jobState.fail(jobKey, jobRecord);
     assertThat(jobState.exists(jobKey)).isTrue();
     assertJobState(jobKey, State.FAILED);
-    assertListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    assertListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1);
     jobState.recurAfterBackoff(jobKey, jobRecord);
 
     // then
     assertJobState(jobKey, State.ACTIVATABLE);
-    refuteListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    refuteListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1);
   }
 
   @Test


### PR DESCRIPTION
Remove sneaky state mutation when visiting jobs with expired backoffs. Instead, reliably cleanup backoff when recurring or deleting the job. When a backoff is found again before the first `RECUR_AFTER_BACKOFF` command is processed, another `RECUR_AFTER_BACKOFF` command is written. This is okay because on processing, we ignore jobs that no longer exist or that have a newer recurring time set.

Closes #13041 