### PR TITLE
[Backport stable/8.1] fix(broker): don't call listeners when transition is cancelled

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
@@ -69,4 +69,15 @@ public interface PartitionTransition {
       super("Partition transition was cancelled");
     }
   }
+
+  /**
+   * Used to exceptionally complete transition futures when the prepare phase of the transition did
+   * not complete successfully. This is useful to distinguish between transitions that were prepared
+   * but later failed or were cancelled, and transitions that couldn't even be prepared properly.
+   */
+  final class FailedPartitionTransitionPreparation extends RuntimeException {
+    public FailedPartitionTransitionPreparation(final Throwable cause) {
+      super("Preparing for partition transition failed", cause);
+    }
+  }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
@@ -18,7 +18,8 @@ public interface PartitionTransition {
    * opening a follower partition.
    *
    * @param currentTerm the current term on which the transition happens
-   * @return an ActorFuture to be completed when the transition is complete
+   * @return an ActorFuture to be completed when the transition is complete. Completed exceptionally
+   *     with {@link CancelledPartitionTransition} if the partition was cancelled.
    */
   ActorFuture<Void> toFollower(final long currentTerm);
 
@@ -27,14 +28,16 @@ public interface PartitionTransition {
    * a leader partition.
    *
    * @param currentTerm the current term on which the transition happens
-   * @return an ActorFuture to be completed when the transition is complete
+   * @return an ActorFuture to be completed when the transition is complete. Completed exceptionally
+   *     * with {@link CancelledPartitionTransition} if the partition was cancelled.
    */
   ActorFuture<Void> toLeader(final long currentTerm);
 
   /**
    * Closes the current partition's components asynchronously.
    *
-   * @return an ActorFuture completed when the transition is complete
+   * @return an ActorFuture completed when the transition is complete. Completed exceptionally *
+   *     with {@link CancelledPartitionTransition} if the partition was cancelled.
    * @param term
    */
   ActorFuture<Void> toInactive(final long term);
@@ -57,4 +60,7 @@ public interface PartitionTransition {
    * @return null if transition is healthy or a {@link HealthIssue} if not.
    */
   HealthIssue getHealthIssue();
+
+  /** Used to exceptionally complete transition futures when the transition was cancelled. */
+  final class CancelledPartitionTransition extends RuntimeException {}
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransitionException;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.health.HealthIssue;
@@ -62,5 +63,10 @@ public interface PartitionTransition {
   HealthIssue getHealthIssue();
 
   /** Used to exceptionally complete transition futures when the transition was cancelled. */
-  final class CancelledPartitionTransition extends RuntimeException {}
+  final class CancelledPartitionTransition extends RecoverablePartitionTransitionException {
+
+    public CancelledPartitionTransition() {
+      super("Partition transition was cancelled");
+    }
+  }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -86,10 +86,8 @@ public final class PartitionTransitionImpl implements PartitionTransition {
               (v, error) -> {
                 // term and role should only bet se after the transition is completed, since on
                 // preparation we expect old term and role to make decision based on that
-                if (error == null) {
-                  context.setCurrentTerm(term);
-                  context.setCurrentRole(role);
-                }
+                context.setCurrentTerm(term);
+                context.setCurrentRole(role);
                 lastTransition = nextTransition;
               });
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -84,11 +84,19 @@ public final class PartitionTransitionImpl implements PartitionTransition {
               new PartitionTransitionProcess(steps, concurrencyControl, context, term, role);
           nextTransitionFuture.onComplete(
               (v, error) -> {
-                // term and role should only bet se after the transition is completed, since on
-                // preparation we expect old term and role to make decision based on that
-                context.setCurrentTerm(term);
-                context.setCurrentRole(role);
                 lastTransition = nextTransition;
+
+                if (!(error instanceof FailedPartitionTransitionPreparation)) {
+                  // Prepare phase succeeded and the transition either completed successfully,
+                  // failed or was cancelled. Either way, we update term and role to ensure that the
+                  // next transition will go through the necessary prepare phase.
+                  // If a `FailedPartitionTransitionPreparation` is actually thrown, the next
+                  // transition must attempt the same preparation again which means we can't update
+                  // term and role yet.
+
+                  context.setCurrentTerm(term);
+                  context.setCurrentRole(role);
+                }
               });
 
           enqueueNextTransition(term, role, nextTransitionFuture, nextTransition);
@@ -154,7 +162,8 @@ public final class PartitionTransitionImpl implements PartitionTransition {
             if (error != null) {
               LOG.error("Error during transition preparation: {}", error.getMessage(), error);
               LOG.info("Aborting transition to {} on term {} due to error.", role, term);
-              nextTransitionFuture.completeExceptionally(error);
+              nextTransitionFuture.completeExceptionally(
+                  new FailedPartitionTransitionPreparation(error));
             } else {
               nextTransition.start(nextTransitionFuture);
             }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransition.CancelledPartitionTransition;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -72,7 +73,7 @@ final class PartitionTransitionProcess {
   private void proceedWithTransition(final ActorFuture<Void> future) {
     if (cancelRequested) {
       LOG.info("Cancelling transition to {} on term {}", role, term);
-      future.complete(null);
+      future.completeExceptionally(new CancelledPartitionTransition());
       completed = true;
       return;
     }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
@@ -336,7 +336,7 @@ class PartitionTransitionImplTest {
 
     assertThatThrownBy(secondTransitionFuture::join)
         .isInstanceOf(ExecutionException.class)
-        .cause()
+        .rootCause()
         .isSameAs(testException);
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransition.CancelledPartitionTransition;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorTransitionStep;
@@ -141,8 +142,12 @@ class PartitionTransitionImplTest {
 
     // then
 
-    // both transitions completed orderly
-    assertThat(firstTransitionFuture.isCompletedExceptionally()).isFalse();
+    // the first transition was cancelled
+    assertThat(firstTransitionFuture.isCompletedExceptionally()).isTrue();
+    assertThat(firstTransitionFuture.getException())
+        .isInstanceOf(CancelledPartitionTransition.class);
+
+    // the second transition completed successfully
     assertThat(secondTransitionFuture.isCompletedExceptionally()).isFalse();
 
     // the first transition was cancelled before the second step


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/13541