### PR TITLE
Automatically mark PR as stale after 1 month of inactivity

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,23 @@
+name: 'Mark PR as stale'
+on:
+  workflow_dispatch: { }
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/stale
+      - uses: actions/stale@v8
+        with:
+          days-before-issue-stale: -1 # Don't mark issues as stale
+          days-before-pr-stale: 31
+          days-before-close: -1 # Do not close anything automatically
+          stale-pr-label: stale
+          stale-pr-message: >-
+            Hi :wave: We noticed there has not been any activity on this PR in the last month.
+            As a result we have marked it as stale. We may close the PR if it remains inactive.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
   * [Creating a Pull Request](#creating-a-pull-request)
   * [Reviewing a Pull Request](#reviewing-a-pull-request)
   * [Review Emoji Code](#review-emoji-code)
+  * [Stale Pull Requests](#stale-pull-requests)
   * [Backporting changes](#backporting-changes)
   * [Commit Message Guidelines](#commit-message-guidelines)
 * [Contributor License Agreement](#contributor-license-agreement)
@@ -192,6 +193,11 @@ For example, to distinguish a required change from an optional suggestion.
 - 💭 or `:thought_balloon:`: I’m just thinking out loud here. Something doesn’t necessarily have to change, but I want to make sure to share my thoughts.
 
 _Inspired by [Microsofts emoji code](https://devblogs.microsoft.com/appcenter/how-the-visual-studio-mobile-center-team-does-code-review/#introducing-the-emoji-code)._
+
+### Stale pull requests
+
+If there has not been any activity in your PR after a month it is automatically marked as stale. If it remains inactive we may decide to close the PR.
+When this happens and you're still interested in contributing, please feel free to reopen it.
 
 ## Backporting changes
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR automatically marks a PR as stale after 1 month of inactivity. If it regains activity the label is automatically removed again.
The action also provides an option to automatically close stale PRs. I have opted to not do this at this time.

If a PR becomes stale it places a comment explaining why it happened and informing that we may close the PR if it remains inactive.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13601 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
