### PR TITLE
[Backport stable/8.2] ci(go): fix go lint cache issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,9 @@ jobs:
         with:
           # fixed to avoid triggering false positive; see https://github.com/golangci/golangci-lint-action/issues/535
           version: v1.52.2
+          # caching issues, see: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775
+          skip-pkg-cache: true
+          skip-build-cache: true
           working-directory: clients/go
   go-apidiff:
     name: Go Backward Compatibility


### PR DESCRIPTION
# Description
Backport of #13308 to `stable/8.2`.

relates to 