### PR TITLE
Split partition distribution out of PartitionManager

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -198,6 +198,13 @@ public final class RaftPartitionGroup implements ManagedPartitionGroup {
       super(config);
     }
 
+    /**
+     * Configure how partitions are distributed among the members.
+     *
+     * @param partitionDistribution a collection of partition metadata that describes partition
+     *     distribution
+     * @return the Raft partition group builder
+     */
     public Builder withPartitionDistribution(
         final Collection<PartitionMetadata> partitionDistribution) {
       config.setPartitionDistribution(partitionDistribution);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -134,8 +134,6 @@ public final class RaftPartitionGroup implements ManagedPartitionGroup {
         + config
         + ", partitions="
         + partitions
-        + ", sortedPartitionIds="
-        + partitionIds
         + '}';
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -17,12 +17,9 @@
 package io.atomix.raft.partition;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import io.atomix.cluster.Member;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionGroup;
@@ -43,8 +40,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -211,54 +206,6 @@ public final class RaftPartitionGroup implements ManagedPartitionGroup {
     public Builder withPartitionDistribution(
         final Collection<PartitionMetadata> partitionDistribution) {
       config.setPartitionDistribution(partitionDistribution);
-      return this;
-    }
-
-    /**
-     * Sets the Raft partition group members.
-     *
-     * @param members the Raft partition group members
-     * @return the Raft partition group builder
-     * @throws NullPointerException if the members are null
-     */
-    public Builder withMembers(final Collection<String> members) {
-      config.setMembers(Sets.newHashSet(checkNotNull(members, "members cannot be null")));
-      return this;
-    }
-
-    /**
-     * Sets the Raft partition group members.
-     *
-     * @param members the Raft partition group members
-     * @return the Raft partition group builder
-     * @throws NullPointerException if the members are null
-     */
-    public Builder withMembers(final Member... members) {
-      return withMembers(
-          Stream.of(members).map(node -> node.id().id()).collect(Collectors.toList()));
-    }
-
-    /**
-     * Sets the number of partitions.
-     *
-     * @param numPartitions the number of partitions
-     * @return the Raft partition group builder
-     * @throws IllegalArgumentException if the number of partitions is not positive
-     */
-    public Builder withNumPartitions(final int numPartitions) {
-      config.setPartitionCount(numPartitions);
-      return this;
-    }
-
-    /**
-     * Sets the partition size.
-     *
-     * @param partitionSize the partition size
-     * @return the Raft partition group builder
-     * @throws IllegalArgumentException if the partition size is not positive
-     */
-    public Builder withPartitionSize(final int partitionSize) {
-      config.setReplicationFactor(partitionSize);
       return this;
     }
 
@@ -439,18 +386,6 @@ public final class RaftPartitionGroup implements ManagedPartitionGroup {
      */
     public Builder withMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
       config.getPartitionConfig().setMaxQuorumResponseTimeout(maxQuorumResponseTimeout);
-      return this;
-    }
-
-    /**
-     * Sets the partition distributor to use. The partition distributor determines which members
-     * will own which partitions, and ensures they are correctly replicated.
-     *
-     * @param partitionDistributor the partition distributor to use
-     * @return this builder for chaining
-     */
-    public Builder withPartitionDistributor(final PartitionDistributor partitionDistributor) {
-      config.getPartitionConfig().setPartitionDistributor(partitionDistributor);
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
@@ -86,10 +86,18 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
     return this;
   }
 
+  /**
+   * @return the partition distribution
+   */
   public Collection<PartitionMetadata> getPartitionDistribution() {
     return partitionDistribution;
   }
 
+  /**
+   * Sets how partitions are distributed among the members
+   *
+   * @param partitionDistribution partition distribution info
+   */
   public void setPartitionDistribution(final Collection<PartitionMetadata> partitionDistribution) {
     this.partitionDistribution = partitionDistribution;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
@@ -31,7 +31,7 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
 
   private static final int DEFAULT_PARTITIONS = 7;
 
-  private Set<String> members = new HashSet<>();
+  private final Set<String> members = new HashSet<>();
   private int replicationFactor;
   private RaftStorageConfig storageConfig = new RaftStorageConfig();
   private RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
@@ -44,46 +44,6 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   @Override
   protected int getDefaultPartitions() {
     return DEFAULT_PARTITIONS;
-  }
-
-  /**
-   * Returns the set of members in the partition group.
-   *
-   * @return the set of members in the partition group
-   */
-  public Set<String> getMembers() {
-    return members;
-  }
-
-  /**
-   * Sets the set of members in the partition group.
-   *
-   * @param members the set of members in the partition group
-   * @return the Raft partition group configuration
-   */
-  public RaftPartitionGroupConfig setMembers(final Set<String> members) {
-    this.members = members;
-    return this;
-  }
-
-  /**
-   * Returns the partition size.
-   *
-   * @return the partition size
-   */
-  public int getReplicationFactor() {
-    return replicationFactor;
-  }
-
-  /**
-   * Sets the partition size.
-   *
-   * @param replicationFactor the partition size
-   * @return the Raft partition group configuration
-   */
-  public RaftPartitionGroupConfig setReplicationFactor(final int replicationFactor) {
-    this.replicationFactor = replicationFactor;
-    return this;
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
@@ -19,8 +19,10 @@ package io.atomix.raft.partition;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
 import io.atomix.primitive.partition.PartitionGroup.Type;
 import io.atomix.primitive.partition.PartitionGroupConfig;
+import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -33,6 +35,8 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   private int replicationFactor;
   private RaftStorageConfig storageConfig = new RaftStorageConfig();
   private RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
+
+  private Collection<PartitionMetadata> partitionDistribution;
 
   @Optional("EntryValidator")
   private EntryValidator entryValidator = new NoopEntryValidator();
@@ -80,6 +84,14 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   public RaftPartitionGroupConfig setReplicationFactor(final int replicationFactor) {
     this.replicationFactor = replicationFactor;
     return this;
+  }
+
+  public Collection<PartitionMetadata> getPartitionDistribution() {
+    return partitionDistribution;
+  }
+
+  public void setPartitionDistribution(final Collection<PartitionMetadata> partitionDistribution) {
+    this.partitionDistribution = partitionDistribution;
   }
 
   /**

--- a/atomix/cluster/src/test/java/io/atomix/cluster/AtomixClusterTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/AtomixClusterTest.java
@@ -22,14 +22,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
-import io.atomix.raft.partition.RaftPartitionGroupConfig;
-import io.atomix.raft.partition.RaftStorageConfig;
 import io.atomix.utils.net.Address;
-import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -49,28 +45,7 @@ public class AtomixClusterTest {
     // given
     final var atomix =
         atomixClusterRule
-            .startAtomix(
-                1,
-                Arrays.asList(1),
-                (builder) -> {
-                  final var groupConfig =
-                      new RaftPartitionGroupConfig()
-                          .setName("raft")
-                          .setReplicationFactor(3)
-                          .setPartitionCount(7)
-                          .setMembers(Set.of("1"))
-                          .setStorageConfig(
-                              new RaftStorageConfig()
-                                  .setDirectory(
-                                      new File(
-                                              atomixClusterRule.getDataDir(),
-                                              "start-stop-consensus")
-                                          .getPath())
-                                  .setPersistedSnapshotStoreFactory(
-                                      new NoopSnapshotStoreFactory()));
-
-                  return builder.build();
-                })
+            .startAtomix(1, Arrays.asList(1), AtomixClusterBuilder::build)
             .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
 
     // when

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -348,6 +348,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
@@ -93,7 +93,7 @@ public interface BrokerStartupContext {
 
   void setJobStreamService(final JobStreamService jobStreamService);
 
-  ClusterTopology getClusterTopology();
+  PartitionDistribution getClusterTopology();
 
-  void setClusterTopology(ClusterTopology clusterTopology);
+  void setClusterTopology(PartitionDistribution partitionDistribution);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
@@ -91,4 +92,8 @@ public interface BrokerStartupContext {
   JobStreamService getJobStreamService();
 
   void setJobStreamService(final JobStreamService jobStreamService);
+
+  ClusterTopology getClusterTopology();
+
+  void setClusterTopology(ClusterTopology clusterTopology);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
@@ -53,6 +54,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private PartitionManagerImpl partitionManager;
   private BrokerAdminServiceImpl brokerAdminService;
   private JobStreamService jobStreamService;
+  private ClusterTopology clusterTopology;
 
   public BrokerStartupContextImpl(
       final BrokerInfo brokerInfo,
@@ -221,5 +223,15 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public void setJobStreamService(final JobStreamService jobStreamService) {
     this.jobStreamService = jobStreamService;
+  }
+
+  @Override
+  public ClusterTopology getClusterTopology() {
+    return clusterTopology;
+  }
+
+  @Override
+  public void setClusterTopology(final ClusterTopology clusterTopology) {
+    this.clusterTopology = clusterTopology;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
@@ -54,7 +54,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private PartitionManagerImpl partitionManager;
   private BrokerAdminServiceImpl brokerAdminService;
   private JobStreamService jobStreamService;
-  private ClusterTopology clusterTopology;
+  private PartitionDistribution partitionDistribution;
 
   public BrokerStartupContextImpl(
       final BrokerInfo brokerInfo,
@@ -226,12 +226,12 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public ClusterTopology getClusterTopology() {
-    return clusterTopology;
+  public PartitionDistribution getClusterTopology() {
+    return partitionDistribution;
   }
 
   @Override
-  public void setClusterTopology(final ClusterTopology clusterTopology) {
-    this.clusterTopology = clusterTopology;
+  public void setClusterTopology(final PartitionDistribution partitionDistribution) {
+    this.partitionDistribution = partitionDistribution;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -47,6 +47,7 @@ public final class BrokerStartupProcess {
     final var result = new ArrayList<StartupStep<BrokerStartupContext>>();
 
     result.add(new ClusterServicesStep());
+    result.add(new ClusterTopologyManagerStep());
 
     // must be executed before any disk space usage listeners are registered
     result.add(new DiskSpaceUsageMonitorStep());

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterTopologyManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterTopologyManagerStep.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopologyManager;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+
+public class ClusterTopologyManagerStep
+    implements io.camunda.zeebe.scheduler.startup.StartupStep<BrokerStartupContext> {
+
+  @Override
+  public String getName() {
+    return "Cluster Topology Manager";
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> startup(
+      final BrokerStartupContext brokerStartupContext) {
+    final ActorFuture<BrokerStartupContext> started =
+        brokerStartupContext.getConcurrencyControl().createFuture();
+    try {
+      brokerStartupContext.setClusterTopology(
+          new ClusterTopologyManager()
+              .resolveTopology(
+                  brokerStartupContext.getBrokerConfiguration().getExperimental().getPartitioning(),
+                  brokerStartupContext.getBrokerConfiguration().getCluster()));
+      started.complete(brokerStartupContext);
+    } catch (final Exception topologyFailed) {
+      started.completeExceptionally(topologyFailed);
+    }
+
+    return started;
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> shutdown(
+      final BrokerStartupContext brokerStartupContext) {
+    brokerStartupContext.setClusterTopology(null);
+    return CompletableActorFuture.completed(brokerStartupContext);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -36,7 +36,8 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getCommandApiService(),
             brokerStartupContext.getExporterRepository(),
             brokerStartupContext.getGatewayBrokerTransport(),
-            brokerStartupContext.getJobStreamService().jobStreamer());
+            brokerStartupContext.getJobStreamService().jobStreamer(),
+            brokerStartupContext.getClusterTopology());
 
     CompletableFuture.supplyAsync(partitionManager::start)
         .thenCompose(Function.identity())

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -14,7 +14,7 @@ import io.atomix.raft.partition.RaftPartitionGroup;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
@@ -75,7 +75,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
       final ExporterRepository exporterRepository,
       final AtomixServerTransport gatewayBrokerTransport,
       final JobStreamer jobStreamer,
-      final ClusterTopology clusterTopology) {
+      final PartitionDistribution partitionDistribution) {
     this.gatewayBrokerTransport = gatewayBrokerTransport;
 
     snapshotStoreFactory =
@@ -93,7 +93,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
 
     partitionGroup =
         new RaftPartitionGroupFactory()
-            .buildRaftPartitionGroup(brokerCfg, clusterTopology, snapshotStoreFactory);
+            .buildRaftPartitionGroup(brokerCfg, partitionDistribution, snapshotStoreFactory);
 
     final var membershipService = clusterServices.getMembershipService();
     final var communicationService = clusterServices.getCommunicationService();

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -14,6 +14,7 @@ import io.atomix.raft.partition.RaftPartitionGroup;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
@@ -73,7 +74,8 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
       final CommandApiService commandApiService,
       final ExporterRepository exporterRepository,
       final AtomixServerTransport gatewayBrokerTransport,
-      final JobStreamer jobStreamer) {
+      final JobStreamer jobStreamer,
+      final ClusterTopology clusterTopology) {
     this.gatewayBrokerTransport = gatewayBrokerTransport;
 
     snapshotStoreFactory =
@@ -90,7 +92,8 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
     this.jobStreamer = jobStreamer;
 
     partitionGroup =
-        new RaftPartitionGroupFactory().buildRaftPartitionGroup(brokerCfg, snapshotStoreFactory);
+        new RaftPartitionGroupFactory()
+            .buildRaftPartitionGroup(brokerCfg, clusterTopology, snapshotStoreFactory);
 
     final var membershipService = clusterServices.getMembershipService();
     final var communicationService = clusterServices.getCommunicationService();

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -7,22 +7,18 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
-import io.atomix.raft.partition.PartitionDistributor;
 import io.atomix.raft.partition.RaftPartitionGroup;
 import io.atomix.raft.partition.RaftPartitionGroup.Builder;
-import io.atomix.raft.partition.RoundRobinPartitionDistributor;
 import io.atomix.raft.storage.log.DelayedFlusher;
 import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.partitioning.distribution.FixedPartitionDistributor;
-import io.camunda.zeebe.broker.partitioning.distribution.FixedPartitionDistributorBuilder;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
 import io.camunda.zeebe.broker.raft.ZeebeEntryValidator;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
-import io.camunda.zeebe.broker.system.configuration.PartitioningCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
 import io.camunda.zeebe.util.FileUtil;
@@ -30,13 +26,13 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 
 public final class RaftPartitionGroupFactory {
 
   public RaftPartitionGroup buildRaftPartitionGroup(
-      final BrokerCfg configuration, final ReceivableSnapshotStoreFactory snapshotStoreFactory) {
+      final BrokerCfg configuration,
+      final ClusterTopology topology,
+      final ReceivableSnapshotStoreFactory snapshotStoreFactory) {
 
     final DataCfg dataConfiguration = configuration.getData();
     final String rootDirectory = dataConfiguration.getDirectory();
@@ -62,13 +58,9 @@ public final class RaftPartitionGroupFactory {
     final RaftLogFlusher.Factory flusherFactory =
         createFlusherFactory(clusterCfg.getRaft().getFlush(), experimentalCfg);
 
-    final var partitionDistributor =
-        buildPartitionDistributor(configuration.getExperimental().getPartitioning());
     final Builder partitionGroupBuilder =
         RaftPartitionGroup.builder(PartitionManagerImpl.GROUP_NAME)
-            .withNumPartitions(clusterCfg.getPartitionsCount())
-            .withPartitionSize(clusterCfg.getReplicationFactor())
-            .withMembers(getRaftGroupMembers(clusterCfg))
+            .withPartitionDistribution(topology.partitionDistribution())
             .withDataDirectory(raftDataDirectory.toFile())
             .withSnapshotStoreFactory(snapshotStoreFactory)
             .withMaxAppendBatchSize((int) experimentalCfg.getMaxAppendBatchSizeInBytes())
@@ -78,7 +70,6 @@ public final class RaftPartitionGroupFactory {
             .withFreeDiskSpace(dataCfg.getDisk().getFreeSpace().getReplication().toBytes())
             .withJournalIndexDensity(dataCfg.getLogIndexDensity())
             .withPriorityElection(clusterCfg.getRaft().isEnablePriorityElection())
-            .withPartitionDistributor(partitionDistributor)
             .withElectionTimeout(clusterCfg.getElectionTimeout())
             .withHeartbeatInterval(clusterCfg.getHeartbeatInterval())
             .withRequestTimeout(experimentalCfg.getRaft().getRequestTimeout())
@@ -131,39 +122,5 @@ public final class RaftPartitionGroupFactory {
           read the documentation regarding this feature.""");
 
     return RaftLogFlusher.Factory::noop;
-  }
-
-  private List<String> getRaftGroupMembers(final ClusterCfg clusterCfg) {
-    final int clusterSize = clusterCfg.getClusterSize();
-    // node ids are always 0 to clusterSize - 1
-    final List<String> members = new ArrayList<>();
-    for (int i = 0; i < clusterSize; i++) {
-      members.add(Integer.toString(i));
-    }
-    return members;
-  }
-
-  private PartitionDistributor buildPartitionDistributor(final PartitioningCfg config) {
-    switch (config.getScheme()) {
-      case FIXED:
-        return buildFixedPartitionDistributor(config);
-      case ROUND_ROBIN:
-      default:
-        return new RoundRobinPartitionDistributor();
-    }
-  }
-
-  private FixedPartitionDistributor buildFixedPartitionDistributor(final PartitioningCfg config) {
-    final var distributionBuilder =
-        new FixedPartitionDistributorBuilder(PartitionManagerImpl.GROUP_NAME);
-
-    for (final var partition : config.getFixed()) {
-      for (final var node : partition.getNodes()) {
-        distributionBuilder.assignMember(
-            partition.getPartitionId(), node.getNodeId(), node.getPriority());
-      }
-    }
-
-    return distributionBuilder.build();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -12,7 +12,7 @@ import io.atomix.raft.partition.RaftPartitionGroup.Builder;
 import io.atomix.raft.storage.log.DelayedFlusher;
 import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.raft.ZeebeEntryValidator;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
@@ -31,7 +31,7 @@ public final class RaftPartitionGroupFactory {
 
   public RaftPartitionGroup buildRaftPartitionGroup(
       final BrokerCfg configuration,
-      final ClusterTopology topology,
+      final PartitionDistribution topology,
       final ReceivableSnapshotStoreFactory snapshotStoreFactory) {
 
     final DataCfg dataConfiguration = configuration.getData();
@@ -60,7 +60,7 @@ public final class RaftPartitionGroupFactory {
 
     final Builder partitionGroupBuilder =
         RaftPartitionGroup.builder(PartitionManagerImpl.GROUP_NAME)
-            .withPartitionDistribution(topology.partitionDistribution())
+            .withPartitionDistribution(topology.partitions())
             .withDataDirectory(raftDataDirectory.toFile())
             .withSnapshotStoreFactory(snapshotStoreFactory)
             .withMaxAppendBatchSize((int) experimentalCfg.getMaxAppendBatchSizeInBytes())

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopology.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopology.java
@@ -14,4 +14,7 @@ import java.util.Set;
  * ClusterTopology describes how partitions are distributed across broker. It doesn't keep track of
  * the current leader or followers.
  */
-public record ClusterTopology(Set<PartitionMetadata> partitionDistribution) {}
+public record ClusterTopology(Set<PartitionMetadata> partitionDistribution) {
+
+  public static final ClusterTopology NO_PARTITIONS = new ClusterTopology(Set.of());
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopology.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopology.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.topology;
+
+import io.atomix.primitive.partition.PartitionMetadata;
+import java.util.Set;
+
+/**
+ * ClusterTopology describes how partitions are distributed across broker. It doesn't keep track of
+ * the current leader or followers.
+ */
+public record ClusterTopology(Set<PartitionMetadata> partitionDistribution) {}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyManager.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyManager.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.topology;
+
+import static io.camunda.zeebe.broker.system.configuration.partitioning.Scheme.FIXED;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.raft.partition.PartitionDistributor;
+import io.atomix.raft.partition.RoundRobinPartitionDistributor;
+import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.broker.partitioning.distribution.FixedPartitionDistributor;
+import io.camunda.zeebe.broker.partitioning.distribution.FixedPartitionDistributorBuilder;
+import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
+import io.camunda.zeebe.broker.system.configuration.PartitioningCfg;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Manage how partitions are distributed among the brokers.
+ *
+ * <p>Note: Do not confuse it with the {@link TopologyManager}. {@link ClusterTopologyManager}
+ * doesn't keep track of the current leader and followers.
+ */
+public class ClusterTopologyManager {
+
+  public ClusterTopology resolveTopology(
+      final PartitioningCfg partitionCfg, final ClusterCfg clusterCfg) {
+    final var partitionDistributor = buildPartitionDistributor(partitionCfg);
+    final var clusterMembers = getRaftGroupMembers(clusterCfg);
+    final var partitionDistribution =
+        partitionDistributor.distributePartitions(
+            clusterMembers,
+            getSortedPartitionId(clusterCfg.getPartitionsCount()),
+            clusterCfg.getReplicationFactor());
+    return new ClusterTopology(partitionDistribution);
+  }
+
+  private PartitionDistributor buildPartitionDistributor(final PartitioningCfg config) {
+    return config.getScheme() == FIXED
+        ? buildFixedPartitionDistributor(config)
+        : new RoundRobinPartitionDistributor();
+  }
+
+  private FixedPartitionDistributor buildFixedPartitionDistributor(final PartitioningCfg config) {
+    final var distributionBuilder =
+        new FixedPartitionDistributorBuilder(PartitionManagerImpl.GROUP_NAME);
+
+    for (final var partition : config.getFixed()) {
+      for (final var node : partition.getNodes()) {
+        distributionBuilder.assignMember(
+            partition.getPartitionId(), node.getNodeId(), node.getPriority());
+      }
+    }
+
+    return distributionBuilder.build();
+  }
+
+  private Set<MemberId> getRaftGroupMembers(final ClusterCfg clusterCfg) {
+    final int clusterSize = clusterCfg.getClusterSize();
+    // node ids are always 0 to clusterSize - 1
+    return IntStream.range(0, clusterSize)
+        .mapToObj(nodeId -> MemberId.from(Integer.toString(nodeId)))
+        .collect(Collectors.toSet());
+  }
+
+  private static List<PartitionId> getSortedPartitionId(final int partitionCount) {
+    // partition ids start from 1
+    return IntStream.rangeClosed(1, partitionCount)
+        .mapToObj(p -> PartitionId.from(PartitionManagerImpl.GROUP_NAME, p))
+        .sorted()
+        .toList();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistribution.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistribution.java
@@ -11,10 +11,10 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import java.util.Set;
 
 /**
- * ClusterTopology describes how partitions are distributed across broker. It doesn't keep track of
- * the current leader or followers.
+ * PartitionDistribution describes how partitions are distributed across broker. It doesn't keep
+ * track of the current leader or followers.
  */
-public record ClusterTopology(Set<PartitionMetadata> partitionDistribution) {
+public record PartitionDistribution(Set<PartitionMetadata> partitions) {
 
-  public static final ClusterTopology NO_PARTITIONS = new ClusterTopology(Set.of());
+  public static final PartitionDistribution NO_PARTITIONS = new PartitionDistribution(Set.of());
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -91,6 +92,7 @@ class PartitionManagerStepTest {
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
       testBrokerStartupContext.setBrokerAdminService(mock(BrokerAdminServiceImpl.class));
       testBrokerStartupContext.setJobStreamService(mock(JobStreamService.class));
+      testBrokerStartupContext.setClusterTopology(ClusterTopology.NO_PARTITIONS);
 
       final var memberConfig = new MemberConfig();
       final var member = new Member(memberConfig);

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -92,7 +92,7 @@ class PartitionManagerStepTest {
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
       testBrokerStartupContext.setBrokerAdminService(mock(BrokerAdminServiceImpl.class));
       testBrokerStartupContext.setJobStreamService(mock(JobStreamService.class));
-      testBrokerStartupContext.setClusterTopology(ClusterTopology.NO_PARTITIONS);
+      testBrokerStartupContext.setClusterTopology(PartitionDistribution.NO_PARTITIONS);
 
       final var memberConfig = new MemberConfig();
       final var member = new Member(memberConfig);

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
@@ -20,6 +20,7 @@ import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -72,7 +73,8 @@ final class PartitionManagerImplTest {
             null,
             mock(ExporterRepository.class),
             null,
-            JobStreamer.noop());
+            JobStreamer.noop(),
+            ClusterTopology.NO_PARTITIONS);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
@@ -101,7 +103,8 @@ final class PartitionManagerImplTest {
             null,
             mock(ExporterRepository.class),
             null,
-            JobStreamer.noop());
+            JobStreamer.noop(),
+            ClusterTopology.NO_PARTITIONS);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
@@ -128,7 +131,8 @@ final class PartitionManagerImplTest {
             null,
             mock(ExporterRepository.class),
             null,
-            JobStreamer.noop());
+            JobStreamer.noop(),
+            ClusterTopology.NO_PARTITIONS);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
@@ -156,7 +160,8 @@ final class PartitionManagerImplTest {
             null,
             mock(ExporterRepository.class),
             null,
-            JobStreamer.noop());
+            JobStreamer.noop(),
+            ClusterTopology.NO_PARTITIONS);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
@@ -20,7 +20,7 @@ import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -74,7 +74,7 @@ final class PartitionManagerImplTest {
             mock(ExporterRepository.class),
             null,
             JobStreamer.noop(),
-            ClusterTopology.NO_PARTITIONS);
+            PartitionDistribution.NO_PARTITIONS);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
@@ -104,7 +104,7 @@ final class PartitionManagerImplTest {
             mock(ExporterRepository.class),
             null,
             JobStreamer.noop(),
-            ClusterTopology.NO_PARTITIONS);
+            PartitionDistribution.NO_PARTITIONS);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
@@ -132,7 +132,7 @@ final class PartitionManagerImplTest {
             mock(ExporterRepository.class),
             null,
             JobStreamer.noop(),
-            ClusterTopology.NO_PARTITIONS);
+            PartitionDistribution.NO_PARTITIONS);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
@@ -161,7 +161,7 @@ final class PartitionManagerImplTest {
             mock(ExporterRepository.class),
             null,
             JobStreamer.noop(),
-            ClusterTopology.NO_PARTITIONS);
+            PartitionDistribution.NO_PARTITIONS);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.raft.partition.RaftPartitionGroupConfig;
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
@@ -184,7 +184,7 @@ final class RaftPartitionGroupFactoryTest {
   private RaftPartitionGroupConfig buildRaftPartitionGroup() {
     final var partitionGroup =
         factory.buildRaftPartitionGroup(
-            brokerCfg, ClusterTopology.NO_PARTITIONS, SNAPSHOT_STORE_FACTORY);
+            brokerCfg, PartitionDistribution.NO_PARTITIONS, SNAPSHOT_STORE_FACTORY);
     return (RaftPartitionGroupConfig) partitionGroup.config();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.raft.partition.RaftPartitionGroupConfig;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopology;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
@@ -181,7 +182,9 @@ final class RaftPartitionGroupFactoryTest {
   }
 
   private RaftPartitionGroupConfig buildRaftPartitionGroup() {
-    final var partitionGroup = factory.buildRaftPartitionGroup(brokerCfg, SNAPSHOT_STORE_FACTORY);
+    final var partitionGroup =
+        factory.buildRaftPartitionGroup(
+            brokerCfg, ClusterTopology.NO_PARTITIONS, SNAPSHOT_STORE_FACTORY);
     return (RaftPartitionGroupConfig) partitionGroup.config();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyManagerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyManagerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
+import io.camunda.zeebe.broker.system.configuration.PartitioningCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class ClusterTopologyManagerTest {
+
+  @Test
+  void shouldGenerateRoundRobinDistribution() {
+    // given
+    final var expectedDistribution =
+        Map.of(
+            1,
+            Set.of(0, 1, 2),
+            2,
+            Set.of(1, 2, 3),
+            3,
+            Set.of(2, 3, 4),
+            4,
+            Set.of(3, 4, 5),
+            5,
+            Set.of(4, 5, 0),
+            6,
+            Set.of(5, 0, 1));
+
+    final PartitioningCfg partitioningCfg = new PartitioningCfg();
+    partitioningCfg.setScheme(Scheme.ROUND_ROBIN);
+    final ClusterCfg clusterCfg = new ClusterCfg();
+    clusterCfg.setClusterSize(6);
+    clusterCfg.setPartitionsCount(6);
+    clusterCfg.setReplicationFactor(3);
+
+    // when
+    final var topology = new ClusterTopologyManager().resolveTopology(partitioningCfg, clusterCfg);
+    final Set<PartitionMetadata> partitionDistribution = topology.partitionDistribution();
+
+    // then
+    // RoundRobinPartitionDistributorTest verifies more cases.
+    final var actualDistribution = getDistribution(partitionDistribution);
+    assertThat(actualDistribution).containsExactlyInAnyOrderEntriesOf(expectedDistribution);
+  }
+
+  private Map<Integer, Set<Integer>> getDistribution(
+      final Set<PartitionMetadata> partitionDistribution) {
+    return partitionDistribution.stream()
+        .collect(
+            Collectors.toMap(
+                p -> p.id().id(),
+                p ->
+                    p.members().stream()
+                        .map(m -> Integer.valueOf(m.id()))
+                        .collect(Collectors.toSet())));
+  }
+
+  @Test
+  void shouldGenerateFixedDistribution() throws IOException {
+    final var expectedDistribution =
+        Map.of(1, Set.of(0, 1, 2), 2, Set.of(1, 2, 0), 3, Set.of(0, 1, 2));
+    final String config =
+        """
+fixed:
+   - partitionId: 1
+     nodes:
+       - nodeId: 0
+         priority: 1
+       - nodeId: 1
+         priority: 2
+       - nodeId: 2
+         priority: 3
+   - partitionId: 2
+     nodes:
+       - nodeId: 0
+         priority: 3
+       - nodeId: 1
+         priority: 2
+       - nodeId: 2
+         priority: 1
+   - partitionId: 3
+     nodes:
+       - nodeId: 0
+         priority: 2
+       - nodeId: 1
+         priority: 3
+       - nodeId: 2
+         priority: 2
+""";
+
+    final var partitioningCfg =
+        new ObjectMapper(new YAMLFactory()).readValue(config, PartitioningCfg.class);
+    final var clusterCfg = new ClusterCfg();
+    clusterCfg.setClusterSize(3);
+    clusterCfg.setPartitionsCount(3);
+    clusterCfg.setReplicationFactor(3);
+
+    // when
+    final var topology = new ClusterTopologyManager().resolveTopology(partitioningCfg, clusterCfg);
+    final Set<PartitionMetadata> partitionDistribution = topology.partitionDistribution();
+
+    // then
+    // FixedPartitionDistributorTest verifies more cases.
+    final var actualDistribution = getDistribution(partitionDistribution);
+    assertThat(actualDistribution).containsExactlyInAnyOrderEntriesOf(expectedDistribution);
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyManagerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyManagerTest.java
@@ -50,7 +50,7 @@ class ClusterTopologyManagerTest {
 
     // when
     final var topology = new ClusterTopologyManager().resolveTopology(partitioningCfg, clusterCfg);
-    final Set<PartitionMetadata> partitionDistribution = topology.partitionDistribution();
+    final Set<PartitionMetadata> partitionDistribution = topology.partitions();
 
     // then
     // RoundRobinPartitionDistributorTest verifies more cases.
@@ -112,7 +112,7 @@ fixed:
 
     // when
     final var topology = new ClusterTopologyManager().resolveTopology(partitioningCfg, clusterCfg);
-    final Set<PartitionMetadata> partitionDistribution = topology.partitionDistribution();
+    final Set<PartitionMetadata> partitionDistribution = topology.partitions();
 
     // then
     // FixedPartitionDistributorTest verifies more cases.

--- a/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -12,6 +12,7 @@ import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.partitioning.RaftPartitionGroupFactory;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterTopologyManager;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -99,8 +100,13 @@ public class RestoreManager {
   private Set<RaftPartition> collectPartitions() {
 
     final var factory = new RaftPartitionGroupFactory();
+    final var clusterTopology =
+        new ClusterTopologyManager()
+            .resolveTopology(
+                configuration.getExperimental().getPartitioning(), configuration.getCluster());
     // snapshot store factory can be null because we are not going start the partitions.
-    final var partitionsGroup = factory.buildRaftPartitionGroup(configuration, null);
+    final var partitionsGroup =
+        factory.buildRaftPartitionGroup(configuration, clusterTopology, null);
 
     final var localBrokerId = configuration.getCluster().getNodeId();
     final var localMember = MemberId.from(String.valueOf(localBrokerId));


### PR DESCRIPTION
## Description

This PR takes resolving partition distribution out of RaftPartitionGroup. Partition distribution is generated by `ClusterTopologyManager` and provided to PartitionManager. Later this ClusterTopologyManager will be able to use the persisted topology if it is available instead of generating one from the static properties.

## Related issues

closes #13739 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
