### PR TITLE
Handle process deleted events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -84,6 +84,7 @@ public final class EventAppliers implements EventApplier {
   private void registerProcessAppliers(final MutableProcessingState state) {
     register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
     register(ProcessIntent.DELETING, new ProcessDeletingApplier(state));
+    register(ProcessIntent.DELETED, new ProcessDeletedApplier(state));
   }
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDeletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDeletedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+
+public class ProcessDeletedApplier implements TypedEventApplier<ProcessIntent, ProcessRecord> {
+
+  private final MutableProcessState processState;
+
+  public ProcessDeletedApplier(final MutableProcessingState state) {
+    processState = state.getProcessState();
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessRecord value) {
+    processState.deleteProcess(value);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -146,7 +146,20 @@ public final class DbProcessState implements MutableProcessState {
   }
 
   @Override
-  public void deleteProcess(final ProcessRecord processRecord) {}
+  public void deleteProcess(final ProcessRecord processRecord) {
+    processDefinitionKey.wrapLong(processRecord.getProcessDefinitionKey());
+    processId.wrapString(processRecord.getBpmnProcessId());
+    processVersion.wrapLong(processRecord.getVersion());
+
+    processColumnFamily.deleteExisting(processDefinitionKey);
+    processByIdAndVersionColumnFamily.deleteExisting(idAndVersionKey);
+    digestByIdColumnFamily.deleteExisting(fkProcessId);
+
+    processesByProcessIdAndVersion.remove(processRecord.getBpmnProcessIdBuffer());
+    processesByKey.remove(processRecord.getProcessDefinitionKey());
+    versionManager.deleteProcessVersion(
+        processRecord.getBpmnProcessId(), processRecord.getVersion());
+  }
 
   private void persistProcess(final long processDefinitionKey, final ProcessRecord processRecord) {
     persistedProcess.wrap(processRecord, processDefinitionKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -145,6 +145,9 @@ public final class DbProcessState implements MutableProcessState {
     updateInMemoryState(process);
   }
 
+  @Override
+  public void deleteProcess(final ProcessRecord processRecord) {}
+
   private void persistProcess(final long processDefinitionKey, final ProcessRecord processRecord) {
     persistedProcess.wrap(processRecord, processDefinitionKey);
     this.processDefinitionKey.wrapLong(processDefinitionKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -70,6 +70,21 @@ public final class ProcessVersionManager {
     return currentValue;
   }
 
+  public void deleteProcessVersion(final String processId, final long version) {
+    if (getCurrentProcessVersion(processId) != version) {
+      // If the deleted version is not the latest version we don't have to do anything.
+      return;
+    }
+
+    processIdKey.wrapString(processId);
+    if (version == 1) {
+      nextValueColumnFamily.deleteExisting(processIdKey);
+      versionCache.remove(processId);
+    } else {
+      setProcessVersion(processId, version - 1);
+    }
+  }
+
   public void clear() {
     versionCache.clear();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -70,18 +70,27 @@ public final class ProcessVersionManager {
     return currentValue;
   }
 
-  public void deleteProcessVersion(final String processId, final long version) {
+  /**
+   * Deletes a specified version of a process
+   *
+   * @param processId the id of the process
+   * @param version the version that needs to be deleted
+   * @param previousVersion the previous known version of the process
+   */
+  public void deleteProcessVersion(
+      final String processId, final long version, final long previousVersion) {
     if (getCurrentProcessVersion(processId) != version) {
       // If the deleted version is not the latest version we don't have to do anything.
       return;
     }
 
     processIdKey.wrapString(processId);
-    if (version == 1) {
+    // If there is no previous version we can delete the process id from the state entirely.
+    if (previousVersion == 0) {
       nextValueColumnFamily.deleteExisting(processIdKey);
       versionCache.remove(processId);
     } else {
-      setProcessVersion(processId, version - 1);
+      setProcessVersion(processId, previousVersion);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
@@ -29,4 +29,11 @@ public interface MutableProcessState extends ProcessState {
    * @param state the new state
    */
   void updateProcessState(final long processDefinitionKey, final PersistedProcessState state);
+
+  /**
+   * Deletes a process fromm the state and cache
+   *
+   * @param processRecord the record of the process that is deleted
+   */
+  void deleteProcess(final ProcessRecord processRecord);
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR introduces the Process.DELETED event applier. When this event is written it will delete the process from the state and cache.

There are some things to note:

1. Ideally we should set the digest to the new latest process upon a deletion. This is out of scope as it is more difficult than it seems. Worst-case people can deploy a duplicate of their process, which has no further impact.
2. We don't want to reuse version. As of this PR that is happening. I wanted to keep this PR small so I left it out of scope for this PR. This will be picked up in https://github.com/camunda/zeebe/issues/13588
3. If the latest process is deleted, we must make sure the latest version becomes the version of the previous undeleted process. Because of this there is some not-so-nice code in this PR. This should be resolved after we've revisited the version management.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9771 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
