### PR TITLE
Raise incident on element instance commands exceeding max message size

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -119,7 +119,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         incidentBehavior.createIncident(
             new Failure(
                 """
-                Expected to transition element '%s', but ran into MAX_MESSAGE_SIZE limitation. \
+                Expected to process element '%s', but exceeded MAX_MESSAGE_SIZE limitation. \
                 If you have large or many variables consider reducing these."""
                     .formatted(BufferUtil.bufferAsString(transitionedContext.getElementId())),
                 ErrorType.MESSAGE_SIZE_EXCEEDED),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -7,11 +7,16 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn;
 
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.COMPLETE_ELEMENT;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.TERMINATE_ELEMENT;
+
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -22,7 +27,10 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.slf4j.Logger;
 
 public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessInstanceRecord> {
@@ -86,6 +94,40 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
             violation ->
                 rejectionWriter.appendRejection(
                     record, RejectionType.INVALID_STATE, violation.getMessage()));
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<ProcessInstanceRecord> command, final Throwable error) {
+    if (error instanceof ExceededBatchRecordSizeException) {
+      context.init(
+          command.getKey(), command.getValue(), (ProcessInstanceIntent) command.getIntent());
+      if (context.getBpmnElementType() != BpmnElementType.PROCESS) {
+        // set element's state to what it was doing, this allows us to resolve the incident later
+        final BpmnElementContext transitionedContext;
+        transitionedContext =
+            switch ((ProcessInstanceIntent) command.getIntent()) {
+              case ACTIVATE_ELEMENT -> stateTransitionBehavior.transitionToActivating(context);
+              case COMPLETE_ELEMENT -> stateTransitionBehavior.transitionToCompleting(context);
+              case TERMINATE_ELEMENT -> stateTransitionBehavior.transitionToTerminating(context);
+                // even though we don't know how to resolve this incident, we can still
+                // raise it so the user can use modification to recover. The incident resolution
+                // logic is smart enough to deal with this case. It will log an error due to
+                // IllegalStateException.
+              default -> context;
+            };
+        incidentBehavior.createIncident(
+            new Failure(
+                """
+                Expected to transition element '%s', but ran into MAX_MESSAGE_SIZE limitation. \
+                If you have large or many variables consider reducing these."""
+                    .formatted(BufferUtil.bufferAsString(transitionedContext.getElementId())),
+                ErrorType.MESSAGE_SIZE_EXCEEDED),
+            transitionedContext);
+        return ProcessingError.EXPECTED_ERROR;
+      }
+    }
+    return ProcessingError.UNEXPECTED_ERROR;
   }
 
   private void processEvent(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentCreatedApplier.java
@@ -29,7 +29,7 @@ final class IncidentCreatedApplier implements TypedEventApplier<IncidentIntent, 
   public void applyState(final long incidentKey, final IncidentRecord value) {
     incidentState.createIncident(incidentKey, value);
 
-    if (ErrorType.MESSAGE_SIZE_EXCEEDED == value.getErrorType()) {
+    if (ErrorType.MESSAGE_SIZE_EXCEEDED == value.getErrorType() && value.getJobKey() != -1) {
       final var jobKey = value.getJobKey();
       final var jobRecord = jobState.getJob(jobKey);
       jobState.disable(jobKey, jobRecord);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CallActivityTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CallActivityTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.it.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.ByteValue;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.springframework.util.unit.DataSize;
+
+public final class CallActivityTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE =
+      new EmbeddedBrokerRule(
+          cfg -> {
+            cfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(100));
+            cfg.getProcessing().setMaxCommandsInBatch(1);
+          });
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldRaiseIncidentWhenExceedingBatchSizeOnCallActivityActivation() {
+    final String child = Strings.newRandomValidBpmnId();
+    final String parent = Strings.newRandomValidBpmnId();
+
+    CLIENT_RULE.deployProcess(Bpmn.createExecutableProcess(child).startEvent("v1").done());
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess(parent)
+            .startEvent("v2")
+            .scriptTask("script1", c -> c.zeebeExpression("x").zeebeResultVariable("a"))
+            .scriptTask("script2", c -> c.zeebeExpression("x").zeebeResultVariable("b"))
+            .scriptTask("script3", c -> c.zeebeExpression("x").zeebeResultVariable("c"))
+            .scriptTask("script4", c -> c.zeebeExpression("x").zeebeResultVariable("d"))
+            .callActivity("call-activity", c -> c.zeebeProcessId(child))
+            .endEvent("end2")
+            .done());
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(parent)
+            .latestVersion()
+            .variables(Map.of("x", "x".repeat((int) ByteValue.ofKilobytes(25))))
+            .send()
+            .join();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .getFirst()
+                .getValue())
+        .describedAs("Expected incident to be raised")
+        .hasElementId("call-activity");
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IncidentIntent.CREATED)
+                .processInstanceRecords()
+                .onlyEvents()
+                .withElementId("call-activity"))
+        .extracting(Record::getIntent)
+        .containsExactly(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+        .doesNotContain(
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            ProcessInstanceIntent.ELEMENT_COMPLETING,
+            ProcessInstanceIntent.ELEMENT_COMPLETED);
+  }
+
+  @Test
+  public void shouldRaiseIncidentWhenExceedingBatchSizeOnCallActivityCompletion() {
+    final String child = Strings.newRandomValidBpmnId();
+    final String parent = Strings.newRandomValidBpmnId();
+
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess(child)
+            .startEvent("child")
+            .scriptTask("script1", c -> c.zeebeExpression("x").zeebeResultVariable("a"))
+            .scriptTask("script2", c -> c.zeebeExpression("x").zeebeResultVariable("b"))
+            .scriptTask("script3", c -> c.zeebeExpression("x").zeebeResultVariable("c"))
+            .scriptTask("script4", c -> c.zeebeExpression("x").zeebeResultVariable("d"))
+            .done());
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess(parent)
+            .startEvent("parent")
+            .callActivity("call-activity", c -> c.zeebeProcessId(child))
+            .endEvent("end2")
+            .done());
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(parent)
+            .latestVersion()
+            .variables(Map.of("x", "x".repeat((int) ByteValue.ofKilobytes(25))))
+            .send()
+            .join();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .getFirst()
+                .getValue())
+        .describedAs("Expected incident to be raised")
+        .hasElementId("call-activity");
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IncidentIntent.CREATED)
+                .processInstanceRecords()
+                .onlyEvents()
+                .withElementId("call-activity"))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            ProcessInstanceIntent.ELEMENT_ACTIVATING,
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            ProcessInstanceIntent.ELEMENT_COMPLETING)
+        .doesNotContain(ProcessInstanceIntent.ELEMENT_COMPLETED);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Instead of banning an instance when the processing of an element instance's command exceeds the max batch size (or max message size), this ensures we raise an incident.

In most cases, this incident is resolvable, allowing users to recover easily. In other cases, the incident makes the problem visual to the user and the user can recover using process instance modification.

Tests have been added to deal with the specifics of the referenced bug, which is the activation/completion of a call activity with many large variables. However, this should also help in most other cases.

This does not completely remove all cases where we ban instances. It only deals with those cases where we exceed the batch size, which is likely the biggest reason at this time.

More effort to deal with other unexpected errors is needed.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13521
relates to #5121 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
