### PR TITLE
Allow cancelling pending commands

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeStreamingClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeStreamingClientFutureImpl.java
@@ -36,6 +36,7 @@ public class ZeebeStreamingClientFutureImpl<ClientResponse, BrokerResponse>
       collector.accept(brokerResponse);
     } catch (final Exception e) {
       completeExceptionally(e);
+      rethrow(e);
     }
   }
 
@@ -47,5 +48,10 @@ public class ZeebeStreamingClientFutureImpl<ClientResponse, BrokerResponse>
   @Override
   public void onCompleted() {
     complete(response);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends Throwable> void rethrow(final Throwable exception) throws T {
+    throw (T) exception;
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImplTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class ZeebeClientFutureImplTest {
+
+  private final Service service = new Service();
+  private final String serverName = InProcessServerBuilder.generateName();
+
+  // using directExecutor allows us to test everything from the main thread, without concurrency
+  private final Server server =
+      InProcessServerBuilder.forName(serverName).addService(service).directExecutor().build();
+
+  @BeforeEach
+  void beforeEach() throws IOException {
+    server.start();
+  }
+
+  @AfterEach
+  void afterEach() {
+    server.shutdownNow();
+  }
+
+  @Test
+  void shouldCancelStreamServerSide() {
+    // given
+    final ActivateJobsRequest request = ActivateJobsRequest.newBuilder().setType("type").build();
+    final ZeebeClientFutureImpl<?, ActivateJobsResponse> future = new ZeebeClientFutureImpl<>();
+    try (final Client client = createClient()) {
+      // when
+      client.stub.activateJobs(request, future);
+      future.cancel(true);
+
+      // then
+      assertThat(service.canceledCalls()).containsExactly("type");
+    }
+  }
+
+  @Test
+  void shouldCancelCallIfFutureAlreadyCanceled() {
+    // given
+    final ActivateJobsRequest request = ActivateJobsRequest.newBuilder().setType("type").build();
+    final ZeebeClientFutureImpl<?, ActivateJobsResponse> future = new ZeebeClientFutureImpl<>();
+    future.cancel(false);
+
+    try (final Client client = createClient()) {
+      // when - then
+      assertThatCode(() -> client.stub.activateJobs(request, future))
+          .isInstanceOf(IllegalStateException.class);
+      assertThat(service.registeredCalls()).isEmpty();
+    }
+  }
+
+  private Client createClient() {
+    return new Client(createChannel());
+  }
+
+  private ManagedChannel createChannel() {
+    return InProcessChannelBuilder.forName(serverName).directExecutor().build();
+  }
+
+  private static final class Client implements AutoCloseable {
+    private final ManagedChannel channel;
+    private final GatewayStub stub;
+
+    private Client(final ManagedChannel channel) {
+      this.channel = channel;
+      stub = GatewayGrpc.newStub(channel);
+    }
+
+    @Override
+    public void close() {
+      channel.shutdownNow();
+    }
+  }
+
+  private static final class Service extends GatewayImplBase {
+    private final Map<String, ServerCallStreamObserver<ActivateJobsResponse>> registeredCalls =
+        new HashMap<>();
+    private final List<String> canceledCalls = new ArrayList<>();
+
+    @Override
+    public void activateJobs(
+        final ActivateJobsRequest request,
+        final StreamObserver<ActivateJobsResponse> responseObserver) {
+      final String callId = request.getType();
+      final ServerCallStreamObserver<ActivateJobsResponse> serverCall =
+          (ServerCallStreamObserver<ActivateJobsResponse>) responseObserver;
+      registeredCalls.put(callId, serverCall);
+      serverCall.setOnCancelHandler(() -> canceledCalls.add(callId));
+    }
+
+    private Map<String, ServerCallStreamObserver<ActivateJobsResponse>> registeredCalls() {
+      return registeredCalls;
+    }
+
+    private List<String> canceledCalls() {
+      // return a new copy to avoid race conditions where the list is updated before the assertion
+      // message is created, but after it was evaluated, leading to weird error messages
+      return new ArrayList<>(canceledCalls);
+    }
+  }
+
+  @Nested
+  final class ZeebeStreamingClientFutureImplTest {
+    @Test
+    void shouldRethrowExceptionOnCollectorError() {
+      // given
+      final RuntimeException error = new RuntimeException("failed");
+      final ZeebeStreamingClientFutureImpl<?, ActivateJobsResponse> future =
+          new ZeebeStreamingClientFutureImpl<>(
+              null,
+              ignored -> {
+                throw error;
+              });
+
+      // when
+      assertThatCode(() -> future.onNext(null)).isSameAs(error);
+    }
+
+    @Test
+    void shouldCloseStreamOnConsumerError() {
+      // given
+      final ActivateJobsRequest request = ActivateJobsRequest.newBuilder().setType("type").build();
+      final RuntimeException error = new RuntimeException("failed");
+      final ZeebeStreamingClientFutureImpl<?, ActivateJobsResponse> future =
+          new ZeebeStreamingClientFutureImpl<>(
+              null,
+              ignored -> {
+                throw error;
+              });
+      try (final Client client = createClient()) {
+        // when
+        client.stub.activateJobs(request, future);
+        service.registeredCalls().get("type").onNext(ActivateJobsResponse.newBuilder().build());
+
+        // then
+        assertThat(service.canceledCalls()).containsOnly("type");
+      }
+    }
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/ServerStreamObserver.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/ServerStreamObserver.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.grpc;
 
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
 /**
@@ -19,5 +20,13 @@ import io.grpc.stub.StreamObserver;
  * @param <GrpcResponseT> the expected gRPC response type
  */
 public interface ServerStreamObserver<GrpcResponseT> extends StreamObserver<GrpcResponseT> {
+  /**
+   * @see ServerCallStreamObserver#isCancelled()
+   */
   boolean isCancelled();
+
+  /**
+   * @see ServerCallStreamObserver#setOnCancelHandler(Runnable)
+   */
+  void setOnCancelHandler(final Runnable handler);
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetrics.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetrics.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.metrics;
 
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.prometheus.client.Gauge;
 
 public final class LongPollingMetrics {
@@ -20,5 +21,10 @@ public final class LongPollingMetrics {
 
   public void setBlockedRequestsCount(final String type, final int count) {
     REQUESTS_QUEUED_CURRENT.labels(type).set(count);
+  }
+
+  @VisibleForTesting("Allows introspecting the long polling state in QA tests")
+  public double getBlockedRequestsCount(final String type) {
+    return REQUESTS_QUEUED_CURRENT.labels(type).get();
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+final class ClientCancelPendingCommandTest {
+  @RegisterExtension
+  final ClusteringRuleExtension cluster = new ClusteringRuleExtension(1, 1, 1, cfg -> {});
+
+  @Test
+  void shouldCancelCommandOnFutureCancellation() {
+    // given
+    final var client = cluster.getClient();
+    final var future =
+        client
+            .newActivateJobsCommand()
+            .jobType("type")
+            .maxJobsToActivate(10)
+            .requestTimeout(Duration.ofHours(1))
+            .send();
+    final var metrics = new LongPollingMetrics();
+    Awaitility.await("until we have one polling client")
+        .untilAsserted(() -> assertThat(metrics.getBlockedRequestsCount("type")).isOne());
+
+    // when - create some jobs after cancellation; the notification will trigger long polling to
+    // remove cancelled requests. unfortunately we can't tell when cancellation is finished
+    future.cancel(true);
+
+    // then
+    Awaitility.await("until no long polling clients are waiting")
+        .untilAsserted(() -> assertThat(metrics.getBlockedRequestsCount("type")).isZero());
+  }
+}


### PR DESCRIPTION
## Description

Allows cancelling in-flight commands via `Future#cancel(boolean)`. If the future is cancelled before the command starts, an `IllegalStateException` is thrown (asynchronously) as the call is considered already cancelled.

To make the most of this, the server side will also have to implement cancellation handlers. For now, we only implement the `ActivateJobs` related cancellation handling, and [a follow up issue was created to handle the rest.](https://github.com/camunda/zeebe/issues/13434)

Cancellation was already mostly handled for `ActivateJobs` - the round robin handler will pro-actively check if it should keep going once a request has been sent out and will stop if the call was cancelled in the mean time. All we add here is a QA test to ensure long polling requests are eagerly removed on cancellation, instead of waiting for a job notification of the right type to do so.

For the QA test, unfortunately I didn't see a nice way to introspect the long polling request state, so I reused the metrics. This is less than ideal, so I'm hoping whoever reviews this has a suggestion :upside_down_face: 

## Related issues

closes #13430 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
