### PR TITLE
[Backport] 13667 back to stable/8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,11 +473,12 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   auto-merge:
-    # This workflow will auto merge a PR authored by dependabot[bot]. It runs only on open PRs ready for
-    # review.
+    # This workflow will auto merge a PR authored by dependabot[bot] or backport-action.
+    # It runs only on open PRs ready for review.
     #
     # It will merge the PR only if: it is authored by dependabot[bot], is a patch semantic update, and
-    # all CI checks are successful (ignoring the soon-to-be-removed Jenkins check).
+    # all CI checks are successful.
+    # OR if it is authored by backport-action and all CI checks are successful.
     #
     # The workflow is divided into multiple sequential jobs to allow giving only minimal permissions to
     # the GitHub token passed around.
@@ -485,10 +486,10 @@ jobs:
     # Once we're using the merge queue feature, I think we can simplify this workflow a lot by relying
     # on dependabot merging PRs via its commands, as it will always wait for checks to be green before
     # merging.
-    name: Auto-merge dependabot PRs
+    name: Auto-merge dependabot and backport PRs
     runs-on: ubuntu-latest
     needs: [ test-summary ]
-    if: github.repository == 'camunda/zeebe' && github.actor == 'dependabot[bot]'
+    if: github.repository == 'camunda/zeebe' && (github.actor == 'dependabot[bot]' || github.actor == 'backport-action')
     permissions:
       checks: read
       pull-requests: write
@@ -499,9 +500,15 @@ jobs:
         uses: dependabot/fetch-metadata@v1.3.6
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - id: approve-and-merge
-        name: Approve and merge PR
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+      - id: approve-and-merge-dependabot
+        name: Approve and merge dependabot PR
+        if: github.actor == 'dependabot[bot]' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+      - id: approve-and-merge-backport
+        name: Approve and merge backport PR
+        if: github.actor == 'backport-action'
         run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
         env:
           GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
Backport of #13667 

Merge-conflict because stable branch didn't auto merge when it was a minor version update. However, we can keep this here without a problem. This prevents backport conflicts in the future.
It's no problem keeping it here as we ignore minor versions for stable branches as configured [here](https://github.com/camunda/zeebe/blob/main/.github/dependabot.yml#L82-L83).