### PR TITLE
feat(ci): auto merge renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,12 +654,13 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   auto-merge:
-    # This workflow will auto merge a PR authored by dependabot[bot] or backport-action.
+    # This workflow will auto merge a PR authored by dependabot[bot], backport-action or renovate[bot].
     # It runs only on open PRs ready for review.
     #
     # It will merge the PR only if: it is authored by dependabot[bot], is a minor or patch semantic
     # update, and all CI checks are successful.
-    # OR if it is authored by backport-action and all CI checks are successful.
+    # OR if it is authored by backport-action and all CI checks are successful
+    # OR if it is authored by renovate[bot] and all CI checks are successful.
     #
     # The workflow is divided into multiple sequential jobs to allow giving only minimal permissions to
     # the GitHub token passed around.
@@ -667,10 +668,10 @@ jobs:
     # Once we're using the merge queue feature, I think we can simplify this workflow a lot by relying
     # on dependabot merging PRs via its commands, as it will always wait for checks to be green before
     # merging.
-    name: Auto-merge dependabot and backport PRs
+    name: Auto-merge dependabot, backport and renovate PRs
     runs-on: ubuntu-latest
     needs: [ test-summary ]
-    if: github.repository == 'camunda/zeebe' && (github.actor == 'dependabot[bot]' || github.actor == 'backport-action')
+    if: github.repository == 'camunda/zeebe' && (github.actor == 'dependabot[bot]' || github.actor == 'backport-action' || github.actor == 'renovate[bot]')
     permissions:
       checks: read
       pull-requests: write
@@ -688,9 +689,9 @@ jobs:
         run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
         env:
           GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
-      - id: approve-and-merge-backport
+      - id: approve-and-merge-backport-renovate
         name: Approve and merge backport PR
-        if: github.actor == 'backport-action'
+        if: github.actor == 'backport-action' || github.actor == 'renovate[bot]'
         run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
         env:
           GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
## Description

As recently done for backport PRs https://github.com/camunda/zeebe/issues/13666 and given we use renovate for docker base image updates only we can automatically merge them on green CI to eliminate the chore to comment `bors merge` manually.

## Related issues

closes #13791