### PR TITLE
[Backport stable/8.2] fix(ci): configure fake gcs server port

### DIFF
--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/util/GcsContainer.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/util/GcsContainer.java
@@ -14,7 +14,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public final class GcsContainer extends GenericContainer<GcsContainer> {
   private static final DockerImageName IMAGE = DockerImageName.parse("fsouza/fake-gcs-server");
-  private static final int PORT = 4443;
+  private static final int PORT = 8000;
 
   /**
    * This uses a common testcontainers hack to start the server with an external url that is only
@@ -49,8 +49,8 @@ public final class GcsContainer extends GenericContainer<GcsContainer> {
     //noinspection OctalInteger
     copyFileToContainer(
         Transferable.of(
-            "/bin/fake-gcs-server -data /data -scheme http -external-url %s"
-                .formatted(externalEndpoint()),
+            "/bin/fake-gcs-server -data /data -scheme http -port %d -external-url %s"
+                .formatted(PORT, externalEndpoint()),
             0777),
         STARTER_SCRIPT);
   }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/GcsContainer.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/GcsContainer.java
@@ -15,13 +15,14 @@ import org.testcontainers.utility.DockerImageName;
 public final class GcsContainer extends GenericContainer<GcsContainer> {
   private static final DockerImageName IMAGE = DockerImageName.parse("fsouza/fake-gcs-server");
   private static final String IMAGE_TAG = "1";
-  private static final int PORT = 4443;
+  private static final int PORT = 8000;
   private final String domain;
 
   public GcsContainer(final Network network, final String domain) {
     super(IMAGE.withTag(IMAGE_TAG));
     this.domain = domain;
-    setCommand("-scheme", "http", "-external-url", internalEndpoint());
+    setCommand(
+        "-scheme", "http", "-external-url", internalEndpoint(), "-port", String.valueOf(PORT));
     setExposedPorts(List.of(PORT));
     setNetworkAliases(List.of(domain));
     setNetwork(network);


### PR DESCRIPTION
# Description
Backport of #13738 to `stable/8.2`.

relates to 
original author: @megglos