### PR TITLE
Process a process deletion

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -314,7 +314,9 @@ public final class EngineProcessors {
             writers,
             processingState.getKeyGenerator(),
             processingState.getDecisionState(),
-            commandDistributionBehavior);
+            commandDistributionBehavior,
+            processingState.getProcessState(),
+            processingState.getElementInstanceState());
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -53,21 +53,23 @@ public class ResourceDeletionProcessor
   @Override
   public void processNewCommand(final TypedRecord<ResourceDeletionRecord> command) {
     final var value = command.getValue();
-    tryDeleteResources(command);
-
     final long eventKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETING, value);
-    responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETING, value, command);
-    stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
 
+    tryDeleteResources(command);
+
+    stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
     commandDistributionBehavior.distributeCommand(eventKey, command);
+    responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETING, value, command);
   }
 
   @Override
   public void processDistributedCommand(final TypedRecord<ResourceDeletionRecord> command) {
     final var value = command.getValue();
-    tryDeleteResources(command);
     stateWriter.appendFollowUpEvent(command.getKey(), ResourceDeletionIntent.DELETING, value);
+
+    tryDeleteResources(command);
+
     stateWriter.appendFollowUpEvent(command.getKey(), ResourceDeletionIntent.DELETED, value);
     commandDistributionBehavior.acknowledgeCommand(command.getKey(), command);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -58,4 +58,12 @@ public interface ElementInstanceState {
    * @return a list of process instance keys
    */
   List<Long> getProcessInstanceKeysByDefinitionKey(final long processDefinitionKey);
+
+  /**
+   * Verifies if there are running instances for a given process definition
+   *
+   * @param processDefinitionKey the key of the process definition
+   * @return a boolean indicating if there are running instances
+   */
+  boolean hasRunningInstances(long processDefinitionKey);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -60,10 +60,10 @@ public interface ElementInstanceState {
   List<Long> getProcessInstanceKeysByDefinitionKey(final long processDefinitionKey);
 
   /**
-   * Verifies if there are running instances for a given process definition
+   * Verifies if there are active process instances for a given process definition
    *
    * @param processDefinitionKey the key of the process definition
    * @return a boolean indicating if there are running instances
    */
-  boolean hasRunningInstances(long processDefinitionKey);
+  boolean hasActiveProcessInstances(long processDefinitionKey);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
@@ -354,6 +355,21 @@ public final class DbElementInstanceState implements MutableElementInstanceState
           processInstanceKeys.add(processInstanceKey.getValue());
         });
     return processInstanceKeys;
+  }
+
+  @Override
+  public boolean hasRunningInstances(final long processDefinitionKey) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    final AtomicBoolean hasRunningInstances = new AtomicBoolean(false);
+
+    processInstanceKeyByProcessDefinitionKeyColumnFamily.whileEqualPrefix(
+        this.processDefinitionKey,
+        (key, value) -> {
+          hasRunningInstances.set(true);
+          return false;
+        });
+
+    return hasRunningInstances.get();
   }
 
   private ElementInstance copyElementInstance(final ElementInstance elementInstance) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -358,18 +358,18 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public boolean hasRunningInstances(final long processDefinitionKey) {
+  public boolean hasActiveProcessInstances(final long processDefinitionKey) {
     this.processDefinitionKey.wrapLong(processDefinitionKey);
-    final AtomicBoolean hasRunningInstances = new AtomicBoolean(false);
+    final AtomicBoolean hasActiveInstances = new AtomicBoolean(false);
 
     processInstanceKeyByProcessDefinitionKeyColumnFamily.whileEqualPrefix(
         this.processDefinitionKey,
         (key, value) -> {
-          hasRunningInstances.set(true);
+          hasActiveInstances.set(true);
           return false;
         });
 
-    return hasRunningInstances.get();
+    return hasActiveInstances.get();
   }
 
   private ElementInstance copyElementInstance(final ElementInstance elementInstance) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
@@ -87,13 +87,15 @@ public class ResourceDeletionMultiPartitionTest {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)
-                  .limit(r -> r.getIntent().equals(DecisionRequirementsIntent.DELETED))
+                  .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED))
                   .collect(Collectors.toList()))
           .extracting(Record::getIntent)
           .endsWith(
               ResourceDeletionIntent.DELETE,
+              ResourceDeletionIntent.DELETING,
               DecisionIntent.DELETED,
-              DecisionRequirementsIntent.DELETED);
+              DecisionRequirementsIntent.DELETED,
+              ResourceDeletionIntent.DELETED);
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
@@ -11,13 +11,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.stream.Collectors;
@@ -91,6 +94,71 @@ public class ResourceDeletionMultiPartitionTest {
               ResourceDeletionIntent.DELETE,
               DecisionIntent.DELETED,
               DecisionRequirementsIntent.DELETED);
