### PR TITLE
Single variable API for Create Process Instance command

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -102,6 +102,16 @@ public interface CreateProcessInstanceCommandStep1 {
     CreateProcessInstanceCommandStep3 variables(Object variables);
 
     /**
+     * Set a single initial variable of the process instance.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CreateProcessInstanceCommandStep3 variable(String key, Object value);
+
+    /**
      * Overrides the default start position of the process. Calling this method will make the
      * process start at the given {@code elementId}, if possible. This method can be called more
      * than once to simultaneously start at different elements in different branches of the process.

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceTest.java
@@ -118,6 +118,20 @@ public final class CreateProcessInstanceTest extends ClientTest {
   }
 
   @Test
+  public void shouldCreateProcessInstanceWithSingleVariable() {
+    // given
+    final String key = "key";
+    final String value = "value";
+
+    // when
+    client.newCreateInstanceCommand().processDefinitionKey(123).variable(key, value).send().join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertThat(fromJsonAsMap(request.getVariables())).containsOnly(entry(key, value));
+  }
+
+  @Test
   public void shouldCreateProcessInstanceWithMapVariables() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceTest.java
@@ -236,12 +236,10 @@ public final class CreateProcessInstanceTest extends ClientTest {
 
   public static class VariableDocument {
 
-    private final String foo = "bar";
-
     VariableDocument() {}
 
     public String getFoo() {
-      return foo;
+      return "bar";
     }
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceWithResultTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceWithResultTest.java
@@ -66,15 +66,14 @@ public final class CreateProcessInstanceWithResultTest extends ClientTest {
     gatewayService.onCreateProcessInstanceWithResultRequest(123, "testProcess", 12, 32, variables);
 
     // when
-    final ProcessInstanceResult response =
-        client
-            .newCreateInstanceCommand()
-            .processDefinitionKey(123)
-            .withResult()
-            .fetchVariables("x")
-            .requestTimeout(Duration.ofSeconds(123))
-            .send()
-            .join();
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .withResult()
+        .fetchVariables("x")
+        .requestTimeout(Duration.ofSeconds(123))
+        .send()
+        .join();
 
     // then
     final CreateProcessInstanceWithResultRequest request = gatewayService.getLastRequest();

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceWithResultTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceWithResultTest.java
@@ -117,6 +117,24 @@ public final class CreateProcessInstanceWithResultTest extends ClientTest {
         .containsOnly(entry("foo", "bar"));
   }
 
+  @Test
+  public void shouldCreateProcessInstanceWithSingleVariable() {
+    // when
+    final String key = "key";
+    final String value = "value";
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .variable(key, value)
+        .withResult()
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceWithResultRequest request = gatewayService.getLastRequest();
+    assertThat(fromJsonAsMap(request.getRequest().getVariables())).containsOnly(entry(key, value));
+  }
+
   private static class VariablesPojo {
     String key;
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
@@ -253,7 +253,7 @@ public final class CreateProcessInstanceTest {
             .variables("[]")
             .send();
 
-    assertThatThrownBy(() -> command.join())
+    assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
         .hasMessageContaining(
             "Property 'variables' is invalid: Expected document to be a root level object, but was 'ARRAY'");
@@ -270,7 +270,7 @@ public final class CreateProcessInstanceTest {
             .latestVersion()
             .send();
 
-    assertThatThrownBy(() -> command.join())
+    assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
         .hasMessageContaining(
             "Expected to find process definition with process ID 'non-existing', but none found");
@@ -282,7 +282,7 @@ public final class CreateProcessInstanceTest {
     final var command =
         CLIENT_RULE.getClient().newCreateInstanceCommand().processDefinitionKey(123L).send();
 
-    assertThatThrownBy(() -> command.join())
+    assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
         .hasMessageContaining("Expected to find process definition with key '123', but none found");
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
@@ -199,6 +199,49 @@ public final class CreateProcessInstanceTest {
   }
 
   @Test
+  public void shouldCreateWithSingleVariable() {
+    // given
+    final String key = "key";
+    final String value = "value";
+
+    // when
+    final ProcessInstanceEvent event =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variable(key, value)
+            .send()
+            .join();
+
+    // then
+    final var createdEvent =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(event.getProcessInstanceKey())
+            .getFirst();
+
+    assertThat(createdEvent.getValue().getVariables()).containsExactlyEntriesOf(Map.of(key, value));
+  }
+
+  @Test
+  public void shouldThrowErrorWhenTryToCreateInstanceWithNullVariable() {
+    // when
+    assertThatThrownBy(
+            () ->
+                CLIENT_RULE
+                    .getClient()
+                    .newCreateInstanceCommand()
+                    .bpmnProcessId(processId)
+                    .latestVersion()
+                    .variable(null, null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   public void shouldRejectCompleteJobIfVariablesAreInvalid() {
     // when
     final var command =

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithLargeResultTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithLargeResultTest.java
@@ -63,4 +63,27 @@ public final class CreateProcessInstanceWithLargeResultTest {
     assertThat(processInstance.getVariables().getBytes(StandardCharsets.UTF_8))
         .hasSizeGreaterThan((int) ByteValue.ofMegabytes(10));
   }
+
+  @Test
+  public void shouldCreateInstanceWithLargeResultAndSingleVariable() {
+    // given
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess("PROCESS").startEvent().endEvent().done());
+
+    // when
+    final ProcessInstanceResult processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId("PROCESS")
+            .latestVersion()
+            .variable("variable", "x".repeat((int) (ByteValue.ofMegabytes(10))))
+            .withResult()
+            .send()
+            .join();
+
+    // then
+    assertThat(processInstance.getVariables().getBytes(StandardCharsets.UTF_8))
+        .hasSizeGreaterThan((int) ByteValue.ofMegabytes(10));
+  }
 }


### PR DESCRIPTION
## Description

Add a new API to `newCreateInstanceProcess()` command to allow user to provide a single variable. This reduce overhead and improve the user experience

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13443 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
