### PR TITLE
Reset reschedule flag correctly on JobTimeoutTrigger

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
@@ -57,9 +57,8 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
 
   @Override
   public void onResumed() {
-    if (shouldReschedule) {
-      scheduleDeactivateTimedOutJobsTask();
-    }
+    shouldReschedule = true;
+    scheduleDeactivateTimedOutJobsTask();
   }
 
   private void scheduleDeactivateTimedOutJobsTask() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -92,6 +92,24 @@ public final class JobTimeOutTest {
   }
 
   @Test
+  public void shouldTimeOutAfterResumed() {
+    // given
+    final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final long timeout = JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL.toMillis() * 2;
+
+    ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
+    ENGINE.pauseProcessing(1);
+    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+
+    // when
+    ENGINE.resumeProcessing(1);
+    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+
+    // then
+    jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
+  }
+
+  @Test
   public void shouldExpireMultipleActivatedJobsAtOnce() {
     // given
     final long instanceKey1 = createInstance();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -110,6 +110,23 @@ public final class JobTimeOutTest {
   }
 
   @Test
+  public void shouldActivateAndTimeOutAfterResumed() {
+    // given
+    final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final long timeout = JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL.toMillis();
+    ENGINE.pauseProcessing(1);
+    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+
+    // when
+    ENGINE.resumeProcessing(1);
+    ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
+    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+
+    // then
+    jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
+  }
+
+  @Test
   public void shouldExpireMultipleActivatedJobsAtOnce() {
     // given
     final long instanceKey1 = createInstance();


### PR DESCRIPTION
## Description
On pause processing we set the `shouldReschedule` flag to false, in order to avoid jobs timing out during the pause of processing.

On resume we haven't reset the flag, which caused us to never timeout jobs again. This PR reset the flag and reschedules the timeout timer

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/13190

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
