### PR TITLE
Allow specifying specific tenant for other commands in Java client 

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
@@ -29,7 +29,9 @@ public interface BroadcastSignalCommandStep1 {
    */
   BroadcastSignalCommandStep2 signalName(String signalName);
 
-  interface BroadcastSignalCommandStep2 extends FinalCommandStep<BroadcastSignalResponse> {
+  interface BroadcastSignalCommandStep2
+      extends CommandWithTenantStep<BroadcastSignalCommandStep2>,
+          FinalCommandStep<BroadcastSignalResponse> {
     /**
      * Set the variables of the signal.
      *

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -135,7 +135,8 @@ public interface CreateProcessInstanceCommandStep1 {
   }
 
   interface CreateProcessInstanceWithResultCommandStep1
-      extends FinalCommandStep<ProcessInstanceResult> {
+      extends CommandWithTenantStep<CreateProcessInstanceWithResultCommandStep1>,
+          FinalCommandStep<ProcessInstanceResult> {
 
     /**
      * Set a list of variables names which should be fetched in the response.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -64,7 +64,9 @@ public interface CreateProcessInstanceCommandStep1 {
     CreateProcessInstanceCommandStep3 latestVersion();
   }
 
-  interface CreateProcessInstanceCommandStep3 extends FinalCommandStep<ProcessInstanceEvent> {
+  interface CreateProcessInstanceCommandStep3
+      extends CommandWithTenantStep<CreateProcessInstanceCommandStep3>,
+          FinalCommandStep<ProcessInstanceEvent> {
     /**
      * Set the initial variables of the process instance.
      *

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/EvaluateDecisionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/EvaluateDecisionCommandStep1.java
@@ -39,7 +39,9 @@ public interface EvaluateDecisionCommandStep1 {
    */
   EvaluateDecisionCommandStep2 decisionKey(long decisionKey);
 
-  interface EvaluateDecisionCommandStep2 extends FinalCommandStep<EvaluateDecisionResponse> {
+  interface EvaluateDecisionCommandStep2
+      extends CommandWithTenantStep<EvaluateDecisionCommandStep2>,
+          FinalCommandStep<EvaluateDecisionResponse> {
 
     /**
      * Set the variables for the decision evaluation.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
@@ -43,7 +43,9 @@ public interface PublishMessageCommandStep1 {
     PublishMessageCommandStep3 correlationKey(String correlationKey);
   }
 
-  interface PublishMessageCommandStep3 extends FinalCommandStep<PublishMessageResponse> {
+  interface PublishMessageCommandStep3
+      extends CommandWithTenantStep<PublishMessageCommandStep3>,
+          FinalCommandStep<PublishMessageResponse> {
     /**
      * Set the id of the message. The message is rejected if another message is already published
      * with the same id, name and correlation-key.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
@@ -86,6 +86,12 @@ public final class BroadcastSignalCommandImpl
     return future;
   }
 
+  @Override
+  public BroadcastSignalCommandStep2 tenantId(final String tenantId) {
+    // todo(#13558): replace dummy implementation
+    return this;
+  }
+
   private void send(
       final BroadcastSignalRequest request,
       final StreamObserver<GatewayOuterClass.BroadcastSignalResponse> streamObserver) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -124,6 +124,12 @@ public final class CreateProcessInstanceCommandImpl
     return future;
   }
 
+  @Override
+  public CreateProcessInstanceCommandStep3 tenantId(final String tenantId) {
+    // todo(#13536): replace dummy implementation
+    return this;
+  }
+
   private void send(
       final CreateProcessInstanceRequest request,
       final StreamObserver<GatewayOuterClass.CreateProcessInstanceResponse> future) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
@@ -107,4 +107,10 @@ public final class CreateProcessInstanceWithResultCommandImpl
     builder.addAllFetchVariables(Arrays.asList(fetchVariables));
     return this;
   }
+
+  @Override
+  public CreateProcessInstanceWithResultCommandStep1 tenantId(final String tenantId) {
+    // todo(#13536): replace dummy implementation
+    return this;
+  }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/EvaluateDecisionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/EvaluateDecisionCommandImpl.java
@@ -95,6 +95,12 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
     return future;
   }
 
+  @Override
+  public EvaluateDecisionCommandStep2 tenantId(final String tenantId) {
+    // todo(#13557): replace dummy implementation
+    return this;
+  }
+
   private void send(
       final EvaluateDecisionRequest request,
       final StreamObserver<GatewayOuterClass.EvaluateDecisionResponse> streamObserver) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -112,4 +112,10 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .publishMessage(request, streamObserver);
   }
+
+  @Override
+  public PublishMessageCommandStep3 tenantId(final String tenantId) {
+    // todo(#13559): replace dummy implementation
+    return this;
+  }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.EvaluateDecisionCommandStep1.EvaluateDecisionCommandStep2;
 import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
 import io.camunda.zeebe.client.api.response.EvaluatedDecision;
 import io.camunda.zeebe.client.api.response.EvaluatedDecisionInput;
@@ -255,6 +256,37 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
 
     // then
     rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdByDecisionId() {
+    // given
+    final EvaluateDecisionCommandStep2 builder = client.newEvaluateDecisionCommand().decisionId("");
+
+    // when
+    final EvaluateDecisionCommandStep2 builderWithTenant = builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13557): verify that tenant id is set in the request
+    assertThat(builderWithTenant)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdByDecisionKey() {
+    // given
+    final EvaluateDecisionCommandStep2 builder =
+        client.newEvaluateDecisionCommand().decisionKey(1L);
+
+    // when
+    final EvaluateDecisionCommandStep2 builderWithTenant = builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13557): verify that tenant id is set in the request
+    assertThat(builderWithTenant)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
   }
 
   private void assertResponse(final EvaluateDecisionResponse response) {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1.BroadcastSignalCommandStep2;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
 import io.camunda.zeebe.client.util.ClientTest;
@@ -148,6 +149,21 @@ public final class BroadcastSignalTest extends ClientTest {
 
     // then
     rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdBy() {
+    // given
+    final BroadcastSignalCommandStep2 builder = client.newBroadcastSignalCommand().signalName("");
+
+    // when
+    final BroadcastSignalCommandStep2 builderWithTenant = builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13558): verify that tenant id is set in the request
+    assertThat(builderWithTenant)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
   }
 
   public static class Variables {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep3;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
@@ -232,6 +233,54 @@ public final class CreateProcessInstanceTest extends ClientTest {
     assertThat(startInstructionA.getElementId()).isEqualTo(ELEMENT_ID_A);
     final ProcessInstanceCreationStartInstruction startInstructionB = startInstructionList.get(1);
     assertThat(startInstructionB.getElementId()).isEqualTo(ELEMENT_ID_B);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdByLatestVersionOfProcessId() {
+    // given
+    final CreateProcessInstanceCommandStep3 builder =
+        client.newCreateInstanceCommand().bpmnProcessId("").latestVersion();
+
+    // when
+    final CreateProcessInstanceCommandStep3 builderWithTenantId = builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13536): verify that tenant id is set in the request
+    assertThat(builderWithTenantId)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdByProcessIdAndVersion() {
+    // given
+    final CreateProcessInstanceCommandStep3 builder =
+        client.newCreateInstanceCommand().bpmnProcessId("").version(3);
+
+    // when
+    final CreateProcessInstanceCommandStep3 builderWithTenantId = builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13536): verify that tenant id is set in the request
+    assertThat(builderWithTenantId)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdByProcessDefinitionKey() {
+    // given
+    final CreateProcessInstanceCommandStep3 builder =
+        client.newCreateInstanceCommand().processDefinitionKey(1L);
+
+    // when
+    final CreateProcessInstanceCommandStep3 builderWithTenantId = builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13536): verify that tenant id is set in the request
+    assertThat(builderWithTenantId)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
   }
 
   public static class VariableDocument {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceWithResultTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceWithResultTest.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.client.util.JsonUtil.fromJsonAsMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1.CreateProcessInstanceWithResultCommandStep1;
 import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
@@ -132,6 +133,57 @@ public final class CreateProcessInstanceWithResultTest extends ClientTest {
     // then
     final CreateProcessInstanceWithResultRequest request = gatewayService.getLastRequest();
     assertThat(fromJsonAsMap(request.getRequest().getVariables())).containsOnly(entry(key, value));
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdByLatestVersionOfProcessId() {
+    // given
+    final CreateProcessInstanceWithResultCommandStep1 builder =
+        client.newCreateInstanceCommand().bpmnProcessId("").latestVersion().withResult();
+
+    // when
+    final CreateProcessInstanceWithResultCommandStep1 builderWithTenantId =
+        builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13536): verify that tenant id is set in the request
+    assertThat(builderWithTenantId)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdByProcessIdAndVersion() {
+    // given
+    final CreateProcessInstanceWithResultCommandStep1 builder =
+        client.newCreateInstanceCommand().bpmnProcessId("").version(3).withResult();
+
+    // when
+    final CreateProcessInstanceWithResultCommandStep1 builderWithTenantId =
+        builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13536): verify that tenant id is set in the request
+    assertThat(builderWithTenantId)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdByProcessDefinitionKey() {
+    // given
+    final CreateProcessInstanceWithResultCommandStep1 builder =
+        client.newCreateInstanceCommand().processDefinitionKey(1L).withResult();
+
+    // when
+    final CreateProcessInstanceWithResultCommandStep1 builderWithTenantId =
+        builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13536): verify that tenant id is set in the request
+    assertThat(builderWithTenantId)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
   }
 
   private static class VariablesPojo {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep3;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
@@ -203,6 +204,22 @@ public final class PublishMessageTest extends ClientTest {
 
     // then
     rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantId() {
+    // given
+    final PublishMessageCommandStep3 builder =
+        client.newPublishMessageCommand().messageName("").correlationKey("");
+
+    // when
+    final PublishMessageCommandStep3 builderWithTenant = builder.tenantId("custom tenant");
+
+    // then
+    // todo(#13559): verify that tenant id is set in the request
+    assertThat(builderWithTenant)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
   }
 
   public static class Variables {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This is the second in several pull requests to:
- #13517

This pull request adds the same new `tenantId` method that is added in #13575 to other command builders that need to allow specifying it.

The method is added to the builders of the following command:
- Create Process Instance
- Create Process Instance With Result
- Evaluate Decision
- Broadcast Signal
- Publish Message

Again, please note that the new `tenantId` method on the command builders has no effect at this time. The feature is still under development. The API is added so others can already start using this method during development. I'll inform the relevant teams once this is available to them.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13562

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
