### PR TITLE
Define ClusterTopology to represent cluster configuration

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterChangePlan.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterChangePlan.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+record ClusterChangePlan() {
+  static ClusterChangePlan empty() {
+    return new ClusterChangePlan();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopology.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopology.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+import com.google.common.collect.ImmutableMap;
+import io.atomix.cluster.MemberId;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Represents the cluster topology which describes the current active, joining or leaving brokers
+ * and the partitions that each broker replicates.
+ */
+public record ClusterTopology(
+    long version, Map<MemberId, MemberState> members, ClusterChangePlan changes) {
+
+  static ClusterTopology init() {
+    return new ClusterTopology(0, Map.of(), ClusterChangePlan.empty());
+  }
+
+  ClusterTopology addMember(final MemberId memberId, final MemberState state) {
+    if (members.containsKey(memberId)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected add a new member, but member %s already exists with state %s",
+              memberId.id(), members.get(memberId)));
+    }
+
+    final var newMembers =
+        ImmutableMap.<MemberId, MemberState>builder().putAll(members).put(memberId, state).build();
+    return new ClusterTopology(version, newMembers, changes);
+  }
+
+  ClusterTopology updateMember(
+      final MemberId memberId, final UnaryOperator<MemberState> memberStateUpdater) {
+    if (!members.containsKey(memberId)) {
+      throw new IllegalStateException(
+          String.format("Expected to update member %s, but member does not exist", memberId.id()));
+    }
+    final var updateMemberState = memberStateUpdater.apply(members.get(memberId));
+    final var newMembers =
+        ImmutableMap.<MemberId, MemberState>builder()
+            .putAll(members)
+            .put(memberId, updateMemberState)
+            .buildKeepingLast();
+    return new ClusterTopology(version, newMembers, changes);
+  }
+
+  ClusterTopology merge(final ClusterTopology other) {
+    final var newVersion = Math.max(version, other.version);
+    final var mergedMembers =
+        Stream.concat(members.entrySet().stream(), other.members().entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, MemberState::merge));
+
+    // TODO: changes also have to be merged. We will do it when we add support for configuration
+    // changes.
+    return new ClusterTopology(newVersion, ImmutableMap.copyOf(mergedMembers), changes);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/MemberState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/MemberState.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+record MemberState(long version, State state, Map<Integer, PartitionState> partitions) {
+  static MemberState initializeAsActive(final Map<Integer, PartitionState> initialPartitions) {
+    return new MemberState(0, State.ACTIVE, initialPartitions);
+  }
+
+  static MemberState uninitialized() {
+    return new MemberState(0, State.UNINITIALIZED, Map.of());
+  }
+
+  MemberState toJoining() {
+    return update(State.JOINING, partitions);
+  }
+
+  MemberState toActive() {
+    return update(State.ACTIVE, partitions);
+  }
+
+  MemberState toLeaving() {
+    return update(State.LEAVING, partitions);
+  }
+
+  MemberState toLeft() {
+    return update(State.LEFT, partitions);
+  }
+
+  MemberState addPartition(final int partitionId, final PartitionState partitionState) {
+    if (partitions.containsKey(partitionId)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected add a new partition, but partition %d already exists with state %s",
+              partitionId, partitions.get(partitionId)));
+    }
+
+    return internalUpdatePartition(partitionId, partitionState);
+  }
+
+  MemberState updatePartition(
+      final int partitionId, final UnaryOperator<PartitionState> partitionStateUpdater) {
+    if (!partitions.containsKey(partitionId)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to update partition %d, but partition does not exist", partitionId));
+    }
+
+    final var updatedPartitionState = partitionStateUpdater.apply(partitions.get(partitionId));
+    return internalUpdatePartition(partitionId, updatedPartitionState);
+  }
+
+  MemberState removePartition(final int partitionId) {
+    final var mutableMap = new HashMap<>(partitions);
+    mutableMap.remove(partitionId);
+
+    final var updatedPartitions =
+        ImmutableMap.<Integer, PartitionState>builder().putAll(mutableMap).build();
+    return update(state, updatedPartitions);
+  }
+
+  MemberState merge(final MemberState other) {
+    if (other == null) {
+      return this;
+    }
+    // Choose the one with the highest version. MemberState is always updated by a member by itself.
+    // It is guaranteed that the highest version number is the latest state.
+    if (version >= other.version) {
+      return this;
+    } else {
+      return other;
+    }
+  }
+
+  private MemberState internalUpdatePartition(
+      final int partitionId, final PartitionState partitionState) {
+    final var updatedPartitions =
+        ImmutableMap.<Integer, PartitionState>builder()
+            .putAll(partitions)
+            .put(partitionId, partitionState)
+            .buildKeepingLast(); // choose last one if there are duplicate keys
+    return update(state, updatedPartitions);
+  }
+
+  private MemberState update(final State state, final Map<Integer, PartitionState> partitions) {
+    return new MemberState(version + 1, state, partitions);
+  }
+
+  enum State {
+    UNINITIALIZED,
+    JOINING,
+    ACTIVE,
+    LEAVING,
+    LEFT
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/PartitionState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/PartitionState.java
@@ -17,6 +17,10 @@ record PartitionState(State state, int priority) {
   }
 
   PartitionState toActive() {
+    if (state == State.LEAVING) {
+      throw new IllegalStateException(
+          String.format("Cannot transition to ACTIVE when current state is %s", state));
+    }
     return new PartitionState(State.ACTIVE, priority);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/PartitionState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/PartitionState.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+record PartitionState(State state, int priority) {
+  static PartitionState active(final int priority) {
+    return new PartitionState(State.ACTIVE, priority);
+  }
+
+  static PartitionState joining(final int priority) {
+    return new PartitionState(State.JOINING, priority);
+  }
+
+  PartitionState toActive() {
+    return new PartitionState(State.ACTIVE, priority);
+  }
+
+  PartitionState toLeaving() {
+    return new PartitionState(State.LEAVING, priority);
+  }
+
+  enum State {
+    JOINING,
+    ACTIVE,
+    LEAVING
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyTest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClusterTopologyTest {
+
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyTest.java
@@ -7,8 +7,119 @@
  */
 package io.camunda.zeebe.broker.clustering.topology;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.clustering.topology.MemberState.State;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
 
 class ClusterTopologyTest {
+  @Test
+  void canInitializeClusterWithPreExistingMembers() {
+    // given
+    final var expectedTopology =
+        new ClusterTopology(
+            0,
+            Map.of(
+                member(1),
+                withActivePartition(0, 1),
+                member(2),
+                withActivePartition(0, 2),
+                member(3),
+                withActivePartition(0, 3)),
+            new ClusterChangePlan());
+    // when
+    final var topology =
+        ClusterTopology.init()
+            .addMember(
+                member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))))
+            .addMember(
+                member(2), MemberState.initializeAsActive(Map.of(2, PartitionState.active(1))))
+            .addMember(
+                member(3), MemberState.initializeAsActive(Map.of(3, PartitionState.active(1))));
 
+    // then
+    assertThat(topology).isEqualTo(expectedTopology);
+  }
+
+  @Test
+  void shouldMergeConcurrentUpdatesToMembers() {
+    // given
+    final var expectedMergedTopology =
+        new ClusterTopology(
+            0,
+            Map.of(member(1), withActivePartition(1, 1), member(2), withActivePartition(1, 2)),
+            new ClusterChangePlan());
+    final var topology =
+        ClusterTopology.init()
+            .addMember(
+                member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.joining(1))))
+            .addMember(
+                member(2), MemberState.initializeAsActive(Map.of(2, PartitionState.joining(1))));
+
+    // update topology in one member
+    final var topologyInMemberOne =
+        topology.updateMember(member(1), m -> m.updatePartition(1, PartitionState::toActive));
+    // update topology in the other member concurrently
+    final var topologyInMemberTwo =
+        topology.updateMember(member(2), m -> m.updatePartition(2, PartitionState::toActive));
+
+    // when
+    final var mergedTopologyOne = topologyInMemberOne.merge(topologyInMemberTwo);
+    final var mergedTopologyTwo = topologyInMemberTwo.merge(topologyInMemberOne);
+
+    // then
+    assertThat(mergedTopologyOne).isEqualTo(expectedMergedTopology);
+    assertThat(mergedTopologyTwo).isEqualTo(expectedMergedTopology);
+  }
+
+  @Test
+  void shouldAddANewMember() {
+    // given
+    final var expectedTopology =
+        new ClusterTopology(
+            0,
+            Map.of(
+                member(1),
+                withActivePartition(0, 1),
+                member(2),
+                withActivePartition(0, 2),
+                member(3),
+                new MemberState(1, State.JOINING, Map.of())),
+            new ClusterChangePlan());
+
+    final var initialTopology =
+        ClusterTopology.init()
+            .addMember(
+                member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))))
+            .addMember(
+                member(2), MemberState.initializeAsActive(Map.of(2, PartitionState.active(1))));
+
+    var topologyOnAnotherMember = ClusterTopology.init().merge(initialTopology);
+
+    // when
+    final var updateTopology =
+        initialTopology.addMember(member(3), MemberState.uninitialized().toJoining());
+
+    // then
+    assertThat(updateTopology).isEqualTo(expectedTopology);
+
+    // when
+    topologyOnAnotherMember = topologyOnAnotherMember.merge(updateTopology);
+
+    // then
+    assertThat(topologyOnAnotherMember).isEqualTo(expectedTopology);
+  }
+
+  private MemberId member(final int id) {
+    return MemberId.from(Integer.toString(id));
+  }
+
+  private MemberState withActivePartition(final int version, final int partitionId) {
+    return new MemberState(
+        version,
+        State.ACTIVE,
+        Map.of(partitionId, new PartitionState(PartitionState.State.ACTIVE, 1)));
+  }
 }


### PR DESCRIPTION
## Description

`ClusterTopology` represents the topology of the cluster that involves which brokers are member of the cluster, their state and which partitions they own. This contains all info that is required to restart a cluster with same partition distribution as before.  `ClusterTopology` is persisted and propagated via gossip. 
- This is called topology, and not configuration so as not confuse with the normal configuration. 
- However, this can be confused with the other Topology that we have which keeps track of the current leaders and followers. My hope is that at some point in future we can merge these two into one. However, this is not in the plan for near future. If this is confusing, we can come up with a different name for ClusterTopology.

## Related issues

closes #13793 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
