### PR TITLE
POC: ban instance via API

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
@@ -9,10 +9,12 @@ package io.camunda.zeebe.broker.partitioning;
 
 import static java.util.Objects.requireNonNull;
 
-import io.camunda.zeebe.broker.Loggers;import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;import java.util.Collections;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -67,7 +69,8 @@ final class MultiPartitionAdminAccess implements PartitionAdminAccess {
     final String errorMsg =
         String.format("Can't ban instance %s on all partitions.", processInstanceKey);
     Loggers.CLUSTERING_LOGGER.error(errorMsg);
-    return CompletableActorFuture.completedExceptionally( new UnsupportedOperationException(errorMsg));
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException(errorMsg));
   }
 
   private ActorFuture<Void> callOnEachPartition(

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
@@ -9,10 +9,10 @@ package io.camunda.zeebe.broker.partitioning;
 
 import static java.util.Objects.requireNonNull;
 
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.broker.Loggers;import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
-import java.util.Collections;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -60,6 +60,14 @@ final class MultiPartitionAdminAccess implements PartitionAdminAccess {
   @Override
   public ActorFuture<Void> resumeProcessing() {
     return callOnEachPartition(PartitionAdminAccess::resumeProcessing);
+  }
+
+  @Override
+  public ActorFuture<Void> banInstance(final long processInstanceKey) {
+    final String errorMsg =
+        String.format("Can't ban instance %s on all partitions.", processInstanceKey);
+    Loggers.CLUSTERING_LOGGER.error(errorMsg);
+    return CompletableActorFuture.completedExceptionally( new UnsupportedOperationException(errorMsg));
   }
 
   private ActorFuture<Void> callOnEachPartition(

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -52,6 +52,12 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
     return CompletableActorFuture.completed(null);
   }
 
+  @Override
+  public ActorFuture<Void> banInstance(final long processInstanceKey) {
+    logCall();
+    return CompletableActorFuture.completed(null);
+  }
+
   private void logCall() {
     LOG.warn("Received call on NoOp implementation of PartitionAdminAccess");
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -22,4 +22,6 @@ public interface PartitionAdminAccess {
   ActorFuture<Void> pauseProcessing();
 
   ActorFuture<Void> resumeProcessing();
+
+  ActorFuture<Void> banInstance(final long processInstanceKey);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -8,11 +8,15 @@
 package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 
 public interface PartitionAdminControl {
   StreamProcessor getStreamProcessor();
+
+  ZeebeDb getZeebeDb();
 
   ExporterDirector getExporterDirector();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -9,13 +9,15 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.logstreams.log.LogStream;import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 
 public interface PartitionAdminControl {
   StreamProcessor getStreamProcessor();
 
   ZeebeDb getZeebeDb();
+
+  LogStream getLogStream();
 
   ExporterDirector getExporterDirector();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.logstreams.log.LogStream;import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 import java.util.function.Supplier;
 
@@ -22,18 +22,21 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   private final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier;
   private final Supplier<PartitionProcessingState> partitionProcessingStateSupplier;
   private final Supplier<ZeebeDb> zeebeDbSupplier;
+  private final Supplier<LogStream> logStreamSupplier;
 
   public PartitionAdminControlImpl(
       final Supplier<StreamProcessor> streamProcessorSupplier,
       final Supplier<ExporterDirector> exporterDirectorSupplier,
       final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier,
       final Supplier<PartitionProcessingState> partitionProcessingStateSupplier,
-      final Supplier<ZeebeDb> zeebeDbSupplier) {
+      final Supplier<ZeebeDb> zeebeDbSupplier,
+      final Supplier<LogStream> logStreamSupplier) {
     this.streamProcessorSupplier = streamProcessorSupplier;
     this.exporterDirectorSupplier = exporterDirectorSupplier;
     this.snapshotDirectorSupplier = snapshotDirectorSupplier;
     this.partitionProcessingStateSupplier = partitionProcessingStateSupplier;
     this.zeebeDbSupplier = zeebeDbSupplier;
+    this.logStreamSupplier = logStreamSupplier;
   }
 
   @Override
@@ -84,5 +87,9 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public ZeebeDb getZeebeDb() {
     return zeebeDbSupplier.get();
+  }
+
+  public LogStream getLogStream() {
+    return logStreamSupplier.get();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -20,16 +21,19 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   private final Supplier<ExporterDirector> exporterDirectorSupplier;
   private final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier;
   private final Supplier<PartitionProcessingState> partitionProcessingStateSupplier;
+  private final Supplier<ZeebeDb> zeebeDbSupplier;
 
   public PartitionAdminControlImpl(
       final Supplier<StreamProcessor> streamProcessorSupplier,
       final Supplier<ExporterDirector> exporterDirectorSupplier,
       final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier,
-      final Supplier<PartitionProcessingState> partitionProcessingStateSupplier) {
+      final Supplier<PartitionProcessingState> partitionProcessingStateSupplier,
+      final Supplier<ZeebeDb> zeebeDbSupplier) {
     this.streamProcessorSupplier = streamProcessorSupplier;
     this.exporterDirectorSupplier = exporterDirectorSupplier;
     this.snapshotDirectorSupplier = snapshotDirectorSupplier;
     this.partitionProcessingStateSupplier = partitionProcessingStateSupplier;
+    this.zeebeDbSupplier = zeebeDbSupplier;
   }
 
   @Override
@@ -75,5 +79,10 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public boolean resumeExporting() throws IOException {
     return partitionProcessingStateSupplier.get().resumeExporting();
+  }
+
+  @Override
+  public ZeebeDb getZeebeDb() {
+    return zeebeDbSupplier.get();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -145,7 +145,8 @@ public class PartitionStartupAndTransitionContextImpl
         () -> getPartitionContext().getStreamProcessor(),
         () -> getPartitionContext().getExporterDirector(),
         () -> snapshotDirector,
-        () -> partitionProcessingState);
+        () -> partitionProcessingState,
+        () -> zeebeDb);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -146,7 +146,8 @@ public class PartitionStartupAndTransitionContextImpl
         () -> getPartitionContext().getExporterDirector(),
         () -> snapshotDirector,
         () -> partitionProcessingState,
-        () -> zeebeDb);
+        () -> zeebeDb,
+        () -> logStream);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -155,6 +155,8 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
 
             dbBannedInstanceState.banProcessInstance(processInstanceKey);
 
+            LOG.info("Successful banned instance with key {}", processInstanceKey);
+
           } catch (final Exception e) {
             LOG.error("Could not resume processing", e);
             completed.completeExceptionally(e);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -11,7 +11,8 @@ import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
-import io.camunda.zeebe.db.TransactionContext;import io.camunda.zeebe.db.ZeebeDb;import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.io.IOException;
 import java.util.Optional;
@@ -149,7 +150,8 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
           try {
             final var zeebeDb = adminControl.getZeebeDb();
             final var context = zeebeDb.createContext();
-            final var dbBannedInstanceState = new DbBannedInstanceState(zeebeDb, context, partitionId);
+            final var dbBannedInstanceState =
+                new DbBannedInstanceState(zeebeDb, context, partitionId);
 
             dbBannedInstanceState.banProcessInstance(processInstanceKey);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiRequestReader.java
@@ -24,6 +24,10 @@ public class ApiRequestReader implements RequestReader<AdminRequestDecoder> {
     return messageDecoder;
   }
 
+  public long key() {
+    return messageDecoder.key();
+  }
+
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceEndpoint.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.gateway.Loggers;
+import java.util.concurrent.CompletionException;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.Selector.Match;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@WebEndpoint(id = "banning")
+public final class BanInstanceEndpoint {
+  private static final Logger LOG = Loggers.GATEWAY_LOGGER;
+  final BanInstanceService banInstanceService;
+
+  @Autowired
+  public BanInstanceEndpoint(final BanInstanceService banInstanceService) {
+    this.banInstanceService = banInstanceService;
+  }
+
+  @WriteOperation
+  public WebEndpointResponse<?> post(
+      @Selector(match = Match.SINGLE) final long processInstanceKey) {
+    try {
+      LOG.info("Send AdminRequest to ban instance with key {}", processInstanceKey);
+      banInstanceService.banInstance(processInstanceKey);
+      return new WebEndpointResponse<>(WebEndpointResponse.STATUS_NO_CONTENT);
+    } catch (final CompletionException e) {
+      return new WebEndpointResponse<>(
+          e.getCause(), WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+    } catch (final Exception e) {
+      return new WebEndpointResponse<>(e, WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class BanInstanceService {
+
+  private final BrokerClient client;
+
+  @Autowired
+  public BanInstanceService(final BrokerClient client) {
+    this.client = client;
+  }
+
+  public void banInstance(final long key) {
+    client.sendRequest(new BrokerAdminRequest().banInstance(key));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -125,6 +125,9 @@ public class Engine implements RecordProcessor {
       if (noBanCheckNeeded || !processingState.getBannedInstanceState().isBanned(typedCommand)) {
         currentProcessor.processRecord(record);
       }
+      else {
+        LOG.info("Ignore record {} due to banning", record);
+      }
     }
     return processingResultBuilder.build();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
@@ -63,7 +63,7 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
       LOG.warn(BAN_INSTANCE_MESSAGE, key);
 
       processInstanceKey.wrapLong(key);
-      bannedInstanceColumnFamily.insert(processInstanceKey, DbNil.INSTANCE);
+      bannedInstanceColumnFamily.upsert(processInstanceKey, DbNil.INSTANCE);
       bannedInstanceMetrics.countBannedInstance();
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
@@ -36,7 +36,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   private final ColumnFamily<DbLong, DbNil> bannedInstanceColumnFamily;
   private final DbLong processInstanceKey;
   private final BannedInstanceMetrics bannedInstanceMetrics;
-  private boolean empty = true;
 
   public DbBannedInstanceState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -56,7 +55,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     final var counter = new AtomicInteger(0);
     bannedInstanceColumnFamily.forEach(ignore -> counter.getAndIncrement());
-    empty = counter.get() == 0;
     bannedInstanceMetrics.setBannedInstanceCounter(counter.get());
   }
 
@@ -64,7 +62,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
     if (key >= 0) {
       LOG.warn(BAN_INSTANCE_MESSAGE, key);
 
-      empty = false;
       processInstanceKey.wrapLong(key);
       bannedInstanceColumnFamily.insert(processInstanceKey, DbNil.INSTANCE);
       bannedInstanceMetrics.countBannedInstance();
@@ -72,10 +69,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   }
 
   private boolean isBanned(final long key) {
-    if (empty) {
-      return false;
-    }
-
     processInstanceKey.wrapLong(key);
     return bannedInstanceColumnFamily.exists(processInstanceKey);
   }
@@ -94,7 +87,7 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
 
   @Override
   public boolean isEmpty() {
-    return empty;
+    return bannedInstanceColumnFamily.isEmpty();
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.admin;
 
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.management.AdminRequestEncoder;
@@ -38,6 +39,13 @@ public class BrokerAdminRequest extends BrokerRequest<Void> {
 
   public void resumeExporting() {
     request.setType(AdminRequestType.RESUME_EXPORTING);
+  }
+
+  public BrokerAdminRequest banInstance(final long key) {
+    request.setType(AdminRequestType.BAN_INSTANCE);
+    request.setKey(key);
+    request.setPartitionId(Protocol.decodePartitionId(key));
+    return this;
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -27,7 +27,7 @@ public class AdminRequest implements BufferReader, BufferWriter {
   private int partitionId = AdminRequestEncoder.partitionIdNullValue();
   private AdminRequestType type = AdminRequestType.NULL_VAL;
 
-  private final long key = AdminRequestEncoder.keyNullValue();
+  private long key = AdminRequestEncoder.keyNullValue();
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
@@ -74,6 +74,10 @@ public class AdminRequest implements BufferReader, BufferWriter {
 
   public long getKey() {
     return key;
+  }
+
+  public void setKey(final long key) {
+    this.key = key;
   }
 
   public void setType(final AdminRequestType type) {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -27,6 +27,8 @@ public class AdminRequest implements BufferReader, BufferWriter {
   private int partitionId = AdminRequestEncoder.partitionIdNullValue();
   private AdminRequestType type = AdminRequestType.NULL_VAL;
 
+  private final long key = AdminRequestEncoder.keyNullValue();
+
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
@@ -46,7 +48,8 @@ public class AdminRequest implements BufferReader, BufferWriter {
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .brokerId(brokerId)
         .partitionId(partitionId)
-        .type(type);
+        .type(type)
+        .key(key);
   }
 
   public int getBrokerId() {
@@ -67,6 +70,10 @@ public class AdminRequest implements BufferReader, BufferWriter {
 
   public AdminRequestType getType() {
     return type;
+  }
+
+  public long getKey() {
+    return key;
   }
 
   public void setType(final AdminRequestType type) {

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -281,6 +281,20 @@
           "new": "method io.camunda.zeebe.protocol.record.ImmutableRecordValue io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue::getCommandValue()",
           "justification": "This is a result of adding the Immutable annotation on RecordValue. This doesn't break any backwards compatibility."
         }
+      ,{
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.AdminRequestDecoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.management.AdminRequestDecoder.BLOCK_LENGTH",
+          "justification": "Added a new type to ban an instance"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.AdminRequestEncoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.management.AdminRequestEncoder.BLOCK_LENGTH",
+          "justification": "Added a new type to ban an instance"
+        }
       ]
     }
   }

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -11,6 +11,7 @@
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
       <validValue name="PAUSE_EXPORTING">1</validValue>
       <validValue name="RESUME_EXPORTING">2</validValue>
+      <validValue name="BAN_INSTANCE">3</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">
@@ -41,6 +42,7 @@
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="AdminRequestType"/>
     <field name="brokerId" id="3" type="uint16" presence="optional"/>
+    <field name="key" id="4" type="uint64" presence="optional"/>
   </sbe:message>
 
   <sbe:message name="AdminResponse" id="2">

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -269,12 +269,12 @@ public final class ProcessingStateMachine {
         processingMetrics.observeCommandCount(processedCommandsCount);
       }
 
+      lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
       if (currentProcessingResult.isEmpty()) {
         skipRecord();
         return;
       }
 
-      lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
       writeRecords();
       processedCommandsCount = 0;
     } catch (final RecoverableException recoverableException) {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -220,7 +220,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
 
   private void replayEvent(final LoggedEvent currentEvent) {
     if (eventFilter.applies(currentEvent)
-        && currentEvent.getSourceEventPosition() > snapshotPosition) {
+        && (currentEvent.getSourceEventPosition() > snapshotPosition || currentEvent.getSourceEventPosition() < 0)) { // some events might not have a source pointer
       readMetadata(currentEvent);
       final var currentTypedEvent = readRecordValue(currentEvent);
 


### PR DESCRIPTION
## Description



This POC contains the following:

  * Adding a ban instance type to the admin request
  * Adding a ban instance endpoint/service to dist and gateway
  * Adding the ban instance request handling to the broker, using the zeebedb to directly ban the instance
  * Remove the caching of the ban instances empty state
  * Confirming state change via event on the log, such that this change is applied on followers as well.
  * Fix issue with ban instance, when already banned. 
  * Fix issue with last process position update, on skip record.

<!-- Please explain the changes you made here. -->

## Related issues

>
> ### Related to https://github.com/camunda/zeebe/issues/12696#issuecomment-1628833950
>
> I think we can combine several ideas together to get the best out of it. 
> 
> It makes sense to have a two-step process implemented, which allows to first ban the instance and secondly (if wished) to cancel the instance.
> 
> We provide an API (potentially actuator) where we can send “ban instance X” request. We access the ZeebeDB with a separate context, as we do with the Exporters, and mark the process instance as banned. I think this should bring us a quick win and feels potentially easy to implement. 
> 
> The ban column family is less frequented, which should allows us to already stop the processing for a specific PI, without conflicts. It might make sense to think about the blacklisting cache again, whether we really need it or we just delete it (otherwise we have to update flag).
> 
> The banning of the instance should be confirmed with an event on the log, this allows to replicate the state change, and followers can do the same.
> 
> Please be aware as soon as the instance is banned, there is right now no way to recover. [The process instance is in limbo, as ](https://github.com/camunda/zeebe/issues/12696#:~:text=I%27m%20personally%20more%20in%20favor%20of%20skipping%20the%20commands.%20This%20puts%20the%20process%20instance%20in%20a%20state%20of%20limbo%20just%20like%20a%20blacklisted%20process%20instance.%20All%20we%20need%20is%20a%20way%20to%20start%20up%20processing%20again%2C%20and%20to%20allow%20the%20user%20to%20cancel%20the%20instance.)[Nico Korthout](mailto:nico.korthout@camunda.com) said so nicely. To handle this differently I see this out of the scope of this feature since we expect it to use only for severe issues where the cluster is otherwise not recoverable (and/or can make no progress).
> 
> You may ask why is that actually the case. Because we likely skip commands which are then lost. Furthermore, there is right now no way to remove some PI from the banned instances list. A potential follow-up could be to allow removing instances from that list and applying PI modification (to repair instances).
> 
> We could think of [persisting the skipped records into the state](https://github.com/camunda/zeebe/issues/12696#:~:text=We%20could%20persist%20the%20skipped%20commands.%20As%20soon%20as%20we%20want%20to%20continue%2C%20we%20write%20these%20back%20to%20the%20log%20and%20continue%20processing.%20This%20has%20two%20downsides%3A%20disk%20usage%20and%20fork%20bomb%20would%20continue.%20So%20I%20don%27t%20think%20we%20should%20do%20this.), but I would rather not do that, since it could cause severe other issues due to limited space, etc. It is also not clear to me whether the gains are outweighed by the costs since we can also easily run process instance modification to recover such.
> 
> The approach above is a combination of multiple others mentioned before, and I feel it is best to not make it too easy to erase customer data, which is why cancelation is/can be the second step. 
> 
> Generally, cancelation involves more work, due to the child's cancelation, etc. This should happen in the processing, with a separate command. Since it might fail as well, due to large nested instances, etc, but with this approach it is fine since it is already banned in this case. 
> 
> In order to allow the cancelation we need to make sure that we implement the [cancelation for banned instances.](https://github.com/camunda/zeebe/issues/12772)
