### PR TITLE
Single variable API for Publish Message command

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
@@ -104,5 +104,15 @@ public interface PublishMessageCommandStep1 {
      *     it to the broker.
      */
     PublishMessageCommandStep3 variables(Object variables);
+
+    /**
+     * Set a single variable of the message.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    PublishMessageCommandStep3 variable(String key, Object value);
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -207,12 +207,10 @@ public final class PublishMessageTest extends ClientTest {
 
   public static class Variables {
 
-    private final String foo = "bar";
-
     Variables() {}
 
     public String getFoo() {
-      return foo;
+      return "bar";
     }
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public final class PublishMessageTest extends ClientTest {
@@ -131,6 +132,39 @@ public final class PublishMessageTest extends ClientTest {
     // then
     final PublishMessageRequest request = gatewayService.getLastRequest();
     assertThat(fromJsonAsMap(request.getVariables())).contains(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldPublishMessageWithSingleVariable() {
+    // when
+    final String key = "key";
+    final String value = "value";
+    client
+        .newPublishMessageCommand()
+        .messageName("name")
+        .correlationKey("key")
+        .variable(key, value)
+        .send()
+        .join();
+
+    // then
+    final PublishMessageRequest request = gatewayService.getLastRequest();
+    assertThat(fromJsonAsMap(request.getVariables())).contains(entry(key, value));
+  }
+
+  @Test
+  public void shouldThrowErrorWhenTryToPublishMessageWithNullVariable() {
+    // when
+    Assertions.assertThatThrownBy(
+            () ->
+                client
+                    .newPublishMessageCommand()
+                    .messageName("name")
+                    .correlationKey("key")
+                    .variable(null, null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

Add a new API to `newPublishMessageCommand()` command to allow user to provide a single variable. This reduce overhead and improve the user experience

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13447 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
