### PR TITLE
refactor(client/java): remove tenant inference from javadocs

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -26,7 +26,7 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * <h1>One or more tenants</h1>
    *
    * <p>This method can be called multiple times to specify multiple tenants. If more than one
-   * tenant is provided, ownership of the resulting entities is inferred as described above.
+   * tenant is provided, ownership of the resulting entities is inferred.
    *
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
    * jobs will be owned by the tenant that owns the corresponding process instance.
@@ -53,8 +53,7 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    *
    * <h1>One or more tenants</h1>
    *
-   * <p>If more than one tenant is provided, ownership of the resulting entities is inferred as
-   * described in {@link #tenantId(String)}.
+   * <p>If more than one tenant is provided, ownership of the resulting entities is inferred.
    *
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
    * jobs will be owned by the tenant that owns the corresponding process instance.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -25,8 +25,7 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    *
    * <h1>One or more tenants</h1>
    *
-   * <p>This method can be called multiple times to specify multiple tenants. If more than one
-   * tenant is provided, ownership of the resulting entities is inferred.
+   * <p>This method can be called multiple times to specify multiple tenants.
    *
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
    * jobs will be owned by the tenant that owns the corresponding process instance.
@@ -52,8 +51,6 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * etc.) resulting from this command.
    *
    * <h1>One or more tenants</h1>
-   *
-   * <p>If more than one tenant is provided, ownership of the resulting entities is inferred.
    *
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
    * jobs will be owned by the tenant that owns the corresponding process instance.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
@@ -43,7 +43,8 @@ public interface CommandWithTenantStep<T> {
    * effect, and the interface and its description are subject to change.</strong>
    *
    * <p>Specifies the tenant that will own any entities (e.g. process definition, process instances,
-   * etc.) resulting from this command.
+   * etc.) resulting from this command, or that owns any entities (e.g. jobs) referred to from this
+   * command.
    *
    * <h1>Multi-tenancy</h1>
    *

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
@@ -53,17 +53,7 @@ public interface CommandWithTenantStep<T> {
    * <p>Any entities created before multi-tenancy has been enabled in the Zeebe cluster, are
    * assigned to the {@link #DEFAULT_TENANT_IDENTIFIER}.
    *
-   * <h2>Inferred ownership</h2>
-   *
-   * It's not always necessary to specify the {@code tenantId} explicitly. In many cases, the owning
-   * tenant can be inferred.
-   *
-   * <p>For example, an instance of a process that is owned by tenant {@code "ACME"} can be created
-   * without specifying the {@code tenantId} explicitly. The created process instance is then owned
-   * by {@code "ACME"} as well.
-   *
-   * <p>If no tenant is explicitly specified and the tenant could not be inferred, then the command
-   * is rejected.
+   * <p>If no tenant is explicitly specified, then the command is rejected.
    *
    * <h2>Shared entities</h2>
    *


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Remove tenant inference from the javadocs in the `CommandWithTenantStep` and `CommandWithOneOrMoreTenantsStep` interfaces. Tenant inference will not be supported with the multi-tenancy feature, so it shouldn't be documented in the client API.

:information_source: In the `CommandWithOneOrMoreTenantsStep` I decided to leave the following paragraph as I think it still fits the expected behavior. I'm open to suggestions.
```
<p>If more than one tenant is provided, ownership of the resulting entities is inferred.
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13747 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
