### PR TITLE
Allow specifying tenant for deploy resources in Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/ExperimentalApi.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/ExperimentalApi.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates a public API that can change at any time, and has no guarantee of API stability and
+ * backward-compatibility. If users want stabilization or signature change of a specific API that is
+ * currently annotated {@code @ExperimentalApi}, please comment on its tracking issue on github with
+ * rationale, usecase, and so forth, so that the gRPC team may prioritize the process toward
+ * stabilization of the API.
+ *
+ * <p>Usage guidelines:
+ *
+ * <ol>
+ *   <li>This annotation is used only on public API. Internal interfaces should not use it.
+ *   <li>After gRPC has gained API stability, this annotation can only be added to new API. Adding
+ *       it to an existing API is considered API-breaking.
+ *   <li>Removing this annotation from an API gives it stable status.
+ * </ol>
+ *
+ * <p>Note: This annotation is intended only for gRPC library code. Users should not attach this
+ * annotation to their own code.
+ *
+ * <p>See: <a href="https://github.com/grpc/grpc-java-api-checker">grpc-java-api-checker</a>, an
+ * Error Prone plugin to automatically check for usages of this API.
+ *
+ * <p>This annotation was originally copied from io.grpc.ExperimentalApi, licensed under the Apache
+ * License, Version 2.0. Copyright 2015 The gRPC Authors. Changes have been made since.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({
+  ElementType.ANNOTATION_TYPE,
+  ElementType.CONSTRUCTOR,
+  ElementType.FIELD,
+  ElementType.METHOD,
+  ElementType.PACKAGE,
+  ElementType.TYPE
+})
+@Documented
+public @interface ExperimentalApi {
+  /** Context information such as links to discussion thread, tracking issue etc. */
+  String value();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/ExperimentalApi.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/ExperimentalApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The gRPC Authors
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,23 +25,20 @@ import java.lang.annotation.Target;
  * Indicates a public API that can change at any time, and has no guarantee of API stability and
  * backward-compatibility. If users want stabilization or signature change of a specific API that is
  * currently annotated {@code @ExperimentalApi}, please comment on its tracking issue on github with
- * rationale, usecase, and so forth, so that the gRPC team may prioritize the process toward
+ * rationale, usecase, and so forth, so that the Zeebe team may prioritize the process toward
  * stabilization of the API.
  *
  * <p>Usage guidelines:
  *
  * <ol>
  *   <li>This annotation is used only on public API. Internal interfaces should not use it.
- *   <li>After gRPC has gained API stability, this annotation can only be added to new API. Adding
+ *   <li>After Zeebe has gained API stability, this annotation can only be added to new API. Adding
  *       it to an existing API is considered API-breaking.
  *   <li>Removing this annotation from an API gives it stable status.
  * </ol>
  *
- * <p>Note: This annotation is intended only for gRPC library code. Users should not attach this
+ * <p>Note: This annotation is intended only for Zeebe library code. Users should not attach this
  * annotation to their own code.
- *
- * <p>See: <a href="https://github.com/grpc/grpc-java-api-checker">grpc-java-api-checker</a>, an
- * Error Prone plugin to automatically check for usages of this API.
  *
  * <p>This annotation was originally copied from io.grpc.ExperimentalApi, licensed under the Apache
  * License, Version 2.0. Copyright 2015 The gRPC Authors. Changes have been made since.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.ExperimentalApi;
+
+public interface CommandWithTenantStep<T> {
+
+  /**
+   * This identifier is used for entities that are created before multi-tenancy is enabled in the
+   * Zeebe cluster. After enabling multi-tenancy, these entities can still be interacted by using
+   * this identifier explicitly.
+   */
+  String DEFAULT_TENANT_IDENTIFIER = "[default]";
+
+  /**
+   * This identifier is used for entities that are shared among all tenants. For example, a deployed
+   * process can be shared among all tenants such that all tenants can create their own instances of
+   * the shared process definition. Process instances are always owned by a single tenant.
+   */
+  String SHARED_TENANT_IDENTIFIER = "[shared]";
+
+  /**
+   * <strong>Experimental: This method is under development, and as such using it may have no effect
+   * on the command builder when called. While unimplemented, it simply returns the command builder
+   * instance unchanged. This method already exists for software that is building support for
+   * multi-tenancy, and already wants to use this API during its development. As support for
+   * multi-tenancy is added to Zeebe, each of the commands that implement this method may start to
+   * take effect. Until this warning is removed, anything described below may not yet have taken
+   * effect, and the interface and its description are subject to change.</strong>
+   *
+   * <p>Specifies the tenant that will own any entities (e.g. process definition, process instances,
+   * etc.) resulting from this command.
+   *
+   * <h1>Multi-tenancy</h1>
+   *
+   * <p>Multiple tenants can share a Zeebe cluster. Entities can be assigned to a specific tenant
+   * using an identifier. Only that tenant can access these entities.
+   *
+   * <p>Any entities created before multi-tenancy has been enabled in the Zeebe cluster, are
+   * assigned to the {@link #DEFAULT_TENANT_IDENTIFIER}.
+   *
+   * <h2>Inferred ownership</h2>
+   *
+   * It's not always necessary to specify the {@code tenantId} explicitly. In many cases, the owning
+   * tenant can be inferred.
+   *
+   * <p>For example, an instance of a process that is owned by tenant {@code "ACME"} can be created
+   * without specifying the {@code tenantId} explicitly. The created process instance is then owned
+   * by {@code "ACME"} as well.
+   *
+   * <p>If no tenant is explicitly specified and the tenant could not be inferred, then the command
+   * is rejected.
+   *
+   * <h2>Shared entities</h2>
+   *
+   * <p>Some entities (i.e. process and decision definitions) can be shared among all tenants using
+   * the {@link #SHARED_TENANT_IDENTIFIER}.
+   *
+   * <p>When referring to shared entities in your command, the owning tenant may be inferred from
+   * the client's access.
+   *
+   * <p>For example, an instance of a process that is shared among all tenants can be created
+   * without specifying the {@code tenantId} explicitly, if the client only has access to one
+   * specific tenant. In that case, the tenant owning the created process instance can be inferred
+   * from the client's access.
+   *
+   * @param tenantId the identifier of the tenant to specify for this command, e.g. {@code "ACME"}
+   * @return the builder for this command with the tenant specified
+   * @since 8.3
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
+  T tenantId(String tenantId);
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
@@ -73,10 +73,10 @@ public interface CommandWithTenantStep<T> {
    * <p>When referring to shared entities in your command, the owning tenant may be inferred from
    * the client's access.
    *
-   * <p>For example, an instance of a process that is shared among all tenants can be created
-   * without specifying the {@code tenantId} explicitly, if the client only has access to one
-   * specific tenant. In that case, the tenant owning the created process instance can be inferred
-   * from the client's access.
+   * <p>For example, you can create an instance of a process, where all tenants share the process
+   * definition, without specifying the {@code tenantId} explicitly, if the client only has access
+   * to one specific tenant. In that case, the tenant owning the created process instance can be
+   * inferred from the client's access.
    *
    * @param tenantId the identifier of the tenant to specify for this command, e.g. {@code "ACME"}
    * @return the builder for this command with the tenant specified

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeployResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeployResourceCommandStep1.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.api.command;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.InputStream;
@@ -96,7 +97,24 @@ public interface DeployResourceCommandStep1 {
       BpmnModelInstance processDefinition, String resourceName);
 
   interface DeployResourceCommandStep2
-      extends DeployResourceCommandStep1, FinalCommandStep<DeploymentEvent> {
+      extends DeployResourceCommandStep1,
+          CommandWithTenantStep<DeployResourceCommandStep2>,
+          FinalCommandStep<DeploymentEvent> {
     // the place for new optional parameters
+
+    /**
+     * {@inheritDoc}
+     *
+     * <h1>Deploy resource command specifics</h1>
+     *
+     * <p>When no {@code tenantId} is specified explicitly, the deployed resources are owned by all
+     * tenants using the {@link #SHARED_TENANT_IDENTIFIER} as long as multi-tenancy is enabled in
+     * the Zeebe cluster.
+     *
+     * @since 8.3
+     */
+    @Override
+    @ExperimentalApi("https://github.com/camunda/zeebe/issues/13321")
+    DeployResourceCommandStep2 tenantId(String tenantId);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
@@ -167,6 +167,12 @@ public final class DeployResourceCommandImpl
     return future;
   }
 
+  @Override
+  public DeployResourceCommandStep2 tenantId(final String tenantId) {
+    // todo(#13321): replace dummy implementation
+    return this;
+  }
+
   private void send(final DeployResourceRequest request, final StreamObserver streamObserver) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/DeployResourceTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.impl.command.StreamUtil;
 import io.camunda.zeebe.client.impl.response.DecisionImpl;
@@ -361,6 +362,22 @@ public final class DeployResourceTest extends ClientTest {
 
     // then
     rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantId() {
+    // given
+    final DeployResourceCommandStep2 builder =
+        client.newDeployResourceCommand().addResourceStringUtf8("", "test.bpmn");
+
+    // when
+    final DeployResourceCommandStep2 builderWithTenantId = builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13321): verify that tenant id is set in the request
+    assertThat(builderWithTenantId)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
   }
 
   private byte[] getBytes(final String filename) {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/resource/DeployResourceTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.zeebe.client.process;
+package io.camunda.zeebe.client.resource;
 
 import static io.camunda.zeebe.client.util.RecordingGatewayService.deployedDecision;
 import static io.camunda.zeebe.client.util.RecordingGatewayService.deployedDecisionRequirements;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This is the first in several pull requests to:
- #13517

This pull request adds the ability to specify a single tenant for the deploy resources command builder.

This first pull request contains some additional setup needed to add this, including:
- a new `ExperimentalApi` annotation
- a reusable interface to add `tenantId` to command builder interfaces so we can describe the usage in comprehensive Javadoc

Please note that the new `tenantId` method on the deploy resources command builder has no effect at this time. The feature is still under development. The API is added so others can already start using this method during development. I'll inform the relevant teams once this is available to them.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13561

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
