### PR TITLE
ci(smoke): use aws arm64 runner

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -68,9 +68,6 @@ runs:
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
-        # if we run on arm64 set equivalent architecture as input, else default to x64
-        # see https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
-        architecture: ${{ runner.arch == 'ARM64' && 'aarch64' || 'x64' }}
     # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: 'Create settings.xml'
       uses: s4u/maven-settings-action@v2.8.0

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -119,7 +119,7 @@ runs:
         -D maven.artifact.threads=32
         EOF
     - name: Cache local Maven repository
-      if: inputs.java == 'true' && startsWith(runner.name, 'actions-runner-')
+      if: inputs.java == 'true' && (startsWith(runner.name, 'actions-runner-') || startsWith(runner.name, 'aws-') || startsWith(runner.name, 'gcp-'))
       uses: actions/cache@v3
       with:
         # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
@@ -130,7 +130,7 @@ runs:
         restore-keys: |
           self-hosted-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
     - name: Cache local Maven repository
-      if: inputs.java == 'true' && !startsWith(runner.name, 'actions-runner-')
+      if: inputs.java == 'true' && !(startsWith(runner.name, 'actions-runner-') || startsWith(runner.name, 'aws-') || startsWith(runner.name, 'gcp-'))
       uses: actions/cache@v3
       with:
         # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -118,28 +118,29 @@ runs:
         -D aether.syncContext.named.factory=file-lock
         -D maven.artifact.threads=32
         EOF
+    - name: Determine if running on GH infra or self-hosted
+      if: inputs.java == 'true'
+      id: runner-env
+      shell: bash
+      # it matters for caching as absolute paths on self-hosted and Github runners differ
+      # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
+      run: |
+        if [[ "${{ runner.name }}" =~ ^(actions-runner-|gcp-|aws-|n1-).*$ ]]; then
+          echo "result=self-hosted" >> $GITHUB_OUTPUT
+        else
+          echo "result=gh-hosted" >> $GITHUB_OUTPUT
+        fi
     - name: Cache local Maven repository
-      if: inputs.java == 'true' && (startsWith(runner.name, 'actions-runner-') || startsWith(runner.name, 'aws-') || startsWith(runner.name, 'gcp-'))
+      if: inputs.java == 'true'
       uses: actions/cache@v3
       with:
         # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
         # `aether.enhancedLocalRepository.remotePrefix` defaults to 'cached'
         # `aether.enhancedLocalRepository.releasesPrefix` defaults to 'releases'
         path: ~/.m2/repository/cached/releases/
-        key: self-hosted-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ steps.runner-env.outputs.result }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          self-hosted-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
-    - name: Cache local Maven repository
-      if: inputs.java == 'true' && !(startsWith(runner.name, 'actions-runner-') || startsWith(runner.name, 'aws-') || startsWith(runner.name, 'gcp-'))
-      uses: actions/cache@v3
-      with:
-        # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
-        # `aether.enhancedLocalRepository.remotePrefix` defaults to 'cached'
-        # `aether.enhancedLocalRepository.releasesPrefix` defaults to 'releases'
-        path: ~/.m2/repository/cached/releases/
-        key: gh-hosted-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          gh-hosted-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+          ${{ steps.runner-env.outputs.result }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
           - os: linux
-            runner: [ self-hosted, linux, amd64 ]
+            runner: "aws-arm-core-4-default"
             arch: arm64
     steps:
       - uses: actions/checkout@v3
@@ -194,7 +194,6 @@ jobs:
           push: false
       - name: Run smoke test on ${{ matrix.arch }}
         env:
-          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
           # For non Linux runners there is no container available for testing, see build-docker job
           EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
         run: >


### PR DESCRIPTION
## Description

Uses the new arm runners provided by infra https://confluence.camunda.com/display/HAN/Github+Actions+Self-Hosted+Runners for the arm smoke test.

Pool can scale up to 20 runners https://dashboard.int.camunda.com/d/izL-_Qlnz/gha-self-hosted-runners?orgId=1&var-runnerlabel=aws-arm-core-4-unstable

10+ runs so far did not surface any network issues 🤞 (the only failure was a flaky test on the IT stage)
https://github.com/camunda/zeebe/actions/workflows/ci.yml?query=branch%3Ameg-11590-aws-arm-runners

## Related issues

closes #11590

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark
