### PR TITLE
feat: ban process instances through admin API

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.broker.partitioning;
 
 import static java.util.Objects.requireNonNull;
 
+import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -60,6 +62,15 @@ final class MultiPartitionAdminAccess implements PartitionAdminAccess {
   @Override
   public ActorFuture<Void> resumeProcessing() {
     return callOnEachPartition(PartitionAdminAccess::resumeProcessing);
+  }
+
+  @Override
+  public ActorFuture<Void> banInstance(final long processInstanceKey) {
+    final String errorMsg =
+        String.format("Can't ban instance %s on all partitions.", processInstanceKey);
+    Loggers.CLUSTERING_LOGGER.error(errorMsg);
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException(errorMsg));
   }
 
   private ActorFuture<Void> callOnEachPartition(

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -52,6 +52,12 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
     return CompletableActorFuture.completed(null);
   }
 
+  @Override
+  public ActorFuture<Void> banInstance(final long processInstanceKey) {
+    logCall();
+    return CompletableActorFuture.completed(null);
+  }
+
   private void logCall() {
     LOG.warn("Received call on NoOp implementation of PartitionAdminAccess");
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -22,4 +22,6 @@ public interface PartitionAdminAccess {
   ActorFuture<Void> pauseProcessing();
 
   ActorFuture<Void> resumeProcessing();
+
+  ActorFuture<Void> banInstance(final long processInstanceKey);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 
@@ -16,6 +17,8 @@ public interface PartitionAdminControl {
   StreamProcessor getStreamProcessor();
 
   ZeebeDb getZeebeDb();
+
+  LogStream getLogStream();
 
   ExporterDirector getExporterDirector();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -8,11 +8,14 @@
 package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 
 public interface PartitionAdminControl {
   StreamProcessor getStreamProcessor();
+
+  ZeebeDb getZeebeDb();
 
   ExporterDirector getExporterDirector();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -22,18 +23,21 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   private final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier;
   private final Supplier<PartitionProcessingState> partitionProcessingStateSupplier;
   private final Supplier<ZeebeDb> zeebeDbSupplier;
+  private final Supplier<LogStream> logStreamSupplier;
 
   public PartitionAdminControlImpl(
       final Supplier<StreamProcessor> streamProcessorSupplier,
       final Supplier<ExporterDirector> exporterDirectorSupplier,
       final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier,
       final Supplier<PartitionProcessingState> partitionProcessingStateSupplier,
-      final Supplier<ZeebeDb> zeebeDbSupplier) {
+      final Supplier<ZeebeDb> zeebeDbSupplier,
+      final Supplier<LogStream> logStreamSupplier) {
     this.streamProcessorSupplier = streamProcessorSupplier;
     this.exporterDirectorSupplier = exporterDirectorSupplier;
     this.snapshotDirectorSupplier = snapshotDirectorSupplier;
     this.partitionProcessingStateSupplier = partitionProcessingStateSupplier;
     this.zeebeDbSupplier = zeebeDbSupplier;
+    this.logStreamSupplier = logStreamSupplier;
   }
 
   @Override
@@ -84,5 +88,9 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public ZeebeDb getZeebeDb() {
     return zeebeDbSupplier.get();
+  }
+
+  public LogStream getLogStream() {
+    return logStreamSupplier.get();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -20,16 +21,19 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   private final Supplier<ExporterDirector> exporterDirectorSupplier;
   private final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier;
   private final Supplier<PartitionProcessingState> partitionProcessingStateSupplier;
+  private final Supplier<ZeebeDb> zeebeDbSupplier;
 
   public PartitionAdminControlImpl(
       final Supplier<StreamProcessor> streamProcessorSupplier,
       final Supplier<ExporterDirector> exporterDirectorSupplier,
       final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier,
-      final Supplier<PartitionProcessingState> partitionProcessingStateSupplier) {
+      final Supplier<PartitionProcessingState> partitionProcessingStateSupplier,
+      final Supplier<ZeebeDb> zeebeDbSupplier) {
     this.streamProcessorSupplier = streamProcessorSupplier;
     this.exporterDirectorSupplier = exporterDirectorSupplier;
     this.snapshotDirectorSupplier = snapshotDirectorSupplier;
     this.partitionProcessingStateSupplier = partitionProcessingStateSupplier;
+    this.zeebeDbSupplier = zeebeDbSupplier;
   }
 
   @Override
@@ -75,5 +79,10 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public boolean resumeExporting() throws IOException {
     return partitionProcessingStateSupplier.get().resumeExporting();
+  }
+
+  @Override
+  public ZeebeDb getZeebeDb() {
+    return zeebeDbSupplier.get();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -46,6 +46,16 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   }
 
   @Override
+  public ZeebeDb getZeebeDb() {
+    return zeebeDbSupplier.get();
+  }
+
+  @Override
+  public LogStream getLogStream() {
+    return logStreamSupplier.get();
+  }
+
+  @Override
   public ExporterDirector getExporterDirector() {
     return exporterDirectorSupplier.get();
   }
@@ -83,14 +93,5 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public boolean resumeExporting() throws IOException {
     return partitionProcessingStateSupplier.get().resumeExporting();
-  }
-
-  @Override
-  public ZeebeDb getZeebeDb() {
-    return zeebeDbSupplier.get();
-  }
-
-  public LogStream getLogStream() {
-    return logStreamSupplier.get();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -145,7 +145,8 @@ public class PartitionStartupAndTransitionContextImpl
         () -> getPartitionContext().getStreamProcessor(),
         () -> getPartitionContext().getExporterDirector(),
         () -> snapshotDirector,
-        () -> partitionProcessingState);
+        () -> partitionProcessingState,
+        () -> zeebeDb);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -146,7 +146,8 @@ public class PartitionStartupAndTransitionContextImpl
         () -> getPartitionContext().getExporterDirector(),
         () -> snapshotDirector,
         () -> partitionProcessingState,
-        () -> zeebeDb);
+        () -> zeebeDb,
+        () -> logStream);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -155,6 +155,8 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
 
             dbBannedInstanceState.banProcessInstance(processInstanceKey);
 
+            LOG.info("Successfully banned instance with key {}", processInstanceKey);
+
           } catch (final Exception e) {
             LOG.error("Could not resume processing", e);
             completed.completeExceptionally(e);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -12,8 +12,16 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
 import java.io.IOException;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -144,24 +152,71 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
 
   @Override
   public ActorFuture<Void> banInstance(final long processInstanceKey) {
-    final ActorFuture<Void> completed = concurrencyControl.createFuture();
+    final ActorFuture<Void> future = concurrencyControl.createFuture();
     concurrencyControl.run(
         () -> {
           try {
-            final var zeebeDb = adminControl.getZeebeDb();
-            final var context = zeebeDb.createContext();
-            final var dbBannedInstanceState =
-                new DbBannedInstanceState(zeebeDb, context, partitionId);
 
-            dbBannedInstanceState.banProcessInstance(processInstanceKey);
+            final LogStream logStream = adminControl.getLogStream();
+            logStream
+                .newLogStreamWriter()
+                .onComplete(
+                    (writer, error) -> {
+                      if (error != null) {
+                        LOG.error(
+                            "Could not retrieve writer to write error record for process instance.",
+                            error);
+                        future.completeExceptionally(error);
+                      } else {
+                        final var errorRecord = new ErrorRecord();
+                        errorRecord.initErrorRecord(
+                            new Exception("Instance was banned from outside."), -1);
+                        errorRecord.setProcessInstanceKey(processInstanceKey);
 
-            LOG.info("Successfully banned instance with key {}", processInstanceKey);
+                        final var recordMetadata =
+                            new RecordMetadata()
+                                .recordType(RecordType.EVENT)
+                                .valueType(ValueType.ERROR)
+                                .intent(ErrorIntent.CREATED)
+                                .recordVersion(RecordMetadata.DEFAULT_RECORD_VERSION)
+                                .rejectionType(RejectionType.NULL_VAL)
+                                .rejectionReason("");
+                        final var entry =
+                            RecordBatchEntry.createEntry(
+                                processInstanceKey, recordMetadata, -1, errorRecord);
+                        final var eitherWrittenOrFailure = writer.tryWrite(entry);
 
+                        eitherWrittenOrFailure.ifRightOrLeft(
+                            (position) -> {
+                              LOG.info("Wrote error record on position {}", position);
+
+                              // we only want to make the state change after we wrote the event
+                              final var zeebeDb = adminControl.getZeebeDb();
+                              final var context = zeebeDb.createContext();
+                              final var dbBannedInstanceState =
+                                  new DbBannedInstanceState(zeebeDb, context, partitionId);
+
+                              dbBannedInstanceState.banProcessInstance(processInstanceKey);
+
+                              LOG.info(
+                                  "Successfully banned instance with key {}", processInstanceKey);
+                              future.complete(null);
+                            },
+                            writeFailure -> {
+                              final String errorMsg =
+                                  String.format(
+                                      "Failure %s on writing error record to ban instance %d",
+                                      writeFailure, processInstanceKey);
+                              future.completeExceptionally(new IllegalStateException(errorMsg));
+                              LOG.error(errorMsg);
+                            });
+                      }
+                    });
           } catch (final Exception e) {
             LOG.error("Could not resume processing", e);
-            completed.completeExceptionally(e);
+            future.completeExceptionally(e);
           }
         });
-    return completed;
+    return future;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
+import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.io.IOException;
@@ -134,6 +135,27 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
             }
             completed.complete(null);
           } catch (final IOException e) {
+            LOG.error("Could not resume processing", e);
+            completed.completeExceptionally(e);
+          }
+        });
+    return completed;
+  }
+
+  @Override
+  public ActorFuture<Void> banInstance(final long processInstanceKey) {
+    final ActorFuture<Void> completed = concurrencyControl.createFuture();
+    concurrencyControl.run(
+        () -> {
+          try {
+            final var zeebeDb = adminControl.getZeebeDb();
+            final var context = zeebeDb.createContext();
+            final var dbBannedInstanceState =
+                new DbBannedInstanceState(zeebeDb, context, partitionId);
+
+            dbBannedInstanceState.banProcessInstance(processInstanceKey);
+
+          } catch (final Exception e) {
             LOG.error("Could not resume processing", e);
             completed.completeExceptionally(e);
           }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -12,7 +12,8 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
-import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
+import io.camunda.zeebe.util.Either;
 import java.io.IOException;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -156,9 +158,8 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
     concurrencyControl.run(
         () -> {
           try {
-
-            final LogStream logStream = adminControl.getLogStream();
-            logStream
+            adminControl
+                .getLogStream()
                 .newLogStreamWriter()
                 .onComplete(
                     (writer, error) -> {
@@ -167,50 +168,10 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
                             "Could not retrieve writer to write error record for process instance.",
                             error);
                         future.completeExceptionally(error);
-                      } else {
-                        final var errorRecord = new ErrorRecord();
-                        errorRecord.initErrorRecord(
-                            new Exception("Instance was banned from outside."), -1);
-                        errorRecord.setProcessInstanceKey(processInstanceKey);
-
-                        final var recordMetadata =
-                            new RecordMetadata()
-                                .recordType(RecordType.EVENT)
-                                .valueType(ValueType.ERROR)
-                                .intent(ErrorIntent.CREATED)
-                                .recordVersion(RecordMetadata.DEFAULT_RECORD_VERSION)
-                                .rejectionType(RejectionType.NULL_VAL)
-                                .rejectionReason("");
-                        final var entry =
-                            RecordBatchEntry.createEntry(
-                                processInstanceKey, recordMetadata, -1, errorRecord);
-                        final var eitherWrittenOrFailure = writer.tryWrite(entry);
-
-                        eitherWrittenOrFailure.ifRightOrLeft(
-                            (position) -> {
-                              LOG.info("Wrote error record on position {}", position);
-
-                              // we only want to make the state change after we wrote the event
-                              final var zeebeDb = adminControl.getZeebeDb();
-                              final var context = zeebeDb.createContext();
-                              final var dbBannedInstanceState =
-                                  new DbBannedInstanceState(zeebeDb, context, partitionId);
-
-                              dbBannedInstanceState.banProcessInstance(processInstanceKey);
-
-                              LOG.info(
-                                  "Successfully banned instance with key {}", processInstanceKey);
-                              future.complete(null);
-                            },
-                            writeFailure -> {
-                              final String errorMsg =
-                                  String.format(
-                                      "Failure %s on writing error record to ban instance %d",
-                                      writeFailure, processInstanceKey);
-                              future.completeExceptionally(new IllegalStateException(errorMsg));
-                              LOG.error(errorMsg);
-                            });
+                        return;
                       }
+
+                      writeErrorEventAndBanInstance(processInstanceKey, writer, future);
                     });
           } catch (final Exception e) {
             LOG.error("Could not resume processing", e);
@@ -218,5 +179,53 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
           }
         });
     return future;
+  }
+
+  private void writeErrorEventAndBanInstance(
+      final long processInstanceKey, final LogStreamWriter writer, final ActorFuture<Void> future) {
+    tryWriteErrorEvent(writer, processInstanceKey)
+        .ifRightOrLeft(
+            (position) -> {
+              LOG.info("Wrote error record on position {}", position);
+              // we only want to make the state change after we wrote the event
+              banInstanceInState(processInstanceKey);
+              LOG.info("Successfully banned instance with key {}", processInstanceKey);
+              future.complete(null);
+            },
+            writeFailure -> {
+              final String errorMsg =
+                  String.format(
+                      "Failure %s on writing error record to ban instance %d",
+                      writeFailure, processInstanceKey);
+              future.completeExceptionally(new IllegalStateException(errorMsg));
+              LOG.error(errorMsg);
+            });
+  }
+
+  private void banInstanceInState(final long processInstanceKey) {
+    final var zeebeDb = adminControl.getZeebeDb();
+    final var context = zeebeDb.createContext();
+    final var dbBannedInstanceState = new DbBannedInstanceState(zeebeDb, context, partitionId);
+
+    dbBannedInstanceState.banProcessInstance(processInstanceKey);
+  }
+
+  private static Either<WriteFailure, Long> tryWriteErrorEvent(
+      final LogStreamWriter writer, final long processInstanceKey) {
+    final var errorRecord = new ErrorRecord();
+    errorRecord.initErrorRecord(new Exception("Instance was banned from outside."), -1);
+    errorRecord.setProcessInstanceKey(processInstanceKey);
+
+    final var recordMetadata =
+        new RecordMetadata()
+            .recordType(RecordType.EVENT)
+            .valueType(ValueType.ERROR)
+            .intent(ErrorIntent.CREATED)
+            .recordVersion(RecordMetadata.DEFAULT_RECORD_VERSION)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason("");
+    final var entry =
+        RecordBatchEntry.createEntry(processInstanceKey, recordMetadata, -1, errorRecord);
+    return writer.tryWrite(entry);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.Either;
+import java.util.Optional;
 
 public class AdminApiRequestHandler
     extends AsyncApiRequestHandler<ApiRequestReader, ApiResponseWriter> {
@@ -54,8 +55,51 @@ public class AdminApiRequestHandler
           stepDownIfNotPrimary(responseWriter, partitionId, errorWriter));
       case PAUSE_EXPORTING -> pauseExporting(responseWriter, partitionId, errorWriter);
       case RESUME_EXPORTING -> resumeExporting(responseWriter, partitionId, errorWriter);
+      case BAN_INSTANCE -> banInstance(requestReader, responseWriter, partitionId, errorWriter);
       default -> unknownRequest(errorWriter, requestReader.getMessageDecoder().type());
     };
