### PR TITLE
Extend process version management

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -169,7 +169,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
               .markAsDuplicate();
         } else {
           final var key = keyGenerator.nextKey();
-          processMetadata.setKey(key).setVersion(processState.getProcessVersion(bpmnProcessId) + 1);
+          processMetadata.setKey(key).setVersion(processState.getNextProcessVersion(bpmnProcessId));
 
           stateWriter.appendFollowUpEvent(
               key,

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -335,6 +335,11 @@ public final class DbProcessState implements MutableProcessState {
   }
 
   @Override
+  public int getNextProcessVersion(final String bpmnProcessId) {
+    return (int) versionManager.getCurrentProcessVersion(bpmnProcessId) + 1;
+  }
+
+  @Override
   public <T extends ExecutableFlowElement> T getFlowElement(
       final long processDefinitionKey, final DirectBuffer elementId, final Class<T> elementType) {
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -189,7 +189,7 @@ public final class DbProcessState implements MutableProcessState {
     final var nextVersion = processRecord.getVersion();
 
     if (nextVersion > currentVersion) {
-      versionManager.setProcessVersion(bpmnProcessId, nextVersion);
+      versionManager.addProcessVersion(bpmnProcessId, nextVersion);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -330,7 +330,7 @@ public final class DbProcessState implements MutableProcessState {
   }
 
   @Override
-  public int getProcessVersion(final String bpmnProcessId) {
+  public int getLatestProcessVersion(final String bpmnProcessId) {
     return (int) versionManager.getCurrentProcessVersion(bpmnProcessId);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -158,7 +158,7 @@ public final class DbProcessState implements MutableProcessState {
     processesByKey.remove(processRecord.getProcessDefinitionKey());
 
     final long latestVersion =
-        versionManager.getCurrentProcessVersion(processRecord.getBpmnProcessId());
+        versionManager.getHighestProcessVersion(processRecord.getBpmnProcessId());
 
     if (latestVersion == processRecord.getVersion()) {
       // As we don't set the digest to the digest of the previous there is a chance it does not
@@ -185,7 +185,7 @@ public final class DbProcessState implements MutableProcessState {
     processId.wrapBuffer(processRecord.getBpmnProcessIdBuffer());
     final var bpmnProcessId = processRecord.getBpmnProcessId();
 
-    final var currentVersion = versionManager.getCurrentProcessVersion(bpmnProcessId);
+    final var currentVersion = versionManager.getHighestProcessVersion(bpmnProcessId);
     final var nextVersion = processRecord.getVersion();
 
     if (nextVersion > currentVersion) {
@@ -252,7 +252,7 @@ public final class DbProcessState implements MutableProcessState {
         processesByProcessIdAndVersion.get(processIdBuffer);
 
     processId.wrapBuffer(processIdBuffer);
-    final long latestVersion = versionManager.getCurrentProcessVersion(processIdBuffer);
+    final long latestVersion = versionManager.getHighestProcessVersion(processIdBuffer);
 
     DeployedProcess deployedProcess;
     if (versionMap == null) {
@@ -319,12 +319,12 @@ public final class DbProcessState implements MutableProcessState {
 
   @Override
   public int getLatestProcessVersion(final String bpmnProcessId) {
-    return (int) versionManager.getCurrentProcessVersion(bpmnProcessId);
+    return (int) versionManager.getHighestProcessVersion(bpmnProcessId);
   }
 
   @Override
   public int getNextProcessVersion(final String bpmnProcessId) {
-    return (int) versionManager.getCurrentProcessVersion(bpmnProcessId) + 1;
+    return (int) versionManager.getHighestProcessVersion(bpmnProcessId) + 1;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -319,7 +319,7 @@ public final class DbProcessState implements MutableProcessState {
 
   @Override
   public int getLatestProcessVersion(final String bpmnProcessId) {
-    return (int) versionManager.getHighestProcessVersion(bpmnProcessId);
+    return (int) versionManager.getLatestProcessVersion(bpmnProcessId);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicLong;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
@@ -166,19 +165,8 @@ public final class DbProcessState implements MutableProcessState {
       // exist. This happens when deleting the latest version two times in a row. To be safe we must
       // use deleteIfExists.
       digestByIdColumnFamily.deleteIfExists(fkProcessId);
-
-      final var previousVersion = new AtomicLong(0);
-      processByIdAndVersionColumnFamily.whileEqualPrefix(
-          processId,
-          (key, value) -> {
-            final long version = key.second().getValue();
-            if (version > previousVersion.get()) {
-              previousVersion.set(version);
-            }
-          });
-
       versionManager.deleteProcessVersion(
-          processRecord.getBpmnProcessId(), processRecord.getVersion(), previousVersion.get());
+          processRecord.getBpmnProcessId(), processRecord.getVersion());
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -158,8 +158,7 @@ public final class DbProcessState implements MutableProcessState {
     processesByKey.remove(processRecord.getProcessDefinitionKey());
 
     final long latestVersion =
-        versionManager.getHighestProcessVersion(processRecord.getBpmnProcessId());
-
+        versionManager.getLatestProcessVersion(processRecord.getBpmnProcessId());
     if (latestVersion == processRecord.getVersion()) {
       // As we don't set the digest to the digest of the previous there is a chance it does not
       // exist. This happens when deleting the latest version two times in a row. To be safe we must
@@ -248,7 +247,7 @@ public final class DbProcessState implements MutableProcessState {
         processesByProcessIdAndVersion.get(processIdBuffer);
 
     processId.wrapBuffer(processIdBuffer);
-    final long latestVersion = versionManager.getHighestProcessVersion(processIdBuffer);
+    final long latestVersion = versionManager.getLatestProcessVersion(processIdBuffer);
 
     DeployedProcess deployedProcess;
     if (versionMap == null) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -165,9 +165,10 @@ public final class DbProcessState implements MutableProcessState {
       // exist. This happens when deleting the latest version two times in a row. To be safe we must
       // use deleteIfExists.
       digestByIdColumnFamily.deleteIfExists(fkProcessId);
-      versionManager.deleteProcessVersion(
-          processRecord.getBpmnProcessId(), processRecord.getVersion());
     }
+
+    versionManager.deleteProcessVersion(
+        processRecord.getBpmnProcessId(), processRecord.getVersion());
   }
 
   private void persistProcess(final long processDefinitionKey, final ProcessRecord processRecord) {
@@ -184,13 +185,8 @@ public final class DbProcessState implements MutableProcessState {
   private void updateLatestVersion(final ProcessRecord processRecord) {
     processId.wrapBuffer(processRecord.getBpmnProcessIdBuffer());
     final var bpmnProcessId = processRecord.getBpmnProcessId();
-
-    final var currentVersion = versionManager.getHighestProcessVersion(bpmnProcessId);
-    final var nextVersion = processRecord.getVersion();
-
-    if (nextVersion > currentVersion) {
-      versionManager.addProcessVersion(bpmnProcessId, nextVersion);
-    }
+    final var version = processRecord.getVersion();
+    versionManager.addProcessVersion(bpmnProcessId, version);
   }
 
   // is called on getters, if process is not in memory

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
@@ -49,17 +49,18 @@ public final class NextValue extends UnpackedObject implements DbValue {
   }
 
   public Long getLatestVersion() {
-    final List<Long> knownVersions =
-        StreamSupport.stream(this.knownVersions.spliterator(), false)
-            .map(LongValue::getValue)
-            .sorted()
-            .toList();
-
+    final List<Long> knownVersions = getKnownVersions();
     if (knownVersions.isEmpty()) {
       return 0L;
     }
-
     return knownVersions.get(knownVersions.size() - 1);
+  }
+
+  public List<Long> getKnownVersions() {
+    return StreamSupport.stream(knownVersions.spliterator(), false)
+        .map(LongValue::getValue)
+        .sorted()
+        .toList();
   }
 
   public void addKnownVersion(final long version) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
@@ -41,10 +41,11 @@ public final class NextValue extends UnpackedObject implements DbValue {
    *
    * @param version the version of the process
    */
-  public void setHighestVersion(final long version) {
+  public NextValue setHighestVersion(final long version) {
     if (version > nextValueProp.getValue()) {
       nextValueProp.setValue(version);
     }
+    return this;
   }
 
   public Long getLatestVersion() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
@@ -58,6 +58,7 @@ public final class NextValue extends UnpackedObject implements DbValue {
 
   public void addKnownVersion(final long version) {
     knownVersions.add().setValue(version);
+    setHighestVersion(version);
   }
 
   public void removeKnownVersion(final long version) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/NextValue.java
@@ -53,6 +53,11 @@ public final class NextValue extends UnpackedObject implements DbValue {
             .map(LongValue::getValue)
             .sorted()
             .toList();
+
+    if (knownVersions.isEmpty()) {
+      return 0L;
+    }
+
     return knownVersions.get(knownVersions.size() - 1);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionInfo.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionInfo.java
@@ -15,13 +15,16 @@ import io.camunda.zeebe.msgpack.value.LongValue;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
-public final class NextValue extends UnpackedObject implements DbValue {
-  private final LongProperty nextValueProp = new LongProperty("nextValue", -1L);
+public final class ProcessVersionInfo extends UnpackedObject implements DbValue {
+  // The property key is named nextValue. This is not a great name and doesn't describe what it is.
+  // However, changing this is not backwards compatible. Changing the variable name is the best we
+  // can do to hide this name.
+  private final LongProperty highestVersionProp = new LongProperty("nextValue", -1L);
   private final ArrayProperty<LongValue> knownVersions =
       new ArrayProperty<>("knownVersions", new LongValue());
 
-  public NextValue() {
-    declareProperty(nextValueProp).declareProperty(knownVersions);
+  public ProcessVersionInfo() {
+    declareProperty(highestVersionProp).declareProperty(knownVersions);
   }
 
   /**
@@ -33,7 +36,7 @@ public final class NextValue extends UnpackedObject implements DbValue {
    * @return the highest version we've ever known for this process
    */
   public long getHighestVersion() {
-    return nextValueProp.getValue();
+    return highestVersionProp.getValue();
   }
 
   /**
@@ -41,9 +44,9 @@ public final class NextValue extends UnpackedObject implements DbValue {
    *
    * @param version the version of the process
    */
-  public NextValue setHighestVersion(final long version) {
-    if (version > nextValueProp.getValue()) {
-      nextValueProp.setValue(version);
+  public ProcessVersionInfo setHighestVersion(final long version) {
+    if (version > highestVersionProp.getValue()) {
+      highestVersionProp.setValue(version);
     }
     return this;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionInfo.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionInfo.java
@@ -40,11 +40,12 @@ public final class ProcessVersionInfo extends UnpackedObject implements DbValue 
   }
 
   /**
-   * Sets the highest version of a process. This is the highest version we've ever known.
+   * Sets the highest version of a process. This is the highest version we've ever known. If the
+   * passed version is lower than the current known highest version, nothing is changed.
    *
    * @param version the version of the process
    */
-  public ProcessVersionInfo setHighestVersion(final long version) {
+  public ProcessVersionInfo setHighestVersionIfHigher(final long version) {
     if (version > highestVersionProp.getValue()) {
       highestVersionProp.setValue(version);
     }
@@ -69,7 +70,7 @@ public final class ProcessVersionInfo extends UnpackedObject implements DbValue 
   public void addKnownVersion(final long version) {
     if (!getKnownVersions().contains(version)) {
       knownVersions.add().setValue(version);
-      setHighestVersion(version);
+      setHighestVersionIfHigher(version);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionInfo.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionInfo.java
@@ -67,8 +67,10 @@ public final class ProcessVersionInfo extends UnpackedObject implements DbValue 
   }
 
   public void addKnownVersion(final long version) {
-    knownVersions.add().setValue(version);
-    setHighestVersion(version);
+    if (!getKnownVersions().contains(version)) {
+      knownVersions.add().setValue(version);
+      setHighestVersion(version);
+    }
   }
 
   public void removeKnownVersion(final long version) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -52,6 +52,23 @@ public final class ProcessVersionManager {
   }
 
   /**
+   * Returns the latest known version of a process. A process with this version exists in the state.
+   *
+   * @param processId the process id
+   * @return the latest known version of this process
+   */
+  public long getLatestProcessVersion(final String processId) {
+    processIdKey.wrapString(processId);
+    final var versionInfo = nextValueColumnFamily.get(processIdKey);
+
+    if (versionInfo == null) {
+      return initialValue;
+    }
+
+    return versionInfo.getLatestVersion();
+  }
+
+  /**
    * Returns the highest version ever deployed for a given process. This process could already be
    * deleted from the state.
    *

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -38,11 +38,17 @@ public final class ProcessVersionManager {
     versionCache = new Object2LongHashMap<>(initialValue);
   }
 
-  public void setProcessVersion(final String processId, final long value) {
+  public void addProcessVersion(final String processId, final long value) {
     processIdKey.wrapString(processId);
-    nextVersion.setHighestVersion(value);
-    nextValueColumnFamily.upsert(processIdKey, nextVersion);
-    versionCache.put(processId, value);
+
+    var versionInfo = nextValueColumnFamily.get(processIdKey);
+    if (versionInfo == null) {
+      versionInfo = new NextValue();
+    }
+
+    versionInfo.addKnownVersion(value);
+    nextValueColumnFamily.upsert(processIdKey, versionInfo);
+    versionCache.put(processId, versionInfo.getLatestVersion());
   }
 
   public long getCurrentProcessVersion(final String processId) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -101,7 +101,7 @@ public final class ProcessVersionManager {
             processIdKey.toString(), (key) -> processVersionInfoColumnFamily.get(processIdKey));
 
     if (versionInfo == null) {
-      return new ProcessVersionInfo().setHighestVersion(initialValue);
+      return new ProcessVersionInfo().setHighestVersionIfHigher(initialValue);
     }
 
     return versionInfo;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -51,22 +51,36 @@ public final class ProcessVersionManager {
     versionCache.put(processId, versionInfo.getLatestVersion());
   }
 
-  public long getCurrentProcessVersion(final String processId) {
+  /**
+   * Returns the highest version ever deployed for a given process. This process could already be
+   * deleted from the state.
+   *
+   * @param processId the process id
+   * @return the highest version ever deployed for this process id.
+   */
+  public long getHighestProcessVersion(final String processId) {
     processIdKey.wrapString(processId);
-    return getCurrentProcessVersion();
+    return getHighestProcessVersion();
   }
 
-  public long getCurrentProcessVersion(final DirectBuffer processId) {
+  /**
+   * Returns the highest process id ever deployed for a given process. This process could already be
+   * deleted from the state.
+   *
+   * @param processId the process id
+   * @return the highest version ever deployed for this process id.
+   */
+  public long getHighestProcessVersion(final DirectBuffer processId) {
     processIdKey.wrapBuffer(processId);
-    return getCurrentProcessVersion();
+    return getHighestProcessVersion();
   }
 
-  private long getCurrentProcessVersion() {
+  private long getHighestProcessVersion() {
     return versionCache.computeIfAbsent(
-        processIdKey.toString(), (ToLongFunction<String>) (key) -> getProcessVersionFromDB());
+        processIdKey.toString(), (ToLongFunction<String>) (key) -> getHighestVersionFromDB());
   }
 
-  private long getProcessVersionFromDB() {
+  private long getHighestVersionFromDB() {
     final NextValue readValue = nextValueColumnFamily.get(processIdKey);
 
     long currentValue = initialValue;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -40,7 +40,7 @@ public final class ProcessVersionManager {
 
   public void setProcessVersion(final String processId, final long value) {
     processIdKey.wrapString(processId);
-    nextVersion.set(value);
+    nextVersion.setHighestVersion(value);
     nextValueColumnFamily.upsert(processIdKey, nextVersion);
     versionCache.put(processId, value);
   }
@@ -65,7 +65,7 @@ public final class ProcessVersionManager {
 
     long currentValue = initialValue;
     if (readValue != null) {
-      currentValue = readValue.get();
+      currentValue = readValue.getHighestVersion();
     }
     return currentValue;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -75,23 +75,13 @@ public final class ProcessVersionManager {
    *
    * @param processId the id of the process
    * @param version the version that needs to be deleted
-   * @param previousVersion the previous known version of the process
    */
-  public void deleteProcessVersion(
-      final String processId, final long version, final long previousVersion) {
-    if (getCurrentProcessVersion(processId) != version) {
-      // If the deleted version is not the latest version we don't have to do anything.
-      return;
-    }
-
+  public void deleteProcessVersion(final String processId, final long version) {
     processIdKey.wrapString(processId);
-    // If there is no previous version we can delete the process id from the state entirely.
-    if (previousVersion == 0) {
-      nextValueColumnFamily.deleteExisting(processIdKey);
-      versionCache.remove(processId);
-    } else {
-      setProcessVersion(processId, previousVersion);
-    }
+    final var versionInfo = nextValueColumnFamily.get(processIdKey);
+    versionInfo.removeKnownVersion(version);
+    nextValueColumnFamily.update(processIdKey, versionInfo);
+    versionCache.put(processId, versionInfo.getLatestVersion());
   }
 
   public void clear() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -26,7 +26,14 @@ public interface ProcessState {
 
   DirectBuffer getLatestVersionDigest(DirectBuffer processId);
 
-  int getProcessVersion(String bpmnProcessId);
+  /**
+   * Gets the latest process version. This is the latest version for which we have a process in the
+   * state. It is not necessarily the latest version we've ever known for this process id, as
+   * process could be deleted.
+   *
+   * @param bpmnProcessId the id of the process
+   */
+  int getLatestProcessVersion(String bpmnProcessId);
 
   /**
    * Gets the next version a process of a given id will get. This is used, for example, when a new

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -28,6 +28,14 @@ public interface ProcessState {
 
   int getProcessVersion(String bpmnProcessId);
 
+  /**
+   * Gets the next version a process of a given id will get. This is used, for example, when a new
+   * deployment is done. Using this method we decide the version the newly deployed process gets.
+   *
+   * @param bpmnProcessId the id of the process
+   */
+  int getNextProcessVersion(String bpmnProcessId);
+
   <T extends ExecutableFlowElement> T getFlowElement(
       long processDefinitionKey, DirectBuffer elementId, Class<T> elementType);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -36,8 +36,9 @@ public interface ProcessState {
   int getLatestProcessVersion(String bpmnProcessId);
 
   /**
-   * Gets the next version a process of a given id will get. This is used, for example, when a new
-   * deployment is done. Using this method we decide the version the newly deployed process gets.
+   * Gets the next version a process of a given id will receive. This is used, for example, when a
+   * new deployment is done. Using this method we decide the version the newly deployed process
+   * receives.
    *
    * @param bpmnProcessId the id of the process
    */

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionRequirementsMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessDefinitionVersionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDefinitionMigration;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.ArrayList;
@@ -31,7 +32,8 @@ public class DbMigratorImpl implements DbMigrator {
           new TemporaryVariableMigration(),
           new DecisionMigration(),
           new DecisionRequirementsMigration(),
-          new ProcessInstanceByProcessDefinitionMigration());
+          new ProcessInstanceByProcessDefinitionMigration(),
+          new ProcessDefinitionVersionMigration());
   // Be mindful of https://github.com/camunda/zeebe/issues/7248. In particular, that issue
   // should be solved first, before adding any migration that can take a long time
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessDefinitionVersionMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessDefinitionVersionMigration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import io.camunda.zeebe.engine.state.migration.MigrationTask;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+
+/**
+ * This migration is used to extend the data we have on process definition versions. We used to keep
+ * track of only a single version. This version was the highest known version of the process
+ * definition.
+ *
+ * <p>For resource deletion we need to know all the versions that are available in the state. This
+ * migration will make sure we store a list of all known versions.
+ */
+public class ProcessDefinitionVersionMigration implements MigrationTask {
+
+  @Override
+  public String getIdentifier() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public void runMigration(final MutableProcessingState processingState) {
+    processingState.getMigrationState().migrateProcessDefinitionVersions();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -31,6 +31,8 @@ public interface MutableMigrationState extends MigrationState {
 
   void migrateElementInstancePopulateProcessInstanceByDefinitionKey();
 
+  void migrateProcessDefinitionVersions();
+
   /**
    * Changes the state of a migration to FINISHED to indicate it has been executed.
    *

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -772,7 +772,7 @@ public final class ProcessStateTest {
   public static DeploymentRecord creatingDeploymentRecord(
       final MutableProcessingState processingState, final String processId) {
     final MutableProcessState processState = processingState.getProcessState();
-    final int version = processState.getLatestProcessVersion(processId) + 1;
+    final int version = processState.getNextProcessVersion(processId);
     return creatingDeploymentRecord(processingState, processId, version);
   }
 
@@ -821,7 +821,7 @@ public final class ProcessStateTest {
   public static ProcessRecord creatingProcessRecord(
       final MutableProcessingState processingState, final String processId) {
     final MutableProcessState processState = processingState.getProcessState();
-    final int version = processState.getLatestProcessVersion(processId) + 1;
+    final int version = processState.getNextProcessVersion(processId);
     return creatingProcessRecord(processingState, processId, version);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -104,6 +104,64 @@ public final class ProcessStateTest {
   }
 
   @Test
+  public void shouldGetInitialNextProcessVersion() {
+    // given
+
+    // when
+    final long nextProcessVersion = processState.getNextProcessVersion("foo");
+
+    // then
+    assertThat(nextProcessVersion).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldGetNextProcessVersion() {
+    // given
+    final var processRecord = creatingProcessRecord(processingState);
+    processState.putProcess(processRecord.getKey(), processRecord);
+
+    // when
+    final long processVersion = processState.getNextProcessVersion("processId");
+
+    // then
+    assertThat(processVersion).isEqualTo(2L);
+  }
+
+  @Test
+  public void shouldIncrementNextProcessVersion() {
+    // given
+    final var processRecord = creatingProcessRecord(processingState);
+    processState.putProcess(processRecord.getKey(), processRecord);
+
+    final var processRecord2 = creatingProcessRecord(processingState);
+    processState.putProcess(processRecord2.getKey(), processRecord2);
+
+    // when
+    processState.putProcess(processRecord2.getKey(), processRecord2);
+
+    // then
+    final long processVersion = processState.getNextProcessVersion("processId");
+    assertThat(processVersion).isEqualTo(3L);
+  }
+
+  @Test
+  public void shouldNotIncrementNextProcessVersionForDifferentProcessId() {
+    // given
+    final var processRecord = creatingProcessRecord(processingState);
+    processState.putProcess(processRecord.getKey(), processRecord);
+    final var processRecord2 = creatingProcessRecord(processingState, "other");
+
+    // when
+    processState.putProcess(processRecord2.getKey(), processRecord2);
+
+    // then
+    final long processVersion = processState.getNextProcessVersion("processId");
+    assertThat(processVersion).isEqualTo(2L);
+    final long otherversion = processState.getNextProcessVersion("other");
+    assertThat(otherversion).isEqualTo(2L);
+  }
+
+  @Test
   public void shouldReturnNullOnGetLatest() {
     // given
 
@@ -548,6 +606,7 @@ public final class ProcessStateTest {
         .isNull();
     assertThat(processState.getLatestVersionDigest(BufferUtil.wrapString(processId))).isNull();
     assertThat(processState.getProcessVersion(processId)).isEqualTo(0);
+    assertThat(processState.getNextProcessVersion(processId)).isEqualTo(2);
   }
 
   @Test
@@ -584,6 +643,7 @@ public final class ProcessStateTest {
     assertThat(processState.getLatestVersionDigest(BufferUtil.wrapString(processId)))
         .isEqualTo(wrapString("newChecksum"));
     assertThat(processState.getProcessVersion(processId)).isEqualTo(2);
+    assertThat(processState.getNextProcessVersion(processId)).isEqualTo(3);
   }
 
   @Test
@@ -619,6 +679,7 @@ public final class ProcessStateTest {
         .isNull();
     assertThat(processState.getLatestVersionDigest(BufferUtil.wrapString(processId))).isNull();
     assertThat(processState.getProcessVersion(processId)).isEqualTo(1);
+    assertThat(processState.getNextProcessVersion(processId)).isEqualTo(3);
   }
 
   @Test
@@ -662,6 +723,7 @@ public final class ProcessStateTest {
         .isNull();
     assertThat(processState.getLatestVersionDigest(BufferUtil.wrapString(processId))).isNull();
     assertThat(processState.getProcessVersion(processId)).isEqualTo(1);
+    assertThat(processState.getNextProcessVersion(processId)).isEqualTo(4);
   }
 
   public static DeploymentRecord creatingDeploymentRecord(

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -134,7 +134,6 @@ public final class ProcessStateTest {
     processState.putProcess(processRecord.getKey(), processRecord);
 
     final var processRecord2 = creatingProcessRecord(processingState);
-    processState.putProcess(processRecord2.getKey(), processRecord2);
 
     // when
     processState.putProcess(processRecord2.getKey(), processRecord2);
@@ -142,6 +141,20 @@ public final class ProcessStateTest {
     // then
     final long processVersion = processState.getNextProcessVersion("processId");
     assertThat(processVersion).isEqualTo(3L);
+  }
+
+  @Test
+  public void shouldNotIncrementOnNextProcessVersionOnDuplicate() {
+    // given
+    final var processRecord = creatingProcessRecord(processingState);
+    processState.putProcess(processRecord.getKey(), processRecord);
+
+    // when
+    processState.putProcess(processRecord.getKey(), processRecord);
+
+    // then
+    final long processVersion = processState.getNextProcessVersion("processId");
+    assertThat(processVersion).isEqualTo(2L);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -50,7 +50,7 @@ public final class ProcessStateTest {
     // given
 
     // when
-    final long nextProcessVersion = processState.getProcessVersion("foo");
+    final long nextProcessVersion = processState.getLatestProcessVersion("foo");
 
     // then
     assertThat(nextProcessVersion).isZero();
@@ -63,7 +63,7 @@ public final class ProcessStateTest {
     processState.putProcess(processRecord.getKey(), processRecord);
 
     // when
-    final long processVersion = processState.getProcessVersion("processId");
+    final long processVersion = processState.getLatestProcessVersion("processId");
 
     // then
     assertThat(processVersion).isEqualTo(1L);
@@ -82,7 +82,7 @@ public final class ProcessStateTest {
     processState.putProcess(processRecord2.getKey(), processRecord2);
 
     // then
-    final long processVersion = processState.getProcessVersion("processId");
+    final long processVersion = processState.getLatestProcessVersion("processId");
     assertThat(processVersion).isEqualTo(2L);
   }
 
@@ -97,9 +97,9 @@ public final class ProcessStateTest {
     processState.putProcess(processRecord2.getKey(), processRecord2);
 
     // then
-    final long processVersion = processState.getProcessVersion("processId");
+    final long processVersion = processState.getLatestProcessVersion("processId");
     assertThat(processVersion).isEqualTo(1L);
-    final long otherversion = processState.getProcessVersion("other");
+    final long otherversion = processState.getLatestProcessVersion("other");
     assertThat(otherversion).isEqualTo(1L);
   }
 
@@ -605,7 +605,7 @@ public final class ProcessStateTest {
     assertThat(processState.getProcessByProcessIdAndVersion(BufferUtil.wrapString(processId), 1))
         .isNull();
     assertThat(processState.getLatestVersionDigest(BufferUtil.wrapString(processId))).isNull();
-    assertThat(processState.getProcessVersion(processId)).isEqualTo(0);
+    assertThat(processState.getLatestProcessVersion(processId)).isEqualTo(0);
     assertThat(processState.getNextProcessVersion(processId)).isEqualTo(2);
   }
 
@@ -642,7 +642,7 @@ public final class ProcessStateTest {
         .isNotNull();
     assertThat(processState.getLatestVersionDigest(BufferUtil.wrapString(processId)))
         .isEqualTo(wrapString("newChecksum"));
-    assertThat(processState.getProcessVersion(processId)).isEqualTo(2);
+    assertThat(processState.getLatestProcessVersion(processId)).isEqualTo(2);
     assertThat(processState.getNextProcessVersion(processId)).isEqualTo(3);
   }
 
@@ -678,7 +678,7 @@ public final class ProcessStateTest {
     assertThat(processState.getProcessByProcessIdAndVersion(BufferUtil.wrapString(processId), 2))
         .isNull();
     assertThat(processState.getLatestVersionDigest(BufferUtil.wrapString(processId))).isNull();
-    assertThat(processState.getProcessVersion(processId)).isEqualTo(1);
+    assertThat(processState.getLatestProcessVersion(processId)).isEqualTo(1);
     assertThat(processState.getNextProcessVersion(processId)).isEqualTo(3);
   }
 
@@ -722,7 +722,7 @@ public final class ProcessStateTest {
     assertThat(processState.getProcessByProcessIdAndVersion(BufferUtil.wrapString(processId), 3))
         .isNull();
     assertThat(processState.getLatestVersionDigest(BufferUtil.wrapString(processId))).isNull();
-    assertThat(processState.getProcessVersion(processId)).isEqualTo(1);
+    assertThat(processState.getLatestProcessVersion(processId)).isEqualTo(1);
     assertThat(processState.getNextProcessVersion(processId)).isEqualTo(4);
   }
 
@@ -734,7 +734,7 @@ public final class ProcessStateTest {
   public static DeploymentRecord creatingDeploymentRecord(
       final MutableProcessingState processingState, final String processId) {
     final MutableProcessState processState = processingState.getProcessState();
-    final int version = processState.getProcessVersion(processId) + 1;
+    final int version = processState.getLatestProcessVersion(processId) + 1;
     return creatingDeploymentRecord(processingState, processId, version);
   }
 
@@ -783,7 +783,7 @@ public final class ProcessStateTest {
   public static ProcessRecord creatingProcessRecord(
       final MutableProcessingState processingState, final String processId) {
     final MutableProcessState processState = processingState.getProcessState();
-    final int version = processState.getProcessVersion(processId) + 1;
+    final int version = processState.getLatestProcessVersion(processId) + 1;
     return creatingProcessRecord(processingState, processId, version);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessDefinitionVersionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessDefinitionVersionMigrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.deployment.NextValue;
+import io.camunda.zeebe.engine.state.immutable.MigrationState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+public class ProcessDefinitionVersionMigrationTest {
+
+  final ProcessDefinitionVersionMigration sut = new ProcessDefinitionVersionMigration();
+
+  private static final class LegacyProcessVersionState {
+    private final DbString processIdKey;
+    private final ColumnFamily<DbString, NextValue> nextValueColumnFamily;
+
+    public LegacyProcessVersionState(
+        final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+      processIdKey = new DbString();
+      nextValueColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.PROCESS_VERSION, transactionContext, processIdKey, new NextValue());
+    }
+
+    public void insertProcessVersion(final String processId, final int version) {
+      processIdKey.wrapString(processId);
+      final var value = new NextValue().setHighestVersion(version);
+      nextValueColumnFamily.insert(processIdKey, value);
+    }
+  }
+
+  @Nested
+  class MockBasedTests {
+
+    @Test
+    void migrationNeededWhenMigrationNotFinished() {
+      // given
+      final var mockProcessingState = mock(ProcessingState.class);
+      final var migrationState = mock(MigrationState.class);
+      when(mockProcessingState.getMigrationState()).thenReturn(migrationState);
+      when(migrationState.isMigrationFinished(anyString())).thenReturn(false);
+
+      // when
+      final var actual = sut.needsToRun(mockProcessingState);
+
+      // then
+      assertThat(actual).isTrue();
+    }
+  }
+
+  @Nested
+  @ExtendWith(ProcessingStateExtension.class)
+  class ProcessVersionMigrationTest {
+
+    private ZeebeDb<ZbColumnFamilies> zeebeDb;
+    private MutableProcessingState processingState;
+    private TransactionContext transactionContext;
+    private LegacyProcessVersionState legacyState;
+    private DbString processIdKey;
+    private ColumnFamily<DbString, NextValue> nextValueColumnFamily;
+
+    @BeforeEach
+    void setup() {
+      legacyState = new LegacyProcessVersionState(zeebeDb, transactionContext);
+      processIdKey = new DbString();
+      nextValueColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.PROCESS_VERSION, transactionContext, processIdKey, new NextValue());
+    }
+
+    @Test
+    void shouldMigrateProcessVersion() {
+      // given
+      final String processId = "processId";
+      legacyState.insertProcessVersion(processId, 5);
+
+      // when
+      sut.runMigration(processingState);
+
+      // then
+      processIdKey.wrapString(processId);
+      final var versionInfo = nextValueColumnFamily.get(processIdKey);
+      assertThat(versionInfo.getHighestVersion()).isEqualTo(5);
+      assertThat(versionInfo.getKnownVersions()).containsExactly(1L, 2L, 3L, 4L, 5L);
+    }
+
+    @Test
+    void shouldNotSetKnownVersionsIfHighestVersionIsZero() {
+      // given
+      final String processId = "processId";
+      legacyState.insertProcessVersion(processId, 0);
+
+      // when
+      sut.runMigration(processingState);
+
+      // then
+      processIdKey.wrapString(processId);
+      final var versionInfo = nextValueColumnFamily.get(processIdKey);
+      assertThat(versionInfo.getHighestVersion()).isEqualTo(0);
+      assertThat(versionInfo.getKnownVersions()).isEmpty();
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessDefinitionVersionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessDefinitionVersionMigrationTest.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbString;
-import io.camunda.zeebe.engine.state.deployment.NextValue;
+import io.camunda.zeebe.engine.state.deployment.ProcessVersionInfo;
 import io.camunda.zeebe.engine.state.immutable.MigrationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -33,20 +33,23 @@ public class ProcessDefinitionVersionMigrationTest {
 
   private static final class LegacyProcessVersionState {
     private final DbString processIdKey;
-    private final ColumnFamily<DbString, NextValue> nextValueColumnFamily;
+    private final ColumnFamily<DbString, ProcessVersionInfo> processVersionInfoColumnFamily;
 
     public LegacyProcessVersionState(
         final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
       processIdKey = new DbString();
-      nextValueColumnFamily =
+      processVersionInfoColumnFamily =
           zeebeDb.createColumnFamily(
-              ZbColumnFamilies.PROCESS_VERSION, transactionContext, processIdKey, new NextValue());
+              ZbColumnFamilies.PROCESS_VERSION,
+              transactionContext,
+              processIdKey,
+              new ProcessVersionInfo());
     }
 
     public void insertProcessVersion(final String processId, final int version) {
       processIdKey.wrapString(processId);
-      final var value = new NextValue().setHighestVersion(version);
-      nextValueColumnFamily.insert(processIdKey, value);
+      final var value = new ProcessVersionInfo().setHighestVersion(version);
+      processVersionInfoColumnFamily.insert(processIdKey, value);
     }
   }
 
@@ -78,7 +81,7 @@ public class ProcessDefinitionVersionMigrationTest {
     private TransactionContext transactionContext;
     private LegacyProcessVersionState legacyState;
     private DbString processIdKey;
-    private ColumnFamily<DbString, NextValue> nextValueColumnFamily;
+    private ColumnFamily<DbString, ProcessVersionInfo> nextValueColumnFamily;
 
     @BeforeEach
     void setup() {
@@ -86,7 +89,10 @@ public class ProcessDefinitionVersionMigrationTest {
       processIdKey = new DbString();
       nextValueColumnFamily =
           zeebeDb.createColumnFamily(
-              ZbColumnFamilies.PROCESS_VERSION, transactionContext, processIdKey, new NextValue());
+              ZbColumnFamilies.PROCESS_VERSION,
+              transactionContext,
+              processIdKey,
+              new ProcessVersionInfo());
     }
 
     @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessDefinitionVersionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessDefinitionVersionMigrationTest.java
@@ -48,7 +48,7 @@ public class ProcessDefinitionVersionMigrationTest {
 
     public void insertProcessVersion(final String processId, final int version) {
       processIdKey.wrapString(processId);
-      final var value = new ProcessVersionInfo().setHighestVersion(version);
+      final var value = new ProcessVersionInfo().setHighestVersionIfHigher(version);
       processVersionInfoColumnFamily.insert(processIdKey, value);
     }
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessInstanceByProcessDefinitionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/ProcessInstanceByProcessDefinitionMigrationTest.java
@@ -81,7 +81,7 @@ class ProcessInstanceByProcessDefinitionMigrationTest {
 
   @Nested
   @ExtendWith(ProcessingStateExtension.class)
-  class BlackboxTest {
+  class ProcessInstanceKeyByProcessDefinitionKeyTest {
     private ZeebeDb<ZbColumnFamilies> zeebeDb;
     private MutableProcessingState processingState;
     private TransactionContext transactionContext;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The current way of managing versions of process management is pretty limited. We only store a single version for each process id, which is the latest one.

For resource deletion we need more information than this. We don't want to reuse versions, so for one we must always keep track of the highest version for a process id.
Additionally we must make sure that if we delete the latest version a process, the previous undeleted version becomes the new lated. Because of this we need to keep track of a list of all undeleted process versions.

This PR makes this change. It changes the object we store in the state to contain more data and does some refactoring to try and make the difference between versions more clear.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13588 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
