### PR TITLE
[Backport stable/8.2] Don't mutate state when checking for job timeouts and backoffs

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
@@ -37,9 +38,10 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
   @Override
   public void processRecord(final TypedRecord<JobRecord> record) {
     final long jobKey = record.getKey();
-    final JobState.State state = jobState.getState(jobKey);
+    final var job = jobState.getJob(jobKey);
+    final var state = jobState.getState(jobKey);
 
-    if (state == State.FAILED) {
+    if (state == State.FAILED && hasRecurred(job)) {
       final JobRecord recurredJob = jobState.getJob(jobKey);
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.RECURRED_AFTER_BACKOFF, recurredJob);
     } else {
@@ -63,5 +65,9 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
       final String errorMessage = String.format(NOT_FAILED_JOB_MESSAGE, jobKey, textState);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);
     }
+  }
+
+  private boolean hasRecurred(final JobRecord job) {
+    return job.getRecurringTime() < ActorClock.currentTimeMillis();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -40,7 +40,7 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
     final JobState.State state = jobState.getState(jobKey);
 
     if (state == State.FAILED) {
-      final JobRecord recurredJob = record.getValue();
+      final JobRecord recurredJob = jobState.getJob(jobKey);
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.RECURRED_AFTER_BACKOFF, recurredJob);
     } else {
       final String textState;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord> {
@@ -38,22 +39,26 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> record) {
-    final long jobKey = record.getKey();
-    final JobState.State state = jobState.getState(jobKey);
+    final var jobKey = record.getKey();
+    final var job = jobState.getJob(jobKey);
+    final var state = jobState.getState(jobKey);
 
-    if (state == State.ACTIVATED) {
-      final JobRecord timedOutJob = record.getValue();
-      stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, timedOutJob);
-      jobMetrics.jobTimedOut(timedOutJob.getType());
+    final var now = ActorClock.currentTimeMillis();
+    final var deadline = job.getDeadline();
+    final var hasTimedOut = now > deadline;
+
+    if (state == State.ACTIVATED && hasTimedOut) {
+      stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, job);
+      jobMetrics.jobTimedOut(job.getType());
     } else {
-      final var reason = switch (state) {
-        case ACTIVATED -> throw new IllegalStateException(
-            "This should never happen, if a job is activated it should be timed out not rejected");
-        case ACTIVATABLE -> "it must be activated first";
-        case FAILED -> "it is marked as failed and is not activated";
-        case ERROR_THROWN -> "it has thrown an error and is not activated";
-        case NOT_FOUND -> "no such job was found";
-      };
+      final var reason =
+          switch (state) {
+            case ACTIVATED -> "it has not timed out";
+            case ACTIVATABLE -> "it must be activated first";
+            case FAILED -> "it is marked as failed and is not activated";
+            case ERROR_THROWN -> "it has thrown an error and is not activated";
+            case NOT_FOUND -> "no such job was found";
+          };
 
       final String errorMessage = String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, reason);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -43,11 +43,7 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
     final var job = jobState.getJob(jobKey);
     final var state = jobState.getState(jobKey);
 
-    final var now = ActorClock.currentTimeMillis();
-    final var deadline = job.getDeadline();
-    final var hasTimedOut = now > deadline;
-
-    if (state == State.ACTIVATED && hasTimedOut) {
+    if (state == State.ACTIVATED && hasTimedOut(job)) {
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, job);
       jobMetrics.jobTimedOut(job.getType());
     } else {
@@ -63,5 +59,9 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
       final String errorMessage = String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, reason);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);
     }
