### PR TITLE
ci(release): use new stable release runner pool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   release:
     name: Maven & Go Release
-    runs-on: n1-standard-8-netssd-preempt-quick
+    runs-on: gcp-core-16-release
     timeout-minutes: 60
     outputs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}


### PR DESCRIPTION
## Description

We now have non preempt runners for the release, let's use them.

I also went for a bit more powerful node, it yields at least some gains on buildtime, that are welcome on the release which currently may take up to 30m. E.g. `Build Go Client & Zeebe` took [5m22s on this node ](https://github.com/camunda/zeebe/actions/runs/5658940152/job/15331375069) while it took [6m58s on the previous](https://github.com/camunda/zeebe/actions/runs/5657914389/job/15330888398)
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11359
