### PR TITLE
refactor: move buffered message metrics to engine module

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/BufferedMessagesMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/BufferedMessagesMetrics.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.db.impl.rocksdb;
+package io.camunda.zeebe.engine.metrics;
 
 import io.prometheus.client.Gauge;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.EngineConfiguration;
-import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
@@ -72,9 +71,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
 
   @Override
   public Supplier<ScheduledTaskState> getScheduledTaskStateFactory() {
-    return () ->
-        new ScheduledTaskDbState(
-            zeebeDb, zeebeDb.createContext(), new BufferedMessagesMetrics(partitionId));
+    return () -> new ScheduledTaskDbState(zeebeDb, zeebeDb.createContext(), partitionId);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.db.impl.rocksdb.BufferedMessagesMetrics;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.db.impl.rocksdb.BufferedMessagesMetrics;
+import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
 import io.camunda.zeebe.engine.state.deployment.DbDecisionState;
 import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
 import io.camunda.zeebe.engine.state.deployment.DbProcessState;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
 import io.camunda.zeebe.engine.state.deployment.DbDecisionState;
 import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
 import io.camunda.zeebe.engine.state.deployment.DbProcessState;
@@ -97,8 +96,7 @@ public class ProcessingDbState implements MutableProcessingState {
 
     deploymentState = new DbDeploymentState(zeebeDb, transactionContext);
     jobState = new DbJobState(zeebeDb, transactionContext, partitionId);
-    messageState =
-        new DbMessageState(zeebeDb, transactionContext, new BufferedMessagesMetrics(partitionId));
+    messageState = new DbMessageState(zeebeDb, transactionContext, partitionId);
     messageSubscriptionState = new DbMessageSubscriptionState(zeebeDb, transactionContext);
     messageStartEventSubscriptionState =
         new DbMessageStartEventSubscriptionState(zeebeDb, transactionContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.db.impl.rocksdb.BufferedMessagesMetrics;
+import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.state;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
@@ -28,9 +27,9 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final BufferedMessagesMetrics bufferedMessagesMetrics) {
+      final int partitionId) {
     distributionState = new DbDistributionState(zeebeDb, transactionContext);
-    messageState = new DbMessageState(zeebeDb, transactionContext, bufferedMessagesMetrics);
+    messageState = new DbMessageState(zeebeDb, transactionContext, partitionId);
     timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -124,7 +124,7 @@ public final class DbMessageState implements MutableMessageState {
   public DbMessageState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final BufferedMessagesMetrics bufferedMessagesMetrics) {
+      final int partitionId) {
     messageKey = new DbLong();
     fkMessage = new DbForeignKey<>(messageKey, ZbColumnFamilies.MESSAGE_KEY);
     message = new StoredMessage();
@@ -197,7 +197,7 @@ public final class DbMessageState implements MutableMessageState {
             processInstanceKey,
             correlationKey);
 
-    this.bufferedMessagesMetrics = bufferedMessagesMetrics;
+    bufferedMessagesMetrics = new BufferedMessagesMetrics(partitionId);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
-import io.camunda.zeebe.db.impl.rocksdb.BufferedMessagesMetrics;
+import io.camunda.zeebe.engine.metrics.BufferedMessagesMetrics;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;


### PR DESCRIPTION
This is a minor cleanup after #13113. The commit messages contain a bit more details on why I think it makes sense to move the class around.