### PR TITLE
[Backport stable/8.0] Don't mutate state when checking for job timeouts and backoffs

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
 
 public class JobRecurProcessor implements CommandProcessor<JobRecord> {
 
@@ -30,9 +31,10 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
   public boolean onCommand(
       final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
     final long jobKey = command.getKey();
-    final JobState.State state = jobState.getState(jobKey);
+    final var job = jobState.getJob(jobKey);
+    final var state = jobState.getState(jobKey);
 
-    if (state == State.FAILED) {
+    if (state == State.FAILED && hasRecurred(job)) {
       final JobRecord recurredJob = jobState.getJob(jobKey);
 
       commandControl.accept(JobIntent.RECURRED_AFTER_BACKOFF, recurredJob);
@@ -58,5 +60,9 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
           RejectionType.NOT_FOUND, String.format(NOT_FAILED_JOB_MESSAGE, jobKey, textState));
     }
     return true;
+  }
+
+  private boolean hasRecurred(final JobRecord job) {
+    return job.getRecurringTime() < ActorClock.currentTimeMillis();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -33,7 +33,9 @@ public class JobRecurProcessor implements CommandProcessor<JobRecord> {
     final JobState.State state = jobState.getState(jobKey);
 
     if (state == State.FAILED) {
-      commandControl.accept(JobIntent.RECURRED_AFTER_BACKOFF, command.getValue());
+      final JobRecord recurredJob = jobState.getJob(jobKey);
+
+      commandControl.accept(JobIntent.RECURRED_AFTER_BACKOFF, recurredJob);
     } else {
       final String textState;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -36,11 +36,7 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
     final var job = jobState.getJob(jobKey);
     final var state = jobState.getState(jobKey);
 
-    final var now = ActorClock.currentTimeMillis();
-    final var deadline = job.getDeadline();
-    final var hasTimedOut = now > deadline;
-
-    if (state == State.ACTIVATED && hasTimedOut) {
+    if (state == State.ACTIVATED && hasTimedOut(job)) {
       commandControl.accept(JobIntent.TIMED_OUT, job);
       jobMetrics.jobTimedOut(job.getType());
     } else {
@@ -57,5 +53,9 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
           RejectionType.NOT_FOUND, String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, reason));
     }
     return true;
+  }
+
+  private boolean hasTimedOut(final JobRecord job) {
+    return job.getDeadline() < ActorClock.currentTimeMillis();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
 
 public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
@@ -31,21 +32,27 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
   @Override
   public boolean onCommand(
       final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
-    final long jobKey = command.getKey();
-    final JobState.State state = jobState.getState(jobKey);
+    final var jobKey = command.getKey();
+    final var job = jobState.getJob(jobKey);
+    final var state = jobState.getState(jobKey);
 
-    if (state == State.ACTIVATED) {
-      commandControl.accept(JobIntent.TIMED_OUT, command.getValue());
-      jobMetrics.jobTimedOut(command.getValue().getType());
+    final var now = ActorClock.currentTimeMillis();
+    final var deadline = job.getDeadline();
+    final var hasTimedOut = now > deadline;
+
+    if (state == State.ACTIVATED && hasTimedOut) {
+      commandControl.accept(JobIntent.TIMED_OUT, job);
+      jobMetrics.jobTimedOut(job.getType());
     } else {
-      final var reason = switch (state) {
-        case ACTIVATED -> throw new IllegalStateException(
-            "This should never happen, if a job is activated it should be timed out not rejected");
-        case ACTIVATABLE -> "it must be activated first";
-        case FAILED -> "it is marked as failed and is not activated";
-        case ERROR_THROWN -> "it has thrown an error and is not activated";
-        case NOT_FOUND -> "no such job was found";
-      };
+      final var reason =
+          switch (state) {
+            case ACTIVATED -> "it has not timed out";
+            case ACTIVATABLE -> "it must be activated first";
+            case FAILED -> "it is marked as failed and is not activated";
+            case ERROR_THROWN -> "it has thrown an error and is not activated";
+            case NOT_FOUND -> "no such job was found";
+          };
+
       commandControl.reject(
           RejectionType.NOT_FOUND, String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, reason));
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
@@ -15,7 +15,7 @@ import org.agrona.DirectBuffer;
 
 public interface JobState {
 
-  void forEachTimedOutEntry(long upperBound, BiFunction<Long, JobRecord, Boolean> callback);
+  void forEachTimedOutEntry(long upperBound, BiPredicate<Long, JobRecord> callback);
 
   boolean exists(long jobKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -178,6 +178,7 @@ public final class DbJobState implements JobState, MutableJobState {
     makeJobNotActivatable(type);
 
     removeJobDeadline(key, record.getDeadline());
+    removeJobBackoff(key, record.getRecurringTime());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -130,9 +130,7 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void recurAfterBackoff(final long key, final JobRecord record) {
     updateJob(key, record, State.ACTIVATABLE);
-    jobKey.wrapLong(key);
-    backoffKey.wrapLong(record.getRecurringTime());
-    backoffColumnFamily.deleteExisting(backoffJobKey);
+    removeJobBackoff(key, record.getRecurringTime());
   }
 
   @Override
@@ -186,9 +184,7 @@ public final class DbJobState implements JobState, MutableJobState {
   public void fail(final long key, final JobRecord updatedValue) {
     if (updatedValue.getRetries() > 0) {
       if (updatedValue.getRetryBackoff() > 0) {
-        jobKey.wrapLong(key);
-        backoffKey.wrapLong(updatedValue.getRecurringTime());
-        backoffColumnFamily.insert(backoffJobKey, DbNil.INSTANCE);
+        addJobBackoff(key, updatedValue.getRecurringTime());
         updateJob(key, updatedValue, State.FAILED);
       } else {
         updateJob(key, updatedValue, State.ACTIVATABLE);
@@ -408,6 +404,22 @@ public final class DbJobState implements JobState, MutableJobState {
       jobKey.wrapLong(job);
       deadlineKey.wrapLong(deadline);
       deadlinesColumnFamily.deleteIfExists(deadlineJobKey);
+    }
+  }
+
+  private void addJobBackoff(final long job, final long backoff) {
+    if (backoff > 0) {
+      jobKey.wrapLong(job);
+      backoffKey.wrapLong(backoff);
+      backoffColumnFamily.insert(backoffJobKey, DbNil.INSTANCE);
+    }
+  }
+
+  private void removeJobBackoff(final long job, final long backoff) {
+    if (backoff > 0) {
+      jobKey.wrapLong(job);
+      backoffKey.wrapLong(backoff);
+      backoffColumnFamily.deleteIfExists(backoffJobKey);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -255,7 +255,7 @@ public final class DbJobState implements JobState, MutableJobState {
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().inner().getValue();
-            return visitJob(jobKey1, callback, () -> deadlinesColumnFamily.deleteExisting(key));
+            return visitJob(jobKey1, callback, () -> {});
           }
           return false;
         });

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -124,8 +124,7 @@ public final class DbJobState implements JobState, MutableJobState {
 
     makeJobNotActivatable(type);
 
-    deadlineKey.wrapLong(deadline);
-    deadlinesColumnFamily.insert(deadlineJobKey, DbNil.INSTANCE);
+    addJobDeadline(key, deadline);
   }
 
   @Override
@@ -145,7 +144,6 @@ public final class DbJobState implements JobState, MutableJobState {
     EnsureUtil.ensureGreaterThan("deadline", deadline, 0);
 
     updateJob(key, record, State.ACTIVATABLE);
-    removeJobDeadline(deadline);
   }
 
   @Override
@@ -173,7 +171,6 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void delete(final long key, final JobRecord record) {
     final DirectBuffer type = record.getTypeBuffer();
-    final long deadline = record.getDeadline();
 
     jobKey.wrapLong(key);
     jobsColumnFamily.deleteExisting(jobKey);
@@ -182,7 +179,7 @@ public final class DbJobState implements JobState, MutableJobState {
 
     makeJobNotActivatable(type);
 
-    removeJobDeadline(deadline);
+    removeJobDeadline(key, record.getDeadline());
   }
 
   @Override
@@ -225,7 +222,6 @@ public final class DbJobState implements JobState, MutableJobState {
 
   private void updateJob(final long key, final JobRecord updatedValue, final State newState) {
     final DirectBuffer type = updatedValue.getTypeBuffer();
-    final long deadline = updatedValue.getDeadline();
 
     validateParameters(type);
 
@@ -237,8 +233,12 @@ public final class DbJobState implements JobState, MutableJobState {
       makeJobActivatable(type, key);
     }
 
-    if (deadline > 0) {
-      removeJobDeadline(deadline);
+    if (newState != State.ACTIVATED) {
+      // This only works because none of the events actually remove the deadline from the job
+      // record.
+      // If, say on job failure, the deadline is removed or reset to 0, then we would need to look
+      // at the current state of the job to determine what deadline to remove.
+      removeJobDeadline(key, updatedValue.getDeadline());
     }
   }
 
@@ -395,8 +395,19 @@ public final class DbJobState implements JobState, MutableJobState {
     activatableColumnFamily.deleteIfExists(typeJobKey);
   }
 
-  private void removeJobDeadline(final long deadline) {
-    deadlineKey.wrapLong(deadline);
-    deadlinesColumnFamily.deleteIfExists(deadlineJobKey);
+  private void addJobDeadline(final long job, final long deadline) {
+    if (deadline > 0) {
+      jobKey.wrapLong(job);
+      deadlineKey.wrapLong(deadline);
+      deadlinesColumnFamily.insert(deadlineJobKey, DbNil.INSTANCE);
+    }
+  }
+
+  private void removeJobDeadline(final long job, final long deadline) {
+    if (deadline > 0) {
+      jobKey.wrapLong(job);
+      deadlineKey.wrapLong(deadline);
+      deadlinesColumnFamily.deleteIfExists(deadlineJobKey);
+    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -248,15 +248,14 @@ public final class DbJobState implements JobState, MutableJobState {
 
   @Override
   public void forEachTimedOutEntry(
-      final long upperBound, final BiFunction<Long, JobRecord, Boolean> callback) {
+      final long upperBound, final BiPredicate<Long, JobRecord> callback) {
     deadlinesColumnFamily.whileTrue(
         (key, value) -> {
           final long deadline = key.first().getValue();
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().inner().getValue();
-            return visitJob(
-                jobKey1, callback::apply, () -> deadlinesColumnFamily.deleteExisting(key));
+            return visitJob(jobKey1, callback, () -> deadlinesColumnFamily.deleteExisting(key));
           }
           return false;
         });

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -13,8 +13,11 @@ import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -22,6 +25,7 @@ import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -168,6 +172,32 @@ public final class JobTimeOutTest {
 
     // then
     assertThat(timedOutRecord.getSourceRecordPosition()).isLessThan(0);
+  }
+
+  @Test
+  public void shouldRejectIfJobDoesNotExist() {
+    // given
+    final var jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final var job = ENGINE.getZeebeState().getJobState().getJob(jobKey);
+    final var partitionId = Protocol.decodePartitionId(jobKey);
+
+    // when
+    ENGINE.pauseProcessing(partitionId);
+    ENGINE.writeRecords(
+        RecordToWrite.command().key(jobKey).job(JobIntent.COMPLETE, job),
+        RecordToWrite.command().key(jobKey).job(JobIntent.TIME_OUT, job));
+    ENGINE.resumeProcessing(partitionId);
+    Awaitility.await("until everything processed").until(ENGINE::hasReachedEnd);
+
+    // then activated again
+    final var jobEvents =
+        jobRecords()
+            .withRecordKey(jobKey)
+            .withIntent(JobIntent.TIME_OUT)
+            .withRecordType(RecordType.COMMAND_REJECTION)
+            .limit(1)
+            .toList();
+    assertThat(jobEvents).isNotEmpty();
   }
 
   private long createInstance() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -347,8 +347,13 @@ public final class JobStateTest {
   public void shouldFailJobWithRetriesAndBackOff() {
     // given
     final long key = 1L;
+    final long now = 0;
     final var retryBackoff = 100;
-    final JobRecord jobRecord = newJobRecord().setRetries(1).setRetryBackoff(retryBackoff);
+    final JobRecord jobRecord =
+        newJobRecord()
+            .setRetries(1)
+            .setRetryBackoff(retryBackoff)
+            .setRecurringTime(now + retryBackoff);
 
     // when
     jobState.create(key, jobRecord);
@@ -361,7 +366,7 @@ public final class JobStateTest {
     assertJobRecordIsEqualTo(jobState.getJob(key), jobRecord);
     refuteListedAsActivatable(key, jobRecord.getTypeBuffer());
     refuteListedAsTimedOut(key, jobRecord.getDeadline() + 1);
-    assertListedAsBackOff(key, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    assertListedAsBackOff(key, jobRecord.getRecurringTime() + 1);
   }
 
   @Test
@@ -408,8 +413,13 @@ public final class JobStateTest {
   public void shouldRetryJobAfterRecurredAndHasRetries() {
     // given
     final long jobKey = 1L;
+    final long now = 0;
     final long retryBackoff = Duration.ofDays(1).toMillis();
-    final JobRecord jobRecord = newJobRecord().setRetries(1).setRetryBackoff(retryBackoff);
+    final JobRecord jobRecord =
+        newJobRecord()
+            .setRetries(1)
+            .setRetryBackoff(retryBackoff)
+            .setRecurringTime(now + retryBackoff);
 
     // when
     jobState.create(jobKey, jobRecord);
@@ -417,12 +427,12 @@ public final class JobStateTest {
     jobState.fail(jobKey, jobRecord);
     assertThat(jobState.exists(jobKey)).isTrue();
     assertJobState(jobKey, State.FAILED);
-    assertListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    assertListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1);
     jobState.recurAfterBackoff(jobKey, jobRecord);
 
     // then
     assertJobState(jobKey, State.ACTIVATABLE);
-    refuteListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    refuteListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1);
   }
 
   @Test


### PR DESCRIPTION
Manual backport of:
- https://github.com/camunda/zeebe/pull/13035
- https://github.com/camunda/zeebe/pull/13402
- https://github.com/camunda/zeebe/pull/13126

Merge conflicts because command processors use an older API and some classes were renamed or moved. Nothing major as far as I can tell.