### PR TITLE
[Backport stable/8.2] Build starter/worker using mvn install instead of package

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -152,7 +152,7 @@ jobs:
         id: image-tag
         run: |
           echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - run: ./mvnw -B -D skipTests -D skipChecks -pl benchmarks/project -am package
+      - run: ./mvnw -B -D skipTests -D skipChecks -pl benchmarks/project -am install
       - name: Build Starter Image
         run: ./mvnw -pl benchmarks/project jib:build -P starter -D image="gcr.io/zeebe-io/starter:${{ steps.image-tag.outputs.image-tag }}"
       - name: Build Worker Image


### PR DESCRIPTION
# Description
Backport of #13828 to `stable/8.2`.

relates to 
original author: @remcowesterhoud