### PR TITLE
[Backport stable/8.1] Raise incident on element instance commands exceeding max message size

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentCreatedApplier.java
@@ -29,7 +29,7 @@ final class IncidentCreatedApplier implements TypedEventApplier<IncidentIntent, 
   public void applyState(final long incidentKey, final IncidentRecord value) {
     incidentState.createIncident(incidentKey, value);
 
-    if (ErrorType.MESSAGE_SIZE_EXCEEDED == value.getErrorType()) {
+    if (ErrorType.MESSAGE_SIZE_EXCEEDED == value.getErrorType() && value.getJobKey() != -1) {
       final var jobKey = value.getJobKey();
       final var jobRecord = jobState.getJob(jobKey);
       jobState.disable(jobKey, jobRecord);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CallActivityTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CallActivityTest.java
@@ -52,10 +52,10 @@ public final class CallActivityTest {
     CLIENT_RULE.deployProcess(
         Bpmn.createExecutableProcess(parent)
             .startEvent("v2")
-            .scriptTask("script1", c -> c.zeebeExpression("x").zeebeResultVariable("a"))
-            .scriptTask("script2", c -> c.zeebeExpression("x").zeebeResultVariable("b"))
-            .scriptTask("script3", c -> c.zeebeExpression("x").zeebeResultVariable("c"))
-            .scriptTask("script4", c -> c.zeebeExpression("x").zeebeResultVariable("d"))
+            .intermediateThrowEvent("event1", e -> e.zeebeOutputExpression("x", "a"))
+            .intermediateThrowEvent("event2", e -> e.zeebeOutputExpression("x", "b"))
+            .intermediateThrowEvent("event3", e -> e.zeebeOutputExpression("x", "c"))
+            .intermediateThrowEvent("event4", e -> e.zeebeOutputExpression("x", "d"))
             .callActivity("call-activity", c -> c.zeebeProcessId(child))
             .endEvent("end2")
             .done());
@@ -103,10 +103,10 @@ public final class CallActivityTest {
     CLIENT_RULE.deployProcess(
         Bpmn.createExecutableProcess(parent)
             .startEvent("v2")
-            .scriptTask("script1", c -> c.zeebeExpression("x").zeebeResultVariable("a"))
-            .scriptTask("script2", c -> c.zeebeExpression("x").zeebeResultVariable("b"))
-            .scriptTask("script3", c -> c.zeebeExpression("x").zeebeResultVariable("c"))
-            .scriptTask("script4", c -> c.zeebeExpression("x").zeebeResultVariable("d"))
+            .intermediateThrowEvent("event1", e -> e.zeebeOutputExpression("x", "a"))
+            .intermediateThrowEvent("event2", e -> e.zeebeOutputExpression("x", "b"))
+            .intermediateThrowEvent("event3", e -> e.zeebeOutputExpression("x", "c"))
+            .intermediateThrowEvent("event4", e -> e.zeebeOutputExpression("x", "d"))
             .callActivity("call-activity", c -> c.zeebeProcessId(child))
             .endEvent("end2")
             .done());
@@ -157,10 +157,10 @@ public final class CallActivityTest {
     CLIENT_RULE.deployProcess(
         Bpmn.createExecutableProcess(child)
             .startEvent("child")
-            .scriptTask("script1", c -> c.zeebeExpression("x").zeebeResultVariable("a"))
-            .scriptTask("script2", c -> c.zeebeExpression("x").zeebeResultVariable("b"))
-            .scriptTask("script3", c -> c.zeebeExpression("x").zeebeResultVariable("c"))
-            .scriptTask("script4", c -> c.zeebeExpression("x").zeebeResultVariable("d"))
+            .intermediateThrowEvent("event1", e -> e.zeebeOutputExpression("x", "a"))
+            .intermediateThrowEvent("event2", e -> e.zeebeOutputExpression("x", "b"))
+            .intermediateThrowEvent("event3", e -> e.zeebeOutputExpression("x", "c"))
+            .intermediateThrowEvent("event4", e -> e.zeebeOutputExpression("x", "d"))
             .done());
     CLIENT_RULE.deployProcess(
         Bpmn.createExecutableProcess(parent)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CallActivityTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CallActivityTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.it.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.ByteValue;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.springframework.util.unit.DataSize;
+
+public final class CallActivityTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE =
+      new EmbeddedBrokerRule(
+          cfg -> {
+            cfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(100));
+            cfg.getProcessing().setMaxCommandsInBatch(1);
+          });
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldRaiseIncidentWhenExceedingBatchSizeOnCallActivityActivation() {
+    final String child = Strings.newRandomValidBpmnId();
+    final String parent = Strings.newRandomValidBpmnId();
+
+    CLIENT_RULE.deployProcess(Bpmn.createExecutableProcess(child).startEvent("v1").done());
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess(parent)
+            .startEvent("v2")
+            .scriptTask("script1", c -> c.zeebeExpression("x").zeebeResultVariable("a"))
+            .scriptTask("script2", c -> c.zeebeExpression("x").zeebeResultVariable("b"))
+            .scriptTask("script3", c -> c.zeebeExpression("x").zeebeResultVariable("c"))
+            .scriptTask("script4", c -> c.zeebeExpression("x").zeebeResultVariable("d"))
+            .callActivity("call-activity", c -> c.zeebeProcessId(child))
+            .endEvent("end2")
+            .done());
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(parent)
+            .latestVersion()
+            .variables(Map.of("x", "x".repeat((int) ByteValue.ofKilobytes(25))))
+            .send()
+            .join();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .getFirst()
+                .getValue())
+        .describedAs("Expected incident to be raised")
+        .hasElementId("call-activity");
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IncidentIntent.CREATED)
+                .processInstanceRecords()
+                .onlyEvents()
+                .withElementId("call-activity"))
+        .extracting(Record::getIntent)
+        .containsExactly(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+        .doesNotContain(
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            ProcessInstanceIntent.ELEMENT_COMPLETING,
+            ProcessInstanceIntent.ELEMENT_COMPLETED);
+  }
+
+  @Test
+  public void shouldRaiseIncidentWhenExceedingBatchSizeOnCallActivityCompletion() {
+    final String child = Strings.newRandomValidBpmnId();
+    final String parent = Strings.newRandomValidBpmnId();
+
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess(child)
+            .startEvent("child")
+            .scriptTask("script1", c -> c.zeebeExpression("x").zeebeResultVariable("a"))
+            .scriptTask("script2", c -> c.zeebeExpression("x").zeebeResultVariable("b"))
+            .scriptTask("script3", c -> c.zeebeExpression("x").zeebeResultVariable("c"))
+            .scriptTask("script4", c -> c.zeebeExpression("x").zeebeResultVariable("d"))
+            .done());
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess(parent)
+            .startEvent("parent")
+            .callActivity("call-activity", c -> c.zeebeProcessId(child))
+            .endEvent("end2")
+            .done());
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(parent)
+            .latestVersion()
+            .variables(Map.of("x", "x".repeat((int) ByteValue.ofKilobytes(25))))
+            .send()
+            .join();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .getFirst()
+                .getValue())
+        .describedAs("Expected incident to be raised")
+        .hasElementId("call-activity");
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IncidentIntent.CREATED)
+                .processInstanceRecords()
+                .onlyEvents()
+                .withElementId("call-activity"))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            ProcessInstanceIntent.ELEMENT_ACTIVATING,
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            ProcessInstanceIntent.ELEMENT_COMPLETING)
+        .doesNotContain(ProcessInstanceIntent.ELEMENT_COMPLETED);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Link to the PR that is back ported -->

Manual backport of #13789 

There was a small imports conflict in d1d285ab841811617e3319bc5dc6ee0c42ce2afe. I've added 0fff47e8ba38a3421d3b3c603107138a5199c5a0 to avoid using the script task in 8.1.

## Related issues

<!-- Link to the related issues of the origin PR -->

closes https://github.com/camunda/zeebe/issues/13521
relates to https://github.com/camunda/zeebe/issues/5121
