### PR TITLE
Handle `Process.DELETED` events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -84,6 +84,7 @@ public final class EventAppliers implements EventApplier {
   private void registerProcessAppliers(final MutableProcessingState state) {
     register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
     register(ProcessIntent.DELETING, new ProcessDeletingApplier(state));
+    register(ProcessIntent.DELETED, new ProcessDeletedApplier(state));
   }
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDeletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDeletedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+
+public class ProcessDeletedApplier implements TypedEventApplier<ProcessIntent, ProcessRecord> {
+
+  private final MutableProcessState processState;
+
+  public ProcessDeletedApplier(final MutableProcessingState state) {
+    processState = state.getProcessState();
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessRecord value) {
+    processState.deleteProcess(value);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -130,9 +130,9 @@ public final class DbProcessState implements MutableProcessState {
   @Override
   public void putProcess(final long key, final ProcessRecord processRecord) {
     persistProcess(key, processRecord);
-    versionManager.updateCurrentVersion(
+    versionManager.increaseCurrentVersion(
         processRecord.getBpmnProcessId(), processRecord.getVersion());
-    versionManager.updateLatestVersion(
+    versionManager.increaseLatestVersion(
         processRecord.getBpmnProcessId(), processRecord.getVersion());
     putLatestVersionDigest(
         processRecord.getBpmnProcessIdBuffer(), processRecord.getChecksumBuffer());
@@ -241,7 +241,7 @@ public final class DbProcessState implements MutableProcessState {
         processesByProcessIdAndVersion.get(processIdBuffer);
 
     processId.wrapBuffer(processIdBuffer);
-    final long latestVersion = versionManager.getCurrentProcessVersion(processIdBuffer);
+    final long latestVersion = versionManager.getLatestProcessVersion(processIdBuffer);
 
     DeployedProcess deployedProcess;
     if (versionMap == null) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -158,11 +158,11 @@ public final class DbProcessState implements MutableProcessState {
     processesByKey.remove(processRecord.getProcessDefinitionKey());
 
     final var currentProcessVersion =
-        versionManager.getCurrentProcessVersion(processRecord.getBpmnProcessId());
+        versionManager.getLatestProcessVersion(processRecord.getBpmnProcessId());
     final boolean isLatestVersion = currentProcessVersion == processRecord.getVersion();
 
     if (isLatestVersion) {
-      digestByIdColumnFamily.deleteExisting(fkProcessId);
+      digestByIdColumnFamily.deleteIfExists(fkProcessId);
       versionManager.deleteProcessVersion(
           processRecord.getBpmnProcessId(), processRecord.getVersion());
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -130,7 +130,10 @@ public final class DbProcessState implements MutableProcessState {
   @Override
   public void putProcess(final long key, final ProcessRecord processRecord) {
     persistProcess(key, processRecord);
-    updateLatestVersion(processRecord);
+    versionManager.updateCurrentVersion(
+        processRecord.getBpmnProcessId(), processRecord.getVersion());
+    versionManager.updateLatestVersion(
+        processRecord.getBpmnProcessId(), processRecord.getVersion());
     putLatestVersionDigest(
         processRecord.getBpmnProcessIdBuffer(), processRecord.getChecksumBuffer());
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -146,7 +146,20 @@ public final class DbProcessState implements MutableProcessState {
   }
 
   @Override
-  public void deleteProcess(final ProcessRecord processRecord) {}
+  public void deleteProcess(final ProcessRecord processRecord) {
+    processDefinitionKey.wrapLong(processRecord.getProcessDefinitionKey());
+    processId.wrapString(processRecord.getBpmnProcessId());
+    processVersion.wrapLong(processRecord.getVersion());
+
+    processColumnFamily.deleteExisting(processDefinitionKey);
+    processByIdAndVersionColumnFamily.deleteExisting(idAndVersionKey);
+    digestByIdColumnFamily.deleteExisting(fkProcessId);
+
+    processesByProcessIdAndVersion.remove(processRecord.getBpmnProcessIdBuffer());
+    processesByKey.remove(processRecord.getProcessDefinitionKey());
+    versionManager.deleteProcessVersion(
+        processRecord.getBpmnProcessId(), processRecord.getVersion());
+  }
 
   private void persistProcess(final long processDefinitionKey, final ProcessRecord processRecord) {
     persistedProcess.wrap(processRecord, processDefinitionKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -130,7 +130,7 @@ public final class DbProcessState implements MutableProcessState {
   @Override
   public void putProcess(final long key, final ProcessRecord processRecord) {
     persistProcess(key, processRecord);
-    versionManager.increaseCurrentVersion(
+    versionManager.increaseMaximumVersion(
         processRecord.getBpmnProcessId(), processRecord.getVersion());
     versionManager.increaseLatestVersion(
         processRecord.getBpmnProcessId(), processRecord.getVersion());
@@ -308,7 +308,7 @@ public final class DbProcessState implements MutableProcessState {
 
   @Override
   public int getProcessVersion(final String bpmnProcessId) {
-    return (int) versionManager.getCurrentProcessVersion(bpmnProcessId);
+    return (int) versionManager.getMaximumProcessVersion(bpmnProcessId);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -145,6 +145,9 @@ public final class DbProcessState implements MutableProcessState {
     updateInMemoryState(process);
   }
 
+  @Override
+  public void deleteProcess(final ProcessRecord processRecord) {}
+
   private void persistProcess(final long processDefinitionKey, final ProcessRecord processRecord) {
     persistedProcess.wrap(processRecord, processDefinitionKey);
     this.processDefinitionKey.wrapLong(processDefinitionKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -182,14 +182,6 @@ public final class DbProcessState implements MutableProcessState {
     processByIdAndVersionColumnFamily.upsert(idAndVersionKey, persistedProcess);
   }
 
-  private void updateLatestVersion(final ProcessRecord processRecord) {
-    processId.wrapBuffer(processRecord.getBpmnProcessIdBuffer());
-    final var bpmnProcessId = processRecord.getBpmnProcessId();
-
-    final var nextVersion = processRecord.getVersion();
-    versionManager.updateCurrentVersion(bpmnProcessId, nextVersion);
-  }
-
   // is called on getters, if process is not in memory
   private DeployedProcess updateInMemoryState(final PersistedProcess persistedProcess) {
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
@@ -12,17 +12,39 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 
 public final class NextValue extends UnpackedObject implements DbValue {
+
+  // The next value indicate what version the next deployed process with this id should get
   private final LongProperty nextValueProp = new LongProperty("nextValue", -1L);
 
+  // The latest value indicates the latest version of a deployed process we should start when no
+  // version is specified.
+  private final LongProperty latestValueProp = new LongProperty("latestValue", -1L);
+
   public NextValue() {
-    declareProperty(nextValueProp);
+    declareProperty(nextValueProp).declareProperty(latestValueProp);
   }
 
-  public void set(final long value) {
+  public NextValue set(final long value) {
     nextValueProp.setValue(value);
+    return this;
   }
 
   public long get() {
     return nextValueProp.getValue();
+  }
+
+  public long getLatestVersion() {
+    final long latestVersion = latestValueProp.getValue();
+    // If the latestVersion is not set this is an older process and no instances have been deleted
+    // for this process yet. As a result we should consider the next value to be the latest.
+    if (latestVersion == -1L) {
+      return get();
+    }
+    return latestVersion;
+  }
+
+  public NextValue setLatestVersion(final long value) {
+    latestValueProp.setValue(value);
+    return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
@@ -24,13 +24,13 @@ public final class NextValue extends UnpackedObject implements DbValue {
     declareProperty(nextValueProp).declareProperty(latestValueProp);
   }
 
-  public NextValue set(final long value) {
-    nextValueProp.setValue(value);
-    return this;
+  public long getMaximumVersion() {
+    return nextValueProp.getValue();
   }
 
-  public long get() {
-    return nextValueProp.getValue();
+  public NextValue setMaximumVersion(final long value) {
+    nextValueProp.setValue(value);
+    return this;
   }
 
   public long getLatestVersion() {
@@ -38,7 +38,7 @@ public final class NextValue extends UnpackedObject implements DbValue {
     // If the latestVersion is not set this is an older process and no instances have been deleted
     // for this process yet. As a result we should consider the next value to be the latest.
     if (latestVersion == -1L) {
-      return get();
+      return getMaximumVersion();
     }
     return latestVersion;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -70,6 +70,21 @@ public final class ProcessVersionManager {
     return currentValue;
   }
 
+  public void deleteProcessVersion(final String processId, final long version) {
+    if (getCurrentProcessVersion(processId) != version) {
+      // If the deleted version is not the latest version we don't have to do anything.
+      return;
+    }
+
+    processIdKey.wrapString(processId);
+    if (version == 1) {
+      nextValueColumnFamily.deleteExisting(processIdKey);
+      versionCache.remove(processId);
+    } else {
+      setProcessVersion(processId, version - 1);
+    }
+  }
+
   public void clear() {
     versionCache.clear();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -82,6 +82,11 @@ public final class ProcessVersionManager {
     return getProcessVersionInfo().get();
   }
 
+  public long getLatestProcessVersion(final String processId) {
+    processIdKey.wrapString(processId);
+    return getProcessVersionInfo().getLatestVersion();
+  }
+
   private NextValue getProcessVersionInfo() {
     return versionCache.computeIfAbsent(
         processIdKey.toString(), (key) -> getProcessVersionFromDB());
@@ -97,11 +102,8 @@ public final class ProcessVersionManager {
 
   public void deleteProcessVersion(final String processId, final long version) {
     processIdKey.wrapString(processId);
-    if (version == 1) {
-      nextValueColumnFamily.deleteExisting(processIdKey);
-      versionCache.remove(processId);
-    } else {
-      updateCurrentVersion(processId, version - 1);
+    if (version >= 1) {
+      updateLatestVersion(processId, version - 1);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -68,8 +68,10 @@ public final class ProcessVersionManager {
   public void updateLatestVersion(final String processId, final long version) {
     processIdKey.wrapString(processId);
 
-    final var versionInfo = nextValueColumnFamily.get(processIdKey);
+    final var versionInfo = getProcessVersionInfo();
     versionInfo.setLatestVersion(version);
+    nextValueColumnFamily.upsert(processIdKey, nextVersion);
+    versionCache.put(processId, versionInfo);
   }
 
   public long getCurrentProcessVersion(final String processId) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -38,19 +38,19 @@ public final class ProcessVersionManager {
   }
 
   /**
-   * Updates the current version of the process. The current version is the maximum version number
+   * Updates the maximum version of the process. The maximum version is the maximum version number
    * we know of this process. When we create a new process it will be this value + 1. This is not
    * necessarily the latest version, as the latest version could be deleted.
    *
    * @param processId id of the process
    * @param version the version number
    */
-  public void increaseCurrentVersion(final String processId, final long version) {
+  public void increaseMaximumVersion(final String processId, final long version) {
     processIdKey.wrapString(processId);
     final var versionInfo = getProcessVersionInfo();
 
-    if (versionInfo.get() < version) {
-      versionInfo.set(version);
+    if (versionInfo.getMaximumVersion() < version) {
+      versionInfo.setMaximumVersion(version);
     }
 
     nextValueColumnFamily.upsert(processIdKey, nextVersion);
@@ -105,14 +105,14 @@ public final class ProcessVersionManager {
     versionCache.put(processId, versionInfo);
   }
 
-  public long getCurrentProcessVersion(final String processId) {
+  public long getMaximumProcessVersion(final String processId) {
     processIdKey.wrapString(processId);
-    return getProcessVersionInfo().get();
+    return getProcessVersionInfo().getMaximumVersion();
   }
 
-  public long getCurrentProcessVersion(final DirectBuffer processId) {
+  public long getMaximumProcessVersion(final DirectBuffer processId) {
     processIdKey.wrapBuffer(processId);
-    return getProcessVersionInfo().get();
+    return getProcessVersionInfo().getMaximumVersion();
   }
 
   public long getLatestProcessVersion(final String processId) {
@@ -135,7 +135,7 @@ public final class ProcessVersionManager {
     if (readValue != null) {
       return readValue;
     }
-    return new NextValue().setLatestVersion(initialValue).set(initialValue);
+    return new NextValue().setLatestVersion(initialValue).setMaximumVersion(initialValue);
   }
 
   public void deleteProcessVersion(final String processId, final long version) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
@@ -29,4 +29,11 @@ public interface MutableProcessState extends ProcessState {
    * @param state the new state
    */
   void updateProcessState(final long processDefinitionKey, final PersistedProcessState state);
+
+  /**
+   * Deletes a process fromm the state and cache
+   *
+   * @param processRecord the record of the process that is deleted
+   */
+  void deleteProcess(final ProcessRecord processRecord);
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR introduces the Process.DELETED event applier. When this event is written it will delete the process from the state and cache.
This is less straightforward as it seems as it requires other stuff:

1. We don't want to reuse versions. This means we need to change the version manager and have it keep track of multiple versions. Ones the latest version, which is what will be returned what we try to get the latest version of a process. The other is the maximum version. This is the maximum version we've ever known for a specific process id. It is used upon deploying a new process. The version of the process becomes the maximum version + 1.
2. If the latest process is deleted, we must make sure the latest version becomes the version of the previous undeleted process.
3. Ideally we should set the digest to the new latest process upon a deletion. This is out of scope as it is more difficult than it seems. Worst-case people can deploy a duplicate of their process, which has no further impact.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
