### PR TITLE
fix(broker): report health on change only

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -57,19 +58,12 @@ class ZeebePartitionHealth implements HealthMonitorable {
       healthReport = HealthReport.healthy(this);
     }
 
-    if (previousStatus != healthReport) {
+    if (!Objects.equals(previousStatus, healthReport)) {
       switch (healthReport.getStatus()) {
-        case HEALTHY:
-          failureListeners.forEach(FailureListener::onRecovered);
-          break;
-        case UNHEALTHY:
-          failureListeners.forEach((l) -> l.onFailure(healthReport));
-          break;
-        case DEAD:
-          failureListeners.forEach((l) -> l.onUnrecoverableFailure(healthReport));
-          break;
-        default:
-          break;
+        case HEALTHY -> failureListeners.forEach(FailureListener::onRecovered);
+        case UNHEALTHY -> failureListeners.forEach((l) -> l.onFailure(healthReport));
+        case DEAD -> failureListeners.forEach((l) -> l.onUnrecoverableFailure(healthReport));
+        default -> {}
       }
     }
   }


### PR DESCRIPTION
## Description

Previously every invocation of updateHealthStatus caused listeners to be called even if nothing changed.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13650 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark