### PR TITLE
Stream jobs command integration tests

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
@@ -72,18 +72,22 @@ final class ClientCancelPendingCommandTest {
   private void awaitStreamRegistered(final String workerName) {
     final var brokerBridge = CLUSTER.getBrokerBridge(0);
     final var jobStreamService = brokerBridge.getJobStreamService().orElseThrow();
-    final var assertions = JobStreamServiceAssert.assertThat(jobStreamService);
 
     Awaitility.await("until a stream with the worker name '%s' is registered".formatted(workerName))
-        .untilAsserted(() -> assertions.hasStreamWithWorker(1, workerName));
+        .untilAsserted(
+            () ->
+                JobStreamServiceAssert.assertThat(jobStreamService)
+                    .hasStreamWithWorker(1, workerName));
   }
 
   private void awaitStreamRemoved(final String workerName) {
     final var brokerBridge = CLUSTER.getBrokerBridge(0);
     final var jobStreamService = brokerBridge.getJobStreamService().orElseThrow();
-    final var assertions = JobStreamServiceAssert.assertThat(jobStreamService);
 
     Awaitility.await("until no stream with worker name '%s' is registered".formatted(workerName))
-        .untilAsserted(() -> assertions.doesNotHaveStreamWithWorker(workerName));
+        .untilAsserted(
+            () ->
+                JobStreamServiceAssert.assertThat(jobStreamService)
+                    .doesNotHaveStreamWithWorker(workerName));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
@@ -9,21 +9,26 @@ package io.camunda.zeebe.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
+import io.camunda.zeebe.qa.util.JobStreamServiceAssert;
 import java.time.Duration;
+import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 final class ClientCancelPendingCommandTest {
   @RegisterExtension
-  final ClusteringRuleExtension cluster = new ClusteringRuleExtension(1, 1, 1, cfg -> {});
+  private static final ClusteringRuleExtension CLUSTER =
+      new ClusteringRuleExtension(1, 1, 1, cfg -> {});
+
+  private final ZeebeClient client = CLUSTER.getClient();
 
   @Test
   void shouldCancelCommandOnFutureCancellation() {
     // given
-    final var client = cluster.getClient();
     final var future =
         client
             .newActivateJobsCommand()
@@ -42,5 +47,43 @@ final class ClientCancelPendingCommandTest {
     // then
     Awaitility.await("until no long polling clients are waiting")
         .untilAsserted(() -> assertThat(metrics.getBlockedRequestsCount("type")).isZero());
+  }
+
+  @Test
+  void shouldRemoveStreamOnCancel() {
+    // given
+    final var uniqueWorkerName = UUID.randomUUID().toString();
+    final var stream =
+        client
+            .newStreamJobsCommand()
+            .jobType("jobs")
+            .consumer(ignored -> {})
+            .workerName(uniqueWorkerName)
+            .send();
+
+    // when
+    awaitStreamRegistered(uniqueWorkerName);
+    stream.cancel(true);
+
+    // then
+    awaitStreamRemoved(uniqueWorkerName);
+  }
+
+  private void awaitStreamRegistered(final String workerName) {
+    final var brokerBridge = CLUSTER.getBrokerBridge(0);
+    final var jobStreamService = brokerBridge.getJobStreamService().orElseThrow();
+    final var assertions = JobStreamServiceAssert.assertThat(jobStreamService);
+
+    Awaitility.await("until a stream with the worker name '%s' is registered".formatted(workerName))
+        .untilAsserted(() -> assertions.hasStreamWithWorker(1, workerName));
+  }
+
+  private void awaitStreamRemoved(final String workerName) {
+    final var brokerBridge = CLUSTER.getBrokerBridge(0);
+    final var jobStreamService = brokerBridge.getJobStreamService().orElseThrow();
+    final var assertions = JobStreamServiceAssert.assertThat(jobStreamService);
+
+    Awaitility.await("until no stream with worker name '%s' is registered".formatted(workerName))
+        .untilAsserted(() -> assertions.doesNotHaveStreamWithWorker(workerName));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/StreamJobsTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/StreamJobsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+final class StreamJobsTest {
+  @RegisterExtension
+  private static final ClusteringRuleExtension CLUSTER = new ClusteringRuleExtension(1, 1, 1);
+
+  @Test
+  void shouldStreamSequencedJobs() {
+    // given
+    final var jobs = new ArrayList<ActivatedJob>();
+    final var process =
+        Bpmn.createExecutableProcess("sequence")
+            .startEvent()
+            .serviceTask("task01", b -> b.zeebeJobType("sequence"))
+            .serviceTask("task02", b -> b.zeebeJobType("sequence"))
+            .serviceTask("task03", b -> b.zeebeJobType("sequence"))
+            .endEvent()
+            .done();
+    final Consumer<ActivatedJob> jobHandler =
+        job -> {
+          jobs.add(job);
+          CLUSTER.getClient().newCompleteCommand(job).send();
+        };
+    deployProcess(process);
+
+    // when
+    final var stream =
+        CLUSTER.getClient().newStreamJobsCommand().jobType("sequence").consumer(jobHandler).send();
+    final boolean processInstanceCompleted;
+    awaitStreamRegistered();
+
+    try {
+      final var processInstanceKey = createProcessInstance("sequence");
+      processInstanceCompleted =
+          RecordingExporter.processInstanceRecords()
+              .withProcessInstanceKey(processInstanceKey)
+              .limitToProcessInstanceCompleted()
+              .findFirst()
+              .isPresent();
+    } finally {
+      stream.cancel(true);
+    }
+
+    // then
+    assertThat(processInstanceCompleted)
+        .as("all tasks were completed to complete the process instance")
+        .isTrue();
+    assertThat(jobs).hasSize(3);
+  }
+
+  private void awaitStreamRegistered() {
+    final var brokerBridge = CLUSTER.getBrokerBridge(0);
+    final var jobStreamService = brokerBridge.getJobStreamService().orElseThrow();
+    Awaitility.await("until a job stream is registered")
+        .untilAsserted(
+            () -> assertThat(jobStreamService.remoteStreamService().streams()).hasSize(1));
+  }
+
+  private long createProcessInstance(final String processId) {
+    return CLUSTER
+        .getClient()
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  private void deployProcess(final BpmnModelInstance process) {
+    CLUSTER
+        .getClient()
+        .newDeployResourceCommand()
+        .addProcessModel(process, "sequence.bpmn")
+        .send()
+        .join();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/StreamJobsTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/StreamJobsTest.java
@@ -9,48 +9,79 @@ package io.camunda.zeebe.it.client.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamInfo;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
 import java.util.function.Consumer;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ThrowingConsumer;
+import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 final class StreamJobsTest {
+  @SuppressWarnings("JUnitMalformedDeclaration")
   @RegisterExtension
   private static final ClusteringRuleExtension CLUSTER = new ClusteringRuleExtension(1, 1, 1);
 
+  private ZeebeClient client;
+
+  @BeforeEach
+  void beforeEach() {
+    client = CLUSTER.getClient();
+  }
+
   @Test
-  void shouldStreamSequencedJobs() {
+  void shouldStreamJobs() {
     // given
     final var jobs = new ArrayList<ActivatedJob>();
+    final var uniqueId = Strings.newRandomValidBpmnId();
     final var process =
-        Bpmn.createExecutableProcess("sequence")
+        Bpmn.createExecutableProcess(uniqueId)
             .startEvent()
-            .serviceTask("task01", b -> b.zeebeJobType("sequence"))
-            .serviceTask("task02", b -> b.zeebeJobType("sequence"))
-            .serviceTask("task03", b -> b.zeebeJobType("sequence"))
+            .serviceTask("task01", b -> b.zeebeJobType(uniqueId))
+            .serviceTask("task02", b -> b.zeebeJobType(uniqueId))
+            .serviceTask("task03", b -> b.zeebeJobType(uniqueId))
             .endEvent()
             .done();
     final Consumer<ActivatedJob> jobHandler =
         job -> {
           jobs.add(job);
-          CLUSTER.getClient().newCompleteCommand(job).send();
+          client.newCompleteCommand(job).send();
         };
     deployProcess(process);
 
     // when
     final var stream =
-        CLUSTER.getClient().newStreamJobsCommand().jobType("sequence").consumer(jobHandler).send();
+        client
+            .newStreamJobsCommand()
+            .jobType(uniqueId)
+            .consumer(jobHandler)
+            .workerName("streamer")
+            .fetchVariables("foo")
+            .timeout(Duration.ofSeconds(5))
+            .send();
+    final var initialTime = System.currentTimeMillis();
     final boolean processInstanceCompleted;
-    awaitStreamRegistered();
 
     try {
-      final var processInstanceKey = createProcessInstance("sequence");
+      awaitStreamRegistered(uniqueId);
+      final var processInstanceKey =
+          createProcessInstance(uniqueId, Map.of("foo", "bar", "baz", "buz"));
       processInstanceCompleted =
           RecordingExporter.processInstanceRecords()
               .withProcessInstanceKey(processInstanceKey)
@@ -65,23 +96,110 @@ final class StreamJobsTest {
     assertThat(processInstanceCompleted)
         .as("all tasks were completed to complete the process instance")
         .isTrue();
-    assertThat(jobs).hasSize(3);
+    assertThat(jobs)
+        .hasSize(3)
+        .allSatisfy(
+            job -> {
+              assertThat(job.getWorker()).isEqualTo("streamer");
+              assertThat(job.getDeadline()).isCloseTo(initialTime + 5000, Offset.offset(500L));
+              assertThat(job.getVariablesAsMap()).isEqualTo(Map.of("foo", "bar"));
+            });
   }
 
-  private void awaitStreamRegistered() {
+  @Test
+  void shouldNotInterfereWithPolling() {
+    // given
+    final var streamedJobs = new ArrayList<ActivatedJob>();
+    final var uniqueId = Strings.newRandomValidBpmnId();
+    final var process =
+        Bpmn.createExecutableProcess(uniqueId)
+            .startEvent()
+            .serviceTask("task01", b -> b.zeebeJobType(uniqueId))
+            .endEvent()
+            .done();
+    final Consumer<ActivatedJob> streamHandler = streamedJobs::add;
+    deployProcess(process);
+
+    // when - create a process instance and wait for the job to be created; this cannot be streamed
+    // since the stream doesn't know about older jobs, but it can be polled! The second process
+    // instance is guaranteed to stream, because we prefer streaming to polling
+    final var firstPIKey = createProcessInstance(uniqueId);
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(firstPIKey)
+                .limit(1)
+                .exists())
+        .as("job for the first process was created")
+        .isTrue();
+
+    // open the stream
+    final var stream =
+        client
+            .newStreamJobsCommand()
+            .jobType(uniqueId)
+            .consumer(streamHandler)
+            .workerName("stream")
+            .send();
+    final long secondPIKey;
+    try {
+      awaitStreamRegistered(uniqueId);
+      secondPIKey = createProcessInstance(uniqueId);
+      Awaitility.await("until job has been streamed")
+          .untilAsserted(() -> assertThat(streamedJobs).hasSize(1));
+    } finally {
+      stream.cancel(true);
+    }
+
+    // poll after the newer job was streamed, showing that polling for older jobs work
+    final var polledJobs =
+        client
+            .newActivateJobsCommand()
+            .jobType(uniqueId)
+            .maxJobsToActivate(2)
+            .workerName("poller")
+            .send()
+            .join();
+
+    // then
+    assertThat(polledJobs.getJobs())
+        .first(InstanceOfAssertFactories.type(ActivatedJob.class))
+        .extracting(ActivatedJob::getProcessInstanceKey)
+        .isEqualTo(firstPIKey);
+    assertThat(streamedJobs)
+        .first(InstanceOfAssertFactories.type(ActivatedJob.class))
+        .extracting(ActivatedJob::getProcessInstanceKey)
+        .isEqualTo(secondPIKey);
+  }
+
+  private void awaitStreamRegistered(final String jobType) {
+    awaitStreamRegistered(
+        streams ->
+            assertThat(streams)
+                .as("has one stream with type '%s'", jobType)
+                .satisfiesOnlyOnce(
+                    stream ->
+                        assertThat(BufferUtil.bufferAsString(stream.streamType()))
+                            .isEqualTo(jobType)));
+  }
+
+  private void awaitStreamRegistered(
+      final ThrowingConsumer<Collection<RemoteStreamInfo<JobActivationProperties>>> assertions) {
     final var brokerBridge = CLUSTER.getBrokerBridge(0);
     final var jobStreamService = brokerBridge.getJobStreamService().orElseThrow();
-    Awaitility.await("until a job stream is registered")
-        .untilAsserted(
-            () -> assertThat(jobStreamService.remoteStreamService().streams()).hasSize(1));
+    Awaitility.await("until one or more matching job streams are registered")
+        .untilAsserted(() -> assertions.accept(jobStreamService.remoteStreamService().streams()));
   }
 
   private long createProcessInstance(final String processId) {
-    return CLUSTER
-        .getClient()
+    return createProcessInstance(processId, Map.of());
+  }
+
+  private long createProcessInstance(final String processId, final Map<String, Object> variables) {
+    return client
         .newCreateInstanceCommand()
         .bpmnProcessId(processId)
         .latestVersion()
+        .variables(variables)
         .send()
         .join()
         .getProcessInstanceKey();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/StreamJobsTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/StreamJobsTest.java
@@ -170,10 +170,11 @@ final class StreamJobsTest {
   private void awaitStreamRegistered(final String jobType) {
     final var brokerBridge = CLUSTER.getBrokerBridge(0);
     final var jobStreamService = brokerBridge.getJobStreamService().orElseThrow();
-    final var assertion = JobStreamServiceAssert.assertThat(jobStreamService);
 
     Awaitility.await("until stream with type '%s' is registered".formatted(jobType))
-        .untilAsserted(() -> assertion.hasStreamWithType(1, jobType));
+        .untilAsserted(
+            () ->
+                JobStreamServiceAssert.assertThat(jobStreamService).hasStreamWithType(1, jobType));
   }
 
   private long createProcessInstance(final String processId) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -408,6 +408,10 @@ public class ClusteringRule extends ExternalResource {
     return base;
   }
 
+  public SpringBrokerBridge getBrokerBridge(final int nodeId) {
+    return springBrokerBridge.get(nodeId);
+  }
+
   private Gateway createGateway() {
     final List<String> initialContactPoints =
         brokerCfgs.values().stream()

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRuleExtension.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRuleExtension.java
@@ -80,8 +80,8 @@ public class ClusteringRuleExtension extends ClusteringRule
   }
 
   private void teardown() throws IOException {
-    FileUtil.deleteFolderIfExists(tempDir);
     super.after();
+    FileUtil.deleteFolderIfExists(tempDir);
   }
 
   @Override

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -82,5 +82,30 @@
       <artifactId>assertj-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-transport</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -77,5 +77,10 @@
       <artifactId>toxiproxy-java</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/JobStreamServiceAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/JobStreamServiceAssert.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util;
+
+import io.camunda.zeebe.broker.jobstream.JobStreamService;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamInfo;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.condition.VerboseCondition;
+
+/**
+ * Convenience class to assert certain properties of a {@link JobStreamService}, e.g. is a stream
+ * registered with the given properties, how many streams there are, etc.
+ */
+@SuppressWarnings("UnusedReturnValue")
+public final class JobStreamServiceAssert
+    extends AbstractObjectAssert<JobStreamServiceAssert, JobStreamService> {
+  /**
+   * @param jobStreamService the actual service to assert against
+   */
+  public JobStreamServiceAssert(final JobStreamService jobStreamService) {
+    super(jobStreamService, JobStreamServiceAssert.class);
+  }
+
+  /**
+   * A convenience factory method that's consistent with AssertJ conventions.
+   *
+   * @param actual the actual service to assert against
+   * @return an instance of {@link JobStreamServiceAssert} to assert properties of the given service
+   */
+  public static JobStreamServiceAssert assertThat(final JobStreamService actual) {
+    return new JobStreamServiceAssert(actual);
+  }
+
+  /**
+   * Asserts that the given service contains exactly {@code expectedCount} streams for the given job
+   * type.
+   *
+   * @param expectedCount the exact count of streams to find
+   * @param jobType the expected type of the streams
+   * @return itself for chaining
+   */
+  public JobStreamServiceAssert hasStreamWithType(final int expectedCount, final String jobType) {
+    return hasStreamMatchingCount(expectedCount, hasStreamType(jobType));
+  }
+
+  /**
+   * Asserts that the given service contains exactly {@code expectedCount} streams for the given
+   * worker name.
+   *
+   * @param expectedCount the exact count of streams to find
+   * @param worker the expected worker property of the streams
+   * @return itself for chaining
+   */
+  public JobStreamServiceAssert hasStreamWithWorker(final int expectedCount, final String worker) {
+    return hasStreamMatchingCount(expectedCount, hasWorker(worker));
+  }
+
+  /**
+   * Asserts that the given service does not contain any streams for the given worker name.
+   *
+   * @param worker the expected worker of the streams
+   * @return itself for chaining
+   */
+  public JobStreamServiceAssert doesNotHaveStreamWithWorker(final String worker) {
+    return doesNotHaveStreamMatching(hasWorker(worker));
+  }
+
+  /**
+   * Asserts that the given service contains exactly {@code expectedCount} streams which all match
+   * the same condition.
+   *
+   * <p>NOTE: you can reuse the conditions found as static methods of this class, e.g. {@link
+   * #hasWorker(String)}, {@link #hasStreamType(String)}. If you wish to combine them, you can use
+   * {@link org.assertj.core.condition.AnyOf} or {@link org.assertj.core.condition.AllOf}.
+   *
+   * @param expectedCount the exact count of streams to find
+   * @param condition the condition the streams must match
+   * @return itself for chaining
+   */
+  public JobStreamServiceAssert hasStreamMatchingCount(
+      final int expectedCount,
+      final Condition<RemoteStreamInfo<JobActivationProperties>> condition) {
+    isNotNull();
+
+    final var description =
+        descriptionOrDefault("has at '%d' stream(s) matching assertions", expectedCount);
+    final var streams = actual.remoteStreamService().streams();
+    Assertions.assertThat(streams).as(description).haveExactly(expectedCount, condition);
+
+    return myself;
+  }
+
+  /**
+   * Asserts that the given service does not container any stream which matches the given condition.
+   *
+   * <p>NOTE: you can reuse the conditions found as static methods of this class, e.g. {@link
+   * #hasWorker(String)}, {@link #hasStreamType(String)}. If you wish to combine them, you can use
+   * {@link org.assertj.core.condition.AnyOf} or {@link org.assertj.core.condition.AllOf}.
+   *
+   * @param condition the condition the streams must match
+   * @return itself for chaining
+   */
+  public JobStreamServiceAssert doesNotHaveStreamMatching(
+      final Condition<RemoteStreamInfo<JobActivationProperties>> condition) {
+    isNotNull();
+
+    final var description = descriptionOrDefault("has no streams matching assertions");
+    final var streams = actual.remoteStreamService().streams();
+    Assertions.assertThat(streams).as(description).doNotHave(condition);
+
+    return myself;
+  }
+
+  /** Returns a condition which checks that a stream has the given stream type. */
+  public static Condition<RemoteStreamInfo<JobActivationProperties>> hasStreamType(
+      final String streamType) {
+    return VerboseCondition.verboseCondition(
+        stream -> BufferUtil.bufferAsString(stream.streamType()).equals(streamType),
+        "a stream with type '%s'".formatted(streamType),
+        stream ->
+            " but actual type is '%s'".formatted(BufferUtil.bufferAsString(stream.streamType())));
+  }
+
+  /** Returns a condition which checks that a stream has the given worker name. */
+  public static Condition<RemoteStreamInfo<JobActivationProperties>> hasWorker(
+      final String workerName) {
+    return VerboseCondition.verboseCondition(
+        stream -> BufferUtil.bufferAsString(stream.metadata().worker()).equals(workerName),
+        "a stream with worker '%s'".formatted(workerName),
+        stream ->
+            " but actual worker is '%s'"
+                .formatted(BufferUtil.bufferAsString(stream.metadata().worker())));
+  }
+
+  private String descriptionOrDefault(final String description, final Object... args) {
+    final var userDescription = descriptionText();
+    return userDescription.isBlank() ? description.formatted(args) : userDescription;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds QA tests for the stream job commands. It also adds a new `JobStreamServiceAssert`, which will further be used (and expanded) for more QA tests as part of #11710.

There will be a follow up PR to tackle job worker QA tests; this is just focusing on the command itself. 

This PR only focuses on the commands from a user point of view. There are already integration tests for generic streaming in the transport module which deal more complex error cases, integration test at the gateway level which focus on the protocol implementation, and additional client unit tests.

## Related issues

closes #13516
related to #11710 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
