### PR TITLE
Implement ZeebeClient wrapper for the StreamJobs RPC

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.StreamJobsResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+
+public interface StreamJobsCommandStep1 {
+  /**
+   * Set the type of jobs to work on; only jobs of this type will be activated and consumed by this
+   * stream.
+   *
+   * @param jobType the type of jobs (e.g. "payment")
+   * @return the builder for this command
+   */
+  StreamJobsCommandStep2 jobType(String jobType);
+
+  interface StreamJobsCommandStep2 {
+
+    /**
+     * Sets the consumer to receive activated jobs. Note that jobs can be activated on different
+     * threads, so the consumer should be thread-safe.
+     *
+     * @param consumer the job consumer
+     * @return the builder's next step
+     * @throws NullPointerException if the consumer is null
+     */
+    StreamJobsCommandStep3 consumer(final Consumer<ActivatedJob> consumer);
+  }
+
+  interface StreamJobsCommandStep3 extends FinalCommandStep<StreamJobsResponse> {
+    /**
+     * Set the time for how long a job is exclusively assigned for this subscription.
+     *
+     * <p>In this time, the job can not be assigned by other subscriptions to ensure that only one
+     * subscription work on the job. When the time is over then the job can be assigned again by
+     * this or other subscription if it's not completed yet.
+     *
+     * <p>If no time is set then the default is used from the configuration.
+     *
+     * @param timeout the time as duration (e.g. "Duration.ofMinutes(5)")
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    StreamJobsCommandStep3 timeout(Duration timeout);
+
+    /**
+     * Set the name of the job worker.
+     *
+     * <p>This name is used to identify the worker which activated the jobs. Its main purpose is for
+     * monitoring and auditing. Commands on activated jobs do not check the worker name, i.e.
+     * complete or fail job.
+     *
+     * <p>If no name is set then the default is used from the configuration.
+     *
+     * @param workerName the name of the worker (e.g. "payment-service")
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    StreamJobsCommandStep3 workerName(String workerName);
+
+    /**
+     * Set a list of variable names which should be fetch on job activation.
+     *
+     * <p>The jobs which are activated by this command will only contain variables from this list.
+     *
+     * <p>This can be used to limit the number of variables of the activated jobs.
+     *
+     * @param fetchVariables list of variables names to fetch on activation
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    StreamJobsCommandStep3 fetchVariables(List<String> fetchVariables);
+
+    /**
+     * Set a list of variable names which should be fetched on job activation.
+     *
+     * <p>The jobs which are activated by this command will only contain variables from this list.
+     *
+     * <p>This can be used to limit the number of variables of the activated jobs.
+     *
+     * @param fetchVariables list of variables names to fetch on activation
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    StreamJobsCommandStep3 fetchVariables(String... fetchVariables);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/StreamJobsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/StreamJobsResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface StreamJobsResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
 import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
@@ -53,6 +54,7 @@ import io.camunda.zeebe.client.impl.command.ModifyProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.PublishMessageCommandImpl;
 import io.camunda.zeebe.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.zeebe.client.impl.command.SetVariablesCommandImpl;
+import io.camunda.zeebe.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.TopologyRequestImpl;
 import io.camunda.zeebe.client.impl.util.VersionUtil;
 import io.camunda.zeebe.client.impl.worker.JobClientImpl;
@@ -343,17 +345,18 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
-  public ActivateJobsCommandStep1 newActivateJobsCommand() {
-    return jobClient.newActivateJobsCommand();
-  }
-
-  @Override
   public DeleteResourceCommandStep1 newDeleteResourceCommand(final long resourceKey) {
     return new DeleteResourceCommandImpl(
         resourceKey,
         asyncStub,
         credentialsProvider::shouldRetryRequest,
         config.getDefaultRequestTimeout());
+  }
+
+  @Override
+  public StreamJobsCommandStep1 newStreamJobsCommand() {
+    return new StreamJobsCommandImpl(
+        asyncStub, jsonMapper, credentialsProvider::shouldRetryRequest, config);
   }
 
   private JobClient newJobClient() {
@@ -389,5 +392,10 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public ThrowErrorCommandStep1 newThrowErrorCommand(final ActivatedJob job) {
     return newThrowErrorCommand(job.getKey());
+  }
+
+  @Override
+  public ActivateJobsCommandStep1 newActivateJobsCommand() {
+    return jobClient.newActivateJobsCommand();
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep2;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.StreamJobsResponse;
+import io.camunda.zeebe.client.impl.RetriableStreamingFutureImpl;
+import io.camunda.zeebe.client.impl.response.ActivatedJobImpl;
+import io.camunda.zeebe.client.impl.response.StreamJobsResponseImpl;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest.Builder;
+import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public final class StreamJobsCommandImpl
+    implements StreamJobsCommandStep1, StreamJobsCommandStep2, StreamJobsCommandStep3 {
+
+  private final GatewayStub asyncStub;
+  private final JsonMapper jsonMapper;
+  private final Predicate<Throwable> retryPredicate;
+  private final Builder builder;
+
+  private Consumer<ActivatedJob> consumer;
+  private Duration requestTimeout;
+
+  public StreamJobsCommandImpl(
+      final GatewayStub asyncStub,
+      final JsonMapper jsonMapper,
+      final Predicate<Throwable> retryPredicate,
+      final ZeebeClientConfiguration config) {
+    this.asyncStub = asyncStub;
+    this.jsonMapper = jsonMapper;
+    this.retryPredicate = retryPredicate;
+    builder = StreamActivatedJobsRequest.newBuilder();
+
+    timeout(config.getDefaultJobTimeout()).workerName(config.getDefaultJobWorkerName());
+  }
+
+  @Override
+  public FinalCommandStep<StreamJobsResponse> requestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<StreamJobsResponse> send() {
+    final StreamActivatedJobsRequest request = builder.build();
+    final RetriableStreamingFutureImpl<StreamJobsResponse, GatewayOuterClass.ActivatedJob> result =
+        new RetriableStreamingFutureImpl<>(
+            new StreamJobsResponseImpl(),
+            this::consumeJob,
+            retryPredicate,
+            streamObserver -> send(request, streamObserver));
+
+    send(request, result);
+    return result;
+  }
+
+  private void send(
+      final StreamActivatedJobsRequest request,
+      final StreamObserver<GatewayOuterClass.ActivatedJob> observer) {
+    GatewayStub stub = asyncStub;
+    if (requestTimeout != null) {
+      stub = stub.withDeadlineAfter(requestTimeout.toNanos(), TimeUnit.NANOSECONDS);
+    }
+
+    stub.streamActivatedJobs(request, observer);
+  }
+
+  @Override
+  public StreamJobsCommandStep2 jobType(final String jobType) {
+    builder.setType(Objects.requireNonNull(jobType, "must specify a job type"));
+    return this;
+  }
+
+  @Override
+  public StreamJobsCommandStep3 consumer(final Consumer<ActivatedJob> consumer) {
+    this.consumer = Objects.requireNonNull(consumer, "must specify a job consumer");
+    return this;
+  }
+
+  @Override
+  public StreamJobsCommandStep3 timeout(final Duration timeout) {
+    Objects.requireNonNull(timeout, "must specify a job timeout");
+    builder.setTimeout(timeout.toMillis());
+    return this;
+  }
+
+  @Override
+  public StreamJobsCommandStep3 workerName(final String workerName) {
+    builder.setWorker(workerName);
+    return this;
+  }
+
+  @Override
+  public StreamJobsCommandStep3 fetchVariables(final List<String> fetchVariables) {
+    builder.addAllFetchVariable(fetchVariables);
+    return this;
+  }
+
+  @Override
+  public StreamJobsCommandStep3 fetchVariables(final String... fetchVariables) {
+    return fetchVariables(Arrays.asList(fetchVariables));
+  }
+
+  private void consumeJob(final GatewayOuterClass.ActivatedJob job) {
+    final ActivatedJobImpl mappedJob = new ActivatedJobImpl(jsonMapper, job);
+    consumer.accept(mappedJob);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class ActivatedJobImpl implements ActivatedJob {
@@ -44,7 +45,12 @@ public final class ActivatedJobImpl implements ActivatedJob {
 
     key = job.getKey();
     type = job.getType();
-    customHeaders = jsonMapper.fromJsonAsStringMap(job.getCustomHeaders());
+
+    // the default value of a string in Protobuf is an empty string, so this could fail if no
+    // headers were given
+    final String customHeaders = job.getCustomHeaders();
+    this.customHeaders =
+        customHeaders.isEmpty() ? new HashMap<>() : jsonMapper.fromJsonAsStringMap(customHeaders);
     worker = job.getWorker();
     retries = job.getRetries();
     deadline = job.getDeadline();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/StreamJobsResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/StreamJobsResponseImpl.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import io.camunda.zeebe.client.api.response.StreamJobsResponse;
+
+public final class StreamJobsResponseImpl implements StreamJobsResponse {}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/StreamJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/StreamJobsTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.job;
+
+import static io.camunda.zeebe.client.util.JsonUtil.fromJsonAsMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.response.StreamJobsResponse;
+import io.camunda.zeebe.client.util.ClientTest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public final class StreamJobsTest extends ClientTest {
+  @Test
+  public void shouldStreamJobs() {
+    // given
+    final List<io.camunda.zeebe.client.api.response.ActivatedJob> receivedJobs = new ArrayList<>();
+    final ActivatedJob activatedJob1 =
+        ActivatedJob.newBuilder()
+            .setKey(12)
+            .setType("foo")
+            .setProcessInstanceKey(123)
+            .setBpmnProcessId("test1")
+            .setProcessDefinitionVersion(2)
+            .setProcessDefinitionKey(23)
+            .setElementId("foo")
+            .setElementInstanceKey(23213)
+            .setCustomHeaders("{\"version\": \"1\"}")
+            .setWorker("worker1")
+            .setRetries(34)
+            .setDeadline(1231)
+            .setVariables("{\"key\": \"val\"}")
+            .build();
+    final ActivatedJob activatedJob2 =
+        ActivatedJob.newBuilder()
+            .setKey(42)
+            .setType("foo")
+            .setProcessInstanceKey(333)
+            .setBpmnProcessId("test3")
+            .setProcessDefinitionVersion(23)
+            .setProcessDefinitionKey(11)
+            .setElementId("bar")
+            .setElementInstanceKey(111)
+            .setCustomHeaders("{\"key\": \"value\"}")
+            .setWorker("worker1")
+            .setRetries(334)
+            .setDeadline(3131)
+            .setVariables("{\"bar\": 3}")
+            .build();
+    gatewayService.onStreamJobsRequest(activatedJob1, activatedJob2);
+
+    // when
+    final StreamJobsResponse response =
+        client
+            .newStreamJobsCommand()
+            .jobType("foo")
+            .consumer(receivedJobs::add)
+            .timeout(Duration.ofMillis(1000))
+            .workerName("worker1")
+            .send()
+            .join();
+
+    // then - we can more easily compare the results of both jobs by serializing them to JSON
+    final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
+
+    assertThat(request.getType()).isEqualTo("foo");
+    assertThat(request.getTimeout()).isEqualTo(1000);
+    assertThat(request.getWorker()).isEqualTo("worker1");
+
+    assertThat(response).isNotNull();
+    assertThat(receivedJobs).hasSize(2);
+
+    io.camunda.zeebe.client.api.response.ActivatedJob job = receivedJobs.get(0);
+    assertThat(job.getKey()).isEqualTo(activatedJob1.getKey());
+    assertThat(job.getType()).isEqualTo(activatedJob1.getType());
+    assertThat(job.getBpmnProcessId()).isEqualTo(activatedJob1.getBpmnProcessId());
+    assertThat(job.getElementId()).isEqualTo(activatedJob1.getElementId());
+    assertThat(job.getElementInstanceKey()).isEqualTo(activatedJob1.getElementInstanceKey());
+    assertThat(job.getProcessDefinitionVersion())
+        .isEqualTo(activatedJob1.getProcessDefinitionVersion());
+    assertThat(job.getProcessDefinitionKey()).isEqualTo(activatedJob1.getProcessDefinitionKey());
+    assertThat(job.getProcessInstanceKey()).isEqualTo(activatedJob1.getProcessInstanceKey());
+    assertThat(job.getCustomHeaders()).isEqualTo(fromJsonAsMap(activatedJob1.getCustomHeaders()));
+    assertThat(job.getWorker()).isEqualTo(activatedJob1.getWorker());
+    assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
+    assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
+    assertThat(job.getVariables()).isEqualTo(activatedJob1.getVariables());
+
+    job = receivedJobs.get(1);
+    assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());
+    assertThat(job.getType()).isEqualTo(activatedJob2.getType());
+    assertThat(job.getBpmnProcessId()).isEqualTo(activatedJob2.getBpmnProcessId());
+    assertThat(job.getElementId()).isEqualTo(activatedJob2.getElementId());
+    assertThat(job.getElementInstanceKey()).isEqualTo(activatedJob2.getElementInstanceKey());
+    assertThat(job.getProcessDefinitionVersion())
+        .isEqualTo(activatedJob2.getProcessDefinitionVersion());
+    assertThat(job.getProcessDefinitionKey()).isEqualTo(activatedJob2.getProcessDefinitionKey());
+    assertThat(job.getProcessInstanceKey()).isEqualTo(activatedJob2.getProcessInstanceKey());
+    assertThat(job.getCustomHeaders()).isEqualTo(fromJsonAsMap(activatedJob2.getCustomHeaders()));
+    assertThat(job.getWorker()).isEqualTo(activatedJob2.getWorker());
+    assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());
+    assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
+    assertThat(job.getVariables()).isEqualTo(activatedJob2.getVariables());
+  }
+
+  @Test
+  public void shouldSetTimeoutFromDuration() {
+    // given
+    final Duration timeout = Duration.ofMinutes(2);
+
+    // when
+    client
+        .newStreamJobsCommand()
+        .jobType("foo")
+        .consumer(ignored -> {})
+        .timeout(timeout)
+        .send()
+        .join();
+
+    // then
+    final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getTimeout()).isEqualTo(timeout.toMillis());
+  }
+
+  @Test
+  public void shouldSetFetchVariables() {
+    // given
+    final List<String> fetchVariables = Arrays.asList("foo", "bar", "baz");
+
+    // when
+    client
+        .newStreamJobsCommand()
+        .jobType("foo")
+        .consumer(ignored -> {})
+        .fetchVariables(fetchVariables)
+        .send()
+        .join();
+
+    // then
+    final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getFetchVariableList()).containsExactlyInAnyOrderElementsOf(fetchVariables);
+  }
+
+  @Test
+  public void shouldSetFetchVariablesAsVargs() {
+    // given
+    final String[] fetchVariables = new String[] {"foo", "bar", "baz"};
+
+    // when
+    client
+        .newStreamJobsCommand()
+        .jobType("foo")
+        .consumer(ignored -> {})
+        .fetchVariables(fetchVariables)
+        .send()
+        .join();
+
+    // then
+    final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getFetchVariableList()).containsExactlyInAnyOrder(fetchVariables);
+  }
+
+  @Test
+  public void shouldSetDefaultValues() {
+    // when
+    client.newStreamJobsCommand().jobType("foo").consumer(ignored -> {}).send().join();
+
+    // then
+    final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getTimeout())
+        .isEqualTo(client.getConfiguration().getDefaultJobTimeout().toMillis());
+    assertThat(request.getWorker()).isEqualTo(client.getConfiguration().getDefaultJobWorkerName());
+    assertThat(request.getFetchVariableList()).isEmpty();
+  }
+
+  @Test
+  public void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        StreamActivatedJobsRequest.class, () -> new ClientException("Invalid request"));
+
+    // when
+    assertThatThrownBy(
+            () ->
+                client.newStreamJobsCommand().jobType("foo").consumer(ignored -> {}).send().join())
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("Invalid request");
+  }
+
+  @Test
+  public void shouldSetWorker() {
+    // when
+    client
+        .newStreamJobsCommand()
+        .jobType("foo")
+        .consumer(ignored -> {})
+        .workerName("testWorker")
+        .send()
+        .join();
+
+    // then
+    final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getWorker()).isEqualTo("testWorker");
+  }
+
+  @Test
+  public void shouldSetRequestTimeout() {
+    // given
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client
+        .newStreamJobsCommand()
+        .jobType("foo")
+        .consumer(ignored -> {})
+        .requestTimeout(requestTimeout)
+        .send()
+        .join();
+
+    // then
+    Mockito.verify(rule.getGatewayStub(), Mockito.times(1))
+        .withDeadlineAfter(requestTimeout.toNanos(), TimeUnit.NANOSECONDS);
+  }
+}


### PR DESCRIPTION
## Description

This PR implements a new `StreamJobsCommand`, instantiated via `ZeebeClient#newStreamJobsCommand`. The command has two required arguments: the job type, and a consumer of `ActivatedJob`. It also takes in three optional arguments: worker name, job activation timeout, and fetch variables. The API in general for the builder was kept mostly aligned with the `ActivateJobsCommand`.

Since this is a long living stream, we don't want users to wait for the response before receiving jobs, thus the consumer. The actual response is just an empty response to keep things aligned and for future proofing.

Since this is a long living stream, it isn't meant to be completed/terminated. However, it's still recommended to recreate the streams from time to time to allow proper load balancing across gateways. As such, this PR builds on top of #13430, such that users can call `Future#cancel(boolean)` to terminate the stream. Alternatively, they can set a request timeout. **As opposed to the normal commands, the default request timeout is ignored here - by default, there will be no time out, unless the user provides one.**

I've only added unit tests, as without the gateway part, I can't add integration tests yet.

## Related issues

closes #13429 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
