### PR TITLE
Add `state` to `PersistedProcess`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.deployment;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -22,13 +23,16 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty resourceProp = new BinaryProperty("resource");
+  private final EnumProperty<PersistedProcessState> stateProp =
+      new EnumProperty<>("state", PersistedProcessState.class, PersistedProcessState.ACTIVE);
 
   public PersistedProcess() {
     declareProperty(versionProp)
         .declareProperty(keyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(resourceNameProp)
-        .declareProperty(resourceProp);
+        .declareProperty(resourceProp)
+        .declareProperty(stateProp);
   }
 
   public void wrap(final ProcessRecord processRecord, final long processDefinitionKey) {
@@ -58,5 +62,25 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
 
   public DirectBuffer getResource() {
     return resourceProp.getValue();
+  }
+
+  public PersistedProcessState getState() {
+    return stateProp.getValue();
+  }
+
+  public PersistedProcess setState(final PersistedProcessState state) {
+    stateProp.setValue(state);
+    return this;
+  }
+
+  public enum PersistedProcessState {
+    ACTIVE(0),
+    PENDING_DELETION(1);
+
+    byte value;
+
+    PersistedProcessState(final int value) {
+      this.value = (byte) value;
+    }
   }
 }


### PR DESCRIPTION
## Description

With a state we can mark a process definition for deletion.  We will need this to determine upon terminating/completing a process instance whether we need to write an event to delete the process. It is a direct consequence of the decision to make deleting a process an asynchronous action, where the actual process is only deleted after all instances have reached an end-state.

For now the state is not used. This will be part of a follow-up PR.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13348 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
