### PR TITLE
Allow specifying one or more tenants for activate/stream jobs in Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
@@ -41,7 +41,9 @@ public interface ActivateJobsCommandStep1 {
     ActivateJobsCommandStep3 maxJobsToActivate(int maxJobsToActivate);
   }
 
-  interface ActivateJobsCommandStep3 extends FinalCommandStep<ActivateJobsResponse> {
+  interface ActivateJobsCommandStep3
+      extends CommandWithOneOrMoreTenantsStep<ActivateJobsCommandStep3>,
+          FinalCommandStep<ActivateJobsResponse> {
 
     /**
      * Set the time for how long a job is exclusively assigned for this subscription.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.ExperimentalApi;
+import java.util.List;
+
+public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantStep<T> {
+
+  /**
+   * {@inheritDoc}
+   *
+   * <h1>One or more tenants</h1>
+   *
+   * <p>This method can be called multiple times to specify multiple tenants. If more than one
+   * tenant is provided, ownership of the resulting entities is inferred as described above.
+   *
+   * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
+   * jobs will be owned by the tenant that owns the corresponding process instance.
+   *
+   * @param tenantId the identifier of the tenant to specify for this command, e.g. {@code "ACME"}
+   * @return the builder for this command with the tenant specified
+   * @since 8.3
+   */
+  @Override
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
+  T tenantId(String tenantId);
+
+  /**
+   * <strong>Experimental: This method is under development, and as such using it may have no effect
+   * on the command builder when called. While unimplemented, it simply returns the command builder
+   * instance unchanged. This method already exists for software that is building support for
+   * multi-tenancy, and already wants to use this API during its development. As support for
+   * multi-tenancy is added to Zeebe, each of the commands that implement this method may start to
+   * take effect. Until this warning is removed, anything described below may not yet have taken
+   * effect, and the interface and its description are subject to change.</strong>
+   *
+   * <p>Specifies the tenants that may own any entities (e.g. process definition, process instances,
+   * etc.) resulting from this command.
+   *
+   * <h1>One or more tenants</h1>
+   *
+   * <p>If more than one tenant is provided, ownership of the resulting entities is inferred as
+   * described in {@link #tenantId(String)}.
+   *
+   * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
+   * jobs will be owned by the tenant that owns the corresponding process instance.
+   *
+   * @param tenantIds the identifiers of the tenants to specify for this command, e.g. {@code
+   *     ["ACME", "OTHER"]}
+   * @return the builder for this command with the tenants specified
+   * @see #tenantId(String)
+   * @since 8.3
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
+  T tenantIds(List<String> tenantIds);
+
+  /**
+   * <strong>Experimental: This method is under development, and as such using it may have no effect
+   * on the command builder when called. While unimplemented, it simply returns the command builder
+   * instance unchanged. This method already exists for software that is building support for
+   * multi-tenancy, and already wants to use this API during its development. As support for
+   * multi-tenancy is added to Zeebe, each of the commands that implement this method may start to
+   * take effect. Until this warning is removed, anything described below may not yet have taken
+   * effect, and the interface and its description are subject to change.</strong>
+   *
+   * <p>Shorthand method for {@link #tenantIds(List)}.
+   *
+   * @param tenantIds the identifiers of the tenants to specify for this command, e.g. {@code
+   *     ["ACME", "OTHER"]}
+   * @return the builder for this command with the tenants specified
+   * @see #tenantIds(List)
+   * @since 8.3
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
+  T tenantIds(String... tenantIds);
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
@@ -44,7 +44,9 @@ public interface StreamJobsCommandStep1 {
     StreamJobsCommandStep3 consumer(final Consumer<ActivatedJob> consumer);
   }
 
-  interface StreamJobsCommandStep3 extends FinalCommandStep<StreamJobsResponse> {
+  interface StreamJobsCommandStep3
+      extends CommandWithOneOrMoreTenantsStep<StreamJobsCommandStep3>,
+          FinalCommandStep<StreamJobsResponse> {
     /**
      * Set the time for how long a job is exclusively assigned for this subscription.
      *

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -126,4 +126,21 @@ public final class ActivateJobsCommandImpl
         .withDeadlineAfter(requestTimeout.plus(DEADLINE_OFFSET).toMillis(), TimeUnit.MILLISECONDS)
         .activateJobs(request, future);
   }
+
+  @Override
+  public ActivateJobsCommandStep3 tenantId(final String tenantId) {
+    // todo(#13560): replace dummy implementation
+    return this;
+  }
+
+  @Override
+  public ActivateJobsCommandStep3 tenantIds(final List<String> tenantIds) {
+    // todo(#13560): replace dummy implementation
+    return this;
+  }
+
+  @Override
+  public ActivateJobsCommandStep3 tenantIds(final String... tenantIds) {
+    return tenantIds(Arrays.asList(tenantIds));
+  }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -131,6 +131,23 @@ public final class StreamJobsCommandImpl
     return fetchVariables(Arrays.asList(fetchVariables));
   }
 
+  @Override
+  public StreamJobsCommandStep3 tenantId(final String tenantId) {
+    // todo(#13560): replace dummy implementation
+    return this;
+  }
+
+  @Override
+  public StreamJobsCommandStep3 tenantIds(final List<String> tenantIds) {
+    // todo(#13560): replace dummy implementation
+    return this;
+  }
+
+  @Override
+  public StreamJobsCommandStep3 tenantIds(final String... tenantIds) {
+    return tenantIds(Arrays.asList(tenantIds));
+  }
+
   private void consumeJob(final GatewayOuterClass.ActivatedJob job) {
     final ActivatedJobImpl mappedJob = new ActivatedJobImpl(jsonMapper, job);
     consumer.accept(mappedJob);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.client.util.JsonUtil.fromJsonAsMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
@@ -244,6 +245,56 @@ public final class ActivateJobsTest extends ClientTest {
 
     // then
     assertThat(variablesPojo.getA()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdsAsList() {
+    // given
+    final ActivateJobsCommandStep3 builder =
+        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3);
+
+    // when
+    final ActivateJobsCommandStep3 builderWithTenants =
+        builder.tenantIds(Arrays.asList("tenant1", "tenant2"));
+
+    // then
+    // todo(#13560): verify that tenant ids are set in the request
+    assertThat(builderWithTenants)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdsAsVarArgs() {
+    // given
+    final ActivateJobsCommandStep3 builder =
+        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3);
+
+    // when
+    final ActivateJobsCommandStep3 builderWithTenants = builder.tenantIds("tenant1", "tenant2");
+
+    // then
+    // todo(#13560): verify that tenant ids are set in the request
+    assertThat(builderWithTenants)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIds() {
+    // given
+    final ActivateJobsCommandStep3 builder =
+        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3);
+
+    // when
+    final ActivateJobsCommandStep3 builderWithTenants =
+        builder.tenantId("tenant1").tenantId("tenant2");
+
+    // then
+    // todo(#13560): verify that tenant ids are set in the request
+    assertThat(builderWithTenants)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
   }
 
   static class VariablesPojo {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/StreamJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/StreamJobsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
 import io.camunda.zeebe.client.api.response.StreamJobsResponse;
 import io.camunda.zeebe.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
@@ -242,5 +243,55 @@ public final class StreamJobsTest extends ClientTest {
     // then
     Mockito.verify(rule.getGatewayStub(), Mockito.times(1))
         .withDeadlineAfter(requestTimeout.toNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdsAsList() {
+    // given
+    final StreamJobsCommandStep3 builder =
+        client.newStreamJobsCommand().jobType("foo").consumer(ignored -> {});
+
+    // when
+    final StreamJobsCommandStep3 builderWithTenants =
+        builder.tenantIds(Arrays.asList("tenant1", "tenant2"));
+
+    // then
+    // todo(#13560): verify that tenant ids are set in the request
+    assertThat(builderWithTenants)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIdsAsVarArgs() {
+    // given
+    final StreamJobsCommandStep3 builder =
+        client.newStreamJobsCommand().jobType("foo").consumer(ignored -> {});
+
+    // when
+    final StreamJobsCommandStep3 builderWithTenants = builder.tenantIds("tenant1", "tenant2");
+
+    // then
+    // todo(#13560): verify that tenant ids are set in the request
+    assertThat(builderWithTenants)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldAllowSpecifyingTenantIds() {
+    // given
+    final StreamJobsCommandStep3 builder =
+        client.newStreamJobsCommand().jobType("foo").consumer(ignored -> {});
+
+    // when
+    final StreamJobsCommandStep3 builderWithTenants =
+        builder.tenantId("tenant1").tenantId("tenant2");
+
+    // then
+    // todo(#13560): verify that tenant ids are set in the request
+    assertThat(builderWithTenants)
+        .describedAs("This method has no effect on the command builder while under development")
+        .isEqualTo(builder);
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This is the third in several pull requests to:
- #13517

This pull request adds the ability to specify one or more tenants for the activate jobs and stream jobs command builders.

This pull request contains a new reusable interface to add tenants through several methods:
- `tenantId(String)` -> adds a single tenant
- `tenantIds(List<String>)` -> adds a list of tenants
- `tenantIds(String...)` -> also adds a list of tenants, shorthand for `tenantIds(List<String>)`

Please note that the new methods on the command builders have no effect at this time. The feature is still under development. The API is added so others can already start using this method during development. I'll inform the relevant teams once this is available to them.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13563

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
