### PR TITLE
Remove unnecessary new version from segment descriptor

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.util.ChecksumGenerator;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
@@ -56,166 +57,43 @@ final class SegmentDescriptor {
   private static final byte NO_META_VERSION = 1;
 
   private final DescriptorMetadataEncoder metadataEncoder = new DescriptorMetadataEncoder();
-  private final DescriptorMetadataDecoder metadataDecoder = new DescriptorMetadataDecoder();
-  private final SegmentDescriptorDecoder segmentDescriptorDecoder = new SegmentDescriptorDecoder();
-
-  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
-  private final MutableDirectBuffer directBuffer = new UnsafeBuffer();
   private final SegmentDescriptorEncoder segmentDescriptorEncoder = new SegmentDescriptorEncoder();
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final ChecksumGenerator checksumGen = new ChecksumGenerator();
   // version in the header. Increment this version if there is non-backward compatible changes in
   // the serialization format.
-  private byte version = CUR_VERSION;
+  private final byte version;
 
   // version of sbe schema. The version will be incremented if fields are added or removed from the
   // sbe schema of descriptor. As long as these changes are backward compatible, there is no need to
   // increment `CUR_VERSION`
-  private int actingSchemaVersion = segmentDescriptorDecoder.sbeSchemaVersion();
-  private long id;
-  private long index;
-  private int maxSegmentSize;
+  private final int actingSchemaVersion;
+  private final long id;
+  private final long index;
+  private final int maxSegmentSize;
+  private final int encodedLength;
   // index of the last entry in this segment. Can be 0 if not set, even if an entry exists.
   private long lastIndex;
   // position of the last entry in this segment. Can be 0 if not set, even if an entry exists.
   private int lastPosition;
-  private int encodedLength;
-  private long checksum;
 
-  SegmentDescriptor(final ByteBuffer buffer) {
-    directBuffer.wrap(buffer);
-
-    try {
-      version = directBuffer.getByte(0);
-      if (version > NO_META_VERSION && version <= CUR_VERSION) {
-        readV2Descriptor(directBuffer);
-      } else if (version == NO_META_VERSION) {
-        readV1Descriptor(directBuffer);
-      } else {
-        throw new UnknownVersionException(
-            String.format(
-                "Expected version to be one [%d %d] but read %d instead.",
-                NO_META_VERSION, CUR_VERSION, version));
-      }
-    } catch (final IndexOutOfBoundsException error) {
-      // Previously SegmentLoader checks if the file has sufficient size for the descriptor. But it
-      // is not checked anymore because the encoded length is not known before reading.
-      throw new CorruptedJournalException("Failed to read segment descriptor", error);
-    }
-  }
-
-  private SegmentDescriptor(final long id, final long index, final int maxSegmentSize) {
+  private SegmentDescriptor(
+      final byte version,
+      final int actingSchemaVersion,
+      final long id,
+      final long index,
+      final int maxSegmentSize,
+      final long lastIndex,
+      final int lastPosition,
+      final int encodedLength) {
+    this.version = version;
+    this.actingSchemaVersion = actingSchemaVersion;
     this.id = id;
     this.index = index;
     this.maxSegmentSize = maxSegmentSize;
-    lastIndex = 0;
-    lastPosition = 0;
-    encodedLength = getEncodingLength();
-  }
-
-  /** Validates the header's schema and template ids before loading the descriptor's fields. */
-  private void readV1Descriptor(final MutableDirectBuffer buffer) {
-    validateHeader(
-        buffer,
-        VERSION_LENGTH,
-        segmentDescriptorDecoder.sbeSchemaId(),
-        segmentDescriptorDecoder.sbeTemplateId());
-
-    readDescriptor(buffer, VERSION_LENGTH);
-  }
-
-  /**
-   * Validates the headers' schema and template ids, as well as the metadata's checksum, before
-   * loading the descriptor's fields.
-   */
-  private void readV2Descriptor(final MutableDirectBuffer buffer) {
-    // validate metadata header
-    validateHeader(
-        buffer, VERSION_LENGTH, metadataDecoder.sbeSchemaId(), metadataDecoder.sbeTemplateId());
-    final int descHeaderOffset = readChecksum(buffer, VERSION_LENGTH);
-
-    // validate descriptor header
-    validateHeader(
-        buffer,
-        descHeaderOffset,
-        segmentDescriptorDecoder.sbeSchemaId(),
-        segmentDescriptorDecoder.sbeTemplateId());
-    final int totalLength = readDescriptor(buffer, descHeaderOffset);
-
-    // length of the header + descriptor
-    final int descriptorLength = totalLength - descHeaderOffset;
-    validateChecksum(buffer, descHeaderOffset, descriptorLength);
-  }
-
-  private void validateChecksum(
-      final MutableDirectBuffer buffer, final int descHeaderOffset, final int descriptorLength) {
-    final ByteBuffer slice = ByteBuffer.allocate(descriptorLength);
-    buffer.getBytes(descHeaderOffset, slice, descriptorLength);
-    final long computedChecksum = checksumGen.compute(slice, 0, descriptorLength);
-
-    if (computedChecksum != checksum) {
-      throw new CorruptedJournalException(
-          "Descriptor doesn't match checksum (possibly due to corruption).");
-    }
-  }
-
-  /**
-   * Loads the descriptor's fields.
-   *
-   * @param offset offset where the descriptor's header starts
-   * @return offset after reading the descriptor
-   */
-  private int readDescriptor(final MutableDirectBuffer buffer, final int offset) {
-    headerDecoder.wrap(buffer, offset);
-    actingSchemaVersion = headerDecoder.version();
-    segmentDescriptorDecoder.wrap(
-        directBuffer,
-        offset + headerDecoder.encodedLength(),
-        headerDecoder.blockLength(),
-        actingSchemaVersion);
-
-    id = segmentDescriptorDecoder.id();
-    index = segmentDescriptorDecoder.index();
-    maxSegmentSize = segmentDescriptorDecoder.maxSegmentSize();
-    lastIndex = Math.max(0, segmentDescriptorDecoder.lastIndex());
-    lastPosition = Math.max(0, (int) segmentDescriptorDecoder.lastPosition());
-    encodedLength =
-        offset + headerDecoder.encodedLength() + segmentDescriptorDecoder.encodedLength();
-
-    return encodedLength;
-  }
-
-  /**
-   * Loads the metadata's checksum field.
-   *
-   * @return offset after the metadata
-   */
-  private int readChecksum(final MutableDirectBuffer buffer, final int offset) {
-    headerDecoder.wrap(buffer, offset);
-    metadataDecoder.wrap(
-        buffer,
-        offset + headerDecoder.encodedLength(),
-        headerDecoder.blockLength(),
-        headerDecoder.version());
-
-    checksum = metadataDecoder.checksum();
-    return offset + headerDecoder.encodedLength() + metadataDecoder.encodedLength();
-  }
-
-  /** Validate that the header's schema and template ids match the expected ones. */
-  private void validateHeader(
-      final MutableDirectBuffer buffer,
-      final int offset,
-      final int schemaId,
-      final int templateId) {
-    headerDecoder.wrap(buffer, offset);
-
-    if (headerDecoder.schemaId() != schemaId || headerDecoder.templateId() != templateId) {
-      throw new CorruptedJournalException(
-          String.format(
-              "Cannot read header. Read schema and template ids ('%d' and '%d') don't match expected '%d' and %d'.",
-              headerDecoder.schemaId(), headerDecoder.templateId(), schemaId, templateId));
-    }
+    this.lastIndex = lastIndex;
+    this.lastPosition = lastPosition;
+    this.encodedLength = encodedLength;
   }
 
   /**
@@ -287,6 +165,7 @@ final class SegmentDescriptor {
    * SegmentDescriptor#getEncodingLength()}
    */
   SegmentDescriptor copyTo(final ByteBuffer buffer) {
+    final MutableDirectBuffer directBuffer = new UnsafeBuffer();
     directBuffer.wrap(buffer);
     directBuffer.putByte(0, CUR_VERSION);
 
@@ -430,7 +309,169 @@ final class SegmentDescriptor {
      * @return The built segment descriptor.
      */
     SegmentDescriptor build() {
-      return new SegmentDescriptor(id, index, maxSegmentSize);
+      return new SegmentDescriptor(
+          CUR_VERSION,
+          SegmentDescriptorEncoder.SCHEMA_VERSION,
+          id,
+          index,
+          maxSegmentSize,
+          0,
+          0,
+          getEncodingLength());
+    }
+  }
+
+  static final class SegmentDescriptorReader {
+    private final DescriptorMetadataDecoder metadataDecoder = new DescriptorMetadataDecoder();
+    private final SegmentDescriptorDecoder segmentDescriptorDecoder =
+        new SegmentDescriptorDecoder();
+    private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+    private final ChecksumGenerator checksumGen = new ChecksumGenerator();
+    private final DirectBuffer directBuffer = new UnsafeBuffer();
+    private byte version = CUR_VERSION;
+    private int actingSchemaVersion = segmentDescriptorDecoder.sbeSchemaVersion();
+    private long id;
+    private long index;
+    private int maxSegmentSize;
+    // index of the last entry in this segment. Can be 0 if not set, even if an entry exists.
+    private long lastIndex;
+    // position of the last entry in this segment. Can be 0 if not set, even if an entry exists.
+    private int lastPosition;
+    private int encodedLength;
+    private long checksum;
+
+    SegmentDescriptor readFrom(final ByteBuffer buffer) {
+      directBuffer.wrap(buffer);
+
+      try {
+        version = directBuffer.getByte(0);
+        if (version > NO_META_VERSION && version <= CUR_VERSION) {
+          readV2Descriptor(directBuffer);
+        } else if (version == NO_META_VERSION) {
+          readV1Descriptor(directBuffer);
+        } else {
+          throw new UnknownVersionException(
+              String.format(
+                  "Expected version to be one [%d %d] but read %d instead.",
+                  NO_META_VERSION, CUR_VERSION, version));
+        }
+      } catch (final IndexOutOfBoundsException error) {
+        // Previously SegmentLoader checks if the file has sufficient size for the descriptor. But
+        // it
+        // is not checked anymore because the encoded length is not known before reading.
+        throw new CorruptedJournalException("Failed to read segment descriptor", error);
+      }
+      return new SegmentDescriptor(
+          version,
+          actingSchemaVersion,
+          id,
+          index,
+          maxSegmentSize,
+          lastIndex,
+          lastPosition,
+          encodedLength);
+    }
+
+    /**
+     * Validates the headers' schema and template ids, as well as the metadata's checksum, before
+     * loading the descriptor's fields.
+     */
+    private void readV2Descriptor(final DirectBuffer buffer) {
+      // validate metadata header
+      validateHeader(
+          buffer, VERSION_LENGTH, metadataDecoder.sbeSchemaId(), metadataDecoder.sbeTemplateId());
+      final int descHeaderOffset = readChecksum(buffer, VERSION_LENGTH);
+
+      // validate descriptor header
+      validateHeader(
+          buffer,
+          descHeaderOffset,
+          segmentDescriptorDecoder.sbeSchemaId(),
+          segmentDescriptorDecoder.sbeTemplateId());
+      final int totalLength = readDescriptor(buffer, descHeaderOffset);
+
+      // length of the header + descriptor
+      final int descriptorLength = totalLength - descHeaderOffset;
+      validateChecksum(buffer, descHeaderOffset, descriptorLength);
+    }
+
+    private void validateChecksum(
+        final DirectBuffer buffer, final int descHeaderOffset, final int descriptorLength) {
+      final ByteBuffer slice = ByteBuffer.allocate(descriptorLength);
+      buffer.getBytes(descHeaderOffset, slice, descriptorLength);
+      final long computedChecksum = checksumGen.compute(slice, 0, descriptorLength);
+
+      if (computedChecksum != checksum) {
+        throw new CorruptedJournalException(
+            "Descriptor doesn't match checksum (possibly due to corruption).");
+      }
+    }
+
+    /**
+     * Loads the descriptor's fields.
+     *
+     * @param offset offset where the descriptor's header starts
+     * @return offset after reading the descriptor
+     */
+    private int readDescriptor(final DirectBuffer buffer, final int offset) {
+      headerDecoder.wrap(buffer, offset);
+      actingSchemaVersion = headerDecoder.version();
+      segmentDescriptorDecoder.wrap(
+          directBuffer,
+          offset + headerDecoder.encodedLength(),
+          headerDecoder.blockLength(),
+          actingSchemaVersion);
+
+      id = segmentDescriptorDecoder.id();
+      index = segmentDescriptorDecoder.index();
+      maxSegmentSize = segmentDescriptorDecoder.maxSegmentSize();
+      lastIndex = Math.max(0, segmentDescriptorDecoder.lastIndex());
+      lastPosition = Math.max(0, (int) segmentDescriptorDecoder.lastPosition());
+      encodedLength =
+          offset + headerDecoder.encodedLength() + segmentDescriptorDecoder.encodedLength();
+
+      return encodedLength;
+    }
+
+    /**
+     * Loads the metadata's checksum field.
+     *
+     * @return offset after the metadata
+     */
+    private int readChecksum(final DirectBuffer buffer, final int offset) {
+      headerDecoder.wrap(buffer, offset);
+      metadataDecoder.wrap(
+          buffer,
+          offset + headerDecoder.encodedLength(),
+          headerDecoder.blockLength(),
+          headerDecoder.version());
+
+      checksum = metadataDecoder.checksum();
+      return offset + headerDecoder.encodedLength() + metadataDecoder.encodedLength();
+    }
+
+    /** Validate that the header's schema and template ids match the expected ones. */
+    private void validateHeader(
+        final DirectBuffer buffer, final int offset, final int schemaId, final int templateId) {
+      headerDecoder.wrap(buffer, offset);
+
+      if (headerDecoder.schemaId() != schemaId || headerDecoder.templateId() != templateId) {
+        throw new CorruptedJournalException(
+            String.format(
+                "Cannot read header. Read schema and template ids ('%d' and '%d') don't match expected '%d' and %d'.",
+                headerDecoder.schemaId(), headerDecoder.templateId(), schemaId, templateId));
+      }
+    }
+
+    /** Validates the header's schema and template ids before loading the descriptor's fields. */
+    private void readV1Descriptor(final DirectBuffer buffer) {
+      validateHeader(
+          buffer,
+          VERSION_LENGTH,
+          segmentDescriptorDecoder.sbeSchemaId(),
+          segmentDescriptorDecoder.sbeTemplateId());
+
+      readDescriptor(buffer, VERSION_LENGTH);
     }
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -49,8 +49,9 @@ final class SegmentDescriptor {
   // contains lastIndex and lastPosition. Version 2 with sbeSchemaVersion 1 does not contain
   // lastIndex and lastPosition.
   static final byte CUR_VERSION = 2;
-  // previous descriptor version containing: header and descriptor
-  static final byte NO_META_VERSION = 1;
+  // First version containing: header and descriptor. We remove support for VERSION 1 as this was
+  // introduced long ago.
+  static final byte META_VERSION = 2;
   static final int VERSION_LENGTH = Byte.BYTES;
   private static final Logger LOG = LoggerFactory.getLogger(SegmentDescriptor.class);
   private final DescriptorMetadataEncoder metadataEncoder = new DescriptorMetadataEncoder();

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptor.java
@@ -18,11 +18,9 @@ package io.camunda.zeebe.journal.file;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.util.ChecksumGenerator;
 import java.nio.ByteBuffer;
 import java.util.Objects;
-import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
@@ -47,15 +45,14 @@ import org.slf4j.LoggerFactory;
  * segment.
  */
 final class SegmentDescriptor {
-  private static final Logger LOG = LoggerFactory.getLogger(SegmentDescriptor.class);
-  private static final int VERSION_LENGTH = Byte.BYTES;
   // current descriptor version containing: header, metadata, header and descriptor. descriptor
   // contains lastIndex and lastPosition. Version 2 with sbeSchemaVersion 1 does not contain
   // lastIndex and lastPosition.
-  private static final byte CUR_VERSION = 2;
+  static final byte CUR_VERSION = 2;
   // previous descriptor version containing: header and descriptor
-  private static final byte NO_META_VERSION = 1;
-
+  static final byte NO_META_VERSION = 1;
+  static final int VERSION_LENGTH = Byte.BYTES;
+  private static final Logger LOG = LoggerFactory.getLogger(SegmentDescriptor.class);
   private final DescriptorMetadataEncoder metadataEncoder = new DescriptorMetadataEncoder();
   private final SegmentDescriptorEncoder segmentDescriptorEncoder = new SegmentDescriptorEncoder();
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
@@ -77,7 +74,7 @@ final class SegmentDescriptor {
   // position of the last entry in this segment. Can be 0 if not set, even if an entry exists.
   private int lastPosition;
 
-  private SegmentDescriptor(
+  SegmentDescriptor(
       final byte version,
       final int actingSchemaVersion,
       final long id,
@@ -318,160 +315,6 @@ final class SegmentDescriptor {
           0,
           0,
           getEncodingLength());
-    }
-  }
-
-  static final class SegmentDescriptorReader {
-    private final DescriptorMetadataDecoder metadataDecoder = new DescriptorMetadataDecoder();
-    private final SegmentDescriptorDecoder segmentDescriptorDecoder =
-        new SegmentDescriptorDecoder();
-    private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
-    private final ChecksumGenerator checksumGen = new ChecksumGenerator();
-    private final DirectBuffer directBuffer = new UnsafeBuffer();
-    private byte version = CUR_VERSION;
-    private int actingSchemaVersion = segmentDescriptorDecoder.sbeSchemaVersion();
-    private long id;
-    private long index;
-    private int maxSegmentSize;
-    // index of the last entry in this segment. Can be 0 if not set, even if an entry exists.
-    private long lastIndex;
-    // position of the last entry in this segment. Can be 0 if not set, even if an entry exists.
-    private int lastPosition;
-    private int encodedLength;
-    private long checksum;
-
-    SegmentDescriptor readFrom(final ByteBuffer buffer) {
-      directBuffer.wrap(buffer);
-
-      try {
-        version = directBuffer.getByte(0);
-        if (version > NO_META_VERSION && version <= CUR_VERSION) {
-          readV2Descriptor(directBuffer);
-        } else if (version == NO_META_VERSION) {
-          readV1Descriptor(directBuffer);
-        } else {
-          throw new UnknownVersionException(
-              String.format(
-                  "Expected version to be one [%d %d] but read %d instead.",
-                  NO_META_VERSION, CUR_VERSION, version));
-        }
-      } catch (final IndexOutOfBoundsException error) {
-        // Previously SegmentLoader checks if the file has sufficient size for the descriptor. But
-        // it
-        // is not checked anymore because the encoded length is not known before reading.
-        throw new CorruptedJournalException("Failed to read segment descriptor", error);
-      }
-      return new SegmentDescriptor(
-          version,
-          actingSchemaVersion,
-          id,
-          index,
-          maxSegmentSize,
-          lastIndex,
-          lastPosition,
-          encodedLength);
-    }
-
-    /**
-     * Validates the headers' schema and template ids, as well as the metadata's checksum, before
-     * loading the descriptor's fields.
-     */
-    private void readV2Descriptor(final DirectBuffer buffer) {
-      // validate metadata header
-      validateHeader(
-          buffer, VERSION_LENGTH, metadataDecoder.sbeSchemaId(), metadataDecoder.sbeTemplateId());
-      final int descHeaderOffset = readChecksum(buffer, VERSION_LENGTH);
-
-      // validate descriptor header
-      validateHeader(
-          buffer,
-          descHeaderOffset,
-          segmentDescriptorDecoder.sbeSchemaId(),
-          segmentDescriptorDecoder.sbeTemplateId());
-      final int totalLength = readDescriptor(buffer, descHeaderOffset);
-
-      // length of the header + descriptor
-      final int descriptorLength = totalLength - descHeaderOffset;
-      validateChecksum(buffer, descHeaderOffset, descriptorLength);
-    }
-
-    private void validateChecksum(
-        final DirectBuffer buffer, final int descHeaderOffset, final int descriptorLength) {
-      final ByteBuffer slice = ByteBuffer.allocate(descriptorLength);
-      buffer.getBytes(descHeaderOffset, slice, descriptorLength);
-      final long computedChecksum = checksumGen.compute(slice, 0, descriptorLength);
-
-      if (computedChecksum != checksum) {
-        throw new CorruptedJournalException(
-            "Descriptor doesn't match checksum (possibly due to corruption).");
-      }
-    }
-
-    /**
-     * Loads the descriptor's fields.
-     *
-     * @param offset offset where the descriptor's header starts
-     * @return offset after reading the descriptor
-     */
-    private int readDescriptor(final DirectBuffer buffer, final int offset) {
-      headerDecoder.wrap(buffer, offset);
-      actingSchemaVersion = headerDecoder.version();
-      segmentDescriptorDecoder.wrap(
-          directBuffer,
-          offset + headerDecoder.encodedLength(),
-          headerDecoder.blockLength(),
-          actingSchemaVersion);
-
-      id = segmentDescriptorDecoder.id();
-      index = segmentDescriptorDecoder.index();
-      maxSegmentSize = segmentDescriptorDecoder.maxSegmentSize();
-      lastIndex = Math.max(0, segmentDescriptorDecoder.lastIndex());
-      lastPosition = Math.max(0, (int) segmentDescriptorDecoder.lastPosition());
-      encodedLength =
-          offset + headerDecoder.encodedLength() + segmentDescriptorDecoder.encodedLength();
-
-      return encodedLength;
-    }
-
-    /**
-     * Loads the metadata's checksum field.
-     *
-     * @return offset after the metadata
-     */
-    private int readChecksum(final DirectBuffer buffer, final int offset) {
-      headerDecoder.wrap(buffer, offset);
-      metadataDecoder.wrap(
-          buffer,
-          offset + headerDecoder.encodedLength(),
-          headerDecoder.blockLength(),
-          headerDecoder.version());
-
-      checksum = metadataDecoder.checksum();
-      return offset + headerDecoder.encodedLength() + metadataDecoder.encodedLength();
-    }
-
-    /** Validate that the header's schema and template ids match the expected ones. */
-    private void validateHeader(
-        final DirectBuffer buffer, final int offset, final int schemaId, final int templateId) {
-      headerDecoder.wrap(buffer, offset);
-
-      if (headerDecoder.schemaId() != schemaId || headerDecoder.templateId() != templateId) {
-        throw new CorruptedJournalException(
-            String.format(
-                "Cannot read header. Read schema and template ids ('%d' and '%d') don't match expected '%d' and %d'.",
-                headerDecoder.schemaId(), headerDecoder.templateId(), schemaId, templateId));
-      }
-    }
-
-    /** Validates the header's schema and template ids before loading the descriptor's fields. */
-    private void readV1Descriptor(final DirectBuffer buffer) {
-      validateHeader(
-          buffer,
-          VERSION_LENGTH,
-          segmentDescriptorDecoder.sbeSchemaId(),
-          segmentDescriptorDecoder.sbeTemplateId());
-
-      readDescriptor(buffer, VERSION_LENGTH);
     }
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptorReader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptorReader.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.CorruptedJournalException;
+import io.camunda.zeebe.journal.util.ChecksumGenerator;
+import java.nio.ByteBuffer;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class SegmentDescriptorReader {
+  private final DescriptorMetadataDecoder metadataDecoder = new DescriptorMetadataDecoder();
+  private final SegmentDescriptorDecoder segmentDescriptorDecoder = new SegmentDescriptorDecoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final ChecksumGenerator checksumGen = new ChecksumGenerator();
+  private final DirectBuffer directBuffer = new UnsafeBuffer();
+  private int actingSchemaVersion = segmentDescriptorDecoder.sbeSchemaVersion();
+  private long id;
+  private long index;
+  private int maxSegmentSize;
+  // index of the last entry in this segment. Can be 0 if not set, even if an entry exists.
+  private long lastIndex;
+  // position of the last entry in this segment. Can be 0 if not set, even if an entry exists.
+  private int lastPosition;
+  private int encodedLength;
+  private long checksum;
+
+  SegmentDescriptor readFrom(final ByteBuffer buffer) {
+    directBuffer.wrap(buffer);
+    final byte version;
+    try {
+      version = directBuffer.getByte(0);
+      if (version > SegmentDescriptor.NO_META_VERSION && version <= SegmentDescriptor.CUR_VERSION) {
+        readV2Descriptor(directBuffer);
+      } else if (version == SegmentDescriptor.NO_META_VERSION) {
+        readV1Descriptor(directBuffer);
+      } else {
+        throw new UnknownVersionException(
+            String.format(
+                "Expected version to be one [%d %d] but read %d instead.",
+                SegmentDescriptor.NO_META_VERSION, SegmentDescriptor.CUR_VERSION, version));
+      }
+    } catch (final IndexOutOfBoundsException error) {
+      // Previously SegmentLoader checks if the file has sufficient size for the descriptor. But
+      // it
+      // is not checked anymore because the encoded length is not known before reading.
+      throw new CorruptedJournalException("Failed to read segment descriptor", error);
+    }
+    return new SegmentDescriptor(
+        version,
+        actingSchemaVersion,
+        id,
+        index,
+        maxSegmentSize,
+        lastIndex,
+        lastPosition,
+        encodedLength);
+  }
+
+  /**
+   * Validates the headers' schema and template ids, as well as the metadata's checksum, before
+   * loading the descriptor's fields.
+   */
+  private void readV2Descriptor(final DirectBuffer buffer) {
+    // validate metadata header
+    validateHeader(
+        buffer,
+        SegmentDescriptor.VERSION_LENGTH,
+        metadataDecoder.sbeSchemaId(),
+        metadataDecoder.sbeTemplateId());
+    final int descHeaderOffset = readChecksum(buffer, SegmentDescriptor.VERSION_LENGTH);
+
+    // validate descriptor header
+    validateHeader(
+        buffer,
+        descHeaderOffset,
+        segmentDescriptorDecoder.sbeSchemaId(),
+        segmentDescriptorDecoder.sbeTemplateId());
+    final int totalLength = readDescriptor(buffer, descHeaderOffset);
+
+    // length of the header + descriptor
+    final int descriptorLength = totalLength - descHeaderOffset;
+    validateChecksum(buffer, descHeaderOffset, descriptorLength);
+  }
+
+  private void validateChecksum(
+      final DirectBuffer buffer, final int descHeaderOffset, final int descriptorLength) {
+    final ByteBuffer slice = ByteBuffer.allocate(descriptorLength);
+    buffer.getBytes(descHeaderOffset, slice, descriptorLength);
+    final long computedChecksum = checksumGen.compute(slice, 0, descriptorLength);
+
+    if (computedChecksum != checksum) {
+      throw new CorruptedJournalException(
+          "Descriptor doesn't match checksum (possibly due to corruption).");
+    }
+  }
+
+  /**
+   * Loads the descriptor's fields.
+   *
+   * @param offset offset where the descriptor's header starts
+   * @return offset after reading the descriptor
+   */
+  private int readDescriptor(final DirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
+    actingSchemaVersion = headerDecoder.version();
+    segmentDescriptorDecoder.wrap(
+        directBuffer,
+        offset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        actingSchemaVersion);
+
+    id = segmentDescriptorDecoder.id();
+    index = segmentDescriptorDecoder.index();
+    maxSegmentSize = segmentDescriptorDecoder.maxSegmentSize();
+    lastIndex = Math.max(0, segmentDescriptorDecoder.lastIndex());
+    lastPosition = Math.max(0, (int) segmentDescriptorDecoder.lastPosition());
+    encodedLength =
+        offset + headerDecoder.encodedLength() + segmentDescriptorDecoder.encodedLength();
+
+    return encodedLength;
+  }
+
+  /**
+   * Loads the metadata's checksum field.
+   *
+   * @return offset after the metadata
+   */
+  private int readChecksum(final DirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
+    metadataDecoder.wrap(
+        buffer,
+        offset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    checksum = metadataDecoder.checksum();
+    return offset + headerDecoder.encodedLength() + metadataDecoder.encodedLength();
+  }
+
+  /** Validate that the header's schema and template ids match the expected ones. */
+  private void validateHeader(
+      final DirectBuffer buffer, final int offset, final int schemaId, final int templateId) {
+    headerDecoder.wrap(buffer, offset);
+
+    if (headerDecoder.schemaId() != schemaId || headerDecoder.templateId() != templateId) {
+      throw new CorruptedJournalException(
+          String.format(
+              "Cannot read header. Read schema and template ids ('%d' and '%d') don't match expected '%d' and %d'.",
+              headerDecoder.schemaId(), headerDecoder.templateId(), schemaId, templateId));
+    }
+  }
+
+  /** Validates the header's schema and template ids before loading the descriptor's fields. */
+  private void readV1Descriptor(final DirectBuffer buffer) {
+    validateHeader(
+        buffer,
+        SegmentDescriptor.VERSION_LENGTH,
+        segmentDescriptorDecoder.sbeSchemaId(),
+        segmentDescriptorDecoder.sbeTemplateId());
+
+    readDescriptor(buffer, SegmentDescriptor.VERSION_LENGTH);
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptorReader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentDescriptorReader.java
@@ -35,15 +35,13 @@ final class SegmentDescriptorReader {
     final byte version;
     try {
       version = directBuffer.getByte(0);
-      if (version > SegmentDescriptor.NO_META_VERSION && version <= SegmentDescriptor.CUR_VERSION) {
+      if (version >= SegmentDescriptor.META_VERSION && version <= SegmentDescriptor.CUR_VERSION) {
         readV2Descriptor(directBuffer);
-      } else if (version == SegmentDescriptor.NO_META_VERSION) {
-        readV1Descriptor(directBuffer);
       } else {
         throw new UnknownVersionException(
             String.format(
-                "Expected version to be one [%d %d] but read %d instead.",
-                SegmentDescriptor.NO_META_VERSION, SegmentDescriptor.CUR_VERSION, version));
+                "Expected version to be one (%d %d] but read %d instead.",
+                SegmentDescriptor.META_VERSION, SegmentDescriptor.CUR_VERSION, version));
       }
     } catch (final IndexOutOfBoundsException error) {
       // Previously SegmentLoader checks if the file has sufficient size for the descriptor. But
@@ -154,16 +152,5 @@ final class SegmentDescriptorReader {
               "Cannot read header. Read schema and template ids ('%d' and '%d') don't match expected '%d' and %d'.",
               headerDecoder.schemaId(), headerDecoder.templateId(), schemaId, templateId));
     }
-  }
-
-  /** Validates the header's schema and template ids before loading the descriptor's fields. */
-  private void readV1Descriptor(final DirectBuffer buffer) {
-    validateHeader(
-        buffer,
-        SegmentDescriptor.VERSION_LENGTH,
-        segmentDescriptorDecoder.sbeSchemaId(),
-        segmentDescriptorDecoder.sbeTemplateId());
-
-    readDescriptor(buffer, SegmentDescriptor.VERSION_LENGTH);
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.journal.file;
 
 import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.JournalException;
-import io.camunda.zeebe.journal.file.SegmentDescriptor.SegmentDescriptorReader;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.ByteOrder;

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.journal.file;
 
 import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.journal.file.SegmentDescriptor.SegmentDescriptorReader;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -153,7 +154,7 @@ final class SegmentLoader {
       final var fileSize = Files.size(file);
       // We don't know the length of segment descriptor, so we let
       final var buffer = channel.map(MapMode.READ_ONLY, 0, fileSize);
-      final var descriptor = new SegmentDescriptor(buffer);
+      final var descriptor = new SegmentDescriptorReader().readFrom(buffer);
       IoUtil.unmap(buffer);
       return descriptor;
     } catch (final IndexOutOfBoundsException e) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.util.ChecksumGenerator;
 import java.nio.ByteBuffer;
-import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -62,30 +61,6 @@ class SegmentDescriptorTest {
 
     // when/then
     assertThatThrownBy(() -> readDescriptor(buffer)).isInstanceOf(UnknownVersionException.class);
-  }
-
-  @Test
-  void shouldReadV1Message() {
-    // given
-    final ByteBuffer buffer = ByteBuffer.allocate(SegmentDescriptor.getEncodingLength());
-    final MutableDirectBuffer directBuffer = new UnsafeBuffer(buffer);
-    final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
-    final SegmentDescriptorEncoder descriptorEncoder = new SegmentDescriptorEncoder();
-
-    directBuffer.putByte(0, (byte) 1);
-    descriptorEncoder
-        .wrapAndApplyHeader(directBuffer, 1, headerEncoder)
-        .id(123)
-        .index(456)
-        .maxSegmentSize(789);
-
-    // when
-    final SegmentDescriptor descriptor = readDescriptor(buffer);
-
-    // then
-    assertThat(descriptor.id()).isEqualTo(123);
-    assertThat(descriptor.index()).isEqualTo(456);
-    assertThat(descriptor.maxSegmentSize()).isEqualTo(789);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -107,7 +107,7 @@ class SegmentDescriptorTest {
   }
 
   @Test
-  void shouldReadV2Message() {
+  void shouldReadV2WithSbeVersion1Message() {
     // given
     final SegmentDescriptor descriptor =
         SegmentDescriptor.builder().withId(2).withIndex(100).withMaxSegmentSize(1024).build();
@@ -127,12 +127,10 @@ class SegmentDescriptorTest {
     assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
     assertThat(descriptorRead.lastIndex()).isZero();
     assertThat(descriptorRead.lastPosition()).isZero();
-    assertThat(descriptorRead.length())
-        .isEqualTo(SegmentDescriptor.getEncodingLengthForVersion((byte) (2)));
   }
 
   @Test
-  void shouldNotOverwriteV2Descriptor() {
+  void shouldNotOverwriteV2WithSbeVersion1Descriptor() {
     // given
     final SegmentDescriptor descriptor =
         SegmentDescriptor.builder().withId(2).withIndex(100).withMaxSegmentSize(1024).build();
@@ -155,8 +153,6 @@ class SegmentDescriptorTest {
     assertThat(descriptorRead.id()).isEqualTo(2);
     assertThat(descriptorRead.index()).isEqualTo(100);
     assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
-    assertThat(descriptorRead.length())
-        .isEqualTo(SegmentDescriptor.getEncodingLengthForVersion((byte) (2)));
     assertThat(descriptorRead.lastIndex()).isZero();
     assertThat(descriptorRead.lastPosition()).isZero();
   }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentDescriptorTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.journal.CorruptedJournalException;
-import io.camunda.zeebe.journal.file.SegmentDescriptor.SegmentDescriptorReader;
 import io.camunda.zeebe.journal.util.ChecksumGenerator;
 import java.nio.ByteBuffer;
 import org.agrona.MutableDirectBuffer;


### PR DESCRIPTION
## Description

Remove keeping track of descriptor length for each version. Instead the length is determined while decoding sbe. As a consequence, we cannot check and fail early before the descriptor is read if the file size is not enough to store the descriptor. 

Since we rely on sbe to determine length, we can also remove version 3 which was introduced recently when new fields were added to the descriptor. 

In addition, this PR also refactors SegmentDescriptor and split the reading from buffer and decoding out of it.

Note:- This is backward **incompatible** with the previous SNAPSHOT and 8.3.0-alpha3, because we removed version 3. But it is still backward compatible with previous minor (8.2.x). 

## Related issues

related #13240 But we decided not use fixed length

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
