### PR TITLE
fix(stream-platform): register record listener before start reading

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -131,11 +131,11 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
         snapshotPosition,
         streamProcessorMode);
 
-    replayNextEvent();
-
     if (streamProcessorMode == StreamProcessorMode.REPLAY) {
       logStream.registerRecordAvailableListener(this);
     }
+
+    replayNextEvent();
 
     return recoveryFuture;
   }


### PR DESCRIPTION
## Description

Couldn't reproduce test failure after 3k runs. 

The failure says replay was never executed. A possible cause is that the ReplayStateMachine misses the commit notification because it registered the listener too late. If the record was committed after `ReplayStateMachine` executed `replayNextEvent`, but before it registered the listener then it do not attempt to read again because the listener is never invoked.

To fix this, we change the order of first attempt to read the record and registering the listener. If the record is committed berfore registering listener, then it is guaranteed to read it in `replayNextEvent`. If it is committed after registering listener, it will either read it in `replayNextEvent` or get notified after that. 

## Related issues

closes #13257

