### PR TITLE
[Backport stable/8.2] fix(release): increased maven & Go release timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
   release:
     name: Maven & Go Release
     runs-on: n1-standard-8-netssd-preempt-quick
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}
     env:


### PR DESCRIPTION
# Description
Backport of #13623 to `stable/8.2`.

relates to 