### PR TITLE
Remove zeebe-util dependency from zeebe-bpmn-model

### DIFF
--- a/bpmn-model/pom.xml
+++ b/bpmn-model/pom.xml
@@ -39,11 +39,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
-    </dependency>
-
     <!-- Test dependencies -->
 
     <dependency>

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/BpmnModelConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/BpmnModelConstants.java
@@ -16,7 +16,7 @@
 
 package io.camunda.zeebe.model.bpmn.impl;
 
-import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.model.bpmn.util.VersionUtil;
 
 /**
  * Constants used in the BPMN 2.0 Language (DI + Semantic)

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/VersionUtil.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/VersionUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class VersionUtil {
+  public static final Logger LOG = LoggerFactory.getLogger(VersionUtil.class);
+
+  private static final String VERSION_PROPERTIES_PATH = "/bpmn-model.properties";
+  private static final String VERSION_PROPERTY_NAME = "zeebe.version";
+  private static final String VERSION_DEV = "development";
+
+  private static String version;
+
+  private VersionUtil() {}
+
+  /**
+   * @return the current version or 'development' if none can be determined.
+   */
+  public static String getVersion() {
+    if (version == null) {
+      // read version from file
+      version = readProperty(VERSION_PROPERTY_NAME);
+      if (version == null) {
+        LOG.warn("Version is not found in version file.");
+        version = VersionUtil.class.getPackage().getImplementationVersion();
+      }
+
+      if (version == null) {
+        version = VERSION_DEV;
+      }
+    }
+
+    return version;
+  }
+
+  private static String readProperty(final String property) {
+    try (final InputStream versionFileStream =
+        VersionUtil.class.getResourceAsStream(VERSION_PROPERTIES_PATH)) {
+      final Properties props = new Properties();
+      props.load(versionFileStream);
+
+      return props.getProperty(property);
+    } catch (final IOException e) {
+      LOG.error(String.format("Can't read version file: %s", VERSION_PROPERTIES_PATH), e);
+    }
+
+    return null;
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/BpmnTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/BpmnTest.java
@@ -22,7 +22,7 @@ import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.MODELER_NS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.model.bpmn.instance.Definitions;
-import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.model.bpmn.util.VersionUtil;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
## Description

`zeebe-util` is an internal module. We don't want to expose it to our clients

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to this [comment](https://github.com/camunda/zeebe/pull/13707#issuecomment-1661879074)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
