### PR TITLE
New getVariable() API

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -107,4 +107,12 @@ public interface ActivatedJob {
    */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/13560")
   String getTenantId();
+
+  /**
+   * Variable returned by name after the process is completed.
+   *
+   * @param name the name of the variable
+   * @return de-serialized variable value
+   */
+  Object getVariable(String name);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -98,6 +98,11 @@ public interface ActivatedJob {
   <T> T getVariablesAsType(Class<T> variableType);
 
   /**
+   * @return de-serialized variable value
+   */
+  Object getVariable(String name);
+
+  /**
    * @return the record encoded as JSON
    */
   String toJson();
@@ -107,12 +112,4 @@ public interface ActivatedJob {
    */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/13560")
   String getTenantId();
-
-  /**
-   * Variable returned by name after the process is completed.
-   *
-   * @param name the name of the variable
-   * @return de-serialized variable value
-   */
-  Object getVariable(String name);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -99,7 +99,8 @@ public interface ActivatedJob {
 
   /**
    * @return de-serialized variable value or null if the provided variable name is present among the
-   * available variables, otherwise throw a {@link io.camunda.zeebe.client.api.command.ClientException}
+   *     available variables, otherwise throw a {@link
+   *     io.camunda.zeebe.client.api.command.ClientException}
    */
   Object getVariable(String name);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -98,7 +98,8 @@ public interface ActivatedJob {
   <T> T getVariablesAsType(Class<T> variableType);
 
   /**
-   * @return de-serialized variable value
+   * @return de-serialized variable value or null if the provided variable name is present among the
+   * available variables, otherwise throw a {@link io.camunda.zeebe.client.api.command.ClientException}
    */
   Object getVariable(String name);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
@@ -56,7 +56,8 @@ public interface ProcessInstanceResult {
    * Variable returned by name after the process is completed.
    *
    * @param name the name of the variable
-   * @return de-serialized variable value
+   * @return de-serialized variable value or null if the provided variable name is present among the
+   * available variables, otherwise throw a {@link io.camunda.zeebe.client.api.command.ClientException}
    */
   Object getVariable(String name);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
@@ -57,7 +57,8 @@ public interface ProcessInstanceResult {
    *
    * @param name the name of the variable
    * @return de-serialized variable value or null if the provided variable name is present among the
-   * available variables, otherwise throw a {@link io.camunda.zeebe.client.api.command.ClientException}
+   *     available variables, otherwise throw a {@link
+   *     io.camunda.zeebe.client.api.command.ClientException}
    */
   Object getVariable(String name);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
@@ -52,10 +52,6 @@ public interface ProcessInstanceResult {
    */
   <T> T getVariablesAsType(Class<T> variableType);
 
-  /** Tenant identifier that owns this process instance */
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13321")
-  String getTenantId();
-
   /**
    * Variable returned by name after the process is completed.
    *
@@ -63,4 +59,8 @@ public interface ProcessInstanceResult {
    * @return de-serialized variable value
    */
   Object getVariable(String name);
+
+  /** Tenant identifier that owns this process instance */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13321")
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
@@ -55,4 +55,12 @@ public interface ProcessInstanceResult {
   /** Tenant identifier that owns this process instance */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/13321")
   String getTenantId();
+
+  /**
+   * Variable returned by name after the process is completed.
+   *
+   * @param name the name of the variable
+   * @return de-serialized variable value
+   */
+  Object getVariable(String name);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -17,7 +17,7 @@ package io.camunda.zeebe.client.impl.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.client.api.JsonMapper;
-import io.camunda.zeebe.client.api.command.InternalClientException;
+import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.HashMap;
@@ -148,7 +148,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   public Object getVariable(final String name) {
     final Map<String, Object> variables = getVariablesAsMap();
     if (!variables.containsKey(name)) {
-      throw new InternalClientException(String.format("The variable %s is not available", name));
+      throw new ClientException(String.format("The variable %s is not available", name));
     }
     return getVariablesAsMap().get(name);
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -148,8 +148,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   public Object getVariable(final String name) {
     final Map<String, Object> variables = getVariablesAsMap();
     if (!variables.containsKey(name)) {
-      throw new InternalClientException(
-          String.format("The variable %s is not available", name));
+      throw new InternalClientException(String.format("The variable %s is not available", name));
     }
     return getVariablesAsMap().get(name);
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -40,6 +40,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final long deadline;
   private final String variables;
 
+  private Map<String, Object> variablesAsMap;
+
   public ActivatedJobImpl(final JsonMapper jsonMapper, final GatewayOuterClass.ActivatedJob job) {
     this.jsonMapper = jsonMapper;
 
@@ -130,7 +132,10 @@ public final class ActivatedJobImpl implements ActivatedJob {
 
   @Override
   public Map<String, Object> getVariablesAsMap() {
-    return jsonMapper.fromJsonAsMap(variables);
+    if (variablesAsMap == null) {
+      variablesAsMap = jsonMapper.fromJsonAsMap(variables);
+    }
+    return variablesAsMap;
   }
 
   @Override
@@ -147,6 +152,11 @@ public final class ActivatedJobImpl implements ActivatedJob {
   public String getTenantId() {
     // todo(#13560): replace dummy implementation
     return "";
+  }
+
+  @Override
+  public Object getVariable(final String name) {
+    return getVariablesAsMap().get(name);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.impl.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.command.InternalClientException;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.HashMap;
@@ -144,6 +145,16 @@ public final class ActivatedJobImpl implements ActivatedJob {
   }
 
   @Override
+  public Object getVariable(final String name) {
+    final Map<String, Object> variables = getVariablesAsMap();
+    if (!variables.containsKey(name)) {
+      throw new InternalClientException(
+          String.format("The variable %s is not available", name));
+    }
+    return getVariablesAsMap().get(name);
+  }
+
+  @Override
   public String toJson() {
     return jsonMapper.toJson(this);
   }
@@ -152,11 +163,6 @@ public final class ActivatedJobImpl implements ActivatedJob {
   public String getTenantId() {
     // todo(#13560): replace dummy implementation
     return "";
-  }
-
-  @Override
-  public Object getVariable(final String name) {
-    return getVariablesAsMap().get(name);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -29,6 +29,8 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   private final long processInstanceKey;
   private final String variables;
 
+  private Map<String, Object> variablesAsMap;
+
   public CreateProcessInstanceWithResultResponseImpl(
       final JsonMapper jsonMapper, final CreateProcessInstanceWithResultResponse response) {
     this.jsonMapper = jsonMapper;
@@ -66,7 +68,10 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
 
   @Override
   public Map<String, Object> getVariablesAsMap() {
-    return jsonMapper.fromJsonAsMap(variables);
+    if (variablesAsMap == null) {
+      variablesAsMap = jsonMapper.fromJsonAsMap(variables);
+    }
+    return variablesAsMap;
   }
 
   @Override
@@ -78,6 +83,11 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   public String getTenantId() {
     // todo(#13536): replace dummy implementation
     return "";
+  }
+
+  @Override
+  public Object getVariable(final String name) {
+    return getVariablesAsMap().get(name);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.client.impl.response;
 
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ClientException;
-import io.camunda.zeebe.client.api.command.InternalClientException;
 import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
 import java.util.Map;
@@ -85,8 +84,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   public Object getVariable(final String name) {
     final Map<String, Object> variables = getVariablesAsMap();
     if (!variables.containsKey(name)) {
-      throw new ClientException(
-          String.format("The variable %s is not available", name));
+      throw new ClientException(String.format("The variable %s is not available", name));
     }
     return getVariablesAsMap().get(name);
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -16,6 +16,8 @@
 package io.camunda.zeebe.client.impl.response;
 
 import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.InternalClientException;
 import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
 import java.util.Map;
@@ -80,14 +82,19 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   }
 
   @Override
-  public String getTenantId() {
-    // todo(#13536): replace dummy implementation
-    return "";
+  public Object getVariable(final String name) {
+    final Map<String, Object> variables = getVariablesAsMap();
+    if (!variables.containsKey(name)) {
+      throw new ClientException(
+          String.format("The variable %s is not available", name));
+    }
+    return getVariablesAsMap().get(name);
   }
 
   @Override
-  public Object getVariable(final String name) {
-    return getVariablesAsMap().get(name);
+  public String getTenantId() {
+    // todo(#13536): replace dummy implementation
+    return "";
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -332,8 +332,7 @@ public final class ActivateJobsTest extends ClientTest {
   public void shouldThrowAnErrorIfVariableNameIsNotPresent() {
     final String variables = "{\"key\" : \"val\", \"foo\" : \"bar\", \"joe\" : \"doe\"}";
     // given
-    final ActivatedJob activatedJob1 =
-        ActivatedJob.newBuilder().setVariables(variables).build();
+    final ActivatedJob activatedJob1 = ActivatedJob.newBuilder().setVariables(variables).build();
 
     gatewayService.onActivateJobsRequest(activatedJob1);
 
@@ -352,8 +351,7 @@ public final class ActivateJobsTest extends ClientTest {
   public void shouldReturnNullIfVariableValueIsNull() {
     final String variables = "{\"key\" : null}";
     // given
-    final ActivatedJob activatedJob1 =
-        ActivatedJob.newBuilder().setVariables(variables).build();
+    final ActivatedJob activatedJob1 = ActivatedJob.newBuilder().setVariables(variables).build();
 
     gatewayService.onActivateJobsRequest(activatedJob1);
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -298,6 +298,36 @@ public final class ActivateJobsTest extends ClientTest {
         .isEqualTo(builder);
   }
 
+  @Test
+  public void shouldGetSingleVariable() {
+    final String variablesJob1 = "{\"key\" : \"val\", \"foo\" : \"bar\", \"joe\" : \"doe\"}";
+    final String variablesJob2 = "{\"key\" : \"val2\", \"foo\" : \"bar2\", \"joe\" : \"doe2\"}";
+    // given
+    final ActivatedJob activatedJob1 =
+        ActivatedJob.newBuilder().setVariables(variablesJob1).build();
+
+    final ActivatedJob activatedJob2 =
+        ActivatedJob.newBuilder().setVariables(variablesJob2).build();
+
+    gatewayService.onActivateJobsRequest(activatedJob1, activatedJob2);
+
+    // when
+    final ActivateJobsResponse response =
+        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join();
+
+    assertThat(response.getJobs()).hasSize(2);
+
+    final io.camunda.zeebe.client.api.response.ActivatedJob job1 = response.getJobs().get(0);
+    assertThat(job1.getVariable("key")).isEqualTo("val");
+    assertThat(job1.getVariable("foo")).isEqualTo("bar");
+    assertThat(job1.getVariable("joe")).isEqualTo("doe");
+
+    final io.camunda.zeebe.client.api.response.ActivatedJob job2 = response.getJobs().get(1);
+    assertThat(job2.getVariable("key")).isEqualTo("val2");
+    assertThat(job2.getVariable("foo")).isEqualTo("bar2");
+    assertThat(job2.getVariable("joe")).isEqualTo("doe2");
+  }
+
   static class VariablesPojo {
 
     int a;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
@@ -397,6 +397,15 @@ public final class CreateProcessInstanceWithResultTest {
         .containsEntry("process instance", "modified");
   }
 
+  @Test
+  public void shouldCreateProcessInstanceAndGetSingleVariable() {
+    final Map<String, Object> variables = Maps.of(entry("foo", "bar"), entry("key", "value"));
+    final ProcessInstanceResult result = createProcessInstanceWithVariables(variables).join();
+
+    assertThat(result.getVariable("foo")).isEqualTo("bar");
+    assertThat(result.getVariable("key")).isEqualTo("value");
+  }
+
   private ZeebeFuture<ProcessInstanceResult> createProcessInstanceWithVariables(
       final Map<String, Object> variables) {
     return CLIENT_RULE

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
@@ -26,8 +26,10 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.collections4.map.HashedMap;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -404,6 +406,25 @@ public final class CreateProcessInstanceWithResultTest {
 
     assertThat(result.getVariable("foo")).isEqualTo("bar");
     assertThat(result.getVariable("key")).isEqualTo("value");
+  }
+
+  @Test
+  public void shouldCreateProcessInstanceAndGetSingleVariableWithNullValue() {
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("key", null);
+    final ProcessInstanceResult result = createProcessInstanceWithVariables(variables).join();
+
+    assertThat(result.getVariable("key")).isNull();
+  }
+
+  @Test
+  public void shouldCreateProcessInstanceAndThrowAnErrorIfVariableIsNotPresent() {
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("key", "value");
+    final ProcessInstanceResult result = createProcessInstanceWithVariables(variables).join();
+
+    assertThatThrownBy(() -> result.getVariable("notPresentKey"))
+        .isInstanceOf(ClientException.class);
   }
 
   private ZeebeFuture<ProcessInstanceResult> createProcessInstanceWithVariables(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.collections4.map.HashedMap;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

To reduce the boilerplate of doing `job.getVariablesAsMap().get("name")` we provide a new API `getVariable(name)`, allowing users to easily get a single variable by name.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13752 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
