### PR TITLE
[Backport stable/8.2] fix: change shouldNotPreallocateSegmentFiles() test when running on M…

### DIFF
--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -42,6 +42,8 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("resource")
@@ -643,7 +645,9 @@ class SegmentedJournalTest {
     PosixPathAssert.assertThat(firstSegment).hasRealSize(segmentSize);
   }
 
+  // This test fails on MAC OS. See issue: #12664
   @Test
+  @DisabledOnOs(OS.MAC)
   void shouldNotPreallocateSegmentFiles(final @TempDir Path tmpDir) {
     // given
     final var segmentSize = 4 * 1024 * 1024;


### PR DESCRIPTION
# Description
Backport of #12816 to `stable/8.2`.

relates to camunda/zeebe#12664