### PR TITLE
[Backport 8.1]: Mark skipped commands as processed

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -263,14 +263,17 @@ public final class ProcessingStateMachine {
         processingMetrics.observeCommandCount(processedCommandsCount);
       }
 
+      finalizeCommandProcessing();
+
       if (currentProcessingResult.isEmpty()) {
-        skipRecord();
+        updateState();
+
+        notifySkippedListener(currentRecord);
+        metrics.eventSkipped();
         return;
       }
 
-      lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
       writeRecords();
-      processedCommandsCount = 0;
     } catch (final RecoverableException recoverableException) {
       // recoverable
       LOG.error(
@@ -305,6 +308,17 @@ public final class ProcessingStateMachine {
           });
     }
   }
+  /**
+   * Finalize the command processing, which includes certain clean-up tasks, like mark the command
+   * as processed and reset transient processing state, etc.
+   *
+   * <p>Should be called after processing or error handling is done.
+   */
+  private void finalizeCommandProcessing() {
+    lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
+    processedCommandsCount = 0;
+  }
+
   /**
    * Starts the batch processing with the given initial command and iterates over ProcessingResult
    * and applies all follow-up commands until the command limit is reached or no more follow-up
@@ -457,7 +471,7 @@ public final class ProcessingStateMachine {
           // we need to mark the command as processed, even if the processing failed
           // otherwise we might replay the events, which have been written during
           // #onProcessingError again on restart
-          lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
+          finalizeCommandProcessing();
         });
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -266,11 +266,8 @@ public final class ProcessingStateMachine {
       finalizeCommandProcessing();
 
       if (currentProcessingResult.isEmpty()) {
-        updateState();
-
         notifySkippedListener(currentRecord);
         metrics.eventSkipped();
-        return;
       }
 
       writeRecords();

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -190,7 +190,7 @@ public final class StreamProcessorTest {
         .until(() -> streamPlatform.getLastSuccessfulProcessedRecordPosition(), pos -> pos >= 1);
   }
 
-  @RegressionTest("not updated when instance was banned")
+  @RegressionTest("https://github.com/camunda/zeebe/pull/13427#issuecomment-1630700316")
   public void shouldUpdateLastProcessPositionEvenWhenProcessingSkippedCommand() {
     // given
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -175,6 +176,25 @@ public final class StreamProcessorTest {
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     final var processingError = new RuntimeException("processing error");
     doThrow(processingError).when(defaultRecordProcessor).process(any(), any());
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.event()
+            .processInstance(ELEMENT_ACTIVATING, Records.processInstance(1))
+            .causedBy(0));
+
+    // then
+    Awaitility.await("last processed position is updated")
+        .until(() -> streamPlatform.getLastSuccessfulProcessedRecordPosition(), pos -> pos >= 1);
+  }
+
+  @RegressionTest("not updated when instance was banned")
+  public void shouldUpdateLastProcessPositionEvenWhenProcessingSkippedCommand() {
+    // given
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    doReturn(EmptyProcessingResult.INSTANCE).when(defaultRecordProcessor).process(any(), any());
     streamPlatform.startStreamProcessor();
 
     // when


### PR DESCRIPTION
## Description

Backports https://github.com/camunda/zeebe/pull/13446
<!-- Please explain the changes you made here. -->

@oleschoenburg I was not able to completely backport all changes, due to some missing parts like dispatcher replacements, which is why the write is a bit different. I not backported https://github.com/camunda/zeebe/pull/13446/commits/c56578ba04f3d33edb57de9e32302a6da5e13b8c and https://github.com/camunda/zeebe/pull/13446/commits/4325fea417dcf13c501c00025065c3da6e1e6bf6 instead I did https://github.com/camunda/zeebe/commit/771b6cd318a4fabef75b39b08edafa857f69bb42 which has a similar behavior. Let me know what you think.

## Related issues

<!-- Which issues are closed by this PR or are related -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
