### PR TITLE
Prevent exceeding max message size on job batch activate commands

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -16,6 +16,10 @@ public final class EngineConfiguration {
 
   public static final int DEFAULT_MAX_ERROR_MESSAGE_SIZE = 10000;
 
+  // This size (in bytes) is used as a buffer when filling an event/command up to the maximum
+  // message size.
+  public static final int BATCH_SIZE_CALCULATION_BUFFER = 1024 * 8;
+
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.msgpack.value.LongValue;
@@ -88,7 +89,10 @@ final class JobBatchCollector {
           // record we would add to the batch, the number of bytes taken by the additional job key,
           // as well as an 8 KB buffer.
           final var jobRecordLength = jobRecord.getLength();
-          final var expectedEventLength = record.getLength() + jobRecordLength + (1024 * 8);
+          final var expectedEventLength =
+              record.getLength()
+                  + jobRecordLength
+                  + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
           if (activatedCount.value <= maxActivatedCount
               && canWriteEventOfLength.test(expectedEventLength)) {
             appendJobToBatch(jobIterator, jobKeyIterator, jobCopyBuffer, key, jobRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -86,10 +86,9 @@ final class JobBatchCollector {
 
           // the expected length is based on the current record's length plus the length of the job
           // record we would add to the batch, the number of bytes taken by the additional job key,
-          // as well as one byte required per job key for its type header. if we ever add more, this
-          // should be updated accordingly.
+          // as well as an 8 KB buffer.
           final var jobRecordLength = jobRecord.getLength();
-          final var expectedEventLength = record.getLength() + jobRecordLength + Long.BYTES + 1;
+          final var expectedEventLength = record.getLength() + jobRecordLength + (1024 * 8);
           if (activatedCount.value <= maxActivatedCount
               && canWriteEventOfLength.test(expectedEventLength)) {
             appendJobToBatch(jobIterator, jobKeyIterator, jobCopyBuffer, key, jobRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ActivateProcessInstanceBatchProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ActivateProcessInstanceBatchProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -98,7 +99,9 @@ public final class ActivateProcessInstanceBatchProcessor
     // follow-up batch command. An excessive 8Kb is added to account for metadata. This is way
     // more than will be necessary.
     final var expectedCommandLength =
-        record.getLength() + childInstanceRecord.getLength() + (1024 * 8);
+        record.getLength()
+            + childInstanceRecord.getLength()
+            + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
     return commandWriter.canWriteCommandOfLength(expectedCommandLength);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/TerminateProcessInstanceBatchProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/TerminateProcessInstanceBatchProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -65,7 +66,9 @@ public final class TerminateProcessInstanceBatchProcessor
     // follow-up batch command. An excessive 8Kb is added to account for metadata. This is way
     // more than will be necessary.
     final var expectedCommandLength =
-        childInstance.getValue().getLength() + record.getLength() + (1024 * 8);
+        childInstance.getValue().getLength()
+            + record.getLength()
+            + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
     return commandWriter.canWriteCommandOfLength(expectedCommandLength);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.awaitility.Awaitility.await;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -390,7 +391,8 @@ public final class ActivateJobsTest {
 
     final long maxMessageSize = ByteValue.ofMegabytes(4);
     final long headerSize = ByteValue.ofKilobytes(2);
-    final long maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
+    final long maxRecordSize =
+        maxMessageSize - headerSize - EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
 
     final int variablesSize = (int) maxRecordSize / expectedJobsInBatch;
     final String variables = "{'key': '" + "x".repeat(variablesSize) + "'}";
@@ -412,7 +414,8 @@ public final class ActivateJobsTest {
     // given
     final var maxMessageSize = ByteValue.ofMegabytes(4);
     final var headerSize = ByteValue.ofKilobytes(2);
-    final var maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
+    final var maxRecordSize =
+        maxMessageSize - headerSize - EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
 
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -390,7 +390,7 @@ public final class ActivateJobsTest {
 
     final long maxMessageSize = ByteValue.ofMegabytes(4);
     final long headerSize = ByteValue.ofKilobytes(2);
-    final long maxRecordSize = maxMessageSize - headerSize;
+    final long maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
 
     final int variablesSize = (int) maxRecordSize / expectedJobsInBatch;
     final String variables = "{'key': '" + "x".repeat(variablesSize) + "'}";
@@ -412,7 +412,7 @@ public final class ActivateJobsTest {
     // given
     final var maxMessageSize = ByteValue.ofMegabytes(4);
     final var headerSize = ByteValue.ofKilobytes(2);
-    final var maxRecordSize = maxMessageSize - headerSize;
+    final var maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
 
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
@@ -272,7 +273,10 @@ final class JobBatchCollectorTest {
     // the expected length is then the length of the initial record + the length of the activated
     // job and an 8 KB buffer
     final var activatedJob = (JobRecord) record.getValue().getJobs().get(0);
-    final int expectedLength = initialLength + activatedJob.getLength() + (1024 * 8);
+    final int expectedLength =
+        initialLength
+            + activatedJob.getLength()
+            + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
     assertThat(estimatedLength.ref).isEqualTo(expectedLength);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -270,9 +270,9 @@ final class JobBatchCollectorTest {
 
     // then
     // the expected length is then the length of the initial record + the length of the activated
-    // job + the length of a key (long) and one byte for its list header
+    // job and an 8 KB buffer
     final var activatedJob = (JobRecord) record.getValue().getJobs().get(0);
-    final int expectedLength = initialLength + activatedJob.getLength() + 9;
+    final int expectedLength = initialLength + activatedJob.getLength() + (1024 * 8);
     assertThat(estimatedLength.ref).isEqualTo(expectedLength);
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
We've been seeing errors where we exceed the max message size upon a job batch activate command. This occurs when there is too many jobs in the command.

In this code we tried to be very clever and calculated the exact size the record could be before it would reach its limit. While this is nice, because it would allow for the largest batches, it is also very fault-sensitive. If anything changes in any of the records it would break the calculation, which will most definitely be missed.

With this commit I have given the expected event length a buffer of 8KB. This is the same buffer we use for PI batch activate/terminate.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12007 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
