### PR TITLE
Distribute broadcasted signal to other partitions

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -161,7 +161,12 @@ public final class EngineProcessors {
         bpmnBehaviors.jobActivationBehavior());
     addResourceDeletionProcessors(
         typedRecordProcessors, writers, processingState, commandDistributionBehavior);
-    addSignalBroadcastProcessors(typedRecordProcessors, bpmnBehaviors, writers, processingState);
+    addSignalBroadcastProcessors(
+        typedRecordProcessors,
+        bpmnBehaviors,
+        writers,
+        processingState,
+        commandDistributionBehavior);
     addCommandDistributionProcessors(
         typedRecordProcessors,
         writers,
@@ -323,7 +328,8 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final BpmnBehaviorsImpl bpmnBehaviors,
       final Writers writers,
-      final MutableProcessingState processingState) {
+      final MutableProcessingState processingState,
+      final CommandDistributionBehavior commandDistributionBehavior) {
     final var signalBroadcastProcessor =
         new SignalBroadcastProcessor(
             writers,
@@ -332,7 +338,8 @@ public final class EngineProcessors {
             processingState.getProcessState(),
             bpmnBehaviors.stateBehavior(),
             bpmnBehaviors.eventTriggerBehavior(),
-            processingState.getSignalSubscriptionState());
+            processingState.getSignalSubscriptionState(),
+            commandDistributionBehavior);
     typedRecordProcessors.onCommand(
         ValueType.SIGNAL, SignalIntent.BROADCAST, signalBroadcastProcessor);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.engine.processing.signal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.SignalClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BroadcastSignalMultiplePartitionsTest {
+
+  public static final String PROCESS_ID = "process";
+  public static final int PARTITION_COUNT = 3;
+  @ClassRule public static final EngineRule ENGINE = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  private static final String SIGNAL_NAME = "a";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private final SignalClient signalClient = ENGINE.signal().withSignalName(SIGNAL_NAME);
+
+  @Test
+  public void shouldWriteDistributingRecordsForOtherPartitions() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().signal(SIGNAL_NAME).endEvent().done();
+    // when
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // then
+    final var signalKey = signalClient.broadcast().getKey();
+    final var commandDistributionRecords =
+        RecordingExporter.commandDistributionRecords()
+            .withIntent(CommandDistributionIntent.DISTRIBUTING)
+            .valueFilter(v -> v.getValueType().equals(ValueType.SIGNAL))
+            .limit(2)
+            .asList();
+
+    assertThat(commandDistributionRecords).extracting(Record::getKey).containsOnly(signalKey);
+
+    assertThat(commandDistributionRecords)
+        .extracting(Record::getValue)
+        .extracting(CommandDistributionRecordValue::getPartitionId)
+        .containsExactly(2, 3);
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -33,6 +34,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   static {
     RECORDS_BY_TYPE.put(ValueType.DEPLOYMENT, DeploymentRecord::new);
     RECORDS_BY_TYPE.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.SIGNAL, SignalRecord::new);
   }
 
   /*


### PR DESCRIPTION
## Description
Distribute broadcasted signal to other partitions.

## Related issues

closes #13242

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
