### PR TITLE
Retrieve owning tenant's identifier in java client responses

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import java.util.Map;
 
 public interface ActivatedJob {
@@ -100,4 +101,10 @@ public interface ActivatedJob {
    * @return the record encoded as JSON
    */
   String toJson();
+
+  /**
+   * @return the identifier of the tenant that owns the job
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13560")
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BroadcastSignalResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BroadcastSignalResponse.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
+
 public interface BroadcastSignalResponse {
   /**
    * Returns the unique key of the signal that was broadcasted.
@@ -22,4 +24,12 @@ public interface BroadcastSignalResponse {
    * @return the unique key of the signal.
    */
   long getKey();
+
+  /**
+   * Returns the tenant id of the signal that was broadcasted.
+   *
+   * @return the identifier of the tenant that owns the broadcasted signal.
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13558")
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeploymentEvent.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeploymentEvent.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import java.util.List;
 
 public interface DeploymentEvent {
@@ -37,4 +38,10 @@ public interface DeploymentEvent {
    * @return the decision requirements which are deployed
    */
   List<DecisionRequirements> getDecisionRequirements();
+
+  /**
+   * @return the tenant identifier that owns this deployment
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13321")
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import java.util.List;
 
 public interface EvaluateDecisionResponse {
@@ -70,4 +71,10 @@ public interface EvaluateDecisionResponse {
    * @return a message describing why the decision which was evaluated failed
    */
   String getFailureMessage();
+
+  /**
+   * @return the tenant identifier that owns this decision evaluation result
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13557")
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceEvent.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceEvent.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
+
 public interface ProcessInstanceEvent {
 
   /** Key of the process which this instance was created for */
@@ -28,4 +30,8 @@ public interface ProcessInstanceEvent {
 
   /** Unique key of the created process instance on the partition */
   long getProcessInstanceKey();
+
+  /** Tenant identifier that owns this process instance */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13321")
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import java.util.Map;
 
 public interface ProcessInstanceResult {
@@ -50,4 +51,8 @@ public interface ProcessInstanceResult {
    * @return de-serialized variables as the given type
    */
   <T> T getVariablesAsType(Class<T> variableType);
+
+  /** Tenant identifier that owns this process instance */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13321")
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PublishMessageResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PublishMessageResponse.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+import io.camunda.zeebe.client.api.ExperimentalApi;
+
 public interface PublishMessageResponse {
 
   /**
@@ -23,4 +25,12 @@ public interface PublishMessageResponse {
    * @return record key of the message.
    */
   long getMessageKey();
+
+  /**
+   * Returns the tenant id of the message that was published.
+   *
+   * @return identifier of the tenant that owns the published message.
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13559")
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -144,6 +144,12 @@ public final class ActivatedJobImpl implements ActivatedJob {
   }
 
   @Override
+  public String getTenantId() {
+    // todo(#13560): replace dummy implementation
+    return "";
+  }
+
+  @Override
   public String toString() {
     return toJson();
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/BroadcastSignalResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/BroadcastSignalResponseImpl.java
@@ -30,4 +30,10 @@ public final class BroadcastSignalResponseImpl implements BroadcastSignalRespons
   public long getKey() {
     return key;
   }
+
+  @Override
+  public String getTenantId() {
+    // todo(#13558): replace dummy implementation
+    return "";
+  }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceResponseImpl.java
@@ -54,6 +54,12 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
   }
 
   @Override
+  public String getTenantId() {
+    // todo(#13536): replace dummy implementation
+    return "";
+  }
+
+  @Override
   public String toString() {
     return "CreateProcessInstanceResponseImpl{"
         + "processDefinitionKey="
@@ -65,6 +71,9 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
         + version
         + ", processInstanceKey="
         + processInstanceKey
+        + ", tenantId='"
+        + getTenantId()
+        + '\''
         + '}';
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -75,6 +75,12 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   }
 
   @Override
+  public String getTenantId() {
+    // todo(#13536): replace dummy implementation
+    return "";
+  }
+
+  @Override
   public String toString() {
     return "CreateProcessInstanceWithResultResponseImpl{"
         + "processDefinitionKey="
@@ -88,6 +94,9 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
         + processInstanceKey
         + ", variables='"
         + variables
+        + '\''
+        + ", tenantId='"
+        + getTenantId()
         + '\''
         + '}';
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DeploymentEventImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DeploymentEventImpl.java
@@ -88,6 +88,12 @@ public final class DeploymentEventImpl implements DeploymentEvent {
   }
 
   @Override
+  public String getTenantId() {
+    // todo(#13321): replace dummy implementation
+    return "";
+  }
+
+  @Override
   public String toString() {
     return "DeploymentEventImpl{"
         + "key="

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluateDecisionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluateDecisionResponseImpl.java
@@ -105,4 +105,10 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
   public String getFailureMessage() {
     return failureMessage;
   }
+
+  @Override
+  public String getTenantId() {
+    // todo(#13557): replace dummy implementation
+    return "";
+  }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/PublishMessageResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/PublishMessageResponseImpl.java
@@ -30,4 +30,10 @@ public final class PublishMessageResponseImpl implements PublishMessageResponse 
   public long getMessageKey() {
     return key;
   }
+
+  @Override
+  public String getTenantId() {
+    // todo(#13559): replace dummy implementation
+    return "";
+  }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/PublishMessageResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/PublishMessageResponseImpl.java
@@ -23,7 +23,7 @@ public final class PublishMessageResponseImpl implements PublishMessageResponse 
   private final long key;
 
   public PublishMessageResponseImpl(final GatewayOuterClass.PublishMessageResponse response) {
-    this.key = response.getKey();
+    key = response.getKey();
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
@@ -306,6 +306,7 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
         .isEqualTo(evaluateDecisionResponse.getFailedDecisionId());
     assertThat(response.getFailureMessage())
         .isEqualTo(evaluateDecisionResponse.getFailureMessage());
+    assertThat(response.getTenantId()).isEqualTo("");
 
     // assert EvaluatedDecision
     assertThat(response.getEvaluatedDecisions()).hasSize(1);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -102,6 +102,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob1.getVariables());
+    assertThat(job.getTenantId()).isEqualTo("");
 
     job = response.getJobs().get(1);
     assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
@@ -47,6 +47,7 @@ public final class BroadcastSignalTest extends ClientTest {
     final BroadcastSignalRequest request = gatewayService.getLastRequest();
     assertThat(request.getSignalName()).isEqualTo("name");
     assertThat(response.getKey()).isEqualTo(key);
+    assertThat(response.getTenantId()).isEqualTo("");
 
     rule.verifyDefaultRequestTimeout();
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceTest.java
@@ -54,6 +54,7 @@ public final class CreateProcessInstanceTest extends ClientTest {
     assertThat(response.getBpmnProcessId()).isEqualTo("testProcess");
     assertThat(response.getVersion()).isEqualTo(12);
     assertThat(response.getProcessInstanceKey()).isEqualTo(32);
+    assertThat(response.getTenantId()).isEqualTo("");
 
     final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
     assertThat(request.getProcessDefinitionKey()).isEqualTo(123);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceWithResultTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CreateProcessInstanceWithResultTest.java
@@ -53,6 +53,7 @@ public final class CreateProcessInstanceWithResultTest extends ClientTest {
     assertThat(response.getVariables()).isEqualTo(variables);
     final VariablesPojo result = response.getVariablesAsType(VariablesPojo.class);
     assertThat(result.getKey()).isEqualTo("val");
+    assertThat(response.getTenantId()).isEqualTo("");
 
     final CreateProcessInstanceWithResultRequest request = gatewayService.getLastRequest();
     assertThat(request.getRequest().getProcessDefinitionKey()).isEqualTo(123);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -58,6 +58,7 @@ public final class PublishMessageTest extends ClientTest {
     assertThat(request.getMessageId()).isEqualTo("theId");
     assertThat(request.getTimeToLive()).isEqualTo(Duration.ofDays(1).toMillis());
     assertThat(response.getMessageKey()).isEqualTo(messageKey);
+    assertThat(response.getTenantId()).isEqualTo("");
 
     rule.verifyDefaultRequestTimeout();
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/resource/DeployResourceTest.java
@@ -223,6 +223,7 @@ public final class DeployResourceTest extends ClientTest {
     assertThat(response.getKey()).isEqualTo(key);
     assertThat(response.getProcesses())
         .containsExactly(new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename));
+    assertThat(response.getTenantId()).isEqualTo("");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This is the fourth (and last) in several pull requests to:
- #13517

This pull request adds a new `getTenantId()` method to the command responses of the Java client. This allows users to understand which tenant owns the entity resulting from the command.

The method is only added to the responses of commands where the tenant can be explicitly set by the user or where the tenant is inferred from the access token. Those are:
- Create Process Instance
- Create Process Instance With Result
- Evaluate Decision
- Broadcast Signal
- Publish Message
- Activate Jobs (for each activated job individually)

In the commands where the tenant should already be clear, it is not provided. Specifically, those responses are typically completely empty anyways. The responses that are left unchanged are:
- Cancel Process Instance
- Modify Process Instance
- Delete Resource
- Complete Job
- Fail Job
- Update Job Retries
- Throw Error
- Resolve Incident
- Set Variables

I've considered Stream Jobs response out of scope, although those likely return the same response object as the response of the Activate Jobs command.

Again, please note that the new `getTenantId()` method does not really return a tenant identifier at this time. It only returns an empty string as dummy value. The feature is still under development. The API is added so others can already start using this method during development. I'll inform the relevant teams once this is available to them.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13564 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
