### PR TITLE
fix(broker): ensure that failure in transition to `INACTIVE` isn't ignored

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransitionException;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.HealthIssue;
 
 public interface PartitionTransition {
@@ -75,7 +76,7 @@ public interface PartitionTransition {
    * not complete successfully. This is useful to distinguish between transitions that were prepared
    * but later failed or were cancelled, and transitions that couldn't even be prepared properly.
    */
-  final class FailedPartitionTransitionPreparation extends RuntimeException {
+  final class FailedPartitionTransitionPreparation extends UnrecoverableException {
     public FailedPartitionTransitionPreparation(final Throwable cause) {
       super("Preparing for partition transition failed", cause);
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -477,9 +477,17 @@ public final class ZeebePartition extends Actor
     // We do not want to mark it as unhealthy, hence we don't reuse transitionToInactive()
     actor.run(
         () -> {
-          if (!closing) {
-            transition.toInactive(context.getCurrentTerm());
+          if (closing) {
+            return;
           }
+          transition
+              .toInactive(context.getCurrentTerm())
+              .onComplete(
+                  (success, error) -> {
+                    if (error != null) {
+                      onInstallFailure(error);
+                    }
+                  });
         });
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -281,7 +281,14 @@ public final class ZeebePartition extends Actor
 
   private ActorFuture<Void> transitionToInactive() {
     zeebePartitionHealth.setServicesInstalled(false);
-    return transition.toInactive(context.getCurrentTerm());
+    final var transitionFuture = transition.toInactive(context.getCurrentTerm());
+    transitionFuture.onComplete(
+        (success, error) -> {
+          if (error != null) {
+            onInstallFailure(error);
+          }
+        });
+    return transitionFuture;
   }
 
   private void registerListeners() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
-import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -42,7 +41,7 @@ class ZeebePartitionHealth implements HealthMonitorable {
 
   private void updateHealthStatus() {
     final HealthReport previousStatus = healthReport;
-    if (healthReport != null && previousStatus.getStatus() == HealthStatus.DEAD) {
+    if (previousStatus != null && previousStatus.isDead()) {
       return;
     }
 
@@ -59,17 +58,10 @@ class ZeebePartitionHealth implements HealthMonitorable {
 
     if (previousStatus != healthReport) {
       switch (healthReport.getStatus()) {
-        case HEALTHY:
-          failureListeners.forEach(FailureListener::onRecovered);
-          break;
-        case UNHEALTHY:
-          failureListeners.forEach((l) -> l.onFailure(healthReport));
-          break;
-        case DEAD:
-          failureListeners.forEach((l) -> l.onUnrecoverableFailure(healthReport));
-          break;
-        default:
-          break;
+        case HEALTHY -> failureListeners.forEach(FailureListener::onRecovered);
+        case UNHEALTHY -> failureListeners.forEach((l) -> l.onFailure(healthReport));
+        case DEAD -> failureListeners.forEach((l) -> l.onUnrecoverableFailure(healthReport));
+        default -> {}
       }
     }
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.health.HealthIssue;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
@@ -33,7 +32,6 @@ public final class PartitionTransitionImpl implements PartitionTransition {
   // transient state - to keep track of the current transitions
   private PartitionTransitionProcess currentTransition;
   private ActorFuture<Void> currentTransitionFuture;
-  private final Duration transitionStepTimeout = Duration.ofSeconds(60);
 
   public PartitionTransitionImpl(final List<PartitionTransitionStep> steps) {
     this.steps = new ArrayList<>(requireNonNull(steps));

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -189,7 +189,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
         return;
       }
 
-      log.warn("{} failed, marking it as unhealthy: {}", componentName, healthReport);
+      log.warn("{} failed, marking it as unhealthy: {}", componentName, report);
       componentHealth.put(componentName, report);
       calculateHealth();
     }


### PR DESCRIPTION
Ensures that a failure to transition to `INACTIVE` will not be silently ignored. Ignoring is not safe because we must go through the `INACTIVE` role when recovering from a snapshot, otherwise we end up not re-installing services.

`FailedPartitionTransitionPreparation` is now considered an `UnrecoverableException`.
The prepare phase should almost never fail. If it does, it is not clear which services were re-installed and which not. This undetermined state is not safe to operate on and so we'd rather shut down the partition.
