### PR TITLE
[Backport stable/8.2] deps(maven): bump version.spring-boot from 3.1.1 to 3.1.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,7 +95,7 @@
     <version.dmn-scala>1.8.1</version.dmn-scala>
     <version.rest-assured>5.3.0</version.rest-assured>
     <version.spring>6.0.11</version.spring>
-    <version.spring-boot>3.1.1</version.spring-boot>
+    <version.spring-boot>3.1.2</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.4.0</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
# Description
Backport of #13569 to `stable/8.2`.

relates to 