### PR TITLE
[Backport stable/8.2] Prevent exceeding max message size on job batch activate commands

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -16,6 +16,10 @@ public final class EngineConfiguration {
 
   public static final int DEFAULT_MAX_ERROR_MESSAGE_SIZE = 10000;
 
+  // This size (in bytes) is used as a buffer when filling an event/command up to the maximum
+  // message size.
+  public static final int BATCH_SIZE_CALCULATION_BUFFER = 1024 * 8;
+
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
@@ -89,7 +90,10 @@ final class JobBatchCollector {
           // record we would add to the batch, the number of bytes taken by the additional job key,
           // as well as an 8 KB buffer.
           final var jobRecordLength = jobRecord.getLength();
-          final var expectedEventLength = record.getLength() + jobRecordLength + (1024 * 8);
+          final var expectedEventLength =
+              record.getLength()
+                  + jobRecordLength
+                  + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
           if (activatedCount.value <= maxActivatedCount
               && canWriteEventOfLength.test(expectedEventLength)) {
             appendJobToBatch(jobIterator, jobKeyIterator, jobCopyBuffer, key, jobRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -87,10 +87,9 @@ final class JobBatchCollector {
 
           // the expected length is based on the current record's length plus the length of the job
           // record we would add to the batch, the number of bytes taken by the additional job key,
-          // as well as one byte required per job key for its type header. if we ever add more, this
-          // should be updated accordingly.
+          // as well as an 8 KB buffer.
           final var jobRecordLength = jobRecord.getLength();
-          final var expectedEventLength = record.getLength() + jobRecordLength + Long.BYTES + 1;
+          final var expectedEventLength = record.getLength() + jobRecordLength + (1024 * 8);
           if (activatedCount.value <= maxActivatedCount
               && canWriteEventOfLength.test(expectedEventLength)) {
             appendJobToBatch(jobIterator, jobKeyIterator, jobCopyBuffer, key, jobRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ActivateProcessInstanceBatchProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ActivateProcessInstanceBatchProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -98,7 +99,9 @@ public final class ActivateProcessInstanceBatchProcessor
     // follow-up batch command. An excessive 8Kb is added to account for metadata. This is way
     // more than will be necessary.
     final var expectedCommandLength =
-        record.getLength() + childInstanceRecord.getLength() + (1024 * 8);
+        record.getLength()
+            + childInstanceRecord.getLength()
+            + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
     return commandWriter.canWriteCommandOfLength(expectedCommandLength);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/TerminateProcessInstanceBatchProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/TerminateProcessInstanceBatchProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -65,7 +66,9 @@ public final class TerminateProcessInstanceBatchProcessor
     // follow-up batch command. An excessive 8Kb is added to account for metadata. This is way
     // more than will be necessary.
     final var expectedCommandLength =
-        childInstance.getValue().getLength() + record.getLength() + (1024 * 8);
+        childInstance.getValue().getLength()
+            + record.getLength()
+            + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
     return commandWriter.canWriteCommandOfLength(expectedCommandLength);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.awaitility.Awaitility.await;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -390,7 +391,8 @@ public final class ActivateJobsTest {
 
     final long maxMessageSize = ByteValue.ofMegabytes(4);
     final long headerSize = ByteValue.ofKilobytes(2);
-    final long maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
+    final long maxRecordSize =
+        maxMessageSize - headerSize - EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
 
     final int variablesSize = (int) maxRecordSize / expectedJobsInBatch;
     final String variables = "{'key': '" + "x".repeat(variablesSize) + "'}";
@@ -412,7 +414,8 @@ public final class ActivateJobsTest {
     // given
     final var maxMessageSize = ByteValue.ofMegabytes(4);
     final var headerSize = ByteValue.ofKilobytes(2);
-    final var maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
+    final var maxRecordSize =
+        maxMessageSize - headerSize - EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
 
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -390,7 +390,7 @@ public final class ActivateJobsTest {
 
     final long maxMessageSize = ByteValue.ofMegabytes(4);
     final long headerSize = ByteValue.ofKilobytes(2);
-    final long maxRecordSize = maxMessageSize - headerSize;
+    final long maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
 
     final int variablesSize = (int) maxRecordSize / expectedJobsInBatch;
     final String variables = "{'key': '" + "x".repeat(variablesSize) + "'}";
@@ -412,7 +412,7 @@ public final class ActivateJobsTest {
     // given
     final var maxMessageSize = ByteValue.ofMegabytes(4);
     final var headerSize = ByteValue.ofKilobytes(2);
-    final var maxRecordSize = maxMessageSize - headerSize;
+    final var maxRecordSize = maxMessageSize - headerSize - (1024 * 8);
 
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
@@ -272,7 +273,10 @@ final class JobBatchCollectorTest {
     // the expected length is then the length of the initial record + the length of the activated
     // job and an 8 KB buffer
     final var activatedJob = (JobRecord) record.getValue().getJobs().get(0);
-    final int expectedLength = initialLength + activatedJob.getLength() + (1024 * 8);
+    final int expectedLength =
+        initialLength
+            + activatedJob.getLength()
+            + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
     assertThat(estimatedLength.ref).isEqualTo(expectedLength);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -270,9 +270,9 @@ final class JobBatchCollectorTest {
 
     // then
     // the expected length is then the length of the initial record + the length of the activated
-    // job + the length of a key (long) and one byte for its list header
+    // job and an 8 KB buffer
     final var activatedJob = (JobRecord) record.getValue().getJobs().get(0);
-    final int expectedLength = initialLength + activatedJob.getLength() + 9;
+    final int expectedLength = initialLength + activatedJob.getLength() + (1024 * 8);
     assertThat(estimatedLength.ref).isEqualTo(expectedLength);
   }
 


### PR DESCRIPTION
# Description
Backport of #13624 to `stable/8.2`.

relates to #12007