### PR TITLE
[Backport stable/8.2] test(stream-platform): clear mock invocations to prevent memory leak

### DIFF
--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
@@ -121,6 +121,7 @@ public class StreamPlatformExtension implements BeforeEachCallback {
       Collections.reverse(closables);
       CloseHelper.quietCloseAll(closables);
       closables.clear();
+      streamPlatform.resetMockInvocations();
       streamPlatform = null;
     }
   }


### PR DESCRIPTION
# Description
Backport of #13698 to `stable/8.2`.

relates to 