+    }
+  }
+
+  @Test
+  public void shouldTestBpmnLifecycle() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final long resourceKey =
+        engine
+            .deployment()
+            .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+
+    // when
+    engine.resourceDeletion().withResourceKey(resourceKey).delete();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
+        .extracting(
+            Record::getIntent,
+            Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the deletion was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(ResourceDeletionIntent.DELETE, RecordType.COMMAND, 1),
+            tuple(ProcessIntent.DELETING, RecordType.EVENT, 1),
+            tuple(ProcessIntent.DELETED, RecordType.EVENT, 1),
+            tuple(ResourceDeletionIntent.DELETED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.records()
+                  .withPartitionId(partitionId)
+                  .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .endsWith(
+              ResourceDeletionIntent.DELETE,
+              ResourceDeletionIntent.DELETING,
+              ProcessIntent.DELETING,
+              ProcessIntent.DELETED,
+              ResourceDeletionIntent.DELETED);
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
@@ -112,7 +112,7 @@ public class ResourceDeletionRejectionTest {
     // given
     final var processId = helper.getBpmnProcessId();
     final var processDefinitionKey = deployProcess(processId);
-    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    engine.processInstance().ofBpmnProcessId(processId).create();
 
     // when
     final var rejection =
@@ -123,8 +123,8 @@ public class ResourceDeletionRejectionTest {
         .describedAs("Expect running instances")
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to delete resource but there are still running instances '[%s]'"
-                .formatted(processInstanceKey));
+            "Expected to delete resource with key `%d` but there are still running instances"
+                .formatted(processDefinitionKey));
   }
 
   private long deployProcess(final String processId) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
@@ -41,6 +41,26 @@ public class ResourceDeletionRejectionTest {
   }
 
   @Test
+  public void shouldRejectCommandWhenResourceIsAlreadyDeleted() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var processDefinitionKey = deployProcess(processId);
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // when
+    final var rejection =
+        engine.resourceDeletion().withResourceKey(processDefinitionKey).expectRejection().delete();
+
+    // then
+    assertThat(rejection)
+        .describedAs("Expect resource is not found")
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to delete resource but no resource found with key `%d`"
+                .formatted(processDefinitionKey));
+  }
+
+  @Test
   public void shouldRejectCreateInstanceCommandWhenOnlyProcessVersionIsDeleted() {
     // given
     final var processId = helper.getBpmnProcessId();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
@@ -10,8 +10,12 @@ package io.camunda.zeebe.engine.processing.resource;
 import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,5 +38,63 @@ public class ResourceDeletionRejectionTest {
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
             "Expected to delete resource but no resource found with key `%d`".formatted(key));
+  }
+
+  @Test
+  public void shouldRejectCreateInstanceCommandWhenOnlyProcessVersionIsDeleted() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var processDefinitionKey = deployProcess(processId);
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // when
+    engine.processInstance().ofBpmnProcessId(processId).expectRejection().create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    Assertions.assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            String.format(
+                "Expected to find process definition with process ID '%s', but none found",
+                processId));
+  }
+
+  @Test
+  public void shouldRejectCreateInstanceByVersionCommandWhenDeletedProcessVersionIsDeleted() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var firstProcessDefinitionKey = deployProcess(processId);
+    deployProcess(processId);
+    engine.resourceDeletion().withResourceKey(firstProcessDefinitionKey).delete();
+
+    // when
+    engine.processInstance().ofBpmnProcessId(processId).withVersion(1).expectRejection().create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    Assertions.assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            String.format(
+                "Expected to find process definition with process ID '%s' and version '%d', but none found",
+                processId, 1));
+  }
+
+  private long deployProcess(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -272,6 +272,32 @@ public class ResourceDeletionTest {
         .getDecisionRequirementsKey();
   }
 
+  private String deployProcessWithBusinessRuleTask(final String decisionId) {
+    final String processId = helper.getBpmnProcessId();
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .businessRuleTask(
+                    "task",
+                    t -> t.zeebeCalledDecisionId(decisionId).zeebeResultVariable(RESULT_VARIABLE))
+                .done())
+        .deploy();
+    return processId;
+  }
+
+  private long deployProcess(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
   private byte[] readResource(final String resourceName) {
     final var resourceAsStream = getClass().getResourceAsStream(resourceName);
     assertThat(resourceAsStream).isNotNull();
@@ -367,32 +393,6 @@ public class ResourceDeletionTest {
             decisionCreatedRecord.getDecisionRequirementsId(),
             decisionCreatedRecord.getDecisionRequirementsKey(),
             decisionCreatedRecord.isDuplicate());
-  }
-
-  private String deployProcessWithBusinessRuleTask(final String decisionId) {
-    final String processId = helper.getBpmnProcessId();
-    engine
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(processId)
-                .startEvent()
-                .businessRuleTask(
-                    "task",
-                    t -> t.zeebeCalledDecisionId(decisionId).zeebeResultVariable(RESULT_VARIABLE))
-                .done())
-        .deploy();
-    return processId;
-  }
-
-  private long deployProcess(final String processId) {
-    return engine
-        .deployment()
-        .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
-        .deploy()
-        .getValue()
-        .getProcessesMetadata()
-        .get(0)
-        .getProcessDefinitionKey();
   }
 
   private void verifyProcessIsDeleted(final String processId, final int version) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -53,7 +53,7 @@ public class ResourceDeletionTest {
     engine.resourceDeletion().withResourceKey(drgKey).delete();
 
     // then
-    verifyDecisionIsDeleted(drgKey, "jedi_or_sith", 1);
+    verifyDecisionIdWithVersionIsDeleted(drgKey, "jedi_or_sith", 1);
     verifyDecisionRequirementsIsDeleted(drgKey);
     verifyResourceIsDeleted(drgKey);
   }
