### PR TITLE
fix(build): run zeebe user in docker image by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,4 +126,6 @@ COPY --from=init --chown=1000:0 /zeebe/tini ${ZB_HOME}/bin/
 COPY --from=init --chown=1000:0 /zeebe/startup.sh /usr/local/bin/startup.sh
 COPY --from=dist --chown=1000:0 /zeebe/camunda-zeebe ${ZB_HOME}
 
+USER zeebe:zeebe
+
 ENTRYPOINT ["tini", "--", "/usr/local/bin/startup.sh"]

--- a/qa/update-tests/pom.xml
+++ b/qa/update-tests/pom.xml
@@ -23,6 +23,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>

--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -341,7 +341,11 @@ final class RollingUpdateTest {
         .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES", "2")
         // ensure we have an exporter present to test sharing exporter state across nodes
         .withEnv("ZEEBE_BROKER_EXECUTIONMETRICSEXPORTERENABLED", "true")
-        .withEnv("ZEEBE_LOG_LEVEL", "DEBUG");
+        .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
+        // user needs to be set to allow a smooth update from zeebe 8.2 to 8.3
+        // as the default user changed to `zeebe` with 8.3 and was `root` with 8.2
+        // TODO remove after 8.3 release
+        .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withUser("zeebe"));
     broker.setDockerImageName(PREVIOUS_VERSION.asCanonicalNameString());
   }
 }


### PR DESCRIPTION
## Description

The purpose of this PR is to use the non-privileged user by default.  I am from the team that maintains the helm chart and docker-compose deployment methods of the camunda platform.  My interest in making this PR is to reduce the amount of calls and support tickets that my team goes on.  Customers often use security tools like AquaSecurity which blocks "insecure" images from being ran (even if we define a non-privileged user in run-time via  runAsUser.

## Related issues

closes #12382 

## Related PR

This PR is an alternative to a PR that currently exists which runs a non-privileged user under gosu (which would be a run-time non-root user).
https://github.com/camunda/zeebe/pull/12931


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done



<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions

With regards to the helm charts,  the user/customer needs to understand how to set the `fsGroup` option to ensure their volumes have the proper ownership.  

* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

This should not be necessary for this PR.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

I tested this change via loading the locally built image into my kind cluster and deploying the helm chart.  I found that I needed to make a change to our helm chart  by removing the already mounted /usr/local/bin/startup.sh  file.  I'm still not quite sure why the helm chart needed to overwrite that file.

After making that helm chart change, the pod started up successfully.

* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.

- [ ] [Distribution](https://github.com/camunda/distribution/issues)

Helm chart needs to be changed with the startup.sh file currently overwriting the startup.sh file inside the image.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
