### PR TITLE
Integrate job streaming to job worker

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -109,6 +109,12 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
@@ -128,6 +134,12 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -26,8 +26,6 @@ import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
-import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
-import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
 import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
@@ -36,7 +34,6 @@ import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.ZeebeClientCloudBuilderImpl;
 import io.camunda.zeebe.client.impl.ZeebeClientImpl;
-import java.time.Duration;
 
 /** The client to communicate with a Zeebe broker/cluster. */
 public interface ZeebeClient extends AutoCloseable, JobClient {
@@ -357,71 +354,4 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return the builder for the command
    */
   DeleteResourceCommandStep1 newDeleteResourceCommand(long resourceKey);
-
-  /**
-   * Activates and streams jobs of a specific type.
-   *
-   * <pre>{@code
-   * final Consumer<ActivatedJob> consumer = ...; // do something with the consumed job
-   * final ZeebeFuture<StreamJobsResponse> stream = jobClient
-   *  .newStreamJobsCommand()
-   *  .jobType("payment")
-   *  .consumer(consumer)
-   *  .workerName("paymentWorker")
-   *  .timeout(Duration.ofMinutes(10))
-   *  .send();
-   *
-   *  stream.whenComplete((ok, error) -> {
-   *    // recreate stream if necessary
-   *    // be careful if you've cancelled the stream explicitly to not recreate it if shutting down
-   *  });
-   *
-   *  // You can later terminate the stream by cancelling the future
-   *  stream.cancel(true);
-   * }</pre>
-   *
-   * <h2>Stream or Activate?</h2>
-   *
-   * <p>As opposed to {@link #newActivateJobsCommand()}, which polls each partition until it has
-   * activated enough jobs or a timeout has elapsed, this command opens a long living stream onto
-   * which activated jobs are pushed. This typically results in lower latency, as jobs are activated
-   * and pushed out immediately, instead of waiting to be polled.
-   *
-   * <h2>Limitations</h2>
-   *
-   * <p>This feature is still under development; as such, there is currently no way to rate limit
-   * how many jobs are streamed over a single call. This can be mitigated by opening more streams of
-   * the same type, which will ensure work is fairly load balanced.
-   *
-   * <p>Additionally, only jobs which are created, retried, or timed out <em>after</em> the command
-   * has been registered will be streamed out. For older jobs, you must still use the {@link
-   * #newActivateJobsCommand()}. It's generally recommended that you use the {@link
-   * io.camunda.zeebe.client.api.worker.JobWorker} API to avoid having to coordinate both calls.
-   *
-   * <h2>Activation</h2>
-   *
-   * <p>Jobs activated via this command will use the given worker name, activation time out, and
-   * fetch variables parameters in the same way as the {@link #newActivateJobsCommand()}.
-   *
-   * <h2>Termination</h2>
-   *
-   * <p>The stream can be explicitly cancelled by performing one of the following:
-   *
-   * <ul>
-   *   <li>Closing the Zeebe client
-   *   <li>Cancelling the result of {@link StreamJobsCommandStep3#send()} via {@link
-   *       io.camunda.zeebe.client.api.ZeebeFuture#cancel(boolean)} (the argument is irrelevant)
-   *   <li>Setting a {@link StreamJobsCommandStep3#requestTimeout(Duration)}; the stream will be
-   *       closed once this time out is reached. By default, there is no request time out at all.
-   *       <strong>It's recommended to assign a long-ish time out and recreate your streams from
-   *       time to time to ensure good load balancing across gateways.</strong>
-   * </ul>
-   *
-   * NOTE: streams can be closed for various reasons - for example, the server is restarting. As
-   * such, it's recommended to add listeners to the resulting future to handle such cases and reopen
-   * streams if necessary.
-   *
-   * @return a builder for the command
-   */
-  StreamJobsCommandStep1 newStreamJobsCommand();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
@@ -15,12 +15,14 @@
  */
 package io.camunda.zeebe.client.api.command;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.StreamJobsResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
 
+@ExperimentalApi("https://github.com/camunda/zeebe/issues/11231")
 public interface StreamJobsCommandStep1 {
   /**
    * Set the type of jobs to work on; only jobs of this type will be activated and consumed by this

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/StreamJobsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/StreamJobsResponse.java
@@ -15,4 +15,7 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
+
+@ExperimentalApi("https://github.com/camunda/zeebe/issues/11231")
 public interface StreamJobsResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.api.worker;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
@@ -240,5 +241,6 @@ public interface JobClient {
    *
    * @return a builder for the command
    */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/11231")
   StreamJobsCommandStep1 newStreamJobsCommand();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
@@ -18,8 +18,11 @@ package io.camunda.zeebe.client.api.worker;
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
 import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import java.time.Duration;
 
 /**
  * A client with access to all job-related operation:
@@ -171,4 +174,71 @@ public interface JobClient {
    * @return a builder for the command
    */
   ActivateJobsCommandStep1 newActivateJobsCommand();
+
+  /**
+   * Activates and streams jobs of a specific type.
+   *
+   * <pre>{@code
+   * final Consumer<ActivatedJob> consumer = ...; // do something with the consumed job
+   * final ZeebeFuture<StreamJobsResponse> stream = jobClient
+   *  .newStreamJobsCommand()
+   *  .jobType("payment")
+   *  .consumer(consumer)
+   *  .workerName("paymentWorker")
+   *  .timeout(Duration.ofMinutes(10))
+   *  .send();
+   *
+   *  stream.whenComplete((ok, error) -> {
+   *    // recreate stream if necessary
+   *    // be careful if you've cancelled the stream explicitly to not recreate it if shutting down
+   *  });
+   *
+   *  // You can later terminate the stream by cancelling the future
+   *  stream.cancel(true);
+   * }</pre>
+   *
+   * <h2>Stream or Activate?</h2>
+   *
+   * <p>As opposed to {@link #newActivateJobsCommand()}, which polls each partition until it has
+   * activated enough jobs or a timeout has elapsed, this command opens a long living stream onto
+   * which activated jobs are pushed. This typically results in lower latency, as jobs are activated
+   * and pushed out immediately, instead of waiting to be polled.
+   *
+   * <h2>Limitations</h2>
+   *
+   * <p>This feature is still under development; as such, there is currently no way to rate limit
+   * how many jobs are streamed over a single call. This can be mitigated by opening more streams of
+   * the same type, which will ensure work is fairly load balanced.
+   *
+   * <p>Additionally, only jobs which are created, retried, or timed out <em>after</em> the command
+   * has been registered will be streamed out. For older jobs, you must still use the {@link
+   * #newActivateJobsCommand()}. It's generally recommended that you use the {@link
+   * io.camunda.zeebe.client.api.worker.JobWorker} API to avoid having to coordinate both calls.
+   *
+   * <h2>Activation</h2>
+   *
+   * <p>Jobs activated via this command will use the given worker name, activation time out, and
+   * fetch variables parameters in the same way as the {@link #newActivateJobsCommand()}.
+   *
+   * <h2>Termination</h2>
+   *
+   * <p>The stream can be explicitly cancelled by performing one of the following:
+   *
+   * <ul>
+   *   <li>Closing the Zeebe client
+   *   <li>Cancelling the result of {@link StreamJobsCommandStep3#send()} via {@link
+   *       io.camunda.zeebe.client.api.ZeebeFuture#cancel(boolean)} (the argument is irrelevant)
+   *   <li>Setting a {@link StreamJobsCommandStep3#requestTimeout(Duration)}; the stream will be
+   *       closed once this time out is reached. By default, there is no request time out at all.
+   *       <strong>It's recommended to assign a long-ish time out and recreate your streams from
+   *       time to time to ensure good load balancing across gateways.</strong>
+   * </ul>
+   *
+   * NOTE: streams can be closed for various reasons - for example, the server is restarting. As
+   * such, it's recommended to add listeners to the resulting future to handle such cases and reopen
+   * streams if necessary.
+   *
+   * @return a builder for the command
+   */
+  StreamJobsCommandStep1 newStreamJobsCommand();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client.api.worker;
 
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import java.time.Duration;
 import java.util.List;
 
@@ -209,6 +210,7 @@ public interface JobWorkerBuilderStep1 {
      *
      * @return the builder for this worker
      */
+    @ExperimentalApi("https://github.com/camunda/zeebe/issues/11231")
     JobWorkerBuilderStep3 enableStreaming();
 
     /**
@@ -225,6 +227,7 @@ public interface JobWorkerBuilderStep1 {
      * @param timeout a timeout, after which the stream is recreated
      * @return the builder for this worker
      */
+    @ExperimentalApi("https://github.com/camunda/zeebe/issues/11231")
     JobWorkerBuilderStep3 streamTimeout(final Duration timeout);
 
     /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -349,12 +349,6 @@ public final class ZeebeClientImpl implements ZeebeClient {
         config.getDefaultRequestTimeout());
   }
 
-  @Override
-  public StreamJobsCommandStep1 newStreamJobsCommand() {
-    return new StreamJobsCommandImpl(
-        asyncStub, jsonMapper, credentialsProvider::shouldRetryRequest, config);
-  }
-
   private JobClient newJobClient() {
     return new JobClientImpl(
         asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
@@ -393,5 +387,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
     return jobClient.newActivateJobsCommand();
+  }
+
+  @Override
+  public StreamJobsCommandStep1 newStreamJobsCommand() {
+    return new StreamJobsCommandImpl(
+        asyncStub, jsonMapper, credentialsProvider::shouldRetryRequest, config);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
@@ -20,12 +20,14 @@ import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.impl.command.ActivateJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.CompleteJobCommandImpl;
 import io.camunda.zeebe.client.impl.command.FailJobCommandImpl;
+import io.camunda.zeebe.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.ThrowErrorCommandImpl;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import java.util.function.Predicate;
@@ -84,5 +86,10 @@ public final class JobClientImpl implements JobClient {
   @Override
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
     return new ActivateJobsCommandImpl(asyncStub, config, jsonMapper, retryPredicate);
+  }
+
+  @Override
+  public StreamJobsCommandStep1 newStreamJobsCommand() {
+    return new StreamJobsCommandImpl(asyncStub, jsonMapper, retryPredicate, config);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamer.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-public interface JobStreamer extends AutoCloseable {
+interface JobStreamer extends AutoCloseable {
 
   @Override
   void close();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import java.util.function.Consumer;
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public interface JobStreamer extends AutoCloseable {
+
+  @Override
+  void close();
+
+  void openStreamer(final Consumer<ActivatedJob> jobConsumer);
+
+  static JobStreamer noop() {
+    return NoopJobStream.INSTANCE;
+  }
+
+  @ThreadSafe
+  final class NoopJobStream implements JobStreamer {
+    private static final NoopJobStream INSTANCE = new NoopJobStream();
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void openStreamer(final Consumer<ActivatedJob> jobConsumer) {}
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamerImpl.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.StreamJobsResponse;
+import io.camunda.zeebe.client.api.worker.BackoffSupplier;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.impl.Loggers;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+
+@ThreadSafe
+final class JobStreamerImpl implements JobStreamer {
+  private static final Logger LOGGER = Loggers.JOB_WORKER_LOGGER;
+
+  private final JobClient jobClient;
+  private final String jobType;
+  private final String workerName;
+  private final Duration timeout;
+  private final List<String> fetchVariables;
+  private final Duration requestTimeout;
+  private final BackoffSupplier backoffSupplier;
+  private final ScheduledExecutorService executor;
+  private final Lock streamLock;
+
+  @GuardedBy("streamLock")
+  private ZeebeFuture<StreamJobsResponse> streamControl;
+
+  @GuardedBy("streamLock")
+  private FinalCommandStep<StreamJobsResponse> command;
+
+  @GuardedBy("streamLock")
+  private boolean isClosed;
+
+  @GuardedBy("streamLock")
+  private long retryDelay;
+
+  public JobStreamerImpl(
+      final JobClient jobClient,
+      final String jobType,
+      final String workerName,
+      final Duration timeout,
+      final List<String> fetchVariables,
+      final Duration requestTimeout,
+      final BackoffSupplier backoffSupplier,
+      final ScheduledExecutorService executor) {
+    this.jobClient = jobClient;
+    this.jobType = jobType;
+    this.workerName = workerName;
+    this.timeout = timeout;
+    this.fetchVariables = fetchVariables;
+    this.requestTimeout = requestTimeout;
+    this.backoffSupplier = backoffSupplier;
+    this.executor = executor;
+
+    streamLock = new ReentrantLock();
+  }
+
+  @Override
+  public void close() {
+    try {
+      streamLock.lockInterruptibly();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return;
+    }
+
+    try {
+      lockedClose();
+    } finally {
+      streamLock.unlock();
+    }
+  }
+
+  @Override
+  public void openStreamer(final Consumer<ActivatedJob> jobConsumer) {
+    final FinalCommandStep<StreamJobsResponse> command = buildCommand(jobConsumer);
+    open(command);
+  }
+
+  private void open(final FinalCommandStep<StreamJobsResponse> command) {
+    try {
+      streamLock.lockInterruptibly();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return;
+    }
+
+    try {
+      this.command = command;
+      lockedOpen();
+    } finally {
+      streamLock.unlock();
+    }
+  }
+
+  private void handleStreamComplete(final Throwable error) {
+    try {
+      streamLock.lockInterruptibly();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return;
+    }
+
+    try {
+      lockedHandleStreamComplete(error);
+    } finally {
+      streamLock.unlock();
+    }
+  }
+
+  private FinalCommandStep<StreamJobsResponse> buildCommand(
+      final Consumer<ActivatedJob> jobConsumer) {
+    StreamJobsCommandStep3 command =
+        jobClient
+            .newStreamJobsCommand()
+            .jobType(jobType)
+            .consumer(jobConsumer)
+            .workerName(workerName)
+            .timeout(timeout);
+
+    if (fetchVariables != null) {
+      command = command.fetchVariables(fetchVariables);
+    }
+
+    return command.requestTimeout(requestTimeout);
+  }
+
+  @GuardedBy("streamLock")
+  private void lockedClose() {
+    isClosed = true;
+    if (streamControl != null) {
+      streamControl.cancel(true);
+    }
+  }
+
+  @GuardedBy("streamLock")
+  private void lockedOpen() {
+    if (streamControl != null) {
+      streamControl.cancel(true);
+      streamControl = null;
+    }
+
+    final ZeebeFuture<StreamJobsResponse> control = command.send();
+    control.whenCompleteAsync((ignored, error) -> handleStreamComplete(error), executor);
+    streamControl = control;
+  }
+
+  @GuardedBy("streamLock")
+  private void lockedHandleStreamComplete(final Throwable error) {
+    if (isClosed) {
+      return;
+    }
+
+    if (error != null) {
+      logStreamError(error);
+      retryDelay = backoffSupplier.supplyRetryDelay(retryDelay);
+      executor.schedule(() -> open(command), retryDelay, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void logStreamError(final Throwable error) {
+    final String errorMsg = "Failed to stream jobs of type '{}' to worker '{}'";
+    if (error instanceof StatusRuntimeException) {
+      final StatusRuntimeException statusRuntimeException = (StatusRuntimeException) error;
+      if (statusRuntimeException.getStatus().getCode() == Status.RESOURCE_EXHAUSTED.getCode()) {
+        LOGGER.trace(errorMsg, jobType, workerName, error);
+        return;
+      }
+    }
+
+    LOGGER.warn(errorMsg, jobType, workerName, error);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.zeebe.client.util.JsonUtil;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.migrationsupport.rules.ExternalResourceSupport;
+
+@ExtendWith(ExternalResourceSupport.class)
+final class JobStreamImplTest {
+  @Rule
+  public final GrpcCleanupRule grpcRule =
+      new GrpcCleanupRule().setTimeout(1, TimeUnit.MILLISECONDS);
+
+  private final Service service = new Service();
+  private final DeterministicScheduler scheduler = new DeterministicScheduler();
+  private JobClient client;
+  private JobStreamerImpl jobStreamer;
+
+  @BeforeEach
+  void beforeEach() throws IOException {
+    final String name = InProcessServerBuilder.generateName();
+    final ManagedChannel clientChannel =
+        grpcRule.register(InProcessChannelBuilder.forName(name).directExecutor().build());
+    final GatewayStub asyncStub = GatewayGrpc.newStub(clientChannel);
+
+    grpcRule.register(
+        InProcessServerBuilder.forName(name).directExecutor().addService(service).build().start());
+    client =
+        new JobClientImpl(
+            asyncStub, new ZeebeClientBuilderImpl(), new ZeebeObjectMapper(), ignored -> false);
+    jobStreamer = createStreamer();
+  }
+
+  @AfterEach
+  void afterEach() {
+    if (jobStreamer != null) {
+      jobStreamer.close();
+    }
+  }
+
+  @Test
+  void shouldCancelStreamOnClose() {
+    // given
+    jobStreamer.openStreamer(ignored -> {});
+
+    // when
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> registeredStream =
+        service.lastStream();
+    jobStreamer.close();
+
+    // then
+    assertThat(registeredStream.isCancelled()).isTrue();
+  }
+
+  @Test
+  void shouldOpenStream() {
+    // given
+    final StreamActivatedJobsRequest expectedRequest =
+        StreamActivatedJobsRequest.newBuilder()
+            .setType("type")
+            .setWorker("worker")
+            .setTimeout(Duration.ofSeconds(10).toMillis())
+            .addFetchVariable("foo")
+            .addFetchVariable("bar")
+            .build();
+
+    // when
+    jobStreamer.openStreamer(ignored -> {});
+
+    // then
+    assertThat(service.lastRequest()).isEqualTo(expectedRequest);
+  }
+
+  @Test
+  void shouldForwardJobsToConsumer() {
+    // given
+    final List<ActivatedJob> jobs = new ArrayList<>();
+    jobStreamer.openStreamer(jobs::add);
+
+    // when
+    service.pushJob();
+    service.pushJob();
+
+    // then
+    assertThat(jobs).hasSize(2).extracting(ActivatedJob::getKey).containsExactly(0L, 1L);
+  }
+
+  @Test
+  void shouldBackOffOnStreamError() {
+    // given
+    jobStreamer.openStreamer(ignored -> {});
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> lastStream =
+        service.lastStream();
+
+    // when - expire exactly the amount of time the stream would back off before opening
+    lastStream.onError(new StatusRuntimeException(Status.ABORTED));
+    scheduler.tick(10, TimeUnit.SECONDS);
+    scheduler.runUntilIdle();
+
+    // then
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> recreatedStream =
+        service.lastStream();
+    assertThat(recreatedStream).isNotEqualTo(lastStream);
+    assertThat(recreatedStream.isCancelled()).isFalse();
+  }
+
+  @Test
+  void shouldNotReopenStreamOnErrorIfClosed() {
+    // given
+    jobStreamer.openStreamer(ignored -> {});
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> lastStream =
+        service.lastStream();
+
+    // when
+    jobStreamer.close();
+    lastStream.onError(new StatusRuntimeException(Status.ABORTED));
+
+    // avoid non-determinism by running all pending tasks
+    scheduler.tick(1, TimeUnit.DAYS);
+    scheduler.runUntilIdle();
+
+    // then
+    assertThat(service.streams).isEmpty();
+  }
+
+  private JobStreamerImpl createStreamer() {
+    return new JobStreamerImpl(
+        client,
+        "type",
+        "worker",
+        Duration.ofSeconds(10),
+        Arrays.asList("foo", "bar"),
+        Duration.ofHours(8),
+        ignored -> 10_000L,
+        scheduler);
+  }
+
+  private static final class Service extends GatewayImplBase {
+    private final ArrayList<StreamActivatedJobsRequest> requests = new ArrayList<>();
+    private final Map<
+            StreamActivatedJobsRequest, ServerCallStreamObserver<GatewayOuterClass.ActivatedJob>>
+        streams = new HashMap<>();
+    private int keyGenerator;
+
+    @Override
+    public void streamActivatedJobs(
+        final StreamActivatedJobsRequest request,
+        final StreamObserver<GatewayOuterClass.ActivatedJob> responseObserver) {
+      final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> stream =
+          (ServerCallStreamObserver<GatewayOuterClass.ActivatedJob>) responseObserver;
+
+      streams.put(request, stream);
+      requests.add(request);
+
+      stream.setOnCancelHandler(() -> streams.remove(request));
+      stream.setOnCloseHandler(() -> streams.remove(request));
+    }
+
+    private StreamActivatedJobsRequest lastRequest() {
+      return requests.get(requests.size() - 1);
+    }
+
+    private ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> lastStream() {
+      return streams.get(lastRequest());
+    }
+
+    private void pushJob() {
+      final StreamActivatedJobsRequest request = lastRequest();
+      final StreamObserver<GatewayOuterClass.ActivatedJob> stream = streams.get(request);
+      final Map<String, String> variables = new HashMap<>();
+      request.getFetchVariableList().forEach(key -> variables.put(key, "value"));
+
+      final GatewayOuterClass.ActivatedJob job =
+          GatewayOuterClass.ActivatedJob.newBuilder()
+              .setType(request.getType())
+              .setDeadline(System.currentTimeMillis() + request.getTimeout())
+              .setWorker(request.getWorker())
+              .setVariables(JsonUtil.toJson(variables))
+              .setKey(keyGenerator++)
+              .build();
+
+      stream.onNext(job);
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -16,34 +16,51 @@
 package io.camunda.zeebe.client.impl.worker;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
 import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import java.io.Closeable;
+import java.io.IOException;
 import java.time.Duration;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
 
+@SuppressWarnings("resource")
 class JobWorkerBuilderImplTest {
 
   private JobWorkerBuilderImpl jobWorkerBuilder;
-  private ZeebeClientConfiguration zeebeClientConfiguration;
   private JobClient jobClient;
-  private ScheduledExecutorService executorService;
   private List<Closeable> closeables;
 
   @BeforeEach
   void setUp() {
-    zeebeClientConfiguration = mock();
-    jobClient = mock();
-    executorService = mock();
-    closeables = Collections.emptyList();
+    final ZeebeClientConfiguration zeebeClientConfiguration = mock();
+    jobClient = mock(JobClient.class, Answers.RETURNS_DEEP_STUBS);
+    final ScheduledExecutorService executorService = mock();
+    closeables = new ArrayList<>();
     jobWorkerBuilder =
         new JobWorkerBuilderImpl(zeebeClientConfiguration, jobClient, executorService, closeables);
+  }
+
+  @AfterEach
+  void afterEach() throws IOException {
+    for (final Closeable closeable : closeables) {
+      closeable.close();
+    }
   }
 
   @Test
@@ -72,5 +89,65 @@ class JobWorkerBuilderImplTest {
         // then
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("timeout must be not zero");
+  }
+
+  @Test
+  void shouldNotUseStreamingIfNotOptedIn() {
+    // given
+    final JobWorkerBuilderStep3 builder =
+        jobWorkerBuilder
+            .jobType("type")
+            .handler((c, j) -> {})
+            .timeout(1)
+            .name("test")
+            .maxJobsActive(30);
+
+    // when
+    builder.open();
+
+    // then
+    verify(jobClient, never()).newStreamJobsCommand();
+  }
+
+  @Test
+  void shouldUseStreamingIfOptedIn() {
+    // given - when
+    final JobWorkerBuilderStep3 builder =
+        jobWorkerBuilder
+            .jobType("type")
+            .handler((c, j) -> {})
+            .timeout(1)
+            .name("test")
+            .maxJobsActive(30);
+
+    // when
+    builder.enableStreaming().open();
+
+    // then
+    verify(jobClient, atLeast(1)).newStreamJobsCommand();
+  }
+
+  @Test
+  void shouldUseStreamTimeoutInsteadOfRequestTimeout() {
+    // given
+    final StreamJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
+    Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
+        .thenReturn(lastStep);
+    Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
+
+    // when
+    jobWorkerBuilder
+        .jobType("type")
+        .handler((c, j) -> {})
+        .requestTimeout(Duration.ofSeconds(10))
+        .streamTimeout(Duration.ofHours(5))
+        .timeout(1)
+        .name("test")
+        .maxJobsActive(30)
+        .enableStreaming()
+        .open();
+
+    // then
+    verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(5));
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -890,6 +890,12 @@
         <groupId>org.jmock</groupId>
         <artifactId>jmock</artifactId>
         <version>${version.jmock}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jmock</groupId>
+            <artifactId>jmock-testjar</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

This PR integrates job streams with the job worker implementation, **_as an opt-in feature_**. By default, this is disabled to avoid breaking any deployments while the feature is still being developed.

To use it, the user must enable it via the builder:

```java
final ZeebeClient client = ...;
final JobWorker worker = client.newWorker()
  .type("type")
  .handle((c, j) -> {})
  .enableStreaming()
  .streamTimeout(Duration.ofHours(5))
  .open();
```

There is an additional `streamTimeout` method, which controls when the stream will be automatically closed. This is to differentiate with the `requestTimeout`, which controls the polling time out.

When a stream is closed (normally or not), and the worker is still open, then the stream is immediately recreated using the back off supplier.

Jobs activated via the stream are handled in the same exact way as those handled by polling.

There are no integration tests yet for this. To keep the PR small, I will add them as a follow up issue. Happy to do it here if you would prefer, however.

## Related issues

closes #13473 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
