### PR TITLE
Resolve regression for large payloads deploy

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -148,8 +148,7 @@ public final class DeploymentCreateProcessor
     final var recordWithoutResource = createDeploymentWithoutResources(deploymentEvent);
     responseWriter.writeEventOnCommand(
         key, DeploymentIntent.CREATED, recordWithoutResource, command);
-    stateWriter.appendFollowUpEvent(
-        command.getKey(), DeploymentIntent.CREATED, recordWithoutResource);
+    stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, recordWithoutResource);
 
     distributionBehavior.distributeCommand(key, command);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -200,7 +200,8 @@ public final class DeploymentCreateProcessor
   /**
    * Create a copy of the provided deployment record without resource
    *
-   * @param deploymentEvent the record to clone and modify
+   * @param deploymentEvent the record to clone
+   * @return a copy of the {@link DeploymentRecord} provided without the resources
    */
   private DeploymentRecord createDeploymentWithoutResources(
       final DeploymentRecord deploymentEvent) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentMultiplePartitionsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentMultiplePartitionsTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
-import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -119,15 +118,6 @@ public final class CreateDeploymentMultiplePartitionsTest {
         .getPartitionIds()
         .forEach(
             partitionId -> {
-              if (DEPLOYMENT_PARTITION == partitionId) {
-                assertDeploymentEventResources(
-                    partitionId,
-                    DeploymentIntent.CREATED,
-                    deployment.getKey(),
-                    (createdDeployment) -> assertDeploymentRecord(deployment, createdDeployment));
-                return;
-              }
-
               assertDeploymentEventResources(
                   partitionId,
                   DeploymentIntent.CREATED,
@@ -416,24 +406,6 @@ public final class CreateDeploymentMultiplePartitionsTest {
 
     assertThat(repeatedDrgs.size()).isEqualTo(PARTITION_COUNT - 1);
     repeatedDrgs.forEach(r -> assertDifferentDrg(originalDrg.get(0), r));
-  }
-
-  private void assertDeploymentRecord(
-      final Record<DeploymentRecordValue> deployment,
-      final Record<DeploymentRecordValue> createdDeployment) {
-    final DeploymentResource resource = createdDeployment.getValue().getResources().get(0);
-
-    Assertions.assertThat(resource).hasResource(bpmnXml(PROCESS));
-
-    final List<ProcessMetadataValue> deployedProcesses =
-        createdDeployment.getValue().getProcessesMetadata();
-
-    assertThat(deployedProcesses).hasSize(1);
-    Assertions.assertThat(deployedProcesses.get(0))
-        .hasBpmnProcessId("shouldCreateDeploymentOnAllPartitions")
-        .hasVersion(1)
-        .hasProcessDefinitionKey(getDeployedProcess(deployment, 0).getProcessDefinitionKey())
-        .hasResourceName("process.bpmn");
   }
 
   private void assertDeploymentRecordWithoutResources(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
-import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -211,14 +210,9 @@ public final class CreateDeploymentTest {
         .extracting(ProcessMetadataValue::getBpmnProcessId)
         .contains(processId, processId2);
 
-    assertThat(deployment.getValue().getResources())
-        .extracting(DeploymentResource::getResourceName)
+    assertThat(deployment.getValue().getProcessesMetadata())
+        .extracting(ProcessMetadataValue::getResourceName)
         .contains("process.bpmn", "process2.bpmn");
-
-    assertThat(deployment.getValue().getResources())
-        .extracting(DeploymentResource::getResource)
-        .contains(
-            Bpmn.convertToString(process).getBytes(), Bpmn.convertToString(process2).getBytes());
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -213,6 +213,17 @@ public final class CreateDeploymentTest {
     assertThat(deployment.getValue().getProcessesMetadata())
         .extracting(ProcessMetadataValue::getResourceName)
         .contains("process.bpmn", "process2.bpmn");
+
+    final var deploymentPartitionRecords =
+        RecordingExporter.records().limit(r -> r.getIntent() == DeploymentIntent.CREATED).toList();
+
+    assertThat(deploymentPartitionRecords)
+        .extracting(Record::getIntent, Record::getRecordType)
+        .containsExactly(
+            tuple(DeploymentIntent.CREATE, RecordType.COMMAND),
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
@@ -32,7 +32,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -219,7 +218,6 @@ public class MultiPartitionDeploymentLifecycleTest {
             RecordType.COMMAND, RecordType.COMMAND, RecordType.COMMAND_REJECTION);
   }
 
-  @Ignore("Regression https://github.com/camunda/zeebe/issues/13233")
   @Test
   public void shouldDeployIfResourceIsLargeButNotTooMuch() {
     // when
@@ -230,7 +228,7 @@ public class MultiPartitionDeploymentLifecycleTest {
                 Bpmn.createExecutableProcess("PROCESS")
                     .startEvent()
                     .documentation(
-                        "x".repeat((int) (ByteValue.ofMegabytes(4) / 2 - ByteValue.ofKilobytes(2))))
+                        "x".repeat((int) (ByteValue.ofMegabytes(2) - ByteValue.ofKilobytes(2))))
                     .done())
             .deploy();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionRejectionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.ByteValue;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MultiPartitionRejectionTest {
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(3);
+
+  @Test
+  public void shouldRejectDeploymentIfResourceIsTooLarge() {
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("PROCESS")
+                    .startEvent()
+                    .documentation(
+                        "x".repeat((int) (ByteValue.ofMegabytes(2) - ByteValue.ofKilobytes(1))))
+                    .done())
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasRejectionType(RejectionType.EXCEEDED_BATCH_RECORD_SIZE)
+        .hasRejectionReason("");
+  }
+
+  @Test // Regression of https://github.com/camunda/zeebe/issues/13254
+  public void shouldNotBeAbleToCreateInstanceWhenDeploymentIsRejected() {
+    // given
+    final BpmnModelInstance invalidProcess =
+        Bpmn.createExecutableProcess("too_large_process")
+            .startEvent()
+            // In order to cause BATCH SIZE EXCEEDING we add a big comment
+            .documentation("x".repeat((int) (ByteValue.ofMegabytes(2) - ByteValue.ofKilobytes(2))))
+            .done();
+    final BpmnModelInstance validProcess =
+        Bpmn.createExecutableProcess("valid_process").startEvent().task().endEvent().done();
+
+    // when
+    engine
+        .deployment()
+        .withXmlResource(invalidProcess)
+        .withXmlResource(validProcess)
+        .expectRejection()
+        .deploy();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getRecordType() == RecordType.COMMAND_REJECTION)
+                .collect(Collectors.toList()))
+        .extracting(Record::getIntent, Record::getRecordType)
+        .doesNotContain(
+            tuple(ProcessIntent.CREATED, RecordType.EVENT),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT));
+
+    engine.processInstance().ofBpmnProcessId("valid_process").expectRejection().create();
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -114,4 +114,8 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
 
     return metadataList;
   }
+
+  public void resetResources() {
+    resourcesProp.reset();
+  }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
-import io.camunda.zeebe.util.ByteValue;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -140,10 +139,7 @@ public final class CreateDeploymentTest {
     final var modelThatFitsJustWithinMaxMessageSize =
         Bpmn.createExecutableProcess("PROCESS")
             .startEvent()
-            .documentation(
-                "x"
-                    .repeat(
-                        (int) (ByteValue.ofMegabytes(MAX_MSG_SIZE_MB) - ByteValue.ofKilobytes(2))))
+            .documentation("x".repeat((1047100)))
             .done();
     final var command =
         CLIENT_RULE

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/DeploymentClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/DeploymentClusteredTest.java
@@ -200,7 +200,6 @@ public final class DeploymentClusteredTest {
                 assertThat(
                         RecordingExporter.deploymentRecords(DeploymentIntent.CREATED)
                             .withPartitionId(2)
-                            .withResourceName("dmn/decision-table.dmn")
                             .limit(2))
                     .describedAs("expect that deployment is distributed twice")
                     .hasSize(2));


### PR DESCRIPTION
## Description

Removed resource from `Deployment:CREATED` event. Resource is still available in `Process:CREATED` or `DecisionRequirements:CREATED`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13233 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
