### PR TITLE
Single variable API for Broadcasting Signal command

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
@@ -65,5 +65,15 @@ public interface BroadcastSignalCommandStep1 {
      *     it to the broker.
      */
     BroadcastSignalCommandStep2 variables(Object variables);
+
+    /**
+     * Set a single variable of the signal.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    BroadcastSignalCommandStep2 variable(String key, Object value);
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
@@ -110,6 +110,18 @@ public final class BroadcastSignalTest extends ClientTest {
   }
 
   @Test
+  public void shouldBroadcastSignalWithSingleVariable() {
+    // when
+    final String key = "key";
+    final String value = "value";
+    client.newBroadcastSignalCommand().signalName("name").variable(key, value).send().join();
+
+    // then
+    final BroadcastSignalRequest request = gatewayService.getLastRequest();
+    assertThat(fromJsonAsMap(request.getVariables())).containsOnly(entry(key, value));
+  }
+
+  @Test
   public void shouldRaiseExceptionOnError() {
     // given
     gatewayService.errorOnRequest(

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
@@ -152,12 +152,10 @@ public final class BroadcastSignalTest extends ClientTest {
 
   public static class Variables {
 
-    private final String foo = "bar";
-
     Variables() {}
 
     public String getFoo() {
-      return foo;
+      return "bar";
     }
   }
 }


### PR DESCRIPTION
## Description

Add a new API to `newBroadcastingSignalCommand()` command to allow user to provide a single variable. This reduce overhead and improve the user experience

## Related issues

closes #13451 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
