### PR TITLE
[Backport stable/8.1] fix(broker): ensure that failure in transition to `INACTIVE` isn't ignored

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransitionException;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.HealthIssue;
 
 public interface PartitionTransition {
@@ -75,7 +76,7 @@ public interface PartitionTransition {
    * not complete successfully. This is useful to distinguish between transitions that were prepared
    * but later failed or were cancelled, and transitions that couldn't even be prepared properly.
    */
-  final class FailedPartitionTransitionPreparation extends RuntimeException {
+  final class FailedPartitionTransitionPreparation extends UnrecoverableException {
     public FailedPartitionTransitionPreparation(final Throwable cause) {
       super("Preparing for partition transition failed", cause);
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -477,9 +477,17 @@ public final class ZeebePartition extends Actor
     // We do not want to mark it as unhealthy, hence we don't reuse transitionToInactive()
     actor.run(
         () -> {
-          if (!closing) {
-            transition.toInactive(context.getCurrentTerm());
+          if (closing) {
+            return;
           }
+          transition
+              .toInactive(context.getCurrentTerm())
+              .onComplete(
+                  (success, error) -> {
+                    if (error != null) {
+                      onInstallFailure(error);
+                    }
+                  });
         });
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -281,7 +281,14 @@ public final class ZeebePartition extends Actor
 
   private ActorFuture<Void> transitionToInactive() {
     zeebePartitionHealth.setServicesInstalled(false);
-    return transition.toInactive(context.getCurrentTerm());
+    final var transitionFuture = transition.toInactive(context.getCurrentTerm());
+    transitionFuture.onComplete(
+        (success, error) -> {
+          if (error != null) {
+            onInstallFailure(error);
+          }
+        });
+    return transitionFuture;
   }
 
   private void registerListeners() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
-import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -43,7 +42,7 @@ class ZeebePartitionHealth implements HealthMonitorable {
 
   private void updateHealthStatus() {
     final HealthReport previousStatus = healthReport;
-    if (healthReport != null && previousStatus.getStatus() == HealthStatus.DEAD) {
+    if (previousStatus != null && previousStatus.isDead()) {
       return;
     }
 

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -189,7 +189,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
         return;
       }
 
-      log.warn("{} failed, marking it as unhealthy: {}", componentName, healthReport);
+      log.warn("{} failed, marking it as unhealthy: {}", componentName, report);
       componentHealth.put(componentName, report);
       calculateHealth();
     }


### PR DESCRIPTION
# Description
Backport of #13608 to `stable/8.1`.

relates to 
original author: @oleschoenburg