### PR TITLE
Cache parsed DRGs

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+
+public final class CachesCfg implements ConfigurationEntry {
+  private int drgCacheCapacity = EngineConfiguration.DEFAULT_DRG_CACHE_CAPACITY;
+
+  public int getDrgCacheCapacity() {
+    return drgCacheCapacity;
+  }
+
+  public void setDrgCacheCapacity(final int drgCacheCapacity) {
+    this.drgCacheCapacity = drgCacheCapacity;
+  }
+
+  @Override
+  public String toString() {
+    return "CachesCfg{" + "drgCacheCapacity=" + drgCacheCapacity + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -14,10 +14,12 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 public final class EngineCfg implements ConfigurationEntry {
 
   private MessagesCfg messages = new MessagesCfg();
+  private CachesCfg caches = new CachesCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     messages.init(globalConfig, brokerBase);
+    caches.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -28,14 +30,23 @@ public final class EngineCfg implements ConfigurationEntry {
     this.messages = messages;
   }
 
+  public CachesCfg getCaches() {
+    return caches;
+  }
+
+  public void setCaches(final CachesCfg caches) {
+    this.caches = caches;
+  }
+
   @Override
   public String toString() {
-    return "EngineCfg{" + "messages=" + messages + '}';
+    return "EngineCfg{" + "messages=" + messages + ", caches=" + caches + '}';
   }
 
   public EngineConfiguration createEngineConfiguration() {
     return new EngineConfiguration()
         .setMessagesTtlCheckerBatchLimit(messages.getTtlCheckerBatchLimit())
-        .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval());
+        .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval())
+        .setDrgCacheCapacity(caches.getDrgCacheCapacity());
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -29,6 +29,7 @@ final class EngineCfgTest {
     // then
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofMinutes(1));
+    assertThat(configuration.getDrgCacheCapacity()).isEqualTo(1000L);
   }
 
   @Test
@@ -42,5 +43,6 @@ final class EngineCfgTest {
     // then
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(1000);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofSeconds(15));
+    assertThat(configuration.getDrgCacheCapacity()).isEqualTo(2000L);
   }
 }

--- a/broker/src/test/resources/system/engine.yaml
+++ b/broker/src/test/resources/system/engine.yaml
@@ -5,3 +5,5 @@ zeebe:
         messages:
           ttlCheckerBatchLimit: 1000
           ttlCheckerInterval: 15s
+        caches:
+          drgCacheCapacity: 2000

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1061,6 +1061,13 @@
           # of messages in a single execution. See `ttlCheckerBatchLimit` to configure the size of these batches.
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERINTERVAL
           # ttlCheckerInterval: 1m
+        
+        # caches:
+          # Allows to configure the Decision Requirements Graph cache size. By default this is set to 1000.
+          # If there are more than 1000 different DRG's actively used in the cluster it is recommended
+          # to increase the size of this cache. The cache prevents having to parse DRG's everytime a
+          # decision is evaluated. If the cache is full, the least used DRG gets evicted.
+          # drgCacheCapacity: 1000
 
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -971,6 +971,13 @@
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERINTERVAL
           # ttlCheckerInterval: 1m
 
