### PR TITLE
[Backport stable/8.0] fix(stream-platform): register record listener before start reading

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
@@ -126,11 +126,11 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
         snapshotPosition,
         streamProcessorMode);
 
-    replayNextEvent();
-
     if (streamProcessorMode == StreamProcessorMode.REPLAY) {
       logStream.registerRecordAvailableListener(this);
     }
+
+    replayNextEvent();
 
     return recoveryFuture;
   }


### PR DESCRIPTION
# Description
Backport of #13778 to `stable/8.0`.

relates to #13257
original author: @deepthidevaki