### PR TITLE
Add QA tests to validate job stream lifecycle

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientCancelPendingCommandTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
-import io.camunda.zeebe.qa.util.JobStreamServiceAssert;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamServiceAssert;
 import java.time.Duration;
 import java.util.UUID;
 import org.awaitility.Awaitility;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/JobWorkerTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/JobWorkerTest.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.it.util.RecordingJobHandler;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.qa.util.JobStreamServiceAssert;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamServiceAssert;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
 import java.util.Map;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/StreamJobsTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/StreamJobsTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.qa.util.JobStreamServiceAssert;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamServiceAssert;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.grpc.Status;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -852,6 +852,10 @@ public class ClusteringRule extends ExternalResource {
     }
   }
 
+  public JobStreamClient gatewayJobStreamClient() {
+    return gatewayResource.jobStreamClient;
+  }
+
   /**
    * Runs until a given number of segments are filled on all brokers. This is useful for publishing
    * messages until a segment is full, thus triggering log compaction.

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobStreamLifecycleIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobStreamLifecycleIT.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamClientAssert;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamServiceAssert;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import org.assertj.core.condition.AllOf;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+final class JobStreamLifecycleIT {
+  @SuppressWarnings("JUnitMalformedDeclaration")
+  @RegisterExtension
+  private static final ClusteringRuleExtension CLUSTER = new ClusteringRuleExtension(1, 2, 2);
+
+  private static GrpcClientRule client;
+
+  private final String jobType = Strings.newRandomValidBpmnId();
+
+  @BeforeAll
+  static void beforeAll() {
+    client = new GrpcClientRule(CLUSTER.getClient());
+  }
+
+  @Test
+  void shouldRegisterStream() {
+    // given
+    final var command =
+        client
+            .getClient()
+            .newStreamJobsCommand()
+            .jobType(jobType)
+            .consumer(ignored -> {})
+            .fetchVariables("foo", "bar")
+            .timeout(Duration.ofMillis(500))
+            .workerName("worker");
+
+    // when
+    command.send();
+
+    // then
+    Awaitility.await("until stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamClientAssert.assertThat(CLUSTER.gatewayJobStreamClient())
+                    .hasStreamMatchingCount(
+                        1,
+                        AllOf.allOf(
+                            JobStreamClientAssert.hasStreamType(jobType),
+                            JobStreamClientAssert.hasWorker("worker"),
+                            JobStreamClientAssert.hasTimeout(500),
+                            JobStreamClientAssert.hasFetchVariables("foo", "bar"))));
+    for (int nodeId = 0; nodeId < 2; nodeId++) {
+      final var service = CLUSTER.getBrokerBridge(nodeId).getJobStreamService().orElseThrow();
+      Awaitility.await("until stream is registered on broker '%d'".formatted(nodeId))
+          .untilAsserted(
+              () ->
+                  JobStreamServiceAssert.assertThat(service)
+                      .hasStreamMatchingCount(
+                          1,
+                          AllOf.allOf(
+                              JobStreamServiceAssert.hasStreamType(jobType),
+                              JobStreamServiceAssert.hasWorker("worker"),
+                              JobStreamServiceAssert.hasTimeout(500),
+                              JobStreamServiceAssert.hasFetchVariables("foo", "bar"))));
+    }
+  }
+
+  @Test
+  void shouldRegisterStreamsWithDifferentProperties() {
+    // given - two logically DIFFERENT streams
+    final var commandA =
+        client
+            .getClient()
+            .newStreamJobsCommand()
+            .jobType(jobType)
+            .consumer(ignored -> {})
+            .fetchVariables("foo", "bar")
+            .timeout(Duration.ofMillis(500))
+            .workerName("commandA");
+    final var commandB =
+        client
+            .getClient()
+            .newStreamJobsCommand()
+            .jobType(jobType)
+            .consumer(ignored -> {})
+            .fetchVariables("foo", "bar")
+            .timeout(Duration.ofMillis(500))
+            .workerName("commandB");
+
+    // when - both are registered individually on the gateway
+    commandA.send();
+    commandB.send();
+    Awaitility.await("until streams are registered")
+        .untilAsserted(
+            () ->
+                JobStreamClientAssert.assertThat(CLUSTER.gatewayJobStreamClient())
+                    .hasStreamWithType(2, jobType));
+
+    // then - the streams are not aggregated on the broker side, as they are logically different
+    for (int nodeId = 0; nodeId < 2; nodeId++) {
+      final var service = CLUSTER.getBrokerBridge(nodeId).getJobStreamService().orElseThrow();
+      Awaitility.await("until stream is registered on broker '%d'".formatted(nodeId))
+          .untilAsserted(
+              () -> JobStreamServiceAssert.assertThat(service).hasStreamWithType(2, jobType));
+    }
+  }
+
+  @Test
+  void shouldAggregateStreams() {
+    // given - two logically equivalent streams
+    final var commandA =
+        client
+            .getClient()
+            .newStreamJobsCommand()
+            .jobType(jobType)
+            .consumer(ignored -> {})
+            .fetchVariables("foo", "bar")
+            .timeout(Duration.ofMillis(500))
+            .workerName("command");
+    final var commandB =
+        client
+            .getClient()
+            .newStreamJobsCommand()
+            .jobType(jobType)
+            .consumer(ignored -> {})
+            .fetchVariables("foo", "bar")
+            .timeout(Duration.ofMillis(500))
+            .workerName("command");
+
+    // when - both streams are opened and registered on the gateway as individual client streams
+    commandA.send();
+    commandB.send();
+    Awaitility.await("until streams are registered")
+        .untilAsserted(
+            () ->
+                JobStreamClientAssert.assertThat(CLUSTER.gatewayJobStreamClient())
+                    .hasStreamWithType(2, jobType));
+
+    // then - only one stream is registered on each broker as it is aggregated per gateway
+    for (int nodeId = 0; nodeId < 2; nodeId++) {
+      final var service = CLUSTER.getBrokerBridge(nodeId).getJobStreamService().orElseThrow();
+      Awaitility.await("until stream is registered on broker '%d'".formatted(nodeId))
+          .untilAsserted(
+              () -> JobStreamServiceAssert.assertThat(service).hasStreamWithType(1, jobType, 2));
+    }
+  }
+
+  @Test
+  void shouldRemoveStreamOnClientCancel() {
+    // given - one stream is registered on the gateway
+    final var stream =
+        client.getClient().newStreamJobsCommand().jobType(jobType).consumer(ignored -> {}).send();
+    Awaitility.await("until stream is fully registered")
+        .untilAsserted(
+            () ->
+                JobStreamClientAssert.assertThat(CLUSTER.gatewayJobStreamClient())
+                    .hasStreamWithType(1, jobType, 0, 1));
+
+    // when - that stream is cancelled
+    stream.cancel(true);
+
+    // then - it is removed everywhere, as it was the last client for this logical stream
+    Awaitility.await("until no gateway streams are registered")
+        .untilAsserted(
+            () ->
+                JobStreamClientAssert.assertThat(CLUSTER.gatewayJobStreamClient())
+                    .doesNotHaveStreamWithType(jobType));
+    for (int nodeId = 0; nodeId < 2; nodeId++) {
+      final var service = CLUSTER.getBrokerBridge(nodeId).getJobStreamService().orElseThrow();
+      Awaitility.await("until no stream is registered on broker '%d'".formatted(nodeId))
+          .untilAsserted(
+              () -> JobStreamServiceAssert.assertThat(service).doesNotHaveStreamWithType(jobType));
+    }
+  }
+
+  @Test
+  void shouldNotRemoveStreamOnClientCancel() {
+    // given - two logically equivalent clients
+    final var stream =
+        client.getClient().newStreamJobsCommand().jobType(jobType).consumer(ignored -> {}).send();
+    client.getClient().newStreamJobsCommand().jobType(jobType).consumer(ignored -> {}).send();
+
+    // when - two clients are registered on the gateway, and one of them is closed
+    Awaitility.await("until gateway streams are fully connected")
+        .untilAsserted(
+            () ->
+                JobStreamClientAssert.assertThat(CLUSTER.gatewayJobStreamClient())
+                    .hasStreamWithType(2, jobType, 0, 1));
+    stream.cancel(true);
+
+    // then - the remaining gateway stream is present, and it's still connected to the brokers
+    Awaitility.await("until gateway has only one stream")
+        .untilAsserted(
+            () ->
+                JobStreamClientAssert.assertThat(CLUSTER.gatewayJobStreamClient())
+                    .hasStreamWithType(1, jobType, 0, 1));
+    for (int nodeId = 0; nodeId < 2; nodeId++) {
+      final var service = CLUSTER.getBrokerBridge(nodeId).getJobStreamService().orElseThrow();
+      JobStreamServiceAssert.assertThat(service).hasStreamWithType(1, jobType);
+    }
+  }
+
+  @Test
+  void shouldRemoveAllStreamsOnGatewayShutdown() {
+    // given - two logically different clients
+    client.getClient().newStreamJobsCommand().jobType(jobType).consumer(ignored -> {}).send();
+    client
+        .getClient()
+        .newStreamJobsCommand()
+        .jobType(jobType)
+        .consumer(ignored -> {})
+        .fetchVariables("foo", "bar")
+        .send();
+    Awaitility.await("until gateway streams are fully connected")
+        .untilAsserted(
+            () ->
+                JobStreamClientAssert.assertThat(CLUSTER.gatewayJobStreamClient())
+                    .hasStreamWithType(2, jobType, 0, 1));
+
+    // when
+    CLUSTER.restartGateway();
+
+    // then - no streams will be registered on any broker
+    for (int nodeId = 0; nodeId < 2; nodeId++) {
+      final var service = CLUSTER.getBrokerBridge(nodeId).getJobStreamService().orElseThrow();
+      Awaitility.await("until no stream is registered on broker '%d'".formatted(nodeId))
+          .untilAsserted(
+              () -> JobStreamServiceAssert.assertThat(service).doesNotHaveStreamWithType(jobType));
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobStreamLifecycleIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobStreamLifecycleIT.java
@@ -185,7 +185,7 @@ final class JobStreamLifecycleIT {
   }
 
   @Test
-  void shouldNotRemoveStreamOnClientCancel() {
+  void shouldNotRemoveOtherStreamOnClientCancel() {
     // given - two logically equivalent clients
     final var stream =
         client.getClient().newStreamJobsCommand().jobType(jobType).consumer(ignored -> {}).send();

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -107,5 +107,20 @@
       <artifactId>zeebe-transport</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/JobStreamClientAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/JobStreamClientAssert.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.jobstream;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
+import io.camunda.zeebe.transport.stream.api.ClientStream;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.condition.AllOf;
+import org.assertj.core.condition.VerboseCondition;
+
+/**
+ * Convenience class to assert certain properties of a {@link JobStreamClient}, e.g. is a stream
+ * registered with the given properties, how many streams there are, etc.
+ *
+ * <p>NOTE: while there's a lot of similar code between this and {@link JobStreamServiceAssert} -
+ * especially the conditions - since the actual values under assertion do not share a common type,
+ * it's likely not worth the effort of deduplication.
+ */
+public class JobStreamClientAssert
+    extends AbstractObjectAssert<JobStreamClientAssert, JobStreamClient> {
+  /**
+   * @param jobStreamClient the actual client to assert against
+   */
+  public JobStreamClientAssert(final JobStreamClient jobStreamClient) {
+    super(jobStreamClient, JobStreamClientAssert.class);
+  }
+
+  /**
+   * A convenience factory method that's consistent with AssertJ conventions.
+   *
+   * @param actual the actual client to assert against
+   * @return an instance of {@link JobStreamClientAssert} to assert properties of the given client
+   */
+  public static JobStreamClientAssert assertThat(final JobStreamClient actual) {
+    return new JobStreamClientAssert(actual);
+  }
+
+  /**
+   * Asserts that the given client contains exactly {@code expectedCount} streams for the given job
+   * type.
+   *
+   * @param expectedCount the exact count of streams to find
+   * @param jobType the expected type of the streams
+   * @return itself for chaining
+   */
+  public JobStreamClientAssert hasStreamWithType(final int expectedCount, final String jobType) {
+    return hasStreamMatchingCount(expectedCount, hasStreamType(jobType));
+  }
+
+  /**
+   * Asserts that the given client contains exactly {@code expectedCount} streams for the given job
+   * type.
+   *
+   * @param expectedCount the exact count of streams to find
+   * @param jobType the expected type of the streams
+   * @return itself for chaining
+   */
+  public JobStreamClientAssert hasStreamWithType(
+      final int expectedCount, final String jobType, final int... connectedTo) {
+    return hasStreamMatchingCount(
+        expectedCount, AllOf.allOf(hasStreamType(jobType), isConnectedTo(connectedTo)));
+  }
+
+  /**
+   * Asserts that the given client contains exactly {@code expectedCount} streams for the given
+   * worker name.
+   *
+   * @param expectedCount the exact count of streams to find
+   * @param worker the expected worker property of the streams
+   * @return itself for chaining
+   */
+  public JobStreamClientAssert hasStreamWithWorker(final int expectedCount, final String worker) {
+    return hasStreamMatchingCount(expectedCount, hasWorker(worker));
+  }
+
+  /**
+   * Asserts that the given client does not contain any streams for the given worker name.
+   *
+   * @param worker the expected worker of the streams
+   * @return itself for chaining
+   */
+  public JobStreamClientAssert doesNotHaveStreamWithWorker(final String worker) {
+    return doesNotHaveStreamMatching(hasWorker(worker));
+  }
+
+  /**
+   * Asserts that the given client does not contain any streams for the given stream type.
+   *
+   * @param streamType the expected job type of the streams
+   * @return itself for chaining
+   */
+  public JobStreamClientAssert doesNotHaveStreamWithType(final String streamType) {
+    return doesNotHaveStreamMatching(hasStreamType(streamType));
+  }
+
+  /**
+   * Asserts that the given client contains exactly {@code expectedCount} streams which all match
+   * the same condition.
+   *
+   * <p>NOTE: you can reuse the conditions found as static methods of this class, e.g. {@link
+   * #hasWorker(String)}, {@link #hasStreamType(String)}. If you wish to combine them, you can use
+   * {@link org.assertj.core.condition.AnyOf} or {@link org.assertj.core.condition.AllOf}.
+   *
+   * @param expectedCount the exact count of streams to find
+   * @param condition the condition the streams must match
+   * @return itself for chaining
+   */
+  public JobStreamClientAssert hasStreamMatchingCount(
+      final int expectedCount, final Condition<ClientStream<JobActivationProperties>> condition) {
+    isNotNull();
+
+    final var description =
+        descriptionOrDefault("has at '%d' stream(s) matching assertions", expectedCount);
+    final var streams = actual.list().join();
+    Assertions.assertThat(streams).as(description).haveExactly(expectedCount, condition);
+
+    return myself;
+  }
+
+  /**
+   * Asserts that the given client does not container any stream which matches the given condition.
+   *
+   * <p>NOTE: you can reuse the conditions found as static methods of this class, e.g. {@link
+   * #hasWorker(String)}, {@link #hasStreamType(String)}. If you wish to combine them, you can use
+   * {@link org.assertj.core.condition.AnyOf} or {@link org.assertj.core.condition.AllOf}.
+   *
+   * @param condition the condition the streams must match
+   * @return itself for chaining
+   */
+  public JobStreamClientAssert doesNotHaveStreamMatching(
+      final Condition<ClientStream<JobActivationProperties>> condition) {
+    isNotNull();
+
+    final var description = descriptionOrDefault("has no streams matching assertions");
+    final var streams = actual.list().join();
+    Assertions.assertThat(streams).as(description).doNotHave(condition);
+
+    return myself;
+  }
+
+  /** Returns a condition which checks that a stream has the given stream type. */
+  public static Condition<ClientStream<JobActivationProperties>> hasStreamType(
+      final String streamType) {
+    return VerboseCondition.verboseCondition(
+        stream -> BufferUtil.bufferAsString(stream.streamType()).equals(streamType),
+        "a stream with type '%s'".formatted(streamType),
+        stream ->
+            " but actual type is '%s'".formatted(BufferUtil.bufferAsString(stream.streamType())));
+  }
+
+  /** Returns a condition which checks that a stream has the given worker name. */
+  public static Condition<ClientStream<JobActivationProperties>> hasWorker(
+      final String workerName) {
+    return VerboseCondition.verboseCondition(
+        stream -> BufferUtil.bufferAsString(stream.metadata().worker()).equals(workerName),
+        "a stream with worker '%s'".formatted(workerName),
+        stream ->
+            " but actual worker is '%s'"
+                .formatted(BufferUtil.bufferAsString(stream.metadata().worker())));
+  }
+
+  /** Returns a condition which checks that a stream is connected to the given brokers by ID. */
+  public static Condition<ClientStream<JobActivationProperties>> isConnectedTo(
+      final int... nodeId) {
+    final var members =
+        Arrays.stream(nodeId)
+            .mapToObj(String::valueOf)
+            .map(MemberId::from)
+            .collect(Collectors.toSet());
+    return VerboseCondition.verboseCondition(
+        stream -> {
+          members.removeAll(stream.liveConnections());
+          return members.isEmpty();
+        },
+        "a stream connected to brokers %s".formatted(Arrays.toString(nodeId)),
+        stream -> " but actual connections are '%s'".formatted(stream.liveConnections()));
+  }
+
+  /** Returns a condition which checks that a stream has the given timeout in milliseconds. */
+  public static Condition<ClientStream<JobActivationProperties>> hasTimeout(
+      final long timeoutMillis) {
+    return VerboseCondition.verboseCondition(
+        stream -> stream.metadata().timeout() == timeoutMillis,
+        "a stream with timeout '%dms'".formatted(timeoutMillis),
+        stream -> " but actual timeout is '%dms'".formatted(stream.metadata().timeout()));
+  }
+
+  /** Returns a condition which checks that a stream has the given timeout in milliseconds. */
+  public static Condition<ClientStream<JobActivationProperties>> hasFetchVariables(
+      final String... variables) {
+    //noinspection DuplicatedCode
+    final var expectedVariables = Arrays.stream(variables).map(BufferUtil::wrapString).toList();
+    return VerboseCondition.verboseCondition(
+        stream ->
+            stream.metadata().fetchVariables().containsAll(expectedVariables)
+                && stream.metadata().fetchVariables().size() == expectedVariables.size(),
+        "a stream with fetch variables %s".formatted(Arrays.toString(variables)),
+        stream ->
+            " but actual variables is %s"
+                .formatted(
+                    stream.metadata().fetchVariables().stream()
+                        .map(BufferUtil::bufferAsString)
+                        .toList()));
+  }
+
+  private String descriptionOrDefault(final String description, final Object... args) {
+    final var userDescription = descriptionText();
+    return userDescription.isBlank() ? description.formatted(args) : userDescription;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds clustered QA tests which validate the job stream lifecycle using the client. This adds a new assertion class (`JobStreamClientAssert`), grouping it with `JobStreamServiceAssert` into a single package, and a bunch of new tests.

> **Note**
> There is some seemingly duplicated code between the two assertion classes, but keep in mind that they operate on completely different types, and do not share a common base type, so it's not so easy to abstract and deduplicate. I think it's fine to keep as is, but happy to discuss.

There are no tests with multiple gateways, but this is already covered extensively in the transport integration tests, and from a client point of view it doesn't matter all that much, since we mostly care about getting jobs pushed from the various brokers/partitions.

## Related issues

closes #11710 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