@@ -67,8 +67,8 @@ public class ResourceDeletionTest {
     engine.resourceDeletion().withResourceKey(drgKey).delete();
 
     // then
-    verifyDecisionIsDeleted(drgKey, "jedi_or_sith", 1);
-    verifyDecisionIsDeleted(drgKey, "force_user", 1);
+    verifyDecisionIdWithVersionIsDeleted(drgKey, "jedi_or_sith", 1);
+    verifyDecisionIdWithVersionIsDeleted(drgKey, "force_user", 1);
     verifyDecisionRequirementsIsDeleted(drgKey);
     verifyResourceIsDeleted(drgKey);
   }
@@ -223,7 +223,7 @@ public class ResourceDeletionTest {
     engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
 
     // then
-    verifyProcessIsDeleted(processId, 1);
+    verifyProcessIdWithVersionIsDeleted(processId, 1);
     verifyResourceIsDeleted(processDefinitionKey);
   }
 
@@ -239,9 +239,9 @@ public class ResourceDeletionTest {
     final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
 
     // then
-    verifyProcessIsDeleted(processId, 2);
+    verifyProcessIdWithVersionIsDeleted(processId, 2);
     verifyResourceIsDeleted(secondProcessDefinitionKey);
-    verifyProcessInstanceIsCompleted(processId, 1, processInstanceKey);
+    verifyInstanceOfProcessWithIdAndVersionIsCompleted(processId, 1, processInstanceKey);
   }
 
   @Test
