### PR TITLE
Add integration tests for Job Push

### DIFF
--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
@@ -181,10 +181,6 @@ public class StreamActivatedJobsTest extends GatewayTest {
             "INVALID_ARGUMENT: Expected to stream activated jobs with timeout to be greater than zero, but it was 0");
   }
 
-  // TODO add test for onClose
-  // How to test onClose? it seems the graceful way to close a stream from the client side is
-  // simply to cancel it, as per the gRPC docs. So is onClose only for when we close it server side?
-
   private TestStreamObserver getStreamActivatedJobsRequestUnblocking(
       final String jobType,
       final String worker,

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobPushIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobPushIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.process.test.assertions.BpmnAssert;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.record.RecordStream;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import io.zeebe.containers.engine.ContainerEngine;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.StreamSupport;
+import org.agrona.CloseHelper;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+final class JobPushIT {
+  private final Network network = Network.newNetwork();
+  private final ZeebeCluster cluster =
+      ZeebeCluster.builder()
+          .withBrokersCount(1)
+          .withGatewaysCount(1)
+          .withPartitionsCount(1)
+          .withEmbeddedGateway(false)
+          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+          .build();
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(cluster::getNodes);
+
+  @Container
+  private final ContainerEngine engine =
+      ContainerEngine.builder()
+          .withDebugReceiverPort(SocketUtil.getNextAddress().getPort())
+          .withCluster(cluster)
+          .withIdlePeriod(Duration.ofSeconds(5))
+          .build();
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(network);
+  }
+
+  @Test
+  void shouldStreamActivatedJobs() throws InterruptedException, TimeoutException {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("foo"))
+            .endEvent()
+            .done();
+
+    try (final var client = engine.createClient()) {
+      final var deploymentEvent =
+          client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+      // when
+      final List<ActivatedJob> jobs = new ArrayList<>();
+      client
+          .newStreamJobsCommand()
+          .jobType("foo")
+          .consumer(jobs::add)
+          .timeout(Duration.ofMinutes(2))
+          .send();
+
+      client
+          .newCreateInstanceCommand()
+          .processDefinitionKey(deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
+          .requestTimeout(Duration.ofMinutes(1))
+          .send()
+          .join();
+
+      // then
+      // wait for the record to be available and consumed
+      engine.waitForIdleState(Duration.ofSeconds(30));
+      assertThat(records())
+          .as("job should become activated immediately")
+          .extracting(Record::getValueType, Record::getIntent)
+          .containsSubsequence(Tuple.tuple(ValueType.JOB_BATCH, JobBatchIntent.ACTIVATED));
+      assertThat(jobs).hasSize(1);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private RecordStream records() {
+    return new RecordStream(
+        StreamSupport.stream(BpmnAssert.getRecordStream().records().spliterator(), false)
+            .map(r -> (Record<RecordValue>) r));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobPushIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobPushIT.java
@@ -42,9 +42,8 @@ final class JobPushIT {
   private final ZeebeCluster cluster =
       ZeebeCluster.builder()
           .withBrokersCount(1)
-          .withGatewaysCount(1)
           .withPartitionsCount(1)
-          .withEmbeddedGateway(false)
+          .withEmbeddedGateway(true)
           .withImage(ZeebeTestContainerDefaults.defaultTestImage())
           .build();
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

IT tests for the Job Push is missing. To cover the happy path scenario end to end, we need to implement IT tests. These cases should also cover closing a stream which will actually test the onClose hook. Please refer to these two discussions for more details:
https://github.com/camunda/zeebe/pull/13351#discussion_r1263414875
https://github.com/camunda/zeebe/pull/13351#discussion_r1263834385

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13516 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
