### PR TITLE
Prototype - refactor(engine): cache parsed DMN graphs

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+
+public final class CachesCfg implements ConfigurationEntry {
+  private int dmnParsedDecisionGraphCacheCapacity =
+      EngineConfiguration.DEFAULT_DMN_PARSED_DECISION_GRAPH_CACHE_CAPACITY;
+
+  public int getDmnParsedDecisionGraphCacheCapacity() {
+    return dmnParsedDecisionGraphCacheCapacity;
+  }
+
+  public void setDmnParsedDecisionGraphCacheCapacity(
+      final int dmnParsedDecisionGraphCacheCapacity) {
+    this.dmnParsedDecisionGraphCacheCapacity = dmnParsedDecisionGraphCacheCapacity;
+  }
+
+  @Override
+  public String toString() {
+    return "CachesCfg{"
+        + "dmnParsedDecisionGraphCacheCapacity="
+        + dmnParsedDecisionGraphCacheCapacity
+        + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 public final class EngineCfg implements ConfigurationEntry {
 
   private MessagesCfg messages = new MessagesCfg();
+  private CachesCfg caches = new CachesCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -28,14 +29,23 @@ public final class EngineCfg implements ConfigurationEntry {
     this.messages = messages;
   }
 
+  public CachesCfg getCaches() {
+    return caches;
+  }
+
+  public void setCaches(final CachesCfg caches) {
+    this.caches = caches;
+  }
+
   @Override
   public String toString() {
-    return "EngineCfg{" + "messages=" + messages + '}';
+    return "EngineCfg{" + "messages=" + messages + ", caches=" + caches + '}';
   }
 
   public EngineConfiguration createEngineConfiguration() {
     return new EngineConfiguration()
         .setMessagesTtlCheckerBatchLimit(messages.getTtlCheckerBatchLimit())
-        .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval());
+        .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval())
+        .setDmnParsedDecisionGraphCacheCapacity(caches.getDmnParsedDecisionGraphCacheCapacity());
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -29,6 +29,7 @@ final class EngineCfgTest {
     // then
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofMinutes(1));
+    assertThat(configuration.getDmnParsedDecisionGraphCacheCapacity()).isEqualTo(5000L);
   }
 
   @Test
@@ -42,5 +43,6 @@ final class EngineCfgTest {
     // then
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(1000);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofSeconds(15));
+    assertThat(configuration.getDmnParsedDecisionGraphCacheCapacity()).isEqualTo(10000L);
   }
 }

--- a/broker/src/test/resources/system/engine.yaml
+++ b/broker/src/test/resources/system/engine.yaml
@@ -5,3 +5,4 @@ zeebe:
         messages:
           ttlCheckerBatchLimit: 1000
           ttlCheckerInterval: 15s
+        dmnParsedDecisionGraphCacheCapacity: 10000

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -952,6 +952,12 @@
         # enabled: false
 
       # engine:
