### PR TITLE
[Backport stable/8.0] fix: more precise and reliable way to force new leaders in tests

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/BrokerLeaderChangeTest.java
@@ -63,7 +63,7 @@ public final class BrokerLeaderChangeTest {
     final var firstLeaderNodeId = firstLeaderInfo.getNodeId();
 
     // when
-    clusteringRule.forceClusterToHaveNewLeader(1, firstLeaderNodeId);
+    clusteringRule.forceNewLeaderForPartition(firstLeaderNodeId, 1);
 
     // then
     assertThat(clusteringRule.getCurrentLeaderForPartition(1).getNodeId())

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/BrokerLeaderChangeTest.java
@@ -63,7 +63,7 @@ public final class BrokerLeaderChangeTest {
     final var firstLeaderNodeId = firstLeaderInfo.getNodeId();
 
     // when
-    clusteringRule.forceClusterToHaveNewLeader(firstLeaderNodeId);
+    clusteringRule.forceClusterToHaveNewLeader(1, firstLeaderNodeId);
 
     // then
     assertThat(clusteringRule.getCurrentLeaderForPartition(1).getNodeId())

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -15,6 +15,7 @@ import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setCluster
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setInitialContactPoints;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.AtomixClusterBuilder;
@@ -611,27 +612,38 @@ public class ClusteringRule extends ExternalResource {
     }
   }
 
-  public void forceClusterToHaveNewLeader(final int expectedLeader) {
-    final var previousLeader = getCurrentLeaderForPartition(1);
-    if (previousLeader.getNodeId() == expectedLeader) {
+  public void forceClusterToHaveNewLeader(final int partitionId, final int expectedLeaderId) {
+    final var previousLeader = getCurrentLeaderForPartition(partitionId);
+    final var expectedLeader = brokers.get(expectedLeaderId);
+
+    if (previousLeader.getNodeId() == expectedLeaderId) {
       return;
     }
 
-    final var broker = brokers.get(expectedLeader);
-    final var atomix = broker.getBrokerContext().getClusterServices();
-    final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
+    final var serverOfExpectedLeader =
+        ((RaftPartition)
+                expectedLeader
+                    .getBrokerContext()
+                    .getPartitionManager()
+                    .getPartitionGroup()
+                    .getPartition(partitionId))
+            .getServer();
 
-    final var raftPartition =
-        broker.getBrokerContext().getPartitionManager().getPartitionGroup().getPartitions().stream()
-            .filter(partition -> partition.members().contains(nodeId))
-            .filter(partition -> partition.id().id() == START_PARTITION_ID)
-            .map(RaftPartition.class::cast)
-            .findFirst()
-            .orElseThrow();
+    Awaitility.await("Promote request is successful")
+        .pollInterval(Duration.ofMillis(500))
+        .timeout(Duration.ofMinutes(1))
+        .untilAsserted(
+            () ->
+                assertThat(serverOfExpectedLeader.promote())
+                    .succeedsWithin(Duration.ofSeconds(15)));
 
-    raftPartition.getServer().promote().join();
-
-    awaitOtherLeader(START_PARTITION_ID, previousLeader.getNodeId());
+    Awaitility.await("New leader of partition %s is %s".formatted(partitionId, expectedLeaderId))
+        .pollInterval(Duration.ofMillis(500))
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions()
+        .until(
+            () -> getLeaderForPartition(partitionId),
+            (leader) -> leader.getNodeId() == expectedLeaderId);
   }
 
   public void waitForTopology(final Consumer<TopologyAssert> assertions) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -612,7 +612,7 @@ public class ClusteringRule extends ExternalResource {
     }
   }
 
-  public void forceClusterToHaveNewLeader(final int partitionId, final int expectedLeaderId) {
+  public void forceNewLeaderForPartition(final int expectedLeaderId, final int partitionId) {
     final var previousLeader = getCurrentLeaderForPartition(partitionId);
     final var expectedLeader = brokers.get(expectedLeaderId);
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -52,7 +52,7 @@ public class InstallRequestHandlingTest {
 
     // then
     clusteringRule.waitForSnapshotAtBroker(followerId);
-    clusteringRule.forceClusterToHaveNewLeader(followerId);
+    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
 
     clientRule.getClient().newCompleteCommand(jobKey).send().join();
     ZeebeAssertHelper.assertProcessInstanceCompleted("process");
@@ -79,7 +79,7 @@ public class InstallRequestHandlingTest {
     clientRule.createProcessInstance(processDefinitionKey);
 
     // then
-    clusteringRule.forceClusterToHaveNewLeader(followerId);
+    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
 
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -52,7 +52,7 @@ public class InstallRequestHandlingTest {
 
     // then
     clusteringRule.waitForSnapshotAtBroker(followerId);
-    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
+    clusteringRule.forceNewLeaderForPartition(followerId, 1);
 
     clientRule.getClient().newCompleteCommand(jobKey).send().join();
     ZeebeAssertHelper.assertProcessInstanceCompleted("process");
@@ -79,7 +79,7 @@ public class InstallRequestHandlingTest {
     clientRule.createProcessInstance(processDefinitionKey);
 
     // then
-    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
+    clusteringRule.forceNewLeaderForPartition(followerId, 1);
 
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -68,7 +68,7 @@ public class ReaderCloseTest {
             .getConfig()
             .getCluster()
             .getNodeId();
-    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
+    clusteringRule.forceNewLeaderForPartition(followerId, 1);
     // because of https://github.com/camunda/zeebe/issues/8329
     // we need to add another record so we can do a snapshot
     clientRule

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -68,7 +68,7 @@ public class ReaderCloseTest {
             .getConfig()
             .getCluster()
             .getNodeId();
-    clusteringRule.forceClusterToHaveNewLeader(followerId);
+    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
     // because of https://github.com/camunda/zeebe/issues/8329
     // we need to add another record so we can do a snapshot
     clientRule


### PR DESCRIPTION
# Description
Backport of #10066 to `stable/8.0`.

relates to #9921