### PR TITLE
[Backport stable/8.0] Prevent exceeding max message size on job batch activate commands

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -87,10 +87,9 @@ final class JobBatchCollector {
 
           // the expected length is based on the current record's length plus the length of the job
           // record we would add to the batch, the number of bytes taken by the additional job key,
-          // as well as one byte required per job key for its type header. if we ever add more, this
-          // should be updated accordingly.
+          // as well as an 8 KB buffer.
           final var jobRecordLength = jobRecord.getLength();
-          final var expectedEventLength = record.getLength() + jobRecordLength + Long.BYTES + 1;
+          final var expectedEventLength = record.getLength() + jobRecordLength + (1024 * 8);
           if (activatedCount.value <= maxActivatedCount
               && canWriteEventOfLength.test(expectedEventLength)) {
             appendJobToBatch(jobIterator, jobKeyIterator, jobCopyBuffer, key, jobRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -89,10 +89,7 @@ final class JobBatchCollector {
           // record we would add to the batch, the number of bytes taken by the additional job key,
           // as well as an 8 KB buffer.
           final var jobRecordLength = jobRecord.getLength();
-          final var expectedEventLength =
-              record.getLength()
-                  + jobRecordLength
-                  + (1024 * 8);
+          final var expectedEventLength = record.getLength() + jobRecordLength + (1024 * 8);
           if (activatedCount.value <= maxActivatedCount
               && canWriteEventOfLength.test(expectedEventLength)) {
             appendJobToBatch(jobIterator, jobKeyIterator, jobCopyBuffer, key, jobRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -89,7 +89,10 @@ final class JobBatchCollector {
           // record we would add to the batch, the number of bytes taken by the additional job key,
           // as well as an 8 KB buffer.
           final var jobRecordLength = jobRecord.getLength();
-          final var expectedEventLength = record.getLength() + jobRecordLength + (1024 * 8);
+          final var expectedEventLength =
+              record.getLength()
+                  + jobRecordLength
+                  + (1024 * 8);
           if (activatedCount.value <= maxActivatedCount
               && canWriteEventOfLength.test(expectedEventLength)) {
             appendJobToBatch(jobIterator, jobKeyIterator, jobCopyBuffer, key, jobRecord);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -391,7 +391,7 @@ public final class ActivateJobsTest {
 
     final long maxMessageSize = ByteValue.ofMegabytes(4);
     final long headerSize = ByteValue.ofKilobytes(2);
-    final long maxRecordSize = maxMessageSize - headerSize;
+    final long maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
 
     final int variablesSize = (int) maxRecordSize / expectedJobsInBatch;
     final String variables = "{'key': '" + "x".repeat(variablesSize) + "'}";
@@ -413,7 +413,7 @@ public final class ActivateJobsTest {
     // given
     final var maxMessageSize = ByteValue.ofMegabytes(4);
     final var headerSize = ByteValue.ofKilobytes(2);
-    final var maxRecordSize = maxMessageSize - headerSize;
+    final var maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
 
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -270,9 +270,9 @@ final class JobBatchCollectorTest {
 
     // then
     // the expected length is then the length of the initial record + the length of the activated
-    // job + the length of a key (long) and one byte for its list header
+    // job and an 8 KB buffer
     final var activatedJob = (JobRecord) record.getValue().getJobs().get(0);
-    final int expectedLength = initialLength + activatedJob.getLength() + 9;
+    final int expectedLength = initialLength + activatedJob.getLength() + (1024 * 8);
     assertThat(estimatedLength.ref).isEqualTo(expectedLength);
   }
 


### PR DESCRIPTION
# Description
Backport of #13624 to `stable/8.2`.

relates to #12007

This could not be auto merged because some classes didn't exist. One of which was the `EngineConfiguration` as a result I decided to hardcode (1024 * 8). This version will be unsupported in a few months anyway.