### PR TITLE
[Backport stable/8.2] Mark skipped commands as processed

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -269,14 +269,17 @@ public final class ProcessingStateMachine {
         processingMetrics.observeCommandCount(processedCommandsCount);
       }
 
+      finalizeCommandProcessing();
+
       if (currentProcessingResult.isEmpty()) {
-        skipRecord();
+        updateState();
+
+        notifySkippedListener(currentRecord);
+        metrics.eventSkipped();
         return;
       }
 
-      lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
       writeRecords();
-      processedCommandsCount = 0;
     } catch (final RecoverableException recoverableException) {
       // recoverable
       LOG.error(
@@ -311,6 +314,17 @@ public final class ProcessingStateMachine {
           });
     }
   }
+  /**
+   * Finalize the command processing, which includes certain clean-up tasks, like mark the command
+   * as processed and reset transient processing state, etc.
+   *
+   * <p>Should be called after processing or error handling is done.
+   */
+  private void finalizeCommandProcessing() {
+    lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
+    processedCommandsCount = 0;
+  }
+
   /**
    * Starts the batch processing with the given initial command and iterates over ProcessingResult
    * and applies all follow-up commands until the command limit is reached or no more follow-up
@@ -448,7 +462,7 @@ public final class ProcessingStateMachine {
           // we need to mark the command as processed, even if the processing failed
           // otherwise we might replay the events, which have been written during
           // #onProcessingError again on restart
-          lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
+          finalizeCommandProcessing();
         });
   }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RetryStrategy;
@@ -457,29 +458,41 @@ public final class ProcessingStateMachine {
         });
   }
 
-  private void writeRecords() {
+  private ActorFuture<Boolean> writeWithRetryAsync() {
     final var sourceRecordPosition = typedCommand.getPosition();
 
-    final ActorFuture<Boolean> retryFuture =
-        writeRetryStrategy.runWithRetry(
-            () -> {
-              if (pendingWrites.isEmpty()) { // we skipped the processing
-                notifySkippedListener(currentRecord);
-                metrics.eventSkipped();
-                return true;
-              }
-              final var writeResult = logStreamWriter.tryWrite(pendingWrites, sourceRecordPosition);
-              if (writeResult.isRight()) {
-                writtenPosition = writeResult.get();
-                return true;
-              } else {
-                return false;
-              }
-            },
-            abortCondition);
+    final ActorFuture<Boolean> writeFuture;
+    if (currentProcessingResult.isEmpty()) {
+      // we skipped the processing entirely; we have no results
+      notifySkippedListener(currentRecord);
+      metrics.eventSkipped();
+      writeFuture = CompletableActorFuture.completed(true);
+    } else if (pendingWrites.isEmpty()) {
+      // we might have nothing to write but likely something to send as response
+      // means we will not mark the record as skipped
+      writeFuture = CompletableActorFuture.completed(true);
+    } else {
+      writeFuture =
+          writeRetryStrategy.runWithRetry(
+              () -> {
+                final var writeResult =
+                    logStreamWriter.tryWrite(pendingWrites, sourceRecordPosition);
+                if (writeResult.isRight()) {
+                  writtenPosition = writeResult.get();
+                  return true;
+                } else {
+                  return false;
+                }
+              },
+              abortCondition);
+    }
+    return writeFuture;
+  }
 
+  private void writeRecords() {
+    final ActorFuture<Boolean> writeFuture = writeWithRetryAsync();
     actor.runOnCompletion(
-        retryFuture,
+        writeFuture,
         (bool, t) -> {
           if (t != null) {
             LOG.error(ERROR_MESSAGE_WRITE_RECORD_ABORTED, currentRecord, metadata, t);

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -209,7 +209,7 @@ public final class StreamProcessorTest {
         .until(() -> streamPlatform.getLastSuccessfulProcessedRecordPosition(), pos -> pos >= 1);
   }
 
-  @RegressionTest("not updated when instance was banned")
+  @RegressionTest("https://github.com/camunda/zeebe/pull/13427#issuecomment-1630700316")
   public void shouldUpdateLastProcessPositionEvenWhenProcessingSkippedCommand() {
     // given
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();


### PR DESCRIPTION
# Description
Backport of #13446 to `stable/8.2`.

relates to 