### PR TITLE
`PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY` migration

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -40,7 +40,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final IntegerProperty activeSequenceFlowsProp =
       new IntegerProperty("activeSequenceFlows", 0);
 
-  ElementInstance() {
+  public ElementInstance() {
     declareProperty(parentKeyProp)
         .declareProperty(childCountProp)
         .declareProperty(childActivatedCountProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionRequirementsMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDefinitionMigration;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,8 @@ public class DbMigratorImpl implements DbMigrator {
           new MessageSubscriptionSentTimeMigration(),
           new TemporaryVariableMigration(),
           new DecisionMigration(),
-          new DecisionRequirementsMigration());
+          new DecisionRequirementsMigration(),
+          new ProcessInstanceByProcessDefinitionMigration());
   // Be mindful of https://github.com/camunda/zeebe/issues/7248. In particular, that issue
   // should be solved first, before adding any migration that can take a long time
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessInstanceByProcessDefinitionMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessInstanceByProcessDefinitionMigration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.migration.MigrationTask;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+
+/**
+ * This migration is used to initially fill the PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY ColumnFamily.
+ * It will go over all the element instances, check if they are of the BpmnElementType PROCESS, and
+ * if they are insert them into the ColumnFamily.
+ */
+public class ProcessInstanceByProcessDefinitionMigration implements MigrationTask {
+
+  @Override
+  public String getIdentifier() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public boolean needsToRun(final ProcessingState processingState) {
+    return processingState.isEmpty(ZbColumnFamilies.PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY)
+        && !processingState.isEmpty(ZbColumnFamilies.ELEMENT_INSTANCE_KEY);
+  }
+
+  @Override
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState
+        .getMigrationState()
+        .migrateElementInstancePopulateProcessInstanceByDefinitionKey();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -27,4 +27,6 @@ public interface MutableMigrationState {
   void migrateDecisionsPopulateDecisionVersionByDecisionIdAndDecisionKey();
 
   void migrateDrgPopulateDrgVersionByDrgIdAndKey();
+
+  void migrateElementInstancePopulateProcessInstanceByDefinitionKey();
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessInstanceByProcessDefinitionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessInstanceByProcessDefinitionMigrationTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+class ProcessInstanceByProcessDefinitionMigrationTest {
+
+  final ProcessInstanceByProcessDefinitionMigration sut =
+      new ProcessInstanceByProcessDefinitionMigration();
+
+  private static final class LegacyElementInstanceState {
+    private final DbLong elementInstanceKey;
+    private final ElementInstance elementInstance;
+    private final ColumnFamily<DbLong, ElementInstance> elementInstanceColumnFamily;
+
+    public LegacyElementInstanceState(
+        final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+      elementInstanceKey = new DbLong();
+      elementInstance = new ElementInstance();
+      elementInstanceColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.ELEMENT_INSTANCE_KEY,
+              transactionContext,
+              elementInstanceKey,
+              elementInstance);
+    }
+
+    public void insertElementInstance(final long key, final ElementInstance elementInstance) {
+      elementInstanceKey.wrapLong(key);
+      elementInstanceColumnFamily.insert(elementInstanceKey, elementInstance);
+    }
+  }
+
+  @Nested
+  class MockBasedTests {
+
+    @Test
+    void noMigrationNeededWhenElementInstanceColumnFamilyIsEmptyAndPIByDefinitionIsEmpty() {
+      // given
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.ELEMENT_INSTANCE_KEY)).thenReturn(true);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY))
+          .thenReturn(true);
+
+      // when
+      final var actual = sut.needsToRun(mockProcessingState);
+
+      // then
+      assertThat(actual).isFalse();
+    }
+
+    @Test
+    void noMigrationNeededWhenElementInstanceColumnFamilyIsNotEmptyAndPIByDefinitionIsNotEmpty() {
+      // given
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.ELEMENT_INSTANCE_KEY)).thenReturn(false);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY))
+          .thenReturn(false);
+
+      // when
+      final var actual = sut.needsToRun(mockProcessingState);
+
+      // then
+      assertThat(actual).isFalse();
+    }
+
+    @Test
+    void noMigrationNeededWhenElementInstanceColumnFamilyIsEmptyAndPIByDefinitionIsNotEmpty() {
+      // given
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.ELEMENT_INSTANCE_KEY)).thenReturn(true);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY))
+          .thenReturn(false);
+
+      // when
+      final var actual = sut.needsToRun(mockProcessingState);
+
+      // then
+      assertThat(actual).isFalse();
+    }
+
+    @Test
+    void migrationNeededWhenElementInstanceColumnFamilyIsNotEmptyAndPIByDefinitionIsEmpty() {
+      // given
+      final var mockProcessingState = mock(ProcessingState.class);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.ELEMENT_INSTANCE_KEY)).thenReturn(false);
+      when(mockProcessingState.isEmpty(ZbColumnFamilies.PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY))
+          .thenReturn(true);
+
+      // when
+      final var actual = sut.needsToRun(mockProcessingState);
+
+      // then
+      assertThat(actual).isTrue();
+    }
+  }
+
+  @Nested
+  @ExtendWith(ProcessingStateExtension.class)
+  class BlackboxTest {
+    private ZeebeDb<ZbColumnFamilies> zeebeDb;
+    private MutableProcessingState processingState;
+    private TransactionContext transactionContext;
+    private LegacyElementInstanceState legacyState;
+    private DbLong elementInstanceKey;
+    private ElementInstance elementInstance;
+    private ColumnFamily<DbLong, ElementInstance> elementInstanceColumnFamily;
+    private DbLong processDefinitionKey;
+    private DbCompositeKey<DbLong, DbLong> processInstanceKeyByProcessDefinitionKey;
+
+    /** [process definition key | process instance key] => [Nil] */
+    private ColumnFamily<DbCompositeKey<DbLong, DbLong>, DbNil>
+        processInstanceKeyByProcessDefinitionKeyColumnFamily;
+
+    @BeforeEach
+    void setup() {
+      legacyState = new LegacyElementInstanceState(zeebeDb, transactionContext);
+      elementInstanceKey = new DbLong();
+      elementInstance = new ElementInstance();
+      elementInstanceColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.ELEMENT_INSTANCE_KEY,
+              transactionContext,
+              elementInstanceKey,
+              elementInstance);
+      processDefinitionKey = new DbLong();
+      processInstanceKeyByProcessDefinitionKey =
+          new DbCompositeKey<>(processDefinitionKey, elementInstanceKey);
+      processInstanceKeyByProcessDefinitionKeyColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY,
+              transactionContext,
+              processInstanceKeyByProcessDefinitionKey,
+              DbNil.INSTANCE);
+    }
+
+    @Test
+    void afterMigrationNoFurtherMigrationIsNeeded() {
+      // given
+      final long processInstanceKey = 100L;
+      legacyState.insertElementInstance(
+          processInstanceKey, createElementInstance(processInstanceKey, BpmnElementType.PROCESS));
+
+      // when
+      sut.runMigration(processingState);
+      final var shouldRun = sut.needsToRun(processingState);
+
+      // then
+      assertThat(shouldRun).isFalse();
+    }
+
+    @Test
+    void shouldInsertIntoProcessInstanceByProcessDefinition() {
+      // given
+      final long processInstanceKey = 100L;
+      final long processDefinitionKey = 101L;
+      legacyState.insertElementInstance(
+          processInstanceKey, createElementInstance(processDefinitionKey, BpmnElementType.PROCESS));
+
+      // when
+      sut.runMigration(processingState);
+
+      // then
+      elementInstanceKey.wrapLong(processInstanceKey);
+      this.processDefinitionKey.wrapLong(processDefinitionKey);
+      assertThat(
+              processInstanceKeyByProcessDefinitionKeyColumnFamily.exists(
+                  processInstanceKeyByProcessDefinitionKey))
+          .isTrue();
+    }
+
+    @Test
+    void shouldNotMigrateElementInstancesOfTypeOtherThanProcess() {
+      // given
+      final long elementInstanceKey = 100L;
+      final long processDefinitionKey = 101L;
+      legacyState.insertElementInstance(
+          elementInstanceKey,
+          createElementInstance(processDefinitionKey, BpmnElementType.START_EVENT));
+
+      // when
+      sut.runMigration(processingState);
+
+      // then
+      this.elementInstanceKey.wrapLong(elementInstanceKey);
+      this.processDefinitionKey.wrapLong(processDefinitionKey);
+      assertThat(
+              processInstanceKeyByProcessDefinitionKeyColumnFamily.exists(
+                  processInstanceKeyByProcessDefinitionKey))
+          .isFalse();
+    }
+
+    private ElementInstance createElementInstance(
+        final long processDefinitionKey, final BpmnElementType elementType) {
+      final var elementInstance = new ElementInstance();
+      elementInstance.setValue(
+          new ProcessInstanceRecord()
+              .setProcessDefinitionKey(processDefinitionKey)
+              .setBpmnElementType(elementType));
+      elementInstance.setState(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+      return elementInstance;
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This migration does the initial fill of the `PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY` ColumnFamily. It iterates over
all element instances in the state. It checks if it is of type `PROCESS` and if it is it will insert it with the corresponding process definition key in the new ColumnFamily.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13343 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
