### PR TITLE
[Backport stable/8.0] ci(release): use new stable release runner pool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   release:
     name: Maven & Go Release
-    runs-on: n1-standard-8-netssd-preempt-quick
+    runs-on: gcp-core-16-release
     timeout-minutes: 60
     outputs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}


### PR DESCRIPTION
# Description
Backport of #13628 to `stable/8.0`.

relates to #11359