### PR TITLE
Fix Banned instance metric in Zeebe dashboard

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -198,7 +198,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 9
+            "y": 1
           },
           "id": 68,
           "interval": "1s",
@@ -300,7 +300,7 @@
             "h": 4,
             "w": 9,
             "x": 8,
-            "y": 9
+            "y": 1
           },
           "id": 243,
           "options": {
@@ -401,7 +401,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 9
+            "y": 1
           },
           "id": 116,
           "links": [],
@@ -478,7 +478,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 13
+            "y": 5
           },
           "id": 542,
           "options": {
@@ -503,7 +503,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace)\nor max(zeebe_banned_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace)",
+              "expr": "sum(max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition))\nor sum(max(zeebe_banned_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}) by (namespace, partition))",
               "legendFormat": "{{namespace}}",
               "range": true,
               "refId": "A"
@@ -532,7 +532,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 7
           },
           "hiddenSeries": false,
           "id": 58,
@@ -639,7 +639,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 15
+            "y": 7
           },
           "hiddenSeries": false,
           "id": 270,
@@ -739,7 +739,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 20
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 62,
@@ -855,7 +855,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 20
+            "y": 12
           },
           "id": 232,
           "links": [],
@@ -912,7 +912,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 20
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 74,
@@ -1026,7 +1026,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 22
+            "y": 14
           },
           "id": 118,
           "links": [],
@@ -1103,7 +1103,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 24
+            "y": 16
           },
           "id": 117,
           "links": [],
@@ -1158,7 +1158,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 26
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 39,
@@ -1270,7 +1270,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 26
+            "y": 18
           },
           "id": 190,
           "links": [],
@@ -1336,7 +1336,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 26
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 33,


### PR DESCRIPTION
## Description

Change zeebe dashboard so that the counting of banned instances represents the sum of all banned instances in all partitions instead of picking-up the max value of them. 

Therefore currently we sum the number of the max number of banned instances per partition (the number of the follower might be momentarily behind the leader so we pick the max value). 

<!-- Please explain the changes you made here. -->

Before:
![image](https://github.com/camunda/zeebe/assets/132340590/2c3af174-7ef4-472b-9a84-a8da6ba91a0a)

After:
![image](https://github.com/camunda/zeebe/assets/132340590/7aeff386-fdaa-4fb2-aa63-522d41eb690f)

The changes were tested manually by creating and banning process instances in various partitions so that the changes applied could be observed.

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/13549

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