@@ -256,9 +256,9 @@ public class ResourceDeletionTest {
     final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
 
     // then
-    verifyProcessIsDeleted(processId, 1);
+    verifyProcessIdWithVersionIsDeleted(processId, 1);
     verifyResourceIsDeleted(firstProcessDefinitionKey);
-    verifyProcessInstanceIsCompleted(processId, 2, processInstanceKey);
+    verifyInstanceOfProcessWithIdAndVersionIsCompleted(processId, 2, processInstanceKey);
   }
 
   private long deployDrg(final String drgResource) {
@@ -355,7 +355,7 @@ public class ResourceDeletionTest {
             drgCreatedRecord.getChecksum());
   }
 
-  private void verifyDecisionIsDeleted(
+  private void verifyDecisionIdWithVersionIsDeleted(
       final long drgKey, final String decisionId, final int version) {
     final var decisionCreatedRecord =
         RecordingExporter.decisionRecords()
@@ -395,7 +395,7 @@ public class ResourceDeletionTest {
             decisionCreatedRecord.isDuplicate());
   }
 
-  private void verifyProcessIsDeleted(final String processId, final int version) {
+  private void verifyProcessIdWithVersionIsDeleted(final String processId, final int version) {
     final var processCreatedRecord =
         RecordingExporter.processRecords()
             .withIntent(ProcessIntent.CREATED)
@@ -426,7 +426,7 @@ public class ResourceDeletionTest {
                 processCreatedRecord.getProcessDefinitionKey()));
   }
 
-  private void verifyProcessInstanceIsCompleted(
+  private void verifyInstanceOfProcessWithIdAndVersionIsCompleted(
       final String processId, final int version, final long processInstanceKey) {
     assertThat(
             RecordingExporter.processInstanceRecords()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -17,14 +17,17 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.io.IOException;
@@ -185,6 +188,79 @@ public class ResourceDeletionTest {
         .containsOnly("jedi_or_sith", 2, drgKeyV2);
   }
 
+  @Test
+  public void shouldHaveCorrectLifecycleWhenDeletingProcessWithoutRunningInstances() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var processDefinitionKey = deployProcess(processId);
+
+    // when
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .onlyEvents()
+                .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED)))
+        .describedAs("Should write events in correct order")
+        .extracting(Record::getIntent)
+        .containsExactly(
+            ProcessIntent.CREATED,
+            DeploymentIntent.CREATED,
+            ResourceDeletionIntent.DELETING,
+            ProcessIntent.DELETING,
+            ProcessIntent.DELETED,
+            ResourceDeletionIntent.DELETED);
+  }
+
+  @Test
+  public void shouldWriteEventsForDeletedProcessWithoutRunningInstances() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var processDefinitionKey = deployProcess(processId);
+
+    // when
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // then
+    verifyProcessIsDeleted(processId, 1);
+    verifyResourceIsDeleted(processDefinitionKey);
+  }
+
+  @Test
+  public void shouldCreateInstanceOfVersionOneWhenVersionTwoIsDeleted() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    deployProcess(processId);
+    final var secondProcessDefinitionKey = deployProcess(processId);
+    engine.resourceDeletion().withResourceKey(secondProcessDefinitionKey).delete();
+
+    // when
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    verifyProcessIsDeleted(processId, 2);
+    verifyResourceIsDeleted(secondProcessDefinitionKey);
+    verifyProcessInstanceIsCompleted(processId, 1, processInstanceKey);
+  }
+
+  @Test
+  public void shouldCreateInstanceOfVersionTwoWhenVersionOneIsDeleted() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var firstProcessDefinitionKey = deployProcess(processId);
+    deployProcess(processId);
+    engine.resourceDeletion().withResourceKey(firstProcessDefinitionKey).delete();
+
+    // when
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    verifyProcessIsDeleted(processId, 1);
+    verifyResourceIsDeleted(firstProcessDefinitionKey);
+    verifyProcessInstanceIsCompleted(processId, 2, processInstanceKey);
+  }
+
   private long deployDrg(final String drgResource) {
     return engine
         .deployment()
@@ -306,5 +382,64 @@ public class ResourceDeletionTest {
                 .done())
         .deploy();
     return processId;
+  }
+
+  private long deployProcess(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private void verifyProcessIsDeleted(final String processId, final int version) {
+    final var processCreatedRecord =
+        RecordingExporter.processRecords()
+            .withIntent(ProcessIntent.CREATED)
+            .withBpmnProcessId(processId)
+            .withVersion(version)
+            .getFirst()
+            .getValue();
+
+    assertThat(
+            RecordingExporter.processRecords()
+                .withIntents(ProcessIntent.DELETING, ProcessIntent.DELETED)
+                .withBpmnProcessId(processId)
+                .withVersion(version)
+                .limit(2))
+        .describedAs("Expect deleted process to match created process")
+        .map(Record::getValue)
+        .extracting(
+            ProcessMetadataValue::getBpmnProcessId,
+            ProcessMetadataValue::getResourceName,
+            ProcessMetadataValue::getVersion,
+            ProcessMetadataValue::getProcessDefinitionKey)
+        .containsOnly(
+            tuple(
+                processCreatedRecord.getBpmnProcessId(),
+                processCreatedRecord.getResourceName(),
+                processCreatedRecord.getVersion(),
+                processCreatedRecord.getProcessDefinitionKey()));
+  }
+
+  private void verifyProcessInstanceIsCompleted(
+      final String processId, final int version, final long processInstanceKey) {
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withBpmnProcessId(processId)
+                .withVersion(version)
+                .withElementType(BpmnElementType.PROCESS)
+                .onlyEvents()
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsExactly(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -411,6 +411,7 @@ public class ResourceDeletionTest {
                 .withVersion(version)
                 .limit(2))
         .describedAs("Expect deleted process to match created process")
+        .hasSize(2)
         .map(Record::getValue)
         .extracting(
             ProcessMetadataValue::getBpmnProcessId,

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -396,7 +396,8 @@ public final class ElementInstanceStateTest {
         elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
     Assertions.assertThat(processInstanceKeys).isEmpty();
     final var hasRunningInstances =
-        elementInstanceState.hasRunningInstances(processInstanceRecord.getProcessDefinitionKey());
+        elementInstanceState.hasActiveProcessInstances(
+            processInstanceRecord.getProcessDefinitionKey());
     assertThat(hasRunningInstances).isFalse();
   }
 
@@ -449,7 +450,8 @@ public final class ElementInstanceStateTest {
 
     // when
     final var hasRunningInstances =
-        elementInstanceState.hasRunningInstances(processInstanceRecord.getProcessDefinitionKey());
+        elementInstanceState.hasActiveProcessInstances(
+            processInstanceRecord.getProcessDefinitionKey());
 
     // then
     Assertions.assertThat(hasRunningInstances).isTrue();
@@ -463,7 +465,8 @@ public final class ElementInstanceStateTest {
 
     // when
     final var hasRunningInstances =
-        elementInstanceState.hasRunningInstances(processInstanceRecord.getProcessDefinitionKey());
+        elementInstanceState.hasActiveProcessInstances(
+            processInstanceRecord.getProcessDefinitionKey());
 
     // then
     Assertions.assertThat(hasRunningInstances).isFalse();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -390,11 +390,14 @@ public final class ElementInstanceStateTest {
 
     // when
     elementInstanceState.removeInstance(processInstanceKey);
-    final List<Long> processInstanceKeys =
-        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
 
     // then
+    final List<Long> processInstanceKeys =
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
     Assertions.assertThat(processInstanceKeys).isEmpty();
+    final var hasRunningInstances =
+        elementInstanceState.hasRunningInstances(processInstanceRecord.getProcessDefinitionKey());
+    assertThat(hasRunningInstances).isFalse();
   }
 
   @Test
@@ -433,6 +436,37 @@ public final class ElementInstanceStateTest {
             .collect(Collectors.toList());
 
     assertThat(nonEmptyColumns).describedAs("Expected all columns to be empty").isEmpty();
+  }
+
+  @Test
+  public void shouldFindRunningInstancesForProcessDefinitionKey() {
+    // given
+    final var processInstanceRecord =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+    final var processInstanceKey = 100L;
+    elementInstanceState.newInstance(
+        processInstanceKey, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    final var hasRunningInstances =
+        elementInstanceState.hasRunningInstances(processInstanceRecord.getProcessDefinitionKey());
+
+    // then
+    Assertions.assertThat(hasRunningInstances).isTrue();
+  }
+
+  @Test
+  public void shouldNotFindRunningInstancesForProcessDefinitionKey() {
+    // given
+    final var processInstanceRecord =
+        createProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS);
+
+    // when
+    final var hasRunningInstances =
+        elementInstanceState.hasRunningInstances(processInstanceRecord.getProcessDefinitionKey());
+
+    // then
+    Assertions.assertThat(hasRunningInstances).isFalse();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -83,6 +83,11 @@ public final class ProcessInstanceClient {
       processInstanceCreationRecord.setBpmnProcessId(bpmnProcessId);
     }
 
+    public ProcessInstanceCreationClient withVersion(final int version) {
+      processInstanceCreationRecord.setVersion(version);
+      return this;
+    }
+
     public ProcessInstanceCreationClient withVariables(final Map<String, Object> variables) {
       processInstanceCreationRecord.setVariables(MsgPackUtil.asMsgPack(variables));
       return this;

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -20,14 +20,15 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final StringProperty bpmnProcessIdProp = new StringProperty(PROP_PROCESS_BPMN_PROCESS_ID);
   private final IntegerProperty versionProp = new IntegerProperty(PROP_PROCESS_VERSION);
   private final LongProperty keyProp = new LongProperty(PROP_PROCESS_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
-  private final BinaryProperty checksumProp = new BinaryProperty("checksum");
-  private final BinaryProperty resourceProp = new BinaryProperty("resource");
+  private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
+  private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
 
   public ProcessRecord() {
     declareProperty(bpmnProcessIdProp)

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ExporterRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ExporterRecordStream.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.test.util.stream.StreamWrapper;
+import java.util.Arrays;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -55,6 +56,11 @@ public abstract class ExporterRecordStream<
 
   public S withTimestamp(final long timestamp) {
     return filter(r -> r.getTimestamp() == timestamp);
+  }
+
+  public S withIntents(final Intent... intents) {
+    final var intentsList = Arrays.asList(intents);
+    return filter(m -> intentsList.contains(m.getIntent()));
   }
 
   public S withIntent(final Intent intent) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessRecordStream.java
@@ -29,4 +29,8 @@ public final class ProcessRecordStream extends ExporterRecordStream<Process, Pro
   public ProcessRecordStream withBpmnProcessId(final String bpmnProcessId) {
     return valueFilter(v -> v.getBpmnProcessId().equals(bpmnProcessId));
   }
+
+  public ProcessRecordStream withVersion(final int version) {
+    return valueFilter(v -> v.getVersion() == version);
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR extends the `ResourceDeleteProcessor` with support for deleting BPMN resources. Before it only accepted DMN resources.

It is the most basic implementation for now. We try to find the process in the state. If we find it and it has no running instances we delete it. If it has running instance we only write the `Process.DELETING` event to mark the process for deletion. In another PR we will take care of termination and eventual deletion of resources with running instances. Once we do that we can also modify this processor to not always write the `ResourceDeletion.DELETED` event.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9769

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
