### PR TITLE
Prevent dependabot from updating Opensearch major and minor versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
       # as we need to sync with the other teams before doing that
       - dependency-name: org.elasticsearch.client:*
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      # we will always manually update OS dependencies to minor or major releases
+      # as we need to sync with the other teams before doing that
+      - dependency-name: org.opensearch.client:*
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # After updating to Jacoco 0.8.9 we ran into the issue that our smoke tests on macOS kept
       # failing as it couldn't resolve all of Jacoco's dependencies. It's not quite clear why this
       # happened, but we could identify that it started after updating to this patch version. We

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -31,9 +31,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 final class OpensearchClientIT {
   @Container
   private static final OpensearchContainer CONTAINER =
-      TestSupport.createDefaultContainer()
-          .withSecurityEnabled()
-          .withEnv("plugins.security.restapi.password_score_based_validation_strength", "fair");
+      TestSupport.createDefaultContainer().withSecurityEnabled();
 
   private static final int PARTITION_ID = 1;
 
@@ -139,9 +137,9 @@ final class OpensearchClientIT {
   @Test
   void shouldAuthenticateWithBasicAuth() {
     // given
-    testClient.putUser("user", "strongpassword", List.of("admin"));
+    testClient.putUser("user", "password", List.of("admin"));
     config.getAuthentication().setUsername("user");
-    config.getAuthentication().setPassword("strongpassword");
+    config.getAuthentication().setPassword("password");
 
     // when
     // force recreating the client

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,8 +72,7 @@
     <version.msgpack>0.9.4</version.msgpack>
     <version.netty>4.1.94.Final</version.netty>
     <version.objenesis>3.3</version.objenesis>
-    <version.opensearch>2.8.0</version.opensearch>
-    <version.opensearch-java>2.6.0</version.opensearch-java>
+    <version.opensearch>2.5.0</version.opensearch>
     <version.opensearch.testcontainers>2.0.0</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.23.4</version.protobuf>
@@ -690,7 +689,7 @@
       <dependency>
         <groupId>org.opensearch.client</groupId>
         <artifactId>opensearch-java</artifactId>
-        <version>${version.opensearch-java}</version>
+        <version>${version.opensearch}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Our Opensearch minor version should always stay in sync with the other teams. We can apply patch versions whenever, similar to Elasticsearch.

## Related issues

<!-- Which issues are closed by this PR or are related -->

N/A

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
