### PR TITLE
Streaming job worker QA tests

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/JobWorkerTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/JobWorkerTest.java
@@ -10,18 +10,26 @@ package io.camunda.zeebe.it.client.command;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.it.util.RecordingJobHandler;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.JobStreamServiceAssert;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
 import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 final class JobWorkerTest {
 
@@ -38,8 +46,9 @@ final class JobWorkerTest {
     client = new GrpcClientRule(CLUSTER.getClient());
   }
 
-  @Test
-  void shouldActivateJob() {
+  @ParameterizedTest
+  @MethodSource("provideWorkerConfigurators")
+  void shouldActivateJob(final BiFunction<String, JobWorkerBuilderStep3, JobWorker> configurator) {
     // given
     final var process =
         Bpmn.createExecutableProcess("process")
@@ -67,7 +76,7 @@ final class JobWorkerTest {
             .handler(jobHandler)
             .name("test")
             .timeout(5000);
-    try (final var ignored = builder.open()) {
+    try (final var ignored = configurator.apply(jobType, builder)) {
       Awaitility.await("until all jobs are activated")
           .untilAsserted(() -> assertThat(jobHandler.getHandledJobs()).hasSize(1));
     }
@@ -86,8 +95,10 @@ final class JobWorkerTest {
     assertThat(job.getVariablesAsMap()).isEqualTo(Map.of("a", 1, "b", 2));
   }
 
-  @Test
-  void shouldActivateJobsOfDifferentTypes() {
+  @ParameterizedTest
+  @MethodSource("provideWorkerConfigurators")
+  void shouldActivateJobsOfDifferentTypes(
+      final BiFunction<String, JobWorkerBuilderStep3, JobWorker> configurator) {
     // given
     final var jobX = client.createSingleJob(jobType + "x");
     final var jobY = client.createSingleJob(jobType + "y");
@@ -97,8 +108,8 @@ final class JobWorkerTest {
     final var builderY = client.getClient().newWorker().jobType(jobType + "y").handler(jobHandlerY);
 
     // when
-    try (final var ignoredX = builderX.open();
-        final var ignoredY = builderY.open()) {
+    try (final var ignoredX = configurator.apply(jobType + "x", builderX);
+        final var ignoredY = configurator.apply(jobType + "y", builderY)) {
       Awaitility.await("until all jobs are activated")
           .untilAsserted(() -> assertThat(jobHandlerX.getHandledJobs()).hasSize(1));
       Awaitility.await("until all jobs are activated")
@@ -116,8 +127,10 @@ final class JobWorkerTest {
         .contains(jobY);
   }
 
-  @Test
-  void shouldFetchOnlySpecifiedVariables() {
+  @ParameterizedTest
+  @MethodSource("provideWorkerConfigurators")
+  void shouldFetchOnlySpecifiedVariables(
+      final BiFunction<String, JobWorkerBuilderStep3, JobWorker> configurator) {
     // given
     client.createSingleJob(jobType, b -> {}, "{\"a\":1, \"b\":2, \"c\":3,\"d\":4}");
 
@@ -131,7 +144,7 @@ final class JobWorkerTest {
             .jobType(jobType)
             .handler(jobHandler)
             .fetchVariables(fetchVariables);
-    try (final var ignored = builder.open()) {
+    try (final var ignored = configurator.apply(jobType, builder)) {
       Awaitility.await("until all jobs are activated")
           .untilAsserted(() -> assertThat(jobHandler.getHandledJobs()).hasSize(1));
     }
@@ -139,5 +152,46 @@ final class JobWorkerTest {
     // then
     final ActivatedJob job = jobHandler.getHandledJobs().get(0);
     assertThat(job.getVariablesAsMap()).isEqualTo(Map.of("a", 1, "b", 2));
+  }
+
+  @Test
+  void shouldStreamAndActivateJobs() {
+    // given - a job created before any stream was registered, i.e. can only be polled
+    client.createSingleJob(jobType, b -> {});
+
+    // when - create a worker that streams, and create a new job after the stream is registered
+    final var jobHandler = new RecordingJobHandler();
+    final var builder =
+        client.getClient().newWorker().jobType(jobType).handler(jobHandler).enableStreaming();
+    try (final var ignored = builder.open()) {
+      awaitStreamRegistered(jobType);
+      client.createSingleJob(jobType, b -> {});
+
+      // then - expect both jobs to be activated
+      Awaitility.await("until all jobs are activated")
+          .untilAsserted(() -> assertThat(jobHandler.getHandledJobs()).hasSize(2));
+    }
+  }
+
+  private static Stream<Named<BiFunction<String, JobWorkerBuilderStep3, JobWorker>>>
+      provideWorkerConfigurators() {
+    return Stream.of(
+        Named.named("polling", (ignored, builder) -> builder.open()),
+        Named.named("streaming", JobWorkerTest::prepareStreamingWorker));
+  }
+
+  private static JobWorker prepareStreamingWorker(
+      final String jobType, final JobWorkerBuilderStep3 builder) {
+    final var worker = builder.enableStreaming().open();
+    awaitStreamRegistered(jobType);
+    return worker;
+  }
+
+  private static void awaitStreamRegistered(final String jobType) {
+    final var jobStreamService = CLUSTER.getBrokerBridge(0).getJobStreamService().orElseThrow();
+    Awaitility.await("until stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamServiceAssert.assertThat(jobStreamService).hasStreamWithType(1, jobType));
   }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/JobStreamServiceAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/JobStreamServiceAssert.java
@@ -75,6 +75,16 @@ public final class JobStreamServiceAssert
   }
 
   /**
+   * Asserts that the given service does not contain any streams for the given stream type.
+   *
+   * @param streamType the expected job type of the streams
+   * @return itself for chaining
+   */
+  public JobStreamServiceAssert doesNotHaveStreamWithType(final String streamType) {
+    return doesNotHaveStreamMatching(hasStreamType(streamType));
+  }
+
+  /**
    * Asserts that the given service contains exactly {@code expectedCount} streams which all match
    * the same condition.
    *


### PR DESCRIPTION
## Description

This PR adds streaming job worker QA tests. Existing tests were converted to junit 5 to allow a mix of parameterized and non-parameterized tests in the same class, then all tests were made parameterized to test both streaming and polling behavior independently. One final test is added to test both together.

## Related issues

related to #11710 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
