### PR TITLE
Allow using custom job worker executors

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilder
 import io.grpc.ClientInterceptor;
 import java.time.Duration;
 import java.util.Properties;
+import java.util.concurrent.ScheduledExecutorService;
 
 public interface ZeebeClientBuilder {
 
@@ -59,6 +60,34 @@ public interface ZeebeClientBuilder {
    *     effectively disables subscriptions and workers. Default value is 1.
    */
   ZeebeClientBuilder numJobWorkerExecutionThreads(int numThreads);
+
+  /**
+   * Identical behavior as {@link #jobWorkerExecutor(ScheduledExecutorService,boolean)}, but taking
+   * ownership of the executor by default. This means the given executor is closed when the client
+   * is closed.
+   *
+   * @param executor an executor service to use when invoking job workers
+   * @see #jobWorkerExecutor(ScheduledExecutorService, boolean)
+   */
+  default ZeebeClientBuilder jobWorkerExecutor(final ScheduledExecutorService executor) {
+    return jobWorkerExecutor(executor, true);
+  }
+
+  /**
+   * Allows passing a custom executor service that will be shared by all job workers created via
+   * this client.
+   *
+   * <p>Polling and handling jobs (e.g. via {@link io.camunda.zeebe.client.api.worker.JobHandler}
+   * will all be invoked on this executor.
+   *
+   * <p>When non-null, this setting override {@link #numJobWorkerExecutionThreads(int)}.
+   *
+   * @param executor an executor service to use when invoking job workers
+   * @param takeOwnership if true, the executor will be closed when the client is closed. otherwise,
+   *     it's up to the caller to manage its lifecycle
+   */
+  ZeebeClientBuilder jobWorkerExecutor(
+      final ScheduledExecutorService executor, final boolean takeOwnership);
 
   /**
    * The name of the worker which is used when none is set for a job worker. Default is 'default'.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.client.api.JsonMapper;
 import io.grpc.ClientInterceptor;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 public interface ZeebeClientConfiguration {
   /**
@@ -97,4 +98,14 @@ public interface ZeebeClientConfiguration {
    * @see ZeebeClientBuilder#maxMessageSize(int)
    */
   int getMaxMessageSize();
+
+  /**
+   * @see ZeebeClientBuilder#jobWorkerExecutor(ScheduledExecutorService)
+   */
+  ScheduledExecutorService jobWorkerExecutor();
+
+  /**
+   * @see ZeebeClientBuilder#jobWorkerExecutor(ScheduledExecutorService, boolean)
+   */
+  boolean ownsJobWorkerExecutor();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ScheduledExecutorService;
 
 public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientConfiguration {
   public static final String PLAINTEXT_CONNECTION_VAR = "ZEEBE_INSECURE_CONNECTION";
@@ -66,6 +67,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private JsonMapper jsonMapper = new ZeebeObjectMapper();
   private String overrideAuthority;
   private int maxMessageSize = 4 * ONE_MB;
+  private ScheduledExecutorService jobWorkerExecutor;
+  private boolean ownsJobWorkerExecutor;
 
   @Override
   public String getGatewayAddress() {
@@ -145,6 +148,16 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public int getMaxMessageSize() {
     return maxMessageSize;
+  }
+
+  @Override
+  public ScheduledExecutorService jobWorkerExecutor() {
+    return jobWorkerExecutor;
+  }
+
+  @Override
+  public boolean ownsJobWorkerExecutor() {
+    return ownsJobWorkerExecutor;
   }
 
   @Override
@@ -237,43 +250,51 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder numJobWorkerExecutionThreads(final int numSubscriptionThreads) {
-    this.numJobWorkerExecutionThreads = numSubscriptionThreads;
+    numJobWorkerExecutionThreads = numSubscriptionThreads;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder jobWorkerExecutor(
+      final ScheduledExecutorService executor, final boolean takeOwnership) {
+    jobWorkerExecutor = executor;
+    ownsJobWorkerExecutor = takeOwnership;
     return this;
   }
 
   @Override
   public ZeebeClientBuilder defaultJobWorkerName(final String workerName) {
-    this.defaultJobWorkerName = workerName;
+    defaultJobWorkerName = workerName;
     return this;
   }
 
   @Override
   public ZeebeClientBuilder defaultJobTimeout(final Duration timeout) {
-    this.defaultJobTimeout = timeout;
+    defaultJobTimeout = timeout;
     return this;
   }
 
   @Override
   public ZeebeClientBuilder defaultJobPollInterval(final Duration pollInterval) {
-    this.defaultJobPollInterval = pollInterval;
+    defaultJobPollInterval = pollInterval;
     return this;
   }
 
   @Override
   public ZeebeClientBuilder defaultMessageTimeToLive(final Duration timeToLive) {
-    this.defaultMessageTimeToLive = timeToLive;
+    defaultMessageTimeToLive = timeToLive;
     return this;
   }
 
   @Override
   public ZeebeClientBuilder defaultRequestTimeout(final Duration requestTimeout) {
-    this.defaultRequestTimeout = requestTimeout;
+    defaultRequestTimeout = requestTimeout;
     return this;
   }
 
   @Override
   public ZeebeClientBuilder usePlaintext() {
-    this.usePlaintextConnection = true;
+    usePlaintextConnection = true;
     return this;
   }
 
@@ -313,7 +334,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder overrideAuthority(final String authority) {
-    this.overrideAuthority = authority;
+    overrideAuthority = authority;
     return this;
   }
 
@@ -376,6 +397,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
     appendProperty(sb, "overrideAuthority", overrideAuthority);
     appendProperty(sb, "maxMessageSize", maxMessageSize);
+    appendProperty(sb, "jobWorkerExecutor", jobWorkerExecutor);
+    appendProperty(sb, "ownsJobWorkerExecutor", ownsJobWorkerExecutor);
 
     return sb.toString();
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -32,6 +32,7 @@ import io.grpc.ClientInterceptor;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class ZeebeClientCloudBuilderImpl
     implements ZeebeClientCloudBuilderStep1,
@@ -95,7 +96,7 @@ public class ZeebeClientCloudBuilderImpl
 
   @Override
   public ZeebeClientBuilder applyEnvironmentVariableOverrides(
-      boolean applyEnvironmentVariableOverrides) {
+      final boolean applyEnvironmentVariableOverrides) {
     innerBuilder.applyEnvironmentVariableOverrides(applyEnvironmentVariableOverrides);
     return this;
   }
@@ -115,6 +116,13 @@ public class ZeebeClientCloudBuilderImpl
   @Override
   public ZeebeClientCloudBuilderStep4 numJobWorkerExecutionThreads(final int numThreads) {
     innerBuilder.numJobWorkerExecutionThreads(numThreads);
+    return this;
+  }
+
+  @Override
+  public ZeebeClientCloudBuilderStep4 jobWorkerExecutor(
+      final ScheduledExecutorService executor, final boolean takeOwnership) {
+    innerBuilder.jobWorkerExecutor(executor, takeOwnership);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/ExecutorResource.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/ExecutorResource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.util;
+
+import io.camunda.zeebe.client.api.command.ClientException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents a shared executor service which may or may not be owned by whoever created it. If it
+ * is owned, then close will shut down the service. Otherwise it's a no-op.
+ */
+public final class ExecutorResource implements AutoCloseable {
+  private final ScheduledExecutorService executor;
+  private final boolean ownsResource;
+
+  public ExecutorResource(final ScheduledExecutorService executor, final boolean ownsResource) {
+    this.executor = executor;
+    this.ownsResource = ownsResource;
+  }
+
+  public ScheduledExecutorService executor() {
+    return executor;
+  }
+
+  @Override
+  public void close() {
+    if (!ownsResource) {
+      return;
+    }
+
+    executor.shutdownNow();
+
+    try {
+      if (!executor.awaitTermination(15, TimeUnit.SECONDS)) {
+        throw new ClientException(
+            "Timed out awaiting termination of job worker executor after 15 seconds");
+      }
+    } catch (final InterruptedException e) {
+      throw new ClientException(
+          "Unexpected interrupted awaiting termination of job worker executor", e);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Enables anyone to pass their own custom executor to the job worker, which may or may not be owned by the client. If it is owned by the client, then it is also shut down on client close; otherwise, it's up to the caller to close it.

The executor will be used to poll for jobs, handle responses, and call each job handler.

If no custom executor is provided, the old behavior of creating a thread pool is kept.


## Related issues

closes #13428 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
