### PR TITLE
feat: optionally run all scheduled tasks outside of processing actor

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -29,7 +29,6 @@ public final class ProcessingCfg implements ConfigurationEntry {
     this.maxCommandsInBatch = maxCommandsInBatch;
   }
 
-
   public boolean isEnableAsyncScheduledTasks() {
     return enableAsyncScheduledTasks;
   }
@@ -40,9 +39,11 @@ public final class ProcessingCfg implements ConfigurationEntry {
 
   @Override
   public String toString() {
-    return "ProcessingCfg{" +
-        "maxCommandsInBatch=" + maxCommandsInBatch +
-        ", enableAsyncScheduledTasks=" + enableAsyncScheduledTasks +
-        '}';
+    return "ProcessingCfg{"
+        + "maxCommandsInBatch="
+        + maxCommandsInBatch
+        + ", enableAsyncScheduledTasks="
+        + enableAsyncScheduledTasks
+        + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 public final class ProcessingCfg implements ConfigurationEntry {
+
   private static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
   private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
+  private boolean enableAsyncScheduledTasks = true;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -27,8 +29,20 @@ public final class ProcessingCfg implements ConfigurationEntry {
     this.maxCommandsInBatch = maxCommandsInBatch;
   }
 
+
+  public boolean isEnableAsyncScheduledTasks() {
+    return enableAsyncScheduledTasks;
+  }
+
+  public void setEnableAsyncScheduledTasks(final boolean enableAsyncScheduledTasks) {
+    this.enableAsyncScheduledTasks = enableAsyncScheduledTasks;
+  }
+
   @Override
   public String toString() {
-    return "ProcessingCfg{" + "maxCommandsInBatch=" + maxCommandsInBatch + '}';
+    return "ProcessingCfg{" +
+        "maxCommandsInBatch=" + maxCommandsInBatch +
+        ", enableAsyncScheduledTasks=" + enableAsyncScheduledTasks +
+        '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -144,6 +144,8 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .nodeId(context.getNodeId())
         .commandResponseWriter(context.getCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
+        .setEnableAsyncScheduledTasks(
+            context.getBrokerCfg().getProcessing().isEnableAsyncScheduledTasks())
         .listener(
             new StreamProcessorListener() {
               @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
@@ -78,4 +78,57 @@ final class ProcessingCfgTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxCommandsInBatch must be >= 1");
   }
+
+  @Test
+  void shouldEnableAsyncScheduledTasksByDefault() {
+    // given
+    final var cfg = new ProcessingCfg();
+
+    // when
+    final var enabled = cfg.isEnableAsyncScheduledTasks();
+
+    // then
+    assertThat(enabled).isTrue();
+  }
+
+  @Test
+  void shouldSetAsyncScheduledTasks() {
+    // given
+    final var cfg = new ProcessingCfg();
+    cfg.setEnableAsyncScheduledTasks(false);
+
+    // when
+    final var enabled = cfg.isEnableAsyncScheduledTasks();
+
+    // then
+    assertThat(enabled).isFalse();
+  }
+
+  @Test
+  void shouldSetAsyncScheduledTasksFromConfig() {
+    // given
+    final var cfg =
+        TestConfigReader.readConfig("processing-cfg", Collections.emptyMap()).getProcessing();
+
+    // when
+    final var enabled = cfg.isEnableAsyncScheduledTasks();
+
+    // then
+    assertThat(enabled).isFalse();
+  }
+
+  @Test
+  void shouldDisableAsyncScheduledTasksFromEnvironment() {
+    // given
+    final var environment =
+        Collections.singletonMap("zeebe.broker.processing.enableAsyncScheduledTasks", "true");
+    final var cfg = TestConfigReader.readConfig("processing-cfg", environment).getProcessing();
+
+    // when
+    final var enabled = cfg.isEnableAsyncScheduledTasks();
+
+    // then
+    assertThat(enabled).isFalse();
+
+  }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
@@ -128,7 +128,6 @@ final class ProcessingCfgTest {
     final var enabled = cfg.isEnableAsyncScheduledTasks();
 
     // then
-    assertThat(enabled).isFalse();
-
+    assertThat(enabled).isTrue();
   }
 }

--- a/broker/src/test/resources/system/processing-cfg.yaml
+++ b/broker/src/test/resources/system/processing-cfg.yaml
@@ -2,3 +2,4 @@ zeebe:
   broker:
     processing:
       maxCommandsInBatch: 125
+      enableAsyncScheduledTasks: false

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -822,6 +822,20 @@
       # Lowering the command limit can reduce the frequency of rollback and retry.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_MAXCOMMANDSINBATCH
       # maxCommandsInBatch = 100
+
+      # Allows scheduled processing tasks such as checking for timed-out jobs to run concurrently to
+      # regular processing. This is a performance optimization to ensure that processing is not interrupted by
+      # higher than usual workload for any of the scheduled tasks. This should only be disabled in case of bugs,
+      # for example if one of the scheduled tasks is not safe to run concurrently to regular processing.
+      #
+      # This replaces the deprecated experimental settings that enable async scheduling for specific tasks only, for
+      # example `enableMessageTTLCheckerAsync`. When `enableAsyncScheduledTasks` is enabled (which it is by default),
+      # the deprecated settings take no effect. When `enableAsyncScheduledTasks` is disabled, scheduled tasks are only run async
+      # if explicitly enabled by the deprecated setting.
+      #
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_ENABLEASYNCSCHEDULEDTASKS
+      # enableAsyncScheduledTasks: true
+
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -732,6 +732,19 @@
       # Lowering the command limit can reduce the frequency of rollback and retry.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_MAXCOMMANDSINBATCH
       # maxCommandsInBatch = 100
+
+      # Allows scheduled processing tasks such as checking for timed-out jobs to run concurrently to
+      # regular processing. This is a performance optimization to ensure that processing is not interrupted by
+      # higher than usual workload for any of the scheduled tasks. This should only be disabled in case of bugs,
+      # for example if one of the scheduled tasks is not safe to run concurrently to regular processing.
+      #
+      # This replaces the deprecated experimental settings that enable async scheduling for specific tasks only, for
+      # example `enableMessageTTLCheckerAsync`. When `enableAsyncScheduledTasks` is enabled (which it is by default),
+      # the deprecated settings take no effect. When `enableAsyncScheduledTasks` is disabled, scheduled tasks are only run async
+      # if explicitly enabled by the deprecated setting.
+      #
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_ENABLEASYNCSCHEDULEDTASKS
+      # enableAsyncScheduledTasks: true
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -116,6 +116,7 @@ public final class EngineProcessors {
     addDeploymentRelatedProcessorAndServices(
         bpmnBehaviors,
         processingState,
+        scheduledTaskStateFactory,
         typedRecordProcessors,
         writers,
         deploymentDistributionCommandSender,
@@ -209,6 +210,7 @@ public final class EngineProcessors {
   private static void addDeploymentRelatedProcessorAndServices(
       final BpmnBehaviorsImpl bpmnBehaviors,
       final ProcessingState processingState,
+      final Supplier<ScheduledTaskState> scheduledTaskStateSupplier,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
@@ -231,7 +233,8 @@ public final class EngineProcessors {
     // periodically retries deployment distribution
     final var deploymentRedistributor =
         new DeploymentRedistributor(
-            deploymentDistributionCommandSender, processingState.getDeploymentState());
+            deploymentDistributionCommandSender,
+            scheduledTaskStateSupplier.get().getDeploymentState());
     typedRecordProcessors.withListener(deploymentRedistributor);
 
     // on other partitions DISTRIBUTE command is received and processed

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -144,7 +144,12 @@ public final class EngineProcessors {
     addDecisionProcessors(typedRecordProcessors, decisionBehavior, writers, processingState);
 
     JobEventProcessors.addJobProcessors(
-        typedRecordProcessors, processingState, bpmnBehaviors, writers, jobMetrics);
+        typedRecordProcessors,
+        processingState,
+        scheduledTaskStateFactory,
+        bpmnBehaviors,
+        writers,
+        jobMetrics);
 
     addIncidentProcessors(
         processingState,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -136,6 +136,7 @@ public final class EngineProcessors {
     final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor =
         addProcessProcessors(
             processingState,
+            scheduledTaskStateFactory,
             bpmnBehaviors,
             typedRecordProcessors,
             subscriptionCommandSender,
@@ -193,6 +194,7 @@ public final class EngineProcessors {
 
   private static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(
       final MutableProcessingState processingState,
+      final Supplier<ScheduledTaskState> scheduledTaskState,
       final BpmnBehaviorsImpl bpmnBehaviors,
       final TypedRecordProcessors typedRecordProcessors,
       final SubscriptionCommandSender subscriptionCommandSender,
@@ -200,6 +202,7 @@ public final class EngineProcessors {
       final DueDateTimerChecker timerChecker) {
     return ProcessEventProcessors.addProcessProcessors(
         processingState,
+        scheduledTaskState,
         bpmnBehaviors,
         typedRecordProcessors,
         subscriptionCommandSender,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -97,7 +97,7 @@ public final class MessageEventProcessors {
         .withListener(
             new MessageObserver(
                 scheduledTaskStateFactory,
-                processingState.getPendingMessageSubscriptionState(),
+                scheduledTaskStateFactory.get().getPendingMessageSubscriptionState(),
                 subscriptionCommandSender,
                 config.getMessagesTtlCheckerInterval(),
                 config.getMessagesTtlCheckerBatchLimit(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.state.message.DbMessageStartEventSubscriptionStat
 import io.camunda.zeebe.engine.state.message.DbMessageState;
 import io.camunda.zeebe.engine.state.message.DbMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableBannedInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
@@ -83,7 +84,9 @@ public class ProcessingDbState implements MutableProcessingState {
       final int partitionId,
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final TransientPendingSubscriptionState transientMessageSubscriptionState,
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
     this.partitionId = partitionId;
     this.zeebeDb = zeebeDb;
     this.keyGenerator = Objects.requireNonNull(keyGenerator);
@@ -97,11 +100,14 @@ public class ProcessingDbState implements MutableProcessingState {
     deploymentState = new DbDeploymentState(zeebeDb, transactionContext);
     jobState = new DbJobState(zeebeDb, transactionContext);
     messageState = new DbMessageState(zeebeDb, transactionContext, partitionId);
-    messageSubscriptionState = new DbMessageSubscriptionState(zeebeDb, transactionContext);
+    messageSubscriptionState =
+        new DbMessageSubscriptionState(
+            zeebeDb, transactionContext, transientMessageSubscriptionState);
     messageStartEventSubscriptionState =
         new DbMessageStartEventSubscriptionState(zeebeDb, transactionContext);
     processMessageSubscriptionState =
-        new DbProcessMessageSubscriptionState(zeebeDb, transactionContext);
+        new DbProcessMessageSubscriptionState(
+            zeebeDb, transactionContext, transientProcessMessageSubscriptionState);
     incidentState = new DbIncidentState(zeebeDb, transactionContext, partitionId);
     bannedInstanceState = new DbBannedInstanceState(zeebeDb, transactionContext, partitionId);
     decisionState = new DbDecisionState(zeebeDb, transactionContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -95,7 +95,7 @@ public class ProcessingDbState implements MutableProcessingState {
     eventScopeInstanceState = new DbEventScopeInstanceState(zeebeDb, transactionContext);
 
     deploymentState = new DbDeploymentState(zeebeDb, transactionContext);
-    jobState = new DbJobState(zeebeDb, transactionContext, partitionId);
+    jobState = new DbJobState(zeebeDb, transactionContext);
     messageState = new DbMessageState(zeebeDb, transactionContext, partitionId);
     messageSubscriptionState = new DbMessageSubscriptionState(zeebeDb, transactionContext);
     messageStartEventSubscriptionState =

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -9,20 +9,32 @@ package io.camunda.zeebe.engine.state;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
+import io.camunda.zeebe.engine.state.immutable.DeploymentState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
+import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
+import io.camunda.zeebe.engine.state.instance.DbJobState;
 import io.camunda.zeebe.engine.state.instance.DbTimerInstanceState;
 import io.camunda.zeebe.engine.state.message.DbMessageState;
+import io.camunda.zeebe.engine.state.message.DbMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 /** Contains read-only state that can be accessed safely by scheduled tasks. */
 public final class ScheduledTaskDbState implements ScheduledTaskState {
+
   private final DistributionState distributionState;
   private final MessageState messageState;
   private final TimerInstanceState timerInstanceState;
+  private final JobState jobState;
+  private final DeploymentState deploymentState;
+  private final PendingMessageSubscriptionState pendingMessageSubscriptionState;
+  private final PendingProcessMessageSubscriptionState pendingProcessMessageSubscriptionState;
 
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -31,6 +43,12 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
     distributionState = new DbDistributionState(zeebeDb, transactionContext);
     messageState = new DbMessageState(zeebeDb, transactionContext, partitionId);
     timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
+    jobState = new DbJobState(zeebeDb, transactionContext);
+    deploymentState = new DbDeploymentState(zeebeDb, transactionContext);
+    pendingMessageSubscriptionState = new DbMessageSubscriptionState(zeebeDb, transactionContext);
+    pendingProcessMessageSubscriptionState = new DbProcessMessageSubscriptionState(zeebeDb,
+        transactionContext);
+
   }
 
   @Override
@@ -46,5 +64,25 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   @Override
   public TimerInstanceState getTimerState() {
     return timerInstanceState;
+  }
+
+  @Override
+  public JobState getJobState() {
+    return jobState;
+  }
+
+  @Override
+  public DeploymentState getDeploymentState() {
+    return deploymentState;
+  }
+
+  @Override
+  public PendingMessageSubscriptionState getPendingMessageSubscriptionState() {
+    return pendingMessageSubscriptionState;
+  }
+
+  @Override
+  public PendingProcessMessageSubscriptionState getPendingProcessMessageSubscriptionState() {
+    return pendingProcessMessageSubscriptionState;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.PendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.instance.DbJobState;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.engine.state.instance.DbTimerInstanceState;
 import io.camunda.zeebe.engine.state.message.DbMessageState;
 import io.camunda.zeebe.engine.state.message.DbMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 /** Contains read-only state that can be accessed safely by scheduled tasks. */
@@ -39,16 +41,20 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final int partitionId) {
+      final int partitionId,
+      final TransientPendingSubscriptionState transientMessageSubscriptionState,
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
     distributionState = new DbDistributionState(zeebeDb, transactionContext);
     messageState = new DbMessageState(zeebeDb, transactionContext, partitionId);
     timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
     jobState = new DbJobState(zeebeDb, transactionContext);
     deploymentState = new DbDeploymentState(zeebeDb, transactionContext);
-    pendingMessageSubscriptionState = new DbMessageSubscriptionState(zeebeDb, transactionContext);
-    pendingProcessMessageSubscriptionState = new DbProcessMessageSubscriptionState(zeebeDb,
-        transactionContext);
-
+    pendingMessageSubscriptionState =
+        new DbMessageSubscriptionState(
+            zeebeDb, transactionContext, transientMessageSubscriptionState);
+    pendingProcessMessageSubscriptionState =
+        new DbProcessMessageSubscriptionState(
+            zeebeDb, transactionContext, transientProcessMessageSubscriptionState);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
@@ -14,4 +14,12 @@ public interface ScheduledTaskState {
   MessageState getMessageState();
 
   TimerInstanceState getTimerState();
+
+  JobState getJobState();
+
+  DeploymentState getDeploymentState();
+
+  PendingMessageSubscriptionState getPendingMessageSubscriptionState();
+
+  PendingProcessMessageSubscriptionState getPendingProcessMessageSubscriptionState();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -63,9 +63,7 @@ public final class DbJobState implements JobState, MutableJobState {
   private long nextBackOffDueDate;
 
   public DbJobState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb,
-      final TransactionContext transactionContext,
-      final int partitionId) {
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
 
     jobKey = new DbLong();
     fkJob = new DbForeignKey<>(jobKey, ZbColumnFamilies.JOBS);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -46,11 +46,12 @@ public final class DbMessageSubscriptionState
   private final ColumnFamily<DbCompositeKey<DbCompositeKey<DbString, DbString>, DbLong>, DbNil>
       messageNameAndCorrelationKeyColumnFamily;
 
-  private final TransientPendingSubscriptionState transientState =
-      new TransientPendingSubscriptionState();
+  private final TransientPendingSubscriptionState transientState;
 
   public DbMessageSubscriptionState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final TransactionContext transactionContext,
+      final TransientPendingSubscriptionState transientState) {
 
     elementInstanceKey = new DbLong();
     messageName = new DbString();
@@ -73,6 +74,7 @@ public final class DbMessageSubscriptionState
             transactionContext,
             nameCorrelationAndElementInstanceKey,
             DbNil.INSTANCE);
+    this.transientState = transientState;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -38,15 +38,17 @@ public final class DbProcessMessageSubscriptionState
   private final ColumnFamily<DbCompositeKey<DbLong, DbString>, ProcessMessageSubscription>
       subscriptionColumnFamily;
 
-  private final TransientPendingSubscriptionState transientState =
-      new TransientPendingSubscriptionState();
+  private final TransientPendingSubscriptionState transientState;
 
   public DbProcessMessageSubscriptionState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final TransactionContext transactionContext,
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
     elementInstanceKey = new DbLong();
     messageName = new DbString();
     elementKeyAndMessageName = new DbCompositeKey<>(elementInstanceKey, messageName);
     processMessageSubscription = new ProcessMessageSubscription();
+    transientState = transientProcessMessageSubscriptionState;
 
     subscriptionColumnFamily =
         zeebeDb.createColumnFamily(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -21,6 +22,7 @@ import java.util.Optional;
 import org.agrona.DirectBuffer;
 
 public final class StateQueryService implements QueryService {
+
   private volatile boolean isClosed;
   private ProcessingState state;
   private final ZeebeDb<ZbColumnFamilies> zeebeDb;
@@ -73,7 +75,9 @@ public final class StateQueryService implements QueryService {
               zeebeDb.createContext(),
               () -> {
                 throw new UnsupportedOperationException("Not allowed to generate a new key");
-              });
+              },
+              new TransientPendingSubscriptionState(),
+              new TransientPendingSubscriptionState());
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -141,6 +142,7 @@ public class ProcessingStateExtension implements BeforeEachCallback {
   }
 
   private static final class ProcessingStateExtensionState implements CloseableResource {
+
     private Path tempFolder;
     private ZeebeDb<ZbColumnFamilies> zeebeDb;
     private TransactionContext transactionContext;
@@ -157,7 +159,12 @@ public class ProcessingStateExtension implements BeforeEachCallback {
             new DbKeyGenerator(Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext);
         processingState =
             new ProcessingDbState(
-                Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext, keyGenerator);
+                Protocol.DEPLOYMENT_PARTITION,
+                zeebeDb,
+                transactionContext,
+                keyGenerator,
+                new TransientPendingSubscriptionState(),
+                new TransientPendingSubscriptionState());
       } catch (final Exception e) {
         ExceptionUtils.throwAsUncheckedException(e);
       }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.util;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
+import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -39,7 +40,14 @@ public final class ProcessingStateRule extends ExternalResource {
 
     final var context = db.createContext();
     final var keyGenerator = new DbKeyGenerator(partition, db, context);
-    processingState = new ProcessingDbState(partition, db, context, keyGenerator);
+    processingState =
+        new ProcessingDbState(
+            partition,
+            db,
+            context,
+            keyGenerator,
+            new TransientPendingSubscriptionState(),
+            new TransientPendingSubscriptionState());
   }
 
   @Override

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java
@@ -19,4 +19,9 @@ public interface ReadonlyStreamProcessorContext {
    * @return partition ID
    */
   int getPartitionId();
+
+  /**
+   * @return true when scheduled tasks should run async, concurrently to the processing actor.
+   */
+  boolean enableAsyncScheduledTasks();
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -175,7 +175,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       asyncActor = new AsyncProcessingScheduleServiceActor(asyncScheduleService, partitionId);
       final var extendedProcessingScheduleService =
           new ExtendedProcessingScheduleServiceImpl(
-              processorActorService, asyncScheduleService, asyncActor.getActorControl());
+              processorActorService,
+              asyncScheduleService,
+              asyncActor.getActorControl(),
+              streamProcessorContext.enableAsyncScheduledTasks());
       streamProcessorContext.scheduleService(extendedProcessingScheduleService);
 
       initRecordProcessors();

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -135,4 +135,9 @@ public final class StreamProcessorBuilder {
     streamProcessorContext.maxCommandsInBatch(maxCommandsInBatch);
     return this;
   }
+
+  public StreamProcessorBuilder setEnableAsyncScheduledTasks(final boolean enabled) {
+    streamProcessorContext.setEnableAsyncScheduledTasks(enabled);
+    return this;
+  }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -56,6 +56,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
   private KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
+  private boolean enableAsyncScheduledTasks = true;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -205,5 +206,14 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public int getMaxCommandsInBatch() {
     return maxCommandsInBatch;
+  }
+
+  public StreamProcessorContext setEnableAsyncScheduledTasks(final boolean enabled) {
+    this.enableAsyncScheduledTasks = enabled;
+    return this;
+  }
+
+  public boolean enableAsyncScheduledTasks() {
+    return enableAsyncScheduledTasks;
   }
 }


### PR DESCRIPTION
This adds a new configuration:

``` yaml
zeebe.broker.processing.enableAsyncScheduledTasks: true
```
When enabled, scheduled tasks don't run on the processing actor. As a consequence, scheduled tasks no longer block the processing and don't read uncommitted state changes. This new configuration supersedes more specialized config values such as `enableMessageTTLCheckerAsync` which now only come into effect when the new `enableAsyncScheduledTasks` is disabled.

The feature is **enabled by default**, and the configuration flag is added **non-experimental**. Disabling this feature is only useful in case of a bug that can be prevented by running scheduled tasks on the processing actor or if there is an unforeseen performance impact.

This PR will not be backported as it is a new feature.

Closes https://github.com/camunda/zeebe/issues/12308