+        # caches:
+          # Allows to configure the Decision Requirements Graph cache size. By default this is set to 1000.
+          # If there are more than 1000 different DRG's actively used in the cluster it is recommended
+          # to increase the size of this cache. The cache prevents having to parse DRG's everytime a
+          # decision is evaluated. If the cache is full, the least used DRG gets evicted.
+          # drgCacheCapacity: 1000
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -105,6 +105,11 @@
       <artifactId>cron-utils</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -20,8 +20,11 @@ public final class EngineConfiguration {
   // message size.
   public static final int BATCH_SIZE_CALCULATION_BUFFER = 1024 * 8;
 
+  public static final int DEFAULT_DRG_CACHE_CAPACITY = 1000;
+
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
+  private int drgCacheCapacity = DEFAULT_DRG_CACHE_CAPACITY;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -40,6 +43,15 @@ public final class EngineConfiguration {
   public EngineConfiguration setMessagesTtlCheckerInterval(
       final Duration messagesTtlCheckerInterval) {
     this.messagesTtlCheckerInterval = messagesTtlCheckerInterval;
+    return this;
+  }
+
+  public int getDrgCacheCapacity() {
+    return drgCacheCapacity;
+  }
+
+  public EngineConfiguration setDrgCacheCapacity(final int drgCacheCapacity) {
+    this.drgCacheCapacity = drgCacheCapacity;
     return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -75,7 +75,7 @@ public final class BpmnDecisionBehavior {
     final var decisionOrFailure = decisionBehavior.findDecisionById(decisionId);
     final Either<Failure, ParsedDecisionRequirementsGraph> drgOrFailure =
         decisionOrFailure
-            .flatMap(decision -> decisionBehavior.findAndParseDrgByDecision(decision))
+            .flatMap(decision -> decisionBehavior.findParsedDrgByDecision(decision))
             // any failures above have the same error type and the correct scope
             // decisions invoked by business rule tasks have a different error type
             .mapLeft(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -18,8 +18,8 @@ import io.camunda.zeebe.dmn.MatchedRule;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.dmn.impl.VariablesContext;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -30,7 +30,6 @@ import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.collection.Tuple;
-import java.io.ByteArrayInputStream;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
@@ -67,7 +66,7 @@ public class DecisionBehavior {
   public Either<Failure, ParsedDecisionRequirementsGraph> findParsedDrgByDecision(
       final PersistedDecision persistedDecision) {
     return findDrgByDecision(persistedDecision)
-        .flatMap(drg -> parseDrg(drg.getResource()))
+        .map(DeployedDrg::getParsedDecisionRequirements)
         .mapLeft(
             failure ->
                 formatDecisionLookupFailure(
@@ -152,27 +151,11 @@ public class DecisionBehavior {
     }
   }
 
-  private Either<Failure, PersistedDecisionRequirements> findDrgByDecision(
-      final PersistedDecision decision) {
+  private Either<Failure, DeployedDrg> findDrgByDecision(final PersistedDecision decision) {
     final var key = decision.getDecisionRequirementsKey();
     final var id = decision.getDecisionRequirementsId();
     return Either.ofOptional(decisionState.findDecisionRequirementsByKey(key))
         .orElse(new Failure("no drg found for id '%s'".formatted(bufferAsString(id))));
-  }
-
-  private Either<Failure, ParsedDecisionRequirementsGraph> parseDrg(final DirectBuffer resource) {
-    return Either.<Failure, DirectBuffer>right(resource)
-        .map(BufferUtil::bufferAsArray)
-        .map(ByteArrayInputStream::new)
-        .map(decisionEngine::parse)
-        .flatMap(
-            parseResult -> {
-              if (parseResult.isValid()) {
-                return Either.right(parseResult);
-              } else {
-                return Either.left(new Failure(parseResult.getFailureMessage()));
-              }
-            });
   }
 
   private void addDecisionToEvaluationEvent(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -64,7 +64,7 @@ public class DecisionBehavior {
         .mapLeft(failure -> formatDecisionLookupFailure(failure, decisionKey));
   }
 
-  public Either<Failure, ParsedDecisionRequirementsGraph> findAndParseDrgByDecision(
+  public Either<Failure, ParsedDecisionRequirementsGraph> findParsedDrgByDecision(
       final PersistedDecision persistedDecision) {
     return findDrgByDecision(persistedDecision)
         .flatMap(drg -> parseDrg(drg.getResource()))

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
@@ -58,6 +59,7 @@ public final class DeploymentCreateProcessor
 
   private final DeploymentTransformer deploymentTransformer;
   private final ProcessState processState;
+  private final DecisionState decisionState;
   private final TimerInstanceState timerInstanceState;
   private final CatchEventBehavior catchEventBehavior;
   private final KeyGenerator keyGenerator;
@@ -76,6 +78,7 @@ public final class DeploymentCreateProcessor
       final FeatureFlags featureFlags,
       final CommandDistributionBehavior distributionBehavior) {
     processState = processingState.getProcessState();
+    decisionState = processingState.getDecisionState();
     timerInstanceState = processingState.getTimerState();
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -109,7 +112,12 @@ public final class DeploymentCreateProcessor
   public ProcessingError tryHandleError(
       final TypedRecord<DeploymentRecord> command, final Throwable error) {
     // Make sure the cache does not contain any leftovers from this run (by hard resetting)
-    processState.clearCache();
+    if (command.getValue().hasBpmnResources()) {
+      processState.clearCache();
+    }
+    if (command.getValue().hasDmnResources()) {
+      decisionState.clearCache();
+    }
 
     if (error instanceof final ResourceTransformationFailedException exception) {
       rejectionWriter.appendRejection(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.dmn.ParsedDecision;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsMetadataRecord;
@@ -237,18 +237,16 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
     return drgRecord.getDecisionRequirementsKey();
   }
 
-  private boolean hasSameResourceNameAs(
-      final DeploymentResource resource, final PersistedDecisionRequirements drg) {
+  private boolean hasSameResourceNameAs(final DeploymentResource resource, final DeployedDrg drg) {
     return drg.getResourceName().equals(resource.getResourceNameBuffer());
   }
 
-  private boolean hasSameChecksumAs(
-      final DirectBuffer checksum, final PersistedDecisionRequirements drg) {
+  private boolean hasSameChecksumAs(final DirectBuffer checksum, final DeployedDrg drg) {
     return drg.getChecksum().equals(checksum);
   }
 
   private boolean hasSameDecisionRequirementsKeyAs(
-      final Collection<ParsedDecision> decisions, final PersistedDecisionRequirements drg) {
+      final Collection<ParsedDecision> decisions, final DeployedDrg drg) {
     return decisions.stream()
         .map(ParsedDecision::getId)
         .map(BufferUtil::wrapString)

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/EvaluateDecisionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/EvaluateDecisionProcessor.java
@@ -54,7 +54,7 @@ public class EvaluateDecisionProcessor implements TypedRecordProcessor<DecisionE
     final Either<Failure, PersistedDecision> decisionOrFailure = getDecision(record);
 
     decisionOrFailure
-        .flatMap(decisionBehavior::findAndParseDrgByDecision)
+        .flatMap(decisionBehavior::findParsedDrgByDecision)
         .ifRightOrLeft(
             drg -> {
               final var decision = decisionOrFailure.get();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -13,9 +13,9 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
@@ -123,7 +123,7 @@ public class ResourceDeletionProcessor
     throw new NoSuchResourceException(value.getResourceKey());
   }
 
-  private void deleteDecisionRequirements(final PersistedDecisionRequirements drg) {
+  private void deleteDecisionRequirements(final DeployedDrg drg) {
     decisionState
         .findDecisionsByDecisionRequirementsKey(drg.getDecisionRequirementsKey())
         .forEach(this::deleteDecision);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -48,7 +48,8 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
             context.getTransactionContext(),
             context.getKeyGenerator(),
             transientMessageSubscriptionState,
-            transientProcessMessageSubscriptionState);
+            transientProcessMessageSubscriptionState,
+            config);
     this.writers = writers;
     partitionCommandSender = context.getPartitionCommandSender();
     this.config = config;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.deployment.DbDecisionState;
 import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
 import io.camunda.zeebe.engine.state.deployment.DbProcessState;
@@ -86,7 +87,8 @@ public class ProcessingDbState implements MutableProcessingState {
       final TransactionContext transactionContext,
       final KeyGenerator keyGenerator,
       final TransientPendingSubscriptionState transientMessageSubscriptionState,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final EngineConfiguration config) {
     this.partitionId = partitionId;
     this.zeebeDb = zeebeDb;
     this.keyGenerator = Objects.requireNonNull(keyGenerator);
@@ -110,7 +112,7 @@ public class ProcessingDbState implements MutableProcessingState {
             zeebeDb, transactionContext, transientProcessMessageSubscriptionState);
     incidentState = new DbIncidentState(zeebeDb, transactionContext, partitionId);
     bannedInstanceState = new DbBannedInstanceState(zeebeDb, transactionContext, partitionId);
-    decisionState = new DbDecisionState(zeebeDb, transactionContext);
+    decisionState = new DbDecisionState(zeebeDb, transactionContext, config);
     signalSubscriptionState = new DbSignalSubscriptionState(zeebeDb, transactionContext);
     distributionState = new DbDistributionState(zeebeDb, transactionContext);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -199,6 +199,11 @@ public final class DbDecisionState implements MutableDecisionState {
     return decisions;
   }
 
+  @Override
+  public void clearCache() {
+    drgCache.invalidateAll();
+  }
+
   private DeployedDrg findAndParseDecisionRequirementsByKeyFromDb(
       final long decisionRequirementsKey) throws DrgNotFoundException {
     dbDecisionRequirementsKey.wrapLong(decisionRequirementsKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -142,10 +142,9 @@ public final class DbDecisionState implements MutableDecisionState {
             decisionRequirementsIdAndVersion,
             fkDecisionRequirements);
 
-    // TODO get maximum size from configuration
     drgCache =
         CacheBuilder.newBuilder()
-            .maximumSize(10000L)
+            .maximumSize(config.getDrgCacheCapacity())
             .build(
                 new CacheLoader<>() {
                   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.engine.state.deployment;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -16,19 +19,27 @@ import io.camunda.zeebe.db.impl.DbInt;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.dmn.DecisionEngine;
+import io.camunda.zeebe.dmn.DecisionEngineFactory;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import org.agrona.DirectBuffer;
 
 public final class DbDecisionState implements MutableDecisionState {
+
+  private final DecisionEngine decisionEngine = DecisionEngineFactory.createDecisionEngine();
 
   private final DbLong dbDecisionKey;
   private final DbForeignKey<DbLong> fkDecision;
@@ -60,6 +71,8 @@ public final class DbDecisionState implements MutableDecisionState {
   private final DbCompositeKey<DbString, DbInt> decisionRequirementsIdAndVersion;
   private final ColumnFamily<DbCompositeKey<DbString, DbInt>, DbForeignKey<DbLong>>
       decisionRequirementsKeyByIdAndVersion;
+
+  private final LoadingCache<Long, DeployedDrg> drgCache;
 
   public DbDecisionState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -125,6 +138,18 @@ public final class DbDecisionState implements MutableDecisionState {
             transactionContext,
             decisionRequirementsIdAndVersion,
             fkDecisionRequirements);
+
+    // TODO get maximum size from configuration
+    drgCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(10000L)
+            .build(
+                new CacheLoader<>() {
+                  @Override
+                  public DeployedDrg load(final Long key) throws DrgNotFoundException {
+                    return findAndParseDecisionRequirementsByKeyFromDb(key);
+                  }
+                });
   }
 
   @Override
@@ -142,7 +167,7 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
-  public Optional<PersistedDecisionRequirements> findLatestDecisionRequirementsById(
+  public Optional<DeployedDrg> findLatestDecisionRequirementsById(
       final DirectBuffer decisionRequirementsId) {
     dbDecisionRequirementsId.wrapBuffer(decisionRequirementsId);
 
@@ -152,12 +177,8 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
-  public Optional<PersistedDecisionRequirements> findDecisionRequirementsByKey(
-      final long decisionRequirementsKey) {
-    dbDecisionRequirementsKey.wrapLong(decisionRequirementsKey);
-
-    return Optional.ofNullable(decisionRequirementsByKey.get(dbDecisionRequirementsKey))
-        .map(PersistedDecisionRequirements::copy);
+  public Optional<DeployedDrg> findDecisionRequirementsByKey(final long decisionRequirementsKey) {
+    return findDeployedDrg(decisionRequirementsKey);
   }
 
   @Override
@@ -174,6 +195,35 @@ public final class DbDecisionState implements MutableDecisionState {
         }));
 
     return decisions;
+  }
+
+  private DeployedDrg findAndParseDecisionRequirementsByKeyFromDb(
+      final long decisionRequirementsKey) throws DrgNotFoundException {
+    dbDecisionRequirementsKey.wrapLong(decisionRequirementsKey);
+
+    final PersistedDecisionRequirements persistedDrg =
+        decisionRequirementsByKey.get(dbDecisionRequirementsKey);
+    if (persistedDrg == null) {
+      throw new DrgNotFoundException();
+    }
+
+    final PersistedDecisionRequirements copiedDrg = persistedDrg.copy();
+
+    final var resourceBytes = BufferUtil.bufferAsArray(copiedDrg.getResource());
+    final ParsedDecisionRequirementsGraph parsedDrg =
+        decisionEngine.parse(new ByteArrayInputStream(resourceBytes));
+
+    return new DeployedDrg(parsedDrg, copiedDrg);
+  }
+
+  private Optional<DeployedDrg> findDeployedDrg(final long decisionRequirementsKey) {
+    try {
+      // The cache automatically fetches it from the state if the key does not exist.
+      return Optional.of(drgCache.get(decisionRequirementsKey));
+    } catch (final ExecutionException e) {
+      // We reach this when we couldn't load the DRG from the state.
+      return Optional.empty();
+    }
   }
 
   /**
@@ -294,7 +344,7 @@ public final class DbDecisionState implements MutableDecisionState {
   @Override
   public void deleteDecisionRequirements(final DecisionRequirementsRecord record) {
     findLatestDecisionRequirementsById(record.getDecisionRequirementsIdBuffer())
-        .map(PersistedDecisionRequirements::getDecisionRequirementsVersion)
+        .map(DeployedDrg::getDecisionRequirementsVersion)
         .ifPresent(
             latestVersion -> {
               if (latestVersion == record.getDecisionRequirementsVersion()) {
@@ -371,4 +421,10 @@ public final class DbDecisionState implements MutableDecisionState {
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
     latestDecisionRequirementsKeysById.upsert(dbDecisionRequirementsId, fkDecisionRequirements);
   }
+
+  /**
+   * This exception is thrown when the drgCache can't find a DRG in the state for a given key. This
+   * must be a checked exception, because of the way the {@link LoadingCache} works.
+   */
+  private static final class DrgNotFoundException extends Exception {}
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
@@ -75,7 +76,9 @@ public final class DbDecisionState implements MutableDecisionState {
   private final LoadingCache<Long, DeployedDrg> drgCache;
 
   public DbDecisionState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final TransactionContext transactionContext,
+      final EngineConfiguration config) {
     dbDecisionKey = new DbLong();
     fkDecision = new DbForeignKey<>(dbDecisionKey, ZbColumnFamilies.DMN_DECISIONS);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedDrg.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedDrg.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.deployment;
+
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import org.agrona.DirectBuffer;
+
+/**
+ * This class is a similar to the {@link DeployedProcess} class. It is a wrapper that contains both
+ * the parsed DRG and the persisted DRG. This object is cached upon retrieving a DRG from the state.
+ */
+public final class DeployedDrg {
+  private final ParsedDecisionRequirementsGraph parsedDecisionRequirements;
+
+  private final PersistedDecisionRequirements persistedDecisionRequirements;
+
+  public DeployedDrg(
+      final ParsedDecisionRequirementsGraph parsedDecisionRequirements,
+      final PersistedDecisionRequirements persistedDecisionRequirements) {
+    this.parsedDecisionRequirements = parsedDecisionRequirements;
+    this.persistedDecisionRequirements = persistedDecisionRequirements;
+  }
+
+  public ParsedDecisionRequirementsGraph getParsedDecisionRequirements() {
+    return parsedDecisionRequirements;
+  }
+
+  public int getDecisionRequirementsVersion() {
+    return persistedDecisionRequirements.getDecisionRequirementsVersion();
+  }
+
+  public DirectBuffer getResourceName() {
+    return persistedDecisionRequirements.getResourceName();
+  }
+
+  public DirectBuffer getChecksum() {
+    return persistedDecisionRequirements.getChecksum();
+  }
+
+  public long getDecisionRequirementsKey() {
+    return persistedDecisionRequirements.getDecisionRequirementsKey();
+  }
+
+  public DirectBuffer getDecisionRequirementsId() {
+    return persistedDecisionRequirements.getDecisionRequirementsId();
+  }
+
+  public DirectBuffer getDecisionRequirementsName() {
+    return persistedDecisionRequirements.getDecisionRequirementsName();
+  }
+
+  public DirectBuffer getResource() {
+    return persistedDecisionRequirements.getResource();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -58,4 +58,7 @@ public interface DecisionState {
    *     it
    */
   List<PersistedDecision> findDecisionsByDecisionRequirementsKey(long decisionRequirementsKey);
+
+  /** Completely clears all caches. */
+  void clearCache();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -40,8 +40,7 @@ public interface DecisionState {
    * @return the latest version of the DRG, or {@link Optional#empty()} if no DRG is deployed with
    *     the given id
    */
-  Optional<PersistedDecisionRequirements> findLatestDecisionRequirementsById(
-      DirectBuffer decisionRequirementsId);
+  Optional<DeployedDrg> findLatestDecisionRequirementsById(DirectBuffer decisionRequirementsId);
 
   /**
    * Query decision requirements (DRGs) by the given decision requirements key.
@@ -49,8 +48,7 @@ public interface DecisionState {
    * @param decisionRequirementsKey the key of the DRG
    * @return the DRG, or {@link Optional#empty()} if no DRG is deployed with the given key
    */
-  Optional<PersistedDecisionRequirements> findDecisionRequirementsByKey(
-      long decisionRequirementsKey);
+  Optional<DeployedDrg> findDecisionRequirementsByKey(long decisionRequirementsKey);
 
   /**
    * Query decisions by the given decision requirements (DRG) key.

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.query;
 
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
@@ -77,7 +78,8 @@ public final class StateQueryService implements QueryService {
                 throw new UnsupportedOperationException("Not allowed to generate a new key");
               },
               new TransientPendingSubscriptionState(),
-              new TransientPendingSubscriptionState());
+              new TransientPendingSubscriptionState(),
+              new EngineConfiguration());
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -13,6 +13,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
@@ -164,7 +165,8 @@ public class ProcessingStateExtension implements BeforeEachCallback {
                 transactionContext,
                 keyGenerator,
                 new TransientPendingSubscriptionState(),
-                new TransientPendingSubscriptionState());
+                new TransientPendingSubscriptionState(),
+                new EngineConfiguration());
       } catch (final Exception e) {
         ExceptionUtils.throwAsUncheckedException(e);
       }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
@@ -47,7 +48,8 @@ public final class ProcessingStateRule extends ExternalResource {
             context,
             keyGenerator,
             new TransientPendingSubscriptionState(),
-            new TransientPendingSubscriptionState());
+            new TransientPendingSubscriptionState(),
+            new EngineConfiguration());
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -124,4 +124,16 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
     // todo(#13320): replace dummy implementation
     return "";
   }
+
+  public boolean hasBpmnResources() {
+    return getResources().stream()
+        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
+        .anyMatch(x -> x.endsWith(".bpmn") || x.endsWith(".xml"));
+  }
+
+  public boolean hasDmnResources() {
+    return getResources().stream()
+        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
+        .anyMatch(x -> x.endsWith(".dmn"));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds a cache for parsed DRG, similar to what we already do for for transformed BPMN models.

The cache is added to the `DbDecisionState`. Whenever a DRG is requested from the state, it will first check the cache if it already knows it. If it doesn't it will fetch the DRG from RocksDB, and parse it immediately. It is stored in the cache as a `DeployedDrg`, which contains both the parsed DRG and the persisted DRG.

The cache itself has a maximum capacity. By default this is set to 1000, but it is configurable by users. 1000 should be more than plenty for the average cluster, as I doubt any users are actively using 1000 different DRGs.
If the cache exceeds the maximum capacity the **least used** DRG is evicted from the cache.
Upon restarting the broker is empty of course.

I was planning to use Argona's LRU cache. Unfortunately, this did not allow evicting entries from the cache manually. As this is a hard requirement for deletion of DRGs I went with the cache from Google common instead.


I verified the change using a benchmark. Here we are starting 300 PI/second on the latest main branch:
<img width="1778" alt="image" src="https://github.com/camunda/zeebe/assets/5787702/f0f69250-cc0b-4836-b9fb-7967f3e041b2">
We can see that it is back pressuring a lot. It averages 167 PI/second


Here is 300 PI/second on a branch that contains this change:
<img width="1784" alt="image" src="https://github.com/camunda/zeebe/assets/5787702/ffc5afc1-4d97-47d0-a9d5-e00320851a98">
We can see that there is some back pressure, but not nearly as much as on main. It averages at 288 PI/second. This solely by not having to parse the DRG every time a decision evaluated.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8571 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
