### PR TITLE
Mark skipped commands as processed

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -270,15 +270,6 @@ public final class ProcessingStateMachine {
       }
 
       finalizeCommandProcessing();
-
-      if (currentProcessingResult.isEmpty()) {
-        updateState();
-
-        notifySkippedListener(currentRecord);
-        metrics.eventSkipped();
-        return;
-      }
-
       writeRecords();
     } catch (final RecoverableException recoverableException) {
       // recoverable
@@ -473,7 +464,9 @@ public final class ProcessingStateMachine {
     final ActorFuture<Boolean> retryFuture =
         writeRetryStrategy.runWithRetry(
             () -> {
-              if (pendingWrites.isEmpty()) {
+              if (pendingWrites.isEmpty()) { // we skipped the processing
+                notifySkippedListener(currentRecord);
+                metrics.eventSkipped();
                 return true;
               }
               final var writeResult = logStreamWriter.tryWrite(pendingWrites, sourceRecordPosition);

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -209,7 +209,7 @@ public final class StreamProcessorTest {
         .until(() -> streamPlatform.getLastSuccessfulProcessedRecordPosition(), pos -> pos >= 1);
   }
 
-  @RegressionTest("not updated when instance was banned")
+  @RegressionTest("https://github.com/camunda/zeebe/pull/13427#issuecomment-1630700316")
   public void shouldUpdateLastProcessPositionEvenWhenProcessingSkippedCommand() {
     // given
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();


### PR DESCRIPTION

## Description
_Issue found in recent #13427, see https://github.com/camunda/zeebe/pull/13427#issuecomment-1630700316_


Previously skipped commands, e.g. because of banned instances have been skipped but caused to not update the last processed command position. This can lead to issues, if we have a lot of commands, which need to skip and not update the position we can't do snapshots, nor delete any data. Furthermore, we need to replay all of them on restart.

This commit fixes this issue, we mark the command as processed and reset the transient state. Furthermore, we need to commit the state change, so instead of directly calling skip we have to run updateState in order to commit our transaction.


