### PR TITLE
fix: specify fsGroup on benchmark

### DIFF
--- a/benchmarks/setup/default/values-stable.yaml
+++ b/benchmarks/setup/default/values-stable.yaml
@@ -12,6 +12,10 @@ camunda-platform:
         effect: NoSchedule
         value: 'false'
 
+    # needed till https://github.com/camunda/camunda-platform-helm/pull/778 is merged upstream
+    podSecurityContext:
+      fsGroup: 1000
+
   zeebe-gateway:
     # Prefer scheduling on any non-spot VM
     # GKE does not let us add the cloud.google.com/gke-spot label manually, so when an instance is


### PR DESCRIPTION
## Description

Adopts the benchmark setup to be compatible with the default user having changed to zeebe with 3ceb62b.

Will be obsolete once adaptation was done upstream with https://github.com/camunda/camunda-platform-helm/pull/778#issuecomment-1640509876 but in the meantime new benchmarks would be broken.

## Related issues

relates to #12382