### PR TITLE
fix(release): increased maven & Go release timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
   release:
     name: Maven & Go Release
     runs-on: n1-standard-8-netssd-preempt-quick
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}
     env:


### PR DESCRIPTION
## Description

Runs seem to exceed the timeout of 30m occasionally due to varying upload speeds.
As a follow-up I'd like to check how to reduce the runtime actually ^^

e.g. here https://github.com/camunda/zeebe/actions/runs/5657914389/job/15328066085