+        # caches:
+          # Allows to configure the size of an LRU cache used to hold parsed dmn decision graphs.
+          # The cache significantly improves the processling latency of DMN tasks and should be tuned
+          # to be able to hold frequently processed DMN models.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_DMNPARSEDDECISIONGRAPHCACHECAPACITY
+          # dmnParsedDecisionGraphCacheCapacity: 5000
         # messages:
           # Allows to configure the Message TTL Checker's batch limit. This is the number of buffered
           # messages that it can expire in a single batch. When it reaches this limit, it expires

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -36,8 +36,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
     </dependency>
 
     <dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -36,6 +36,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -19,9 +19,13 @@ public final class EngineConfiguration {
   // This size (in bytes) is used as a buffer when filling an event/command up to the maximum
   // message size.
   public static final int BATCH_SIZE_CALCULATION_BUFFER = 1024 * 8;
+  public static final int DEFAULT_DMN_PARSED_DECISION_GRAPH_CACHE_CAPACITY = 5000;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
+
+  private int dmnParsedDecisionGraphCacheCapacity =
+      DEFAULT_DMN_PARSED_DECISION_GRAPH_CACHE_CAPACITY;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -40,6 +44,16 @@ public final class EngineConfiguration {
   public EngineConfiguration setMessagesTtlCheckerInterval(
       final Duration messagesTtlCheckerInterval) {
     this.messagesTtlCheckerInterval = messagesTtlCheckerInterval;
+    return this;
+  }
+
+  public int getDmnParsedDecisionGraphCacheCapacity() {
+    return dmnParsedDecisionGraphCacheCapacity;
+  }
+
+  public EngineConfiguration setDmnParsedDecisionGraphCacheCapacity(
+      final int dmnParsedDecisionGraphCacheCapacity) {
+    this.dmnParsedDecisionGraphCacheCapacity = dmnParsedDecisionGraphCacheCapacity;
     return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -65,7 +65,6 @@ public final class EngineProcessors {
       final InterPartitionCommandSender interPartitionCommandSender,
       final FeatureFlags featureFlags,
       final JobStreamer jobStreamer) {
-
     final var processingState = typedRecordProcessorContext.getProcessingState();
     final var scheduledTaskStateFactory =
         typedRecordProcessorContext.getScheduledTaskStateFactory();
@@ -91,7 +90,10 @@ public final class EngineProcessors {
 
     final var decisionBehavior =
         new DecisionBehavior(
-            DecisionEngineFactory.createDecisionEngine(), processingState, processEngineMetrics);
+            typedRecordProcessorContext.getConfig(),
+            DecisionEngineFactory.createDecisionEngine(),
+            processingState,
+            processEngineMetrics);
     final BpmnBehaviorsImpl bpmnBehaviors =
         createBehaviors(
             processingState,

--- a/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineParallelDmnTaskPerformanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineParallelDmnTaskPerformanceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.model.bpmn.builder.BusinessRuleTaskBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.clock.DefaultActorClock;
+import io.camunda.zeebe.test.util.AutoCloseableRule;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.junit.rules.TemporaryFolder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Warmup(iterations = 25, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10_000, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class EngineParallelDmnTaskPerformanceTest {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(EngineParallelDmnTaskPerformanceTest.class.getName());
+  public static final String DECISION_ID = "jedi_or_sith";
+  public static final String END_EVENT = "end";
+  private static final String DMN_RESOURCE = "/dmn/drg-force-user.dmn";
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String RESULT_VARIABLE = "result";
+  private long count;
+  private ProcessInstanceClient processInstanceClient;
+  private TestContext testContext;
+  private TestEngine singlePartitionEngine;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = createTestContext();
+
+    singlePartitionEngine = TestEngine.createSinglePartitionEngine(testContext);
+
+    setupState(singlePartitionEngine);
+  }
+
+  /** Will build up a state for the large state performance test */
+  private void setupState(final TestEngine singlePartitionEngine) {
+    AbstractFlowNodeBuilder<?, ?> processBuilder =
+        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().parallelGateway();
+
+    final int numberOfDmnTasks = 10;
+    for (int i = 0; i < numberOfDmnTasks; i++) {
+      processBuilder = processBuilder.businessRuleTask(TASK_ID + i, createBusinessRuleTask());
+
+      if (i < numberOfDmnTasks - 1) {
+        processBuilder = processBuilder.moveToLastGateway();
+      }
+    }
+
+    final BpmnModelInstance model = processBuilder.endEvent(END_EVENT).done();
+
+    singlePartitionEngine
+        .createDeploymentClient()
+        .withXmlClasspathResource(DMN_RESOURCE)
+        .withXmlResource(model)
+        .deploy();
+
+    processInstanceClient = singlePartitionEngine.createProcessInstanceClient();
+  }
+
+  private static Consumer<BusinessRuleTaskBuilder> createBusinessRuleTask() {
+    return t -> t.zeebeCalledDecisionId(DECISION_ID).zeebeResultVariable(RESULT_VARIABLE);
+  }
+
+  private TestContext createTestContext() throws IOException {
+    final var autoCloseableRule = new AutoCloseableRule();
+    final var temporaryFolder = new TemporaryFolder();
+    temporaryFolder.create();
+
+    // scheduler
+    final var builder =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(1)
+            .setIoBoundActorThreadCount(1)
+            .setActorClock(new DefaultActorClock());
+
+    final var actorScheduler = builder.build();
+    autoCloseableRule.manage(actorScheduler);
+    actorScheduler.start();
+    return new TestContext(actorScheduler, temporaryFolder, autoCloseableRule);
+  }
+
+  @TearDown
+  public void tearDown() {
+    LOG.info("Started {} process instances", count);
+    testContext.autoCloseableRule().after();
+  }
+
+  @Benchmark
+  public Record<?> measureProcessExecutionTime() {
+    final long piKey =
+        processInstanceClient
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    final Record<ProcessInstanceRecordValue> record =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(piKey)
+            .withElementType(BpmnElementType.END_EVENT)
+            .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .getFirst();
+
+    count++;
+    singlePartitionEngine.reset();
+    return record;
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineSingleDmnTaskPerformanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineSingleDmnTaskPerformanceTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.BusinessRuleTaskBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.clock.DefaultActorClock;
+import io.camunda.zeebe.test.util.AutoCloseableRule;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.junit.rules.TemporaryFolder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Warmup(iterations = 25, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10_000, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx1g", "-Xms1g"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class EngineSingleDmnTaskPerformanceTest {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(EngineSingleDmnTaskPerformanceTest.class.getName());
+  public static final String DECISION_ID = "jedi_or_sith";
+  public static final String END_EVENT = "end";
+  private static final String DMN_RESOURCE = "/dmn/drg-force-user.dmn";
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String RESULT_VARIABLE = "result";
+  private long count;
+  private ProcessInstanceClient processInstanceClient;
+  private TestContext testContext;
+  private TestEngine singlePartitionEngine;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = createTestContext();
+
+    singlePartitionEngine = TestEngine.createSinglePartitionEngine(testContext);
+
+    setupState(singlePartitionEngine);
+  }
+
+  /** Will build up a state for the large state performance test */
+  private void setupState(final TestEngine singlePartitionEngine) {
+
+    singlePartitionEngine
+        .createDeploymentClient()
+        .withXmlClasspathResource(DMN_RESOURCE)
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .businessRuleTask(TASK_ID, createBusinessRuleTask())
+                .endEvent(END_EVENT)
+                .done())
+        .deploy();
+
+    processInstanceClient = singlePartitionEngine.createProcessInstanceClient();
+  }
+
+  private static Consumer<BusinessRuleTaskBuilder> createBusinessRuleTask() {
+    return t -> t.zeebeCalledDecisionId(DECISION_ID).zeebeResultVariable(RESULT_VARIABLE);
+  }
+
+  private TestContext createTestContext() throws IOException {
+    final var autoCloseableRule = new AutoCloseableRule();
+    final var temporaryFolder = new TemporaryFolder();
+    temporaryFolder.create();
+
+    // scheduler
+    final var builder =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(1)
+            .setIoBoundActorThreadCount(1)
+            .setActorClock(new DefaultActorClock());
+
+    final var actorScheduler = builder.build();
+    autoCloseableRule.manage(actorScheduler);
+    actorScheduler.start();
+    return new TestContext(actorScheduler, temporaryFolder, autoCloseableRule);
+  }
+
+  @TearDown
+  public void tearDown() {
+    LOG.info("Started {} process instances", count);
+    testContext.autoCloseableRule().after();
+  }
+
+  @Benchmark
+  public Record<?> measureProcessExecutionTime() {
+    final long piKey =
+        processInstanceClient
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    final Record<ProcessInstanceRecordValue> record =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(piKey)
+            .withElementType(BpmnElementType.END_EVENT)
+            .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .getFirst();
+
+    count++;
+    singlePartitionEngine.reset();
+    return record;
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/perf/JMHEnginePerformanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/perf/JMHEnginePerformanceTest.java
@@ -24,7 +24,7 @@ public class JMHEnginePerformanceTest {
   private static final double MAX_DEVIATION = 0.15; // 15% of deviation is allowed
 
   @Test
-  public void runJmhBenchmark() throws RunnerException {
+  public void runLargeStateJmhBenchmark() throws RunnerException {
     // given
     final var opt =
         new OptionsBuilder().include(EngineLargeStatePerformanceTest.class.getSimpleName()).build();
@@ -37,6 +37,44 @@ public class JMHEnginePerformanceTest {
       // we are fine with around 10 percent deviation but not more
       assertDeviationWithin(runResult, REFERENCE_SCORE, MAX_DEVIATION);
     }
+  }
+
+  @Test
+  public void runSingleDmnTaskBenchmark() throws RunnerException {
+    // given
+    final var opt =
+        new OptionsBuilder()
+            .include(EngineSingleDmnTaskPerformanceTest.class.getSimpleName())
+            .build();
+
+    // when
+    // TODO setup assert
+    //    final var runResults =
+    new Runner(opt).run();
+
+    // then
+    //    for (final RunResult runResult : runResults) {
+    //      assertDeviationWithin(runResult, 3, 0.5);
+    //    }
+  }
+
+  @Test
+  public void runParallelDmnTaskBenchmark() throws RunnerException {
+    // given
+    final var opt =
+        new OptionsBuilder()
+            .include(EngineParallelDmnTaskPerformanceTest.class.getSimpleName())
+            .build();
+
+    // when
+    // TODO setup assert
+    //    final var runResults =
+    new Runner(opt).run();
+
+    // then
+    //    for (final RunResult runResult : runResults) {
+    //      assertDeviationWithin(runResult, 3, 0.5);
+    //    }
   }
 
   private static void assertDeviationWithin(
@@ -52,7 +90,7 @@ public class JMHEnginePerformanceTest {
 
               return String.format(
                   "Expected reference score is '%.2f' got '%.2f', deviation %s exceeds maximum allowed deviation %s",
-                  REFERENCE_SCORE, score, deviationString, maxDeviationString);
+                  referenceScore, score, deviationString, maxDeviationString);
             })
         .isLessThan(maxDeviation);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/perf/JMHEnginePerformanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/perf/JMHEnginePerformanceTest.java
@@ -52,7 +52,7 @@ public class JMHEnginePerformanceTest {
 
     // then
     for (final RunResult runResult : runResults) {
-      assertDeviationWithin(runResult, 1, 0.25);
+      assertDeviationWithin(runResult, 1.25, 0.25);
     }
   }
 
@@ -69,7 +69,7 @@ public class JMHEnginePerformanceTest {
 
     // then
     for (final RunResult runResult : runResults) {
-      assertDeviationWithin(runResult, 3.5, 0.25);
+      assertDeviationWithin(runResult, 4, 0.5);
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/perf/JMHEnginePerformanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/perf/JMHEnginePerformanceTest.java
@@ -48,14 +48,12 @@ public class JMHEnginePerformanceTest {
             .build();
 
     // when
-    // TODO setup assert
-    //    final var runResults =
-    new Runner(opt).run();
+    final var runResults = new Runner(opt).run();
 
     // then
-    //    for (final RunResult runResult : runResults) {
-    //      assertDeviationWithin(runResult, 3, 0.5);
-    //    }
+    for (final RunResult runResult : runResults) {
+      assertDeviationWithin(runResult, 1, 0.25);
+    }
   }
 
   @Test
@@ -67,14 +65,12 @@ public class JMHEnginePerformanceTest {
             .build();
 
     // when
-    // TODO setup assert
-    //    final var runResults =
-    new Runner(opt).run();
+    final var runResults = new Runner(opt).run();
 
     // then
-    //    for (final RunResult runResult : runResults) {
-    //      assertDeviationWithin(runResult, 3, 0.5);
-    //    }
+    for (final RunResult runResult : runResults) {
+      assertDeviationWithin(runResult, 3.5, 0.25);
+    }
   }
 
   private static void assertDeviationWithin(

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,6 +39,7 @@
     <version.assertj>3.24.2</version.assertj>
     <version.awaitility>4.2.0</version.awaitility>
     <version.bouncycastle>1.70</version.bouncycastle>
+    <version.caffeine>3.1.6</version.caffeine>
     <version.camunda>7.19.0</version.camunda>
     <version.checkstyle>10.12.1</version.checkstyle>
     <version.commons-lang>3.13.0</version.commons-lang>
@@ -514,6 +515,12 @@
         <groupId>org.agrona</groupId>
         <artifactId>agrona</artifactId>
         <version>${version.agrona}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${version.caffeine}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

**Before caching:**

Result "io.camunda.zeebe.engine.perf.EngineSingleDmnTaskPerformanceTest.measureProcessExecutionTime":
  3.749 ±(99.9%) 0.025 ms/op [Average]
  (min, avg, max) = (2.946, 3.749, 12.911), stdev = 0.761
  CI (99.9%): [3.724, 3.774] (assumes normal distribution)

Result "io.camunda.zeebe.engine.perf.EngineParallelDmnTaskPerformanceTest.measureProcessExecutionTime":
  26.837 ±(99.9%) 0.057 ms/op [Average]
  (min, avg, max) = (24.374, 26.837, 50.751), stdev = 1.744
  CI (99.9%): [26.779, 26.894] (assumes normal distribution)

**With parsed Dmn cache**

Result "io.camunda.zeebe.engine.perf.EngineSingleDmnTaskPerformanceTest.measureProcessExecutionTime":
  0.950 ±(99.9%) 0.016 ms/op [Average]
  (min, avg, max) = (0.651, 0.950, 11.944), stdev = 0.498
  CI (99.9%): [0.934, 0.967] (assumes normal distribution)

Result "io.camunda.zeebe.engine.perf.EngineParallelDmnTaskPerformanceTest.measureProcessExecutionTime":
  3.445 ±(99.9%) 0.023 ms/op [Average]
  (min, avg, max) = (2.746, 3.445, 23.453), stdev = 0.707
  CI (99.9%): [3.421, 3.468] (assumes normal distribution)
  
Summary:
**Single DMN Task Process P99.9 latency went down by 75%/ 4 times faster**
**10 Parallel DMN Task Process P99.9 latency went down by 87%/ 7-8 times faster**

## Related issues

relates #8571