+  }
+
+  private ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> banInstance(
+      final ApiRequestReader requestReader,
+      final ApiResponseWriter responseWriter,
+      final int partitionId,
+      final ErrorResponseWriter errorWriter) {
+    final long key = requestReader.key();
+
+    final Optional<PartitionAdminAccess> partitionAdminAccess =
+        adminAccess.forPartition(partitionId);
+
+    if (partitionAdminAccess.isEmpty()) {
+      LOG.warn(
+          "Failed to ban instance {} on partition {}. Could not find the partition.",
+          key,
+          partitionId);
+      return CompletableActorFuture.completed(
+          Either.left(
+              errorWriter.internalError(
+                  "Failed to ban instance %s on partition %s. Could not find the partition.",
+                  key, partitionId)));
+    }
+
+    final ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> result = actor.createFuture();
+    partitionAdminAccess
+        .orElseThrow()
+        .banInstance(requestReader.key())
+        .onComplete(
+            (r, t) -> {
+              if (t == null) {
+                result.complete(Either.right(responseWriter));
+              } else {
+                LOG.error("Failed to ban instance {} on partition {}", key, partitionId, t);
+                result.complete(
+                    Either.left(
+                        errorWriter.internalError(
+                            "Failed to ban instance %s, on partition %s", key, partitionId)));
+              }
+            });
+
+    return result;
   }
 
   private ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> unknownRequest(

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiRequestReader.java
@@ -24,6 +24,10 @@ public class ApiRequestReader implements RequestReader<AdminRequestDecoder> {
     return messageDecoder;
   }
 
+  public long key() {
+    return messageDecoder.key();
+  }
+
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceEndpoint.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.gateway.Loggers;
+import java.util.concurrent.CompletionException;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.Selector.Match;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@WebEndpoint(id = "banning")
+public final class BanInstanceEndpoint {
+  private static final Logger LOG = Loggers.GATEWAY_LOGGER;
+  final BanInstanceService banInstanceService;
+
+  @Autowired
+  public BanInstanceEndpoint(final BanInstanceService banInstanceService) {
+    this.banInstanceService = banInstanceService;
+  }
+
+  @WriteOperation
+  public WebEndpointResponse<?> post(
+      @Selector(match = Match.SINGLE) final long processInstanceKey) {
+    try {
+      LOG.info("Send AdminRequest to ban instance with key {}", processInstanceKey);
+      banInstanceService.banInstance(processInstanceKey);
+      return new WebEndpointResponse<>(WebEndpointResponse.STATUS_NO_CONTENT);
+    } catch (final CompletionException e) {
+      return new WebEndpointResponse<>(
+          e.getCause(), WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+    } catch (final Exception e) {
+      return new WebEndpointResponse<>(e, WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class BanInstanceService {
+
+  private final BrokerClient client;
+
+  @Autowired
+  public BanInstanceService(final BrokerClient client) {
+    this.client = client;
+  }
+
+  public void banInstance(final long key) {
+    client.sendRequest(new BrokerAdminRequest().banInstance(key));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BannedInstanceState.java
@@ -13,6 +13,4 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 public interface BannedInstanceState extends StreamProcessorLifecycleAware {
 
   boolean isBanned(final TypedRecord record);
-
-  boolean isEmpty();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
@@ -63,7 +63,7 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
       LOG.warn(BAN_INSTANCE_MESSAGE, key);
 
       processInstanceKey.wrapLong(key);
-      bannedInstanceColumnFamily.insert(processInstanceKey, DbNil.INSTANCE);
+      bannedInstanceColumnFamily.upsert(processInstanceKey, DbNil.INSTANCE);
       bannedInstanceMetrics.countBannedInstance();
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
@@ -36,7 +36,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   private final ColumnFamily<DbLong, DbNil> bannedInstanceColumnFamily;
   private final DbLong processInstanceKey;
   private final BannedInstanceMetrics bannedInstanceMetrics;
-  private boolean empty = true;
 
   public DbBannedInstanceState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -56,7 +55,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     final var counter = new AtomicInteger(0);
     bannedInstanceColumnFamily.forEach(ignore -> counter.getAndIncrement());
-    empty = counter.get() == 0;
     bannedInstanceMetrics.setBannedInstanceCounter(counter.get());
   }
 
@@ -64,7 +62,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
     if (key >= 0) {
       LOG.warn(BAN_INSTANCE_MESSAGE, key);
 
-      empty = false;
       processInstanceKey.wrapLong(key);
       bannedInstanceColumnFamily.insert(processInstanceKey, DbNil.INSTANCE);
       bannedInstanceMetrics.countBannedInstance();
@@ -72,10 +69,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   }
 
   private boolean isBanned(final long key) {
-    if (empty) {
-      return false;
-    }
-
     processInstanceKey.wrapLong(key);
     return bannedInstanceColumnFamily.exists(processInstanceKey);
   }
@@ -90,11 +83,6 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
       }
     }
     return false;
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return empty;
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BannedInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/BannedInstanceStateTest.java
@@ -134,28 +134,6 @@ public final class BannedInstanceStateTest {
     assertThat(bannedInstanceState.isBanned(differentProcessInstanceRecord)).isFalse();
   }
 
-  @Test
-  public void bannedInstancesIsEmptyIsTrueIfNothingIsBanned() {
-    // given
-
-    // when
-    final boolean bannedStateIsEmpty = bannedInstanceState.isEmpty();
-
-    // then
-    assertThat(bannedStateIsEmpty).isTrue();
-  }
-
-  @Test
-  public void bannedInstanceIsEmptyIsFalseIfSomethingGotBanned() {
-    // given
-
-    // when
-    bannedInstanceState.banProcessInstance(1001);
-
-    // then
-    assertThat(bannedInstanceState.isEmpty()).isFalse();
-  }
-
   private TypedRecordImpl createRecord() {
     return createRecord(1000L);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.admin;
 
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.management.AdminRequestEncoder;
@@ -38,6 +39,13 @@ public class BrokerAdminRequest extends BrokerRequest<Void> {
 
   public void resumeExporting() {
     request.setType(AdminRequestType.RESUME_EXPORTING);
+  }
+
+  public BrokerAdminRequest banInstance(final long key) {
+    request.setType(AdminRequestType.BAN_INSTANCE);
+    request.setKey(key);
+    request.setPartitionId(Protocol.decodePartitionId(key));
+    return this;
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -27,7 +27,7 @@ public class AdminRequest implements BufferReader, BufferWriter {
   private int partitionId = AdminRequestEncoder.partitionIdNullValue();
   private AdminRequestType type = AdminRequestType.NULL_VAL;
 
-  private final long key = AdminRequestEncoder.keyNullValue();
+  private long key = AdminRequestEncoder.keyNullValue();
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
@@ -74,6 +74,10 @@ public class AdminRequest implements BufferReader, BufferWriter {
 
   public long getKey() {
     return key;
+  }
+
+  public void setKey(final long key) {
+    this.key = key;
   }
 
   public void setType(final AdminRequestType type) {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -27,6 +27,8 @@ public class AdminRequest implements BufferReader, BufferWriter {
   private int partitionId = AdminRequestEncoder.partitionIdNullValue();
   private AdminRequestType type = AdminRequestType.NULL_VAL;
 
+  private final long key = AdminRequestEncoder.keyNullValue();
+
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
@@ -46,7 +48,8 @@ public class AdminRequest implements BufferReader, BufferWriter {
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .brokerId(brokerId)
         .partitionId(partitionId)
-        .type(type);
+        .type(type)
+        .key(key);
   }
 
   public int getBrokerId() {
@@ -67,6 +70,10 @@ public class AdminRequest implements BufferReader, BufferWriter {
 
   public AdminRequestType getType() {
     return type;
+  }
+
+  public long getKey() {
+    return key;
   }
 
   public void setType(final AdminRequestType type) {

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -281,6 +281,13 @@
           "new": "method io.camunda.zeebe.protocol.record.ImmutableRecordValue io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue::getCommandValue()",
           "justification": "This is a result of adding the Immutable annotation on RecordValue. This doesn't break any backwards compatibility."
         }
+      ,{
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.management.AdminRequestDecoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.management.AdminRequestDecoder.BLOCK_LENGTH",
+          "justification": "Added a new type to ban an instance"
+        }
       ]
     }
   }

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -3,6 +3,15 @@
     "extension": "revapi.filter",
     "id": "filter",
     "configuration": {
+      "elements": {
+        "exclude": [
+          {
+            "justification": "The management protocol is not public and is allowed to break",
+            "matcher": "java-package",
+            "match": "io.camunda.zeebe.protocol.management"
+          }
+        ]
+      },
       "archives": {
         "justification": "Ignore everything not included in the module itself",
         "include": [
@@ -280,13 +289,6 @@
           "old": "method io.camunda.zeebe.protocol.record.RecordValue io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue::getCommandValue()",
           "new": "method io.camunda.zeebe.protocol.record.ImmutableRecordValue io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue::getCommandValue()",
           "justification": "This is a result of adding the Immutable annotation on RecordValue. This doesn't break any backwards compatibility."
-        }
-      ,{
-          "ignore": true,
-          "code": "java.field.constantValueChanged",
-          "old": "field io.camunda.zeebe.protocol.management.AdminRequestDecoder.BLOCK_LENGTH",
-          "new": "field io.camunda.zeebe.protocol.management.AdminRequestDecoder.BLOCK_LENGTH",
-          "justification": "Added a new type to ban an instance"
         }
       ]
     }

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -11,6 +11,7 @@
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
       <validValue name="PAUSE_EXPORTING">1</validValue>
       <validValue name="RESUME_EXPORTING">2</validValue>
+      <validValue name="BAN_INSTANCE">3</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">
@@ -41,6 +42,7 @@
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="AdminRequestType"/>
     <field name="brokerId" id="3" type="uint16" presence="optional"/>
+    <field name="key" id="4" type="uint64" presence="optional"/>
   </sbe:message>
 
   <sbe:message name="AdminResponse" id="2">

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BanningEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BanningEndpointIT.java
@@ -18,13 +18,13 @@ import io.zeebe.containers.cluster.ZeebeCluster;
 import io.zeebe.containers.exporter.DebugReceiver;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 @Testcontainers
 public class BanningEndpointIT {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BanningEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BanningEndpointIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.management;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.qa.util.actuator.BanningActuator;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import io.zeebe.containers.exporter.DebugReceiver;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+@Testcontainers
+public class BanningEndpointIT {
+
+  private static final CopyOnWriteArrayList<Record<?>> EXPORTED_RECORDS =
+      new CopyOnWriteArrayList<>();
+  private static final DebugReceiver DEBUG_RECEIVER =
+      new DebugReceiver(EXPORTED_RECORDS::add, SocketUtil.getNextAddress()).start();
+
+  @Container
+  private static final ZeebeCluster CLUSTER =
+      ZeebeCluster.builder()
+          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+          .withBrokerConfig(
+              broker -> broker.withDebugExporter(DEBUG_RECEIVER.serverAddress().getPort()))
+          .withEmbeddedGateway(true)
+          .withBrokersCount(2)
+          .withPartitionsCount(1)
+          .withReplicationFactor(2)
+          .build();
+
+  @BeforeAll
+  public static void setup() {
+    DEBUG_RECEIVER.start();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    DEBUG_RECEIVER.stop();
+  }
+
+  @BeforeEach
+  public void cleanup() {
+    EXPORTED_RECORDS.clear();
+  }
+
+  @Test
+  void shouldBanInstance() {
+    // given - a process instance
+    final var actuator = BanningActuator.of(CLUSTER.getBrokers().get(0));
+    final long processInstanceKey;
+    try (final var client = CLUSTER.newClientBuilder().build()) {
+      final var process = Bpmn.createExecutableProcess("processId").startEvent().endEvent().done();
+      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+      final var result =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("processId")
+              .latestVersion()
+              .send()
+              .join();
+      processInstanceKey = result.getProcessInstanceKey();
+    }
+
+    // when & then - process instance can be banned
+    Assertions.assertThatCode(() -> actuator.ban(processInstanceKey)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldWriteErrorEventWhenBanningInstance() {
+    // given
+    final var actuator = BanningActuator.of(CLUSTER.getBrokers().get(0));
+    final long processInstanceKey;
+    try (final var client = CLUSTER.newClientBuilder().build()) {
+      final var process = Bpmn.createExecutableProcess("processId").startEvent().endEvent().done();
+      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+      final var result =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("processId")
+              .latestVersion()
+              .send()
+              .join();
+      processInstanceKey = result.getProcessInstanceKey();
+    }
+
+    // when
+    actuator.ban(processInstanceKey);
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final var errorEvents =
+                  EXPORTED_RECORDS.stream()
+                      .filter(record -> record.getRecordType() == RecordType.EVENT)
+                      .filter(record -> record.getValueType() == ValueType.ERROR)
+                      .filter(record -> record.getKey() == processInstanceKey)
+                      .toList();
+              Assertions.assertThat(errorEvents).isNotEmpty();
+            });
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BanningActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BanningActuator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.actuator;
+
+import feign.Feign;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.zeebe.containers.ZeebeNode;
+
+public interface BanningActuator {
+  static BanningActuator of(final ZeebeNode<?> node) {
+    final var endpoint =
+        String.format("http://%s/actuator/banning", node.getExternalMonitoringAddress());
+    return of(endpoint);
+  }
+
+  static BanningActuator of(final String endpoint) {
+    final var target = new HardCodedTarget<>(BanningActuator.class, endpoint);
+    return Feign.builder()
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+
+  /**
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /{id}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  void ban(@Param final long id);
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -220,7 +220,9 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
 
   private void replayEvent(final LoggedEvent currentEvent) {
     if (eventFilter.applies(currentEvent)
-        && currentEvent.getSourceEventPosition() > snapshotPosition) {
+        && (currentEvent.getSourceEventPosition() > snapshotPosition
+            || currentEvent.getSourceEventPosition()
+                < 0)) { // some events might not have a source pointer
       readMetadata(currentEvent);
       final var currentTypedEvent = readRecordValue(currentEvent);
 
@@ -240,7 +242,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
    * the last processing positions.
    */
   private void onRecordsReplayed() {
-    // Each event is caused by an command, the event points to the source command via the
+    // Each event is caused by a command, the event points to the source command via the
     // source position (pointer). This means the last source position is equal to the last processed
     // position by the processing state machine, which we can backfill after replay.
     final var lastProcessedPosition = lastSourceEventPosition;


### PR DESCRIPTION
This adds an actuator `POST /banning/{processInstanceKey}` that bans the instance. The actuator is available on gateways and on brokers. Both redirect the request to the leader of the partition where this process instance runs.
On the leader, the instance is banned immediately by writing to the state. An error event is written, ensuring that the state change is also applied on followers.

The mechanism is a little bit _weird_: the event is written with `sourceEventPosition=-1` and there is no command that causes the event. As a consequence, it is not possible to detect whether this event was already applied on a restored snapshot or not. In some cases it will be applied twice.


Closes #12696