### PR TITLE
[Backport stable/8.2] fix(stream-platform): register record listener before start reading

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -131,11 +131,11 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
         snapshotPosition,
         streamProcessorMode);
 
-    replayNextEvent();
-
     if (streamProcessorMode == StreamProcessorMode.REPLAY) {
       logStream.registerRecordAvailableListener(this);
     }
+
+    replayNextEvent();
 
     return recoveryFuture;
   }


### PR DESCRIPTION
# Description
Backport of #13778 to `stable/8.2`.

relates to #13257
original author: @deepthidevaki