### PR TITLE
test(stream-platform): clear mock invocations to prevent memory leak

### DIFF
--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
@@ -121,6 +121,7 @@ public class StreamPlatformExtension implements BeforeEachCallback {
       Collections.reverse(closables);
       CloseHelper.quietCloseAll(closables);
       closables.clear();
+      streamPlatform.resetMockInvocations();
       streamPlatform = null;
     }
   }


### PR DESCRIPTION
I was trying to run some tests that make use of `StreamPlatformExtension` repeatedly to reproduce a flaky test. That's when I noticed that memory usage was consistently climbing. It looks like we were leaking a lot of the actor scheduler state (and probably more) through the mocks set up in `StreamPlatformExtension`. Clearing the invocations helped a lot, memory usage now appears to be stable, even after hundreds of runs.