### PR TITLE
Introduce minimal job worker metrics

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -84,6 +84,18 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
@@ -231,6 +231,15 @@ public interface JobWorkerBuilderStep1 {
     JobWorkerBuilderStep3 streamTimeout(final Duration timeout);
 
     /**
+     * Sets the job worker metrics implementation to use. See {@link JobWorkerMetrics} for more.
+     * Defaults to {@link JobWorkerMetrics#noop()}, an implementation which simply does nothing.
+     *
+     * @param metrics the implementation to use
+     * @return the builder for this worker
+     */
+    JobWorkerBuilderStep3 metrics(final JobWorkerMetrics metrics);
+
+    /**
      * Open the worker and start to work on available tasks.
      *
      * @return the worker

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerMetrics.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerMetrics.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.worker;
+
+import io.camunda.zeebe.client.api.worker.metrics.MicrometerJobWorkerMetricsBuilder;
+import io.camunda.zeebe.client.impl.worker.metrics.MicrometerJobWorkerMetricsBuilderImpl;
+
+/** Worker metrics API. Allows basic instrumenting of job activation and handling. */
+public interface JobWorkerMetrics {
+
+  /**
+   * Called every time one or more jobs are activated.
+   *
+   * <p>NOTE: this is called <em>before</em> the job is worked on.
+   *
+   * @param count the amount of jobs that were activated
+   */
+  default void jobActivated(final int count) {}
+
+  /**
+   * Called every time one or more jobs are handled.
+   *
+   * <p>NOTE: this is called <em>after</em> a job has been worked on, successfully or not.
+   *
+   * @param count the amount of jobs that were handled
+   */
+  default void jobHandled(final int count) {}
+
+  /**
+   * Returns a new builder for the Micrometer bridge.
+   *
+   * @throws UnsupportedOperationException if Micrometer is not found in the class path
+   */
+  static MicrometerJobWorkerMetricsBuilder micrometer() {
+    try {
+      Class.forName("io.micrometer.core.instrument.MeterRegistry");
+    } catch (final ClassNotFoundException e) {
+      throw new UnsupportedOperationException(
+          "Expected to create Micrometer worker metrics, but it seems Micrometer is not in your classpath",
+          e);
+    }
+
+    return new MicrometerJobWorkerMetricsBuilderImpl();
+  }
+
+  /** Returns an implementation which does nothing. */
+  static JobWorkerMetrics noop() {
+    return new JobWorkerMetrics() {};
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client.api.worker.metrics;
 import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 
 /**
  * Builder interface for the {@link JobWorkerMetrics} backed by Micrometer. This is an optional
@@ -56,7 +57,7 @@ public interface MicrometerJobWorkerMetricsBuilder {
    * @param tags the tags to apply to all metrics
    * @return this builder for chaining
    */
-  MicrometerJobWorkerMetricsBuilder withTags(final String... tags);
+  MicrometerJobWorkerMetricsBuilder withTags(final Iterable<Tag> tags);
 
   JobWorkerMetrics build();
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.worker.metrics;
+
+import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Builder interface for the {@link JobWorkerMetrics} backed by Micrometer. This is an optional
+ * feature which requires you to add <a href="https://micrometer.io">Micrometer</a> to your
+ * classpath (see <a href="https://micrometer.io/docs/installing">the installation guide</a> for
+ * more).
+ *
+ * <p>This will create a {@link JobWorkerMetrics} implementation which will track the following
+ * metrics:
+ *
+ * <ul>
+ *   <li>A counter for the jobs activated count
+ *   <li>A counter for the jobs handled count
+ * </ul>
+ *
+ * From these counters you can derive the rate of jobs activated, the rate of jobs handled, and
+ * subtract both to estimate the count/rate of jobs queued in a given worker.
+ *
+ * <p>NOTE: the names may be changed depending on the registry backing Micrometer (e.g. Prometheus
+ * names will replace the periods with underscore, etc.)
+ */
+public interface MicrometerJobWorkerMetricsBuilder {
+
+  /**
+   * Specifies where the worker metrics will be registered. If null, {@link
+   * io.micrometer.core.instrument.Metrics#globalRegistry} is used.
+   *
+   * @param meterRegistry the meter registry to use
+   * @return this builder for chaining
+   */
+  MicrometerJobWorkerMetricsBuilder withMeterRegistry(final MeterRegistry meterRegistry);
+
+  /**
+   * Tags which will be applied to all worker metrics. Can be null.
+   *
+   * @param tags the tags to apply to all metrics
+   * @return this builder for chaining
+   */
+  MicrometerJobWorkerMetricsBuilder withTags(final String... tags);
+
+  JobWorkerMetrics build();
+
+  /** Set of possible metrics/metric names. */
+  @SuppressWarnings("NullableProblems")
+  enum Names implements KeyName {
+    /** Counter backing the {@link JobWorkerMetrics#jobActivated(int)} count. */
+    JOB_ACTIVATED {
+      @Override
+      public String asString() {
+        return "zeebe.client.worker.job.activated";
+      }
+    },
+
+    /** Counter backing the {@link JobWorkerMetrics#jobHandled(int)} count. */
+    JOB_HANDLED {
+      @Override
+      public String asString() {
+        return "zeebe.client.worker.job.handled";
+      }
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java
@@ -15,149 +15,18 @@
  */
 package io.camunda.zeebe.client.impl.worker;
 
-import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.worker.JobClient;
-import io.camunda.zeebe.client.impl.Loggers;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
-import java.time.Duration;
-import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
-import org.slf4j.Logger;
 
-public final class JobPoller {
+@FunctionalInterface
+public interface JobPoller {
 
-  private static final Logger LOG = Loggers.JOB_POLLER_LOGGER;
-
-  private final JobClient jobClient;
-  private final Duration requestTimeout;
-  private final String jobType;
-  private final String workerName;
-  private final Duration timeout;
-  private final List<String> fetchVariables;
-
-  private int maxJobsToActivate;
-
-  private Consumer<ActivatedJob> jobConsumer;
-  private IntConsumer doneCallback;
-  private Consumer<Throwable> errorCallback;
-  private int activatedJobs;
-  private BooleanSupplier openSupplier;
-
-  public JobPoller(
-      final JobClient jobClient,
-      final Duration requestTimeout,
-      final String jobType,
-      final String workerName,
-      final Duration timeout,
-      final List<String> fetchVariables,
-      final int maxJobsToActivate) {
-    this.requestTimeout = requestTimeout;
-    this.jobClient = jobClient;
-    this.jobType = jobType;
-    this.workerName = workerName;
-    this.timeout = timeout;
-    this.fetchVariables = fetchVariables;
-    this.maxJobsToActivate = maxJobsToActivate;
-  }
-
-  private void reset() {
-    activatedJobs = 0;
-  }
-
-  /**
-   * Poll for available jobs. Jobs returned by zeebe are activated.
-   *
-   * @param maxJobsToActivate maximum number of jobs to activate
-   * @param jobConsumer consumes each activated job individually
-   * @param doneCallback consumes the number of jobs activated
-   * @param errorCallback consumes thrown error
-   * @param openSupplier supplies whether the consumer is open
-   */
-  public void poll(
-      final int maxJobsToActivate,
-      final Consumer<ActivatedJob> jobConsumer,
-      final IntConsumer doneCallback,
-      final Consumer<Throwable> errorCallback,
-      final BooleanSupplier openSupplier) {
-    reset();
-
-    this.maxJobsToActivate = maxJobsToActivate;
-    this.jobConsumer = jobConsumer;
-    this.doneCallback = doneCallback;
-    this.errorCallback = errorCallback;
-    this.openSupplier = openSupplier;
-
-    poll();
-  }
-
-  private void poll() {
-    LOG.trace(
-        "Polling at max {} jobs for worker {} and job type {}",
-        maxJobsToActivate,
-        workerName,
-        jobType);
-    final ActivateJobsCommandStep3 activateCommand =
-        jobClient
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(maxJobsToActivate)
-            .timeout(timeout)
-            .workerName(workerName);
-    if (fetchVariables != null) {
-      activateCommand.fetchVariables(fetchVariables);
-    }
-    activateCommand
-        .requestTimeout(requestTimeout)
-        .send()
-        .exceptionally(
-            throwable -> {
-              if (openSupplier.getAsBoolean()) {
-                try {
-                  logFailure(throwable);
-                } finally {
-                  errorCallback.accept(throwable);
-                }
-              }
-              return null;
-            })
-        .thenApply(
-            activateJobsResponse -> {
-              final List<ActivatedJob> jobs = activateJobsResponse.getJobs();
-              activatedJobs += jobs.size();
-              jobs.forEach(jobConsumer);
-              if (activatedJobs > 0) {
-                LOG.debug(
-                    "Activated {} jobs for worker {} and job type {}",
-                    activatedJobs,
-                    workerName,
-                    jobType);
-              } else {
-                LOG.trace("No jobs activated for worker {} and job type {}", workerName, jobType);
-              }
-              doneCallback.accept(activatedJobs);
-              return null;
-            });
-  }
-
-  private void logFailure(final Throwable throwable) {
-    final String errorMsg = "Failed to activate jobs for worker {} and job type {}";
-
-    if (throwable instanceof StatusRuntimeException) {
-      final StatusRuntimeException statusRuntimeException = (StatusRuntimeException) throwable;
-      if (statusRuntimeException.getStatus().getCode() == Status.RESOURCE_EXHAUSTED.getCode()) {
-        // Log RESOURCE_EXHAUSTED status exceptions only as trace, otherwise it is just too
-        // noisy. Furthermore it is not worth to be a warning since it is expected on a fully
-        // loaded cluster. It should be handled by our backoff mechanism, but if there is an
-        // issue or an configuration mistake the user can turn on trace logging to see this.
-        LOG.trace(errorMsg, workerName, jobType, throwable);
-        return;
-      }
-    }
-
-    LOG.warn(errorMsg, workerName, jobType, throwable);
-  }
+  void poll(
+      int maxJobsToActivate,
+      Consumer<ActivatedJob> jobConsumer,
+      IntConsumer doneCallback,
+      Consumer<Throwable> errorCallback,
+      BooleanSupplier openSupplier);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPollerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPollerImpl.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.impl.Loggers;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import org.slf4j.Logger;
+
+public final class JobPollerImpl implements JobPoller {
+
+  private static final Logger LOG = Loggers.JOB_POLLER_LOGGER;
+
+  private final JobClient jobClient;
+  private final Duration requestTimeout;
+  private final String jobType;
+  private final String workerName;
+  private final Duration timeout;
+  private final List<String> fetchVariables;
+
+  private int maxJobsToActivate;
+
+  private Consumer<ActivatedJob> jobConsumer;
+  private IntConsumer doneCallback;
+  private Consumer<Throwable> errorCallback;
+  private int activatedJobs;
+  private BooleanSupplier openSupplier;
+
+  public JobPollerImpl(
+      final JobClient jobClient,
+      final Duration requestTimeout,
+      final String jobType,
+      final String workerName,
+      final Duration timeout,
+      final List<String> fetchVariables,
+      final int maxJobsToActivate) {
+    this.requestTimeout = requestTimeout;
+    this.jobClient = jobClient;
+    this.jobType = jobType;
+    this.workerName = workerName;
+    this.timeout = timeout;
+    this.fetchVariables = fetchVariables;
+    this.maxJobsToActivate = maxJobsToActivate;
+  }
+
+  private void reset() {
+    activatedJobs = 0;
+  }
+
+  /**
+   * Poll for available jobs. Jobs returned by zeebe are activated.
+   *
+   * @param maxJobsToActivate maximum number of jobs to activate
+   * @param jobConsumer consumes each activated job individually
+   * @param doneCallback consumes the number of jobs activated
+   * @param errorCallback consumes thrown error
+   * @param openSupplier supplies whether the consumer is open
+   */
+  @Override
+  public void poll(
+      final int maxJobsToActivate,
+      final Consumer<ActivatedJob> jobConsumer,
+      final IntConsumer doneCallback,
+      final Consumer<Throwable> errorCallback,
+      final BooleanSupplier openSupplier) {
+    reset();
+
+    this.maxJobsToActivate = maxJobsToActivate;
+    this.jobConsumer = jobConsumer;
+    this.doneCallback = doneCallback;
+    this.errorCallback = errorCallback;
+    this.openSupplier = openSupplier;
+
+    poll();
+  }
+
+  private void poll() {
+    LOG.trace(
+        "Polling at max {} jobs for worker {} and job type {}",
+        maxJobsToActivate,
+        workerName,
+        jobType);
+    final ActivateJobsCommandStep3 activateCommand =
+        jobClient
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(maxJobsToActivate)
+            .timeout(timeout)
+            .workerName(workerName);
+    if (fetchVariables != null) {
+      activateCommand.fetchVariables(fetchVariables);
+    }
+    activateCommand
+        .requestTimeout(requestTimeout)
+        .send()
+        .exceptionally(
+            throwable -> {
+              if (openSupplier.getAsBoolean()) {
+                try {
+                  logFailure(throwable);
+                } finally {
+                  errorCallback.accept(throwable);
+                }
+              }
+              return null;
+            })
+        .thenApply(
+            activateJobsResponse -> {
+              final List<ActivatedJob> jobs = activateJobsResponse.getJobs();
+              activatedJobs += jobs.size();
+              jobs.forEach(jobConsumer);
+              if (activatedJobs > 0) {
+                LOG.debug(
+                    "Activated {} jobs for worker {} and job type {}",
+                    activatedJobs,
+                    workerName,
+                    jobType);
+              } else {
+                LOG.trace("No jobs activated for worker {} and job type {}", workerName, jobType);
+              }
+              doneCallback.accept(activatedJobs);
+              return null;
+            });
+  }
+
+  private void logFailure(final Throwable throwable) {
+    final String errorMsg = "Failed to activate jobs for worker {} and job type {}";
+
+    if (throwable instanceof StatusRuntimeException) {
+      final StatusRuntimeException statusRuntimeException = (StatusRuntimeException) throwable;
+      if (statusRuntimeException.getStatus().getCode() == Status.RESOURCE_EXHAUSTED.getCode()) {
+        // Log RESOURCE_EXHAUSTED status exceptions only as trace, otherwise it is just too
+        // noisy. Furthermore it is not worth to be a warning since it is expected on a fully
+        // loaded cluster. It should be handled by our backoff mechanism, but if there is an
+        // issue or an configuration mistake the user can turn on trace logging to see this.
+        LOG.trace(errorMsg, workerName, jobType, throwable);
+        return;
+      }
+    }
+
+    LOG.warn(errorMsg, workerName, jobType, throwable);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobRunnableFactoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobRunnableFactoryImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.client.impl.Loggers;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.slf4j.Logger;
+
+public final class JobRunnableFactoryImpl implements JobRunnableFactory {
+
+  private static final Logger LOG = Loggers.JOB_WORKER_LOGGER;
+
+  private final JobClient jobClient;
+  private final JobHandler handler;
+
+  public JobRunnableFactoryImpl(final JobClient jobClient, final JobHandler handler) {
+    this.jobClient = jobClient;
+    this.handler = handler;
+  }
+
+  @Override
+  public Runnable create(final ActivatedJob job, final Runnable doneCallback) {
+    return () -> executeJob(job, doneCallback);
+  }
+
+  private void executeJob(final ActivatedJob job, final Runnable doneCallback) {
+    try {
+      handler.handle(jobClient, job);
+    } catch (final Exception e) {
+      LOG.warn(
+          "Worker {} failed to handle job with key {} of type {}, sending fail command to broker",
+          job.getWorker(),
+          job.getKey(),
+          job.getType(),
+          e);
+      final StringWriter stringWriter = new StringWriter();
+      final PrintWriter printWriter = new PrintWriter(stringWriter);
+      e.printStackTrace(printWriter);
+      final String message = stringWriter.toString();
+      jobClient
+          .newFailCommand(job.getKey())
+          .retries(job.getRetries() - 1)
+          .errorMessage(message)
+          .send();
+    } finally {
+      doneCallback.run();
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -165,9 +165,9 @@ public final class JobWorkerBuilderImpl
     ensureGreaterThan("maxJobsActive", maxJobsActive, 0);
 
     final JobStreamer jobStreamer;
-    final JobRunnableFactory jobRunnableFactory = new JobRunnableFactory(jobClient, handler);
+    final JobRunnableFactory jobRunnableFactory = new JobRunnableFactoryImpl(jobClient, handler);
     final JobPoller jobPoller =
-        new JobPoller(
+        new JobPollerImpl(
             jobClient, requestTimeout, jobType, workerName, timeout, fetchVariables, maxJobsActive);
 
     if (enableStreaming) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -33,7 +33,6 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 
 public final class JobWorkerBuilderImpl
@@ -152,7 +151,7 @@ public final class JobWorkerBuilderImpl
 
   @Override
   public JobWorkerBuilderStep3 metrics(final JobWorkerMetrics metrics) {
-    this.metrics = Optional.ofNullable(metrics).orElse(JobWorkerMetrics.noop());
+    this.metrics = metrics == null ? JobWorkerMetrics.noop() : metrics;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/metrics/MicrometerJobWorkerMetrics.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/metrics/MicrometerJobWorkerMetrics.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker.metrics;
+
+import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
+import io.micrometer.core.instrument.Counter;
+import java.util.Objects;
+
+public final class MicrometerJobWorkerMetrics implements JobWorkerMetrics {
+
+  private final Counter jobActivatedCounter;
+  private final Counter jobHandledCounter;
+
+  public MicrometerJobWorkerMetrics(
+      final Counter jobActivatedCounter, final Counter jobHandledCounter) {
+    this.jobActivatedCounter =
+        Objects.requireNonNull(jobActivatedCounter, "must specify a job activated counter");
+    this.jobHandledCounter =
+        Objects.requireNonNull(jobHandledCounter, "must specify a job handled counter");
+  }
+
+  @Override
+  public void jobActivated(final int count) {
+    jobActivatedCounter.increment(count);
+  }
+
+  @Override
+  public void jobHandled(final int count) {
+    jobHandledCounter.increment(count);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/metrics/MicrometerJobWorkerMetricsBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/metrics/MicrometerJobWorkerMetricsBuilderImpl.java
@@ -20,13 +20,13 @@ import io.camunda.zeebe.client.api.worker.metrics.MicrometerJobWorkerMetricsBuil
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 
 public final class MicrometerJobWorkerMetricsBuilderImpl
     implements MicrometerJobWorkerMetricsBuilder {
-  private static final String[] EMPTY_TAGS_ARRAY = new String[0];
-
   private MeterRegistry meterRegistry = Metrics.globalRegistry;
-  private String[] tags = EMPTY_TAGS_ARRAY;
+  private Iterable<Tag> tags = Tags.empty();
 
   @Override
   public MicrometerJobWorkerMetricsBuilder withMeterRegistry(final MeterRegistry meterRegistry) {
@@ -35,8 +35,8 @@ public final class MicrometerJobWorkerMetricsBuilderImpl
   }
 
   @Override
-  public MicrometerJobWorkerMetricsBuilder withTags(final String... tags) {
-    this.tags = tags == null ? EMPTY_TAGS_ARRAY : tags;
+  public MicrometerJobWorkerMetricsBuilder withTags(final Iterable<Tag> tags) {
+    this.tags = tags == null ? Tags.empty() : tags;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/metrics/MicrometerJobWorkerMetricsBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/metrics/MicrometerJobWorkerMetricsBuilderImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker.metrics;
+
+import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
+import io.camunda.zeebe.client.api.worker.metrics.MicrometerJobWorkerMetricsBuilder;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+
+public final class MicrometerJobWorkerMetricsBuilderImpl
+    implements MicrometerJobWorkerMetricsBuilder {
+  private static final String[] EMPTY_TAGS_ARRAY = new String[0];
+
+  private MeterRegistry meterRegistry = Metrics.globalRegistry;
+  private String[] tags = EMPTY_TAGS_ARRAY;
+
+  @Override
+  public MicrometerJobWorkerMetricsBuilder withMeterRegistry(final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry == null ? Metrics.globalRegistry : meterRegistry;
+    return this;
+  }
+
+  @Override
+  public MicrometerJobWorkerMetricsBuilder withTags(final String... tags) {
+    this.tags = tags == null ? EMPTY_TAGS_ARRAY : tags;
+    return this;
+  }
+
+  @Override
+  public JobWorkerMetrics build() {
+    final Counter jobActivatedCounter = meterRegistry.counter(Names.JOB_ACTIVATED.asString(), tags);
+    final Counter jobHandledCounter = meterRegistry.counter(Names.JOB_HANDLED.asString(), tags);
+    return new MicrometerJobWorkerMetrics(jobActivatedCounter, jobHandledCounter);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobPollerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobPollerImplTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.zeebe.client.job;
+package io.camunda.zeebe.client.impl.worker;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.impl.worker.JobPoller;
 import io.camunda.zeebe.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.grpc.Status;
@@ -36,7 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public final class JobPollerTest extends ClientTest {
+public final class JobPollerImplTest extends ClientTest {
 
   private Consumer<ActivatedJob> jobConsumer;
   private IntConsumer doneCallback;
@@ -106,7 +105,7 @@ public final class JobPollerTest extends ClientTest {
   }
 
   private JobPoller getJobPoller(final Duration requestTimeout) {
-    return new JobPoller(
+    return new JobPollerImpl(
         client,
         requestTimeout,
         "testJobType",

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.ZeebeClientImpl;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
-import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
@@ -44,8 +43,6 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
@@ -241,30 +238,6 @@ public final class JobWorkerImplTest {
       synchronized (metricsLock) {
         return countedPolls;
       }
-    }
-  }
-
-  private static final class TestData {
-    private static GatewayOuterClass.ActivatedJob job() {
-      return GatewayOuterClass.ActivatedJob.newBuilder()
-          .setKey(12)
-          .setType("foo")
-          .setProcessInstanceKey(123)
-          .setBpmnProcessId("test1")
-          .setProcessDefinitionVersion(2)
-          .setProcessDefinitionKey(23)
-          .setElementId("foo")
-          .setElementInstanceKey(23213)
-          .setCustomHeaders("{\"version\": \"1\"}")
-          .setWorker("worker1")
-          .setRetries(34)
-          .setDeadline(1231)
-          .setVariables("{\"key\": \"val\"}")
-          .build();
-    }
-
-    private static List<ActivatedJob> jobs(final int numberOfJobs) {
-      return IntStream.range(0, numberOfJobs).mapToObj(i -> job()).collect(Collectors.toList());
     }
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.zeebe.client.impl.response.ActivatedJobImpl;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.jupiter.api.Test;
+
+final class JobWorkerMetricsTest {
+
+  private final DeterministicScheduler executor = new DeterministicScheduler();
+
+  @Test
+  void shouldCountActivatedStreamedJobs() {
+    // given
+    final TestJobStreamer streamer = new TestJobStreamer();
+    final TestJobWorkerMetrics metrics = new TestJobWorkerMetrics();
+
+    try (final JobWorkerImpl ignored = createWorker(0, streamer, metrics)) {
+      // when
+      streamer.streamJob();
+      streamer.streamJob();
+
+      // then
+      executor.runUntilIdle();
+      assertThat(metrics.jobsActivated).hasValue(2);
+    }
+  }
+
+  @Test
+  void shouldCountHandledStreamedJobs() {
+    // given
+    final TestJobStreamer streamer = new TestJobStreamer();
+    final TestJobWorkerMetrics metrics = new TestJobWorkerMetrics();
+
+    try (final JobWorkerImpl ignored = createWorker(2, streamer, metrics)) {
+      // when
+      streamer.streamJob();
+      streamer.streamJob();
+      streamer.streamJob();
+
+      // then
+      executor.runUntilIdle();
+      assertThat(metrics.jobsHandled).hasValue(2);
+    }
+  }
+
+  @Test
+  void shouldCountActivatedPolledJobs() {
+    // given
+    final TestJobPoller poller = new TestJobPoller();
+    final TestJobWorkerMetrics metrics = new TestJobWorkerMetrics();
+
+    try (final JobWorkerImpl ignored = createWorker(0, poller, metrics)) {
+      // when
+      executor.tick(1, TimeUnit.MINUTES);
+      poller.streamJob();
+      poller.streamJob();
+
+      // then
+      executor.runUntilIdle();
+      assertThat(metrics.jobsActivated).hasValue(2);
+    }
+  }
+
+  @Test
+  void shouldCountHandledPolledJobs() {
+    // given
+    final TestJobPoller poller = new TestJobPoller();
+    final TestJobWorkerMetrics metrics = new TestJobWorkerMetrics();
+
+    try (final JobWorkerImpl ignored = createWorker(3, poller, metrics)) {
+      // when
+      executor.tick(1, TimeUnit.MINUTES);
+      poller.streamJob();
+      poller.streamJob();
+      poller.streamJob();
+      poller.streamJob();
+
+      // then
+      executor.runUntilIdle();
+      assertThat(metrics.jobsHandled).hasValue(3);
+    }
+  }
+
+  private JobWorkerImpl createWorker(
+      final int autoCompleteCount,
+      final TestJobStreamer streamer,
+      final TestJobWorkerMetrics metrics) {
+    return createWorker(autoCompleteCount, new TestJobPoller(), streamer, metrics);
+  }
+
+  private JobWorkerImpl createWorker(
+      final int autoCompleteCount, final TestJobPoller poller, final TestJobWorkerMetrics metrics) {
+    return createWorker(autoCompleteCount, poller, new TestJobStreamer(), metrics);
+  }
+
+  private JobWorkerImpl createWorker(
+      final int autoCompleteCount,
+      final TestJobPoller poller,
+      final TestJobStreamer streamer,
+      final TestJobWorkerMetrics metrics) {
+    return new JobWorkerImpl(
+        1,
+        executor,
+        Duration.ofSeconds(30),
+        new TestJobRunnableFactory(autoCompleteCount),
+        poller,
+        streamer,
+        delay -> delay,
+        metrics);
+  }
+
+  private static final class TestJobWorkerMetrics implements JobWorkerMetrics {
+    private final AtomicInteger jobsActivated = new AtomicInteger();
+    private final AtomicInteger jobsHandled = new AtomicInteger();
+
+    @Override
+    public void jobActivated(final int count) {
+      jobsActivated.addAndGet(count);
+    }
+
+    @Override
+    public void jobHandled(final int count) {
+      jobsHandled.addAndGet(count);
+    }
+  }
+
+  private static final class TestJobPoller implements JobPoller {
+    private final AtomicReference<Consumer<ActivatedJob>> consumerRef = new AtomicReference<>();
+    private final JsonMapper mapper = new ZeebeObjectMapper();
+
+    @Override
+    public void poll(
+        final int maxJobsToActivate,
+        final Consumer<ActivatedJob> jobConsumer,
+        final IntConsumer doneCallback,
+        final Consumer<Throwable> errorCallback,
+        final BooleanSupplier openSupplier) {
+      consumerRef.set(jobConsumer);
+    }
+
+    private void streamJob() {
+      final ActivatedJobImpl job = new ActivatedJobImpl(mapper, TestData.job());
+      Optional.ofNullable(consumerRef.get()).ifPresent(c -> c.accept(job));
+    }
+  }
+
+  private static final class TestJobRunnableFactory implements JobRunnableFactory {
+
+    private final AtomicInteger counter = new AtomicInteger();
+    private final int autoCompleteCount;
+
+    private TestJobRunnableFactory(final int autoCompleteCount) {
+      this.autoCompleteCount = autoCompleteCount;
+    }
+
+    @Override
+    public Runnable create(final ActivatedJob job, final Runnable doneCallback) {
+      if (autoCompleteCount <= 0 || counter.get() < autoCompleteCount) {
+        counter.incrementAndGet();
+        return doneCallback;
+      }
+
+      return () -> {};
+    }
+  }
+
+  private static final class TestJobStreamer implements JobStreamer {
+    private final AtomicReference<Consumer<ActivatedJob>> consumerRef = new AtomicReference<>();
+    private final JsonMapper mapper = new ZeebeObjectMapper();
+
+    @Override
+    public void close() {
+      consumerRef.set(null);
+    }
+
+    @Override
+    public void openStreamer(final Consumer<ActivatedJob> jobConsumer) {
+      consumerRef.set(jobConsumer);
+    }
+
+    private void streamJob() {
+      final ActivatedJobImpl job = new ActivatedJobImpl(mapper, TestData.job());
+      Optional.ofNullable(consumerRef.get()).ifPresent(c -> c.accept(job));
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/TestData.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/TestData.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+final class TestData {
+  static GatewayOuterClass.ActivatedJob job() {
+    return GatewayOuterClass.ActivatedJob.newBuilder()
+        .setKey(12)
+        .setType("foo")
+        .setProcessInstanceKey(123)
+        .setBpmnProcessId("test1")
+        .setProcessDefinitionVersion(2)
+        .setProcessDefinitionKey(23)
+        .setElementId("foo")
+        .setElementInstanceKey(23213)
+        .setCustomHeaders("{\"version\": \"1\"}")
+        .setWorker("worker1")
+        .setRetries(34)
+        .setDeadline(1231)
+        .setVariables("{\"key\": \"val\"}")
+        .build();
+  }
+
+  static List<ActivatedJob> jobs(final int numberOfJobs) {
+    return IntStream.range(0, numberOfJobs).mapToObj(i -> job()).collect(Collectors.toList());
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/metrics/MicrometerJobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/metrics/MicrometerJobWorkerMetricsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker.metrics;
+
+import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
+import io.camunda.zeebe.client.api.worker.metrics.MicrometerJobWorkerMetricsBuilder.Names;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+
+final class MicrometerJobWorkerMetricsTest {
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final Iterable<Tag> tags = Tags.of("foo", "bar");
+  private final JobWorkerMetrics metrics =
+      JobWorkerMetrics.micrometer().withMeterRegistry(meterRegistry).withTags(tags).build();
+
+  @Test
+  void shouldCountActivatedJobs() {
+    // when
+    metrics.jobActivated(5);
+
+    // then
+    Assertions.assertThat(meterRegistry).has(new HasMeter(Names.JOB_ACTIVATED, tags, 5));
+  }
+
+  @Test
+  void shouldCountHandledJobs() {
+    // when
+    metrics.jobHandled(3);
+
+    // then
+    Assertions.assertThat(meterRegistry).has(new HasMeter(Names.JOB_HANDLED, tags, 3));
+  }
+
+  private static final class HasMeter extends Condition<MeterRegistry> {
+    private final Names name;
+    private final Iterable<Tag> tags;
+    private final int count;
+
+    private HasMeter(final Names name, final Iterable<Tag> tags, final int count) {
+      super(
+          String.format(
+              "counter named '%s', with tags %s, and count '%d'", name.asString(), tags, count));
+      this.name = name;
+      this.tags = tags;
+      this.count = count;
+    }
+
+    @Override
+    public boolean matches(final MeterRegistry value) {
+      final Counter counter = value.find(name.asString()).tags(tags).counter();
+      if (counter == null) {
+        return false;
+      }
+
+      return counter.count() == count;
+    }
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -670,6 +670,14 @@
       </dependency>
 
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${version.micrometer}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-client</artifactId>
         <version>${version.elasticsearch}</version>
@@ -802,18 +810,6 @@
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient_hotspot</artifactId>
         <version>${version.prometheus}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-core</artifactId>
-        <version>${version.micrometer}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-registry-prometheus</artifactId>
-        <version>${version.micrometer}</version>
       </dependency>
 
       <dependency>
@@ -1118,13 +1114,6 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${version.gson}</version>
-      </dependency>
-
-      <!-- between micrometer-core 1.10.2 and spring-web 6.0.0 -->
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-observation</artifactId>
-        <version>${version.micrometer}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Adds a new API to the job worker builder that allows users to pass a custom `JobWorkerMetrics` implementation. This currently supports two metrics:

- `jobActivated(int count)`: called every time one or more jobs is activated (but not yet handled)
- `jobHandled(int count)`: called every time one or more jobs has been handled by the `JobHandler`

> **Note**
> While we currently always call the above for each individual jobs, I opted to pass in the count for future proofing.

I opted to go for a minimal set of metrics for now, on the reasoning that it's easier to add things than to remove them. From these two counters we can derive the rate of activation, the rate of handling, and subtract one from the other to estimate the amount of queued jobs.

Additionally, an optional implementation was added for Micrometer, which will help integration with Spring and Micronaut. Users can call `JobWorkerMetrics#micrometer`, which returns a builder that lets them pass a custom `MeterRegistry` and a set of fixed tags (e.g. the worker job type, the app version, etc.)

The Micrometer implementation will create the following counters:

- `zeebe.client.worker.job.activated`
- `zeebe.client.worker.job.handled`

> **Note**
> Micrometer will automatically adapt the meter names to the actual registry backend. For example, for Prometheus, the periods will be replaced with underscores, such that `zeebe.client.worker.job.activated` becomes `zeebe_client_worker_job_activated`.

Finally, some of the commits include test refactoring, namely introducing interfaces for the `JobPoller` and the `JobRunnableFactory`, as this allows us to pass controllable implementation during tests, making it very easy to unit test the job worker. This avoids doing complicated test setups with concurrency primitives to provide synchronization points (e.g. activated job but don't complete it yet) and so on.

## Related issues

closes #4700 
closes #13814 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
