### PR TITLE
Single variable API for Complete Job command

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
@@ -56,4 +56,14 @@ public interface CompleteJobCommandStep1 extends FinalCommandStep<CompleteJobRes
    *     to the broker.
    */
   CompleteJobCommandStep1 variables(Object variables);
+
+  /**
+   * Set a single variable to complete the job with.
+   *
+   * @param key the key of the variable as string
+   * @param value the value of the variable as object
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  CompleteJobCommandStep1 variable(String key, Object value);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CommandWithVariables.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CommandWithVariables.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.impl.command;
 
 import io.camunda.zeebe.client.api.JsonMapper;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Map;
 
 public abstract class CommandWithVariables<T> {
@@ -24,7 +25,7 @@ public abstract class CommandWithVariables<T> {
   protected final JsonMapper objectMapper;
 
   public CommandWithVariables(final JsonMapper jsonMapper) {
-    this.objectMapper = jsonMapper;
+    objectMapper = jsonMapper;
   }
 
   public T variables(final InputStream variables) {
@@ -45,6 +46,12 @@ public abstract class CommandWithVariables<T> {
   public T variables(final Object variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
     return setVariablesInternal(objectMapper.toJson(variables));
+  }
+
+  public T variable(final String key, final Object value) {
+    ArgumentUtil.ensureNotNull("key", key);
+    ArgumentUtil.ensureNotNull("value", value);
+    return variables(Collections.singletonMap(key, value));
   }
 
   protected abstract T setVariablesInternal(String variables);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/CompleteJobTest.java
@@ -137,6 +137,25 @@ public final class CompleteJobTest extends ClientTest {
   }
 
   @Test
+  public void shouldCompleteWithSingleVariable() {
+
+    // given
+    final long jobKey = 12;
+    final String key = "key";
+    final String value = "value";
+
+    // when
+    client.newCompleteCommand(jobKey).variable(key, value).send().join();
+
+    // then
+    final String expectedVariable = JsonUtil.toJson(Collections.singletonMap(key, value));
+
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(jobKey);
+    JsonUtil.assertEquality(request.getVariables(), expectedVariable);
+  }
+
+  @Test
   public void shouldSetRequestTimeout() {
     // given
     final Duration requestTimeout = Duration.ofHours(124);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
@@ -121,4 +121,30 @@ public final class CompleteJobTest {
         .isInstanceOf(ClientStatusException.class)
         .hasMessageContaining(expectedMessage);
   }
+
+  @Test
+  public void shouldCompleteJobWithSingleVariable() {
+    final String key = "key";
+    final var value = "value";
+    // when
+    CLIENT_RULE.getClient().newCompleteCommand(jobKey).variable(key, value).send().join();
+
+    // then
+    ZeebeAssertHelper.assertJobCompleted(
+        jobType, (job) -> assertThat(job.getVariables()).containsOnly(entry(key, value)));
+  }
+
+  @Test
+  public void shouldThrowErrorWhenTryToCompleteJobWithNullVariable() {
+    // when
+    assertThatThrownBy(
+            () ->
+                CLIENT_RULE
+                    .getClient()
+                    .newCompleteCommand(jobKey)
+                    .variable(null, null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 }


### PR DESCRIPTION
## Description

Add a new API to `newCompleteJob()` command to allow user to provide a single variable. This reduce overhead and improve the user experience 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13040 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
