### PR TITLE
Single variable API for Modify Process Instance command

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -162,5 +162,31 @@ public interface ModifyProcessInstanceCommandStep1 {
      * @return the builder for this command
      */
     ModifyProcessInstanceCommandStep3 withVariables(final Object variables, final String scopeId);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variable will be created in the global scope
+     * of the process instance.
+     *
+     * @param key the key of the variable to be serialized to JSON
+     * @param value the value of the variable to be serialized to JSON
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariable(final String key, final Object value);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variable will be created in the scope of the
+     * passed element.
+     *
+     * @param key the key of the variable to be serialized to JSON
+     * @param value the value of the variable to be serialized to JSON
+     * @param scopeId the id of the element in which scope the variable should be created
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariable(
+        final String key, final Object value, final String scopeId);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -166,7 +166,7 @@ public interface ModifyProcessInstanceCommandStep1 {
     /**
      * Create a {@link
      * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
-     * for the element that's getting activated. These variable will be created in the global scope
+     * for the element that's getting activated. This variable will be created in the global scope
      * of the process instance.
      *
      * @param key the key of the variable to be serialized to JSON
@@ -178,7 +178,7 @@ public interface ModifyProcessInstanceCommandStep1 {
     /**
      * Create a {@link
      * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
-     * for the element that's getting activated. These variable will be created in the scope of the
+     * for the element that's getting activated. This variable will be created in the scope of the
      * passed element.
      *
      * @param key the key of the variable to be serialized to JSON

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CommandWithVariables.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CommandWithVariables.java
@@ -50,7 +50,6 @@ public abstract class CommandWithVariables<T> {
 
   public T variable(final String key, final Object value) {
     ArgumentUtil.ensureNotNull("key", key);
-    ArgumentUtil.ensureNotNull("value", value);
     return variables(Collections.singletonMap(key, value));
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstance
 import io.grpc.stub.StreamObserver;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -150,11 +151,32 @@ public final class ModifyProcessInstanceCommandImpl
     return this;
   }
 
+  @Override
+  public ModifyProcessInstanceCommandStep3 withVariable(final String key, final Object value) {
+    return withVariable(key, value, EMPTY_SCOPE_ID);
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep3 withVariable(
+      final String key, final Object value, final String scopeId) {
+    final VariableInstruction variableInstruction = createVariableInstruction(key, value, scopeId);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
+    return this;
+  }
+
   private VariableInstruction createVariableInstruction(
       final InputStream variables, final String scopeId) {
     ArgumentUtil.ensureNotNull("variables", variables);
     final String variablesString = jsonMapper.validateJson("variables", variables);
     return createVariableInstruction(variablesString, scopeId);
+  }
+
+  private VariableInstruction createVariableInstruction(
+      final String key, final Object value, final String scopeId) {
+    ArgumentUtil.ensureNotNull("key", key);
+    ArgumentUtil.ensureNotNull("value", value);
+    final Map<String, Object> variable = Collections.singletonMap(key, value);
+    return createVariableInstruction(variable, scopeId);
   }
 
   private VariableInstruction createVariableInstruction(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -159,9 +159,8 @@ public final class ModifyProcessInstanceCommandImpl
   @Override
   public ModifyProcessInstanceCommandStep3 withVariable(
       final String key, final Object value, final String scopeId) {
-    final VariableInstruction variableInstruction = createVariableInstruction(key, value, scopeId);
-    addVariableInstructionToLatestActivateInstruction(variableInstruction);
-    return this;
+    ArgumentUtil.ensureNotNull("key", key);
+    return withVariables(Collections.singletonMap(key, value), scopeId);
   }
 
   private VariableInstruction createVariableInstruction(
@@ -169,14 +168,6 @@ public final class ModifyProcessInstanceCommandImpl
     ArgumentUtil.ensureNotNull("variables", variables);
     final String variablesString = jsonMapper.validateJson("variables", variables);
     return createVariableInstruction(variablesString, scopeId);
-  }
-
-  private VariableInstruction createVariableInstruction(
-      final String key, final Object value, final String scopeId) {
-    ArgumentUtil.ensureNotNull("key", key);
-    ArgumentUtil.ensureNotNull("value", value);
-    final Map<String, Object> variable = Collections.singletonMap(key, value);
-    return createVariableInstruction(variable, scopeId);
   }
 
   private VariableInstruction createVariableInstruction(

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/ModifyProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/ModifyProcessInstanceTest.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class ModifyProcessInstanceTest extends ClientTest {
@@ -294,25 +295,6 @@ public class ModifyProcessInstanceTest extends ClientTest {
   }
 
   @Test
-  public void shouldActivateElementWithMapVariablesAndScopeId() {
-    // when
-    client
-        .newModifyProcessInstanceCommand(PI_KEY)
-        .activateElement(ELEMENT_ID_A)
-        .withVariables(Collections.singletonMap("foo", "bar"), ELEMENT_ID_B)
-        .send()
-        .join();
-
-    // then
-    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
-    assertRequest(request, 1, 0);
-    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
-    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
-    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
-    assertVariableInstruction(variableInstruction, ELEMENT_ID_B);
-  }
-
-  @Test
   public void shouldActivateElementWithObjectVariablesAndScopeId() {
     // when
     client
@@ -362,6 +344,77 @@ public class ModifyProcessInstanceTest extends ClientTest {
     assertVariableInstruction(variableInstruction3, EMPTY_ELEMENT_ID);
     final VariableInstruction variableInstruction4 = activateInstruction.getVariableInstructions(3);
     assertVariableInstruction(variableInstruction4, EMPTY_ELEMENT_ID);
+  }
+
+  @Test
+  public void shouldActivateElementWithMapVariablesAndScopeId() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(Collections.singletonMap("foo", "bar"), ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, ELEMENT_ID_B);
+  }
+
+  @Test
+  public void shouldActivateElementWithSingleVariableAndScopeId() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariable("foo", "bar", ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, ELEMENT_ID_B);
+  }
+
+  @Test
+  public void shouldActivateElementWithSingleVariable() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariable("foo", "bar")
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, EMPTY_ELEMENT_ID);
+  }
+
+  @Test
+  public void shouldThrowErrorWhenTryToActivateElementWithNullVariable() {
+    // when
+    Assertions.assertThatThrownBy(
+            () ->
+                client
+                    .newModifyProcessInstanceCommand(PI_KEY)
+                    .activateElement(ELEMENT_ID_A)
+                    .withVariable(null, null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   private void assertRequest(


### PR DESCRIPTION
## Description

Add a new API to `newModifyInstanceProcess()` command to allow user to provide a single variable. This reduce overhead and improve the user experience

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13460 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