+  }
+
+  private boolean hasTimedOut(final JobRecord job) {
+    return job.getDeadline() < ActorClock.currentTimeMillis();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -46,21 +46,16 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, timedOutJob);
       jobMetrics.jobTimedOut(timedOutJob.getType());
     } else {
-      final String textState;
+      final var reason = switch (state) {
+        case ACTIVATED -> throw new IllegalStateException(
+            "This should never happen, if a job is activated it should be timed out not rejected");
+        case ACTIVATABLE -> "it must be activated first";
+        case FAILED -> "it is marked as failed and is not activated";
+        case ERROR_THROWN -> "it has thrown an error and is not activated";
+        case NOT_FOUND -> "no such job was found";
+      };
 
-      switch (state) {
-        case ACTIVATABLE:
-          textState = "it must be activated first";
-          break;
-        case FAILED:
-          textState = "it is marked as failed";
-          break;
-        default:
-          textState = "no such job was found";
-          break;
-      }
-
-      final String errorMessage = String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, textState);
+      final String errorMessage = String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, reason);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
@@ -14,7 +14,7 @@ import org.agrona.DirectBuffer;
 
 public interface JobState {
 
-  void forEachTimedOutEntry(long upperBound, BiFunction<Long, JobRecord, Boolean> callback);
+  void forEachTimedOutEntry(long upperBound, BiPredicate<Long, JobRecord> callback);
 
   boolean exists(long jobKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -322,7 +322,8 @@ public final class DbJobState implements JobState, MutableJobState {
           boolean consumed = false;
           if (deadline <= timestamp) {
             final long jobKey = key.second().inner().getValue();
-            consumed = visitJob(jobKey, callback, () -> backoffColumnFamily.deleteExisting(key));
+            consumed = visitJob(jobKey, callback, () -> {
+            });
           }
           if (!consumed) {
             nextBackOffDueDate = deadline;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -180,6 +180,7 @@ public final class DbJobState implements JobState, MutableJobState {
     makeJobNotActivatable(type);
 
     removeJobDeadline(key, record.getDeadline());
+    removeJobBackoff(key, record.getRecurringTime());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -259,7 +259,7 @@ public final class DbJobState implements JobState, MutableJobState {
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().inner().getValue();
-            return visitJob(jobKey1, callback, () -> {});
+            return visitJob(jobKey1, callback);
           }
           return false;
         });
@@ -298,8 +298,7 @@ public final class DbJobState implements JobState, MutableJobState {
         jobTypeKey,
         ((compositeKey, zbNil) -> {
           final long jobKey = compositeKey.second().inner().getValue();
-          // TODO #6521 reconsider race condition and whether or not the cleanup task is needed
-          return visitJob(jobKey, callback::apply, () -> {});
+          return visitJob(jobKey, callback::apply);
         }));
   }
 
@@ -319,8 +318,7 @@ public final class DbJobState implements JobState, MutableJobState {
           boolean consumed = false;
           if (deadline <= timestamp) {
             final long jobKey = key.second().inner().getValue();
-            consumed = visitJob(jobKey, callback, () -> {
-            });
+            consumed = visitJob(jobKey, callback);
           }
           if (!consumed) {
             nextBackOffDueDate = deadline;
@@ -330,14 +328,10 @@ public final class DbJobState implements JobState, MutableJobState {
     return nextBackOffDueDate;
   }
 
-  boolean visitJob(
-      final long jobKey,
-      final BiPredicate<Long, JobRecord> callback,
-      final Runnable cleanupRunnable) {
+  boolean visitJob(final long jobKey, final BiPredicate<Long, JobRecord> callback) {
     final JobRecord job = getJob(jobKey);
     if (job == null) {
       LOG.error("Expected to find job with key {}, but no job found", jobKey);
-      cleanupRunnable.run();
       return true; // we want to continue with the iteration
     }
     return callback.test(jobKey, job);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -255,15 +255,14 @@ public final class DbJobState implements JobState, MutableJobState {
 
   @Override
   public void forEachTimedOutEntry(
-      final long upperBound, final BiFunction<Long, JobRecord, Boolean> callback) {
+      final long upperBound, final BiPredicate<Long, JobRecord> callback) {
     deadlinesColumnFamily.whileTrue(
         (key, value) -> {
           final long deadline = key.first().getValue();
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().inner().getValue();
-            return visitJob(
-                jobKey1, callback::apply, () -> deadlinesColumnFamily.deleteExisting(key));
+            return visitJob(jobKey1, callback, () -> deadlinesColumnFamily.deleteExisting(key));
           }
           return false;
         });

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -262,7 +262,7 @@ public final class DbJobState implements JobState, MutableJobState {
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().inner().getValue();
-            return visitJob(jobKey1, callback, () -> deadlinesColumnFamily.deleteExisting(key));
+            return visitJob(jobKey1, callback, () -> {});
           }
           return false;
         });

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -13,8 +13,11 @@ import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -22,6 +25,7 @@ import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -203,6 +207,32 @@ public final class JobTimeOutTest {
 
     // then
     assertThat(timedOutRecord.getSourceRecordPosition()).isLessThan(0);
+  }
+
+  @Test
+  public void shouldRejectIfJobDoesNotExist() {
+    // given
+    final var jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final var job = ENGINE.getProcessingState().getJobState().getJob(jobKey);
+    final var partitionId = Protocol.decodePartitionId(jobKey);
+
+    // when
+    ENGINE.pauseProcessing(partitionId);
+    ENGINE.writeRecords(
+        RecordToWrite.command().key(jobKey).job(JobIntent.COMPLETE, job),
+        RecordToWrite.command().key(jobKey).job(JobIntent.TIME_OUT, job));
+    ENGINE.resumeProcessing(partitionId);
+    Awaitility.await("until everything processed").until(ENGINE::hasReachedEnd);
+
+    // then activated again
+    final List<Record<JobRecordValue>> jobEvents =
+        jobRecords()
+            .withRecordKey(jobKey)
+            .withIntent(JobIntent.TIME_OUT)
+            .withRecordType(RecordType.COMMAND_REJECTION)
+            .limit(1)
+            .toList();
+    assertThat(jobEvents).isNotEmpty();
   }
 
   private long createInstance() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -347,8 +347,13 @@ public final class JobStateTest {
   public void shouldFailJobWithRetriesAndBackOff() {
     // given
     final long key = 1L;
+    final long now = 0;
     final var retryBackoff = 100;
-    final JobRecord jobRecord = newJobRecord().setRetries(1).setRetryBackoff(retryBackoff);
+    final JobRecord jobRecord =
+        newJobRecord()
+            .setRetries(1)
+            .setRetryBackoff(retryBackoff)
+            .setRecurringTime(now + retryBackoff);
 
     // when
     jobState.create(key, jobRecord);
@@ -361,7 +366,7 @@ public final class JobStateTest {
     assertJobRecordIsEqualTo(jobState.getJob(key), jobRecord);
     refuteListedAsActivatable(key, jobRecord.getTypeBuffer());
     refuteListedAsTimedOut(key, jobRecord.getDeadline() + 1);
-    assertListedAsBackOff(key, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    assertListedAsBackOff(key, jobRecord.getRecurringTime() + 1);
   }
 
   @Test
@@ -408,8 +413,13 @@ public final class JobStateTest {
   public void shouldRetryJobAfterRecurredAndHasRetries() {
     // given
     final long jobKey = 1L;
+    final long now = 0;
     final long retryBackoff = Duration.ofDays(1).toMillis();
-    final JobRecord jobRecord = newJobRecord().setRetries(1).setRetryBackoff(retryBackoff);
+    final JobRecord jobRecord =
+        newJobRecord()
+            .setRetries(1)
+            .setRetryBackoff(retryBackoff)
+            .setRecurringTime(now + retryBackoff);
 
     // when
     jobState.create(jobKey, jobRecord);
@@ -417,12 +427,12 @@ public final class JobStateTest {
     jobState.fail(jobKey, jobRecord);
     assertThat(jobState.exists(jobKey)).isTrue();
     assertJobState(jobKey, State.FAILED);
-    assertListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    assertListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1);
     jobState.recurAfterBackoff(jobKey, jobRecord);
 
     // then
     assertJobState(jobKey, State.ACTIVATABLE);
-    refuteListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1 + retryBackoff);
+    refuteListedAsBackOff(jobKey, jobRecord.getRecurringTime() + 1);
   }
 
   @Test


### PR DESCRIPTION
Manual backport of:
- https://github.com/camunda/zeebe/pull/13035
- https://github.com/camunda/zeebe/pull/13402
- https://github.com/camunda/zeebe/pull/13126
- https://github.com/camunda/zeebe/pull/13508