### PR TITLE
refactor(atomix): reuse state thread context

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/LogCompactor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/LogCompactor.java
@@ -12,7 +12,6 @@ import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.VisibleForTesting;
-import java.util.concurrent.Executor;
 import org.agrona.LangUtil;
 import org.slf4j.Logger;
 
@@ -73,9 +72,8 @@ public final class LogCompactor {
   }
 
   /** Compacts the log based on the snapshot store's lowest compaction bound. */
-  public void compactFromSnapshots(
-      final PersistedSnapshotStore snapshotStore, final Executor executor) {
-    snapshotStore.getCompactionBound().onComplete(this::onSnapshotCompactionBound, executor);
+  public void compactFromSnapshots(final PersistedSnapshotStore snapshotStore) {
+    snapshotStore.getCompactionBound().onComplete(this::onSnapshotCompactionBound, threadContext);
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -254,7 +254,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     threadContext.execute(
         () -> {
           currentSnapshot = persistedSnapshot;
-          logCompactor.compactFromSnapshots(persistedSnapshotStore, threadContext);
+          logCompactor.compactFromSnapshots(persistedSnapshotStore);
         });
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/impl/LogCompactorTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/impl/LogCompactorTest.java
@@ -34,6 +34,14 @@ final class LogCompactorTest {
   void beforeEach() {
     threadContext = Mockito.mock(ThreadContext.class);
     raftLog = Mockito.mock(RaftLog.class);
+    // immediately run anything to be executed
+    Mockito.doAnswer(
+            i -> {
+              i.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(threadContext)
+        .execute(Mockito.any());
 
     compactor =
         new LogCompactor(
@@ -92,7 +100,7 @@ final class LogCompactorTest {
     InMemorySnapshot.newPersistedSnapshot(30L, 1, 30, store);
 
     // when
-    compactor.compactFromSnapshots(store, Runnable::run);
+    compactor.compactFromSnapshots(store);
 
     // then
     Mockito.verify(


### PR DESCRIPTION
## Description

I just realized the thread context is already present in the log compactor, so we can just reuse it. It's also slightly nicer as we can ensure that it's always on the same context.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
