### PR TITLE
Initialize ClusterTopology  from BrokerCfg and persists it locally

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterTopologyManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterTopologyManagerStep.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopologyManager;
+import io.camunda.zeebe.broker.partitioning.topology.StaticPartitionDistributionResolver;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 
@@ -26,7 +26,7 @@ public class ClusterTopologyManagerStep
         brokerStartupContext.getConcurrencyControl().createFuture();
     try {
       brokerStartupContext.setClusterTopology(
-          new ClusterTopologyManager()
+          new StaticPartitionDistributionResolver()
               .resolveTopology(
                   brokerStartupContext.getBrokerConfiguration().getExperimental().getPartitioning(),
                   brokerStartupContext.getBrokerConfiguration().getCluster()));

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopology.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopology.java
@@ -7,8 +7,12 @@
  */
 package io.camunda.zeebe.broker.clustering.topology;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.atomix.cluster.MemberId;
+import java.io.IOException;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -25,11 +29,20 @@ import java.util.stream.Stream;
  *
  * <p>changes - keeps track of the ongoing configuration changes
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ClusterTopology(
     long version, Map<MemberId, MemberState> members, ClusterChangePlan changes) {
 
   static ClusterTopology init() {
     return new ClusterTopology(0, Map.of(), ClusterChangePlan.empty());
+  }
+
+  static ClusterTopology decode(final byte[] serializedTopology) throws IOException {
+    return new ObjectMapper().readValue(serializedTopology, ClusterTopology.class);
+  }
+
+  byte[] encode() throws JsonProcessingException {
+    return new ObjectMapper().writeValueAsBytes(this);
   }
 
   ClusterTopology addMember(final MemberId memberId, final MemberState state) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManager.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManager.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.partitioning.topology.StaticPartitionDistribution
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -52,7 +53,7 @@ final class ClusterTopologyManager {
     return startFuture;
   }
 
-  private void initialize(final BrokerCfg brokerCfg) {
+  private void initialize(final BrokerCfg brokerCfg) throws IOException {
     persistedClusterTopology.initialize();
     if (persistedClusterTopology.getTopology() == null) {
       final var topology = initializeFromConfig(brokerCfg);
@@ -62,7 +63,7 @@ final class ClusterTopologyManager {
     }
   }
 
-  private ClusterTopology initializeFromConfig(final BrokerCfg brokerCfg) {
+  private ClusterTopology initializeFromConfig(final BrokerCfg brokerCfg) throws IOException {
     final var partitionDistribution =
         new StaticPartitionDistributionResolver()
             .resolveTopology(brokerCfg.getExperimental().getPartitioning(), brokerCfg.getCluster());
@@ -96,7 +97,7 @@ final class ClusterTopologyManager {
     return topology;
   }
 
-  private void updateLocalTopology(final ClusterTopology topology) {
+  private void updateLocalTopology(final ClusterTopology topology) throws IOException {
     persistedClusterTopology.update(topology);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManager.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManager.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.clustering.topology;
 
-import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.partitioning.topology.StaticPartitionDistributionResolver;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -58,7 +57,7 @@ final class ClusterTopologyManager {
     if (persistedClusterTopology.getTopology() == null) {
       final var topology = initializeFromConfig(brokerCfg);
       persistedClusterTopology.update(topology);
-      LOG.trace(
+      LOG.info(
           "Initialized ClusterTopology from BrokerCfg {}", persistedClusterTopology.getTopology());
     }
   }
@@ -83,13 +82,8 @@ final class ClusterTopologyManager {
 
     final var memberStates =
         partitionsOwnedByMembers.entrySet().stream()
-            .map(
-                entry -> {
-                  final MemberId memberId = entry.getKey();
-                  final Map<Integer, PartitionState> partitionInfo = entry.getValue();
-                  return Map.entry(memberId, MemberState.initializeAsActive(partitionInfo));
-                })
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            .collect(
+                Collectors.toMap(Entry::getKey, e -> MemberState.initializeAsActive(e.getValue())));
 
     final var topology = new ClusterTopology(0, memberStates, ClusterChangePlan.empty());
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManager.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManager.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.partitioning.topology.StaticPartitionDistributionResolver;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Responsible for initializing ClusterTopology and managing ClusterTopology changes. */
+final class ClusterTopologyManager {
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterTopologyManager.class);
+
+  private final ConcurrencyControl executor;
+  private final PersistedClusterTopology persistedClusterTopology;
+
+  ClusterTopologyManager(
+      final ConcurrencyControl executor, final PersistedClusterTopology persistedClusterTopology) {
+    this.executor = executor;
+    this.persistedClusterTopology = persistedClusterTopology;
+  }
+
+  ActorFuture<ClusterTopology> getClusterTopology() {
+    return executor.call(persistedClusterTopology::getTopology);
+  }
+
+  ActorFuture<Void> start(final BrokerCfg brokerCfg) {
+    final ActorFuture<Void> startFuture = executor.createFuture();
+
+    executor.run(
+        () -> {
+          try {
+            initialize(brokerCfg);
+            startFuture.complete(null);
+          } catch (final Exception e) {
+            LOG.error("Failed to initialize ClusterTopology", e);
+            startFuture.completeExceptionally(e);
+          }
+        });
+
+    return startFuture;
+  }
+
+  private void initialize(final BrokerCfg brokerCfg) {
+    persistedClusterTopology.initialize();
+    if (persistedClusterTopology.getTopology() == null) {
+      final var topology = initializeFromConfig(brokerCfg);
+      persistedClusterTopology.update(topology);
+      LOG.trace(
+          "Initialized ClusterTopology from BrokerCfg {}", persistedClusterTopology.getTopology());
+    }
+  }
+
+  private ClusterTopology initializeFromConfig(final BrokerCfg brokerCfg) {
+    final var partitionDistribution =
+        new StaticPartitionDistributionResolver()
+            .resolveTopology(brokerCfg.getExperimental().getPartitioning(), brokerCfg.getCluster());
+
+    final var partitionsOwnedByMembers =
+        partitionDistribution.partitions().stream()
+            .flatMap(
+                p ->
+                    p.members().stream()
+                        .map(m -> Map.entry(m, Map.entry(p.id().id(), p.getPriority(m)))))
+            .collect(
+                Collectors.groupingBy(
+                    Entry::getKey,
+                    Collectors.toMap(
+                        e -> e.getValue().getKey(),
+                        e -> PartitionState.active(e.getValue().getValue()))));
+
+    final var memberStates =
+        partitionsOwnedByMembers.entrySet().stream()
+            .map(
+                entry -> {
+                  final MemberId memberId = entry.getKey();
+                  final Map<Integer, PartitionState> partitionInfo = entry.getValue();
+                  return Map.entry(memberId, MemberState.initializeAsActive(partitionInfo));
+                })
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    final var topology = new ClusterTopology(0, memberStates, ClusterChangePlan.empty());
+
+    updateLocalTopology(topology);
+    return topology;
+  }
+
+  private void updateLocalTopology(final ClusterTopology topology) {
+    persistedClusterTopology.update(topology);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+
+public final class ClusterTopologyManagerService extends Actor {
+
+  private final ClusterTopologyManager clusterTopologyManager;
+
+  public ClusterTopologyManagerService() {
+    clusterTopologyManager = new ClusterTopologyManager(this, new PersistedClusterTopology());
+  }
+
+  /**
+   * NOTE: Do not integrate this into Broker startup steps until data layout and serialization
+   * `ClusterTopology` is finalized. This is to prevent any backward incompatible changes to be
+   * included in a released version.
+   *
+   * <p>Starts ClusterTopologyManager which initializes ClusterTopology
+   */
+  ActorFuture<Void> start(
+      final ActorSchedulingService actorSchedulingService, final BrokerCfg brokerCfg) {
+    final var startFuture = new CompletableActorFuture<Void>();
+    actorSchedulingService
+        .submitActor(this)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                actor.run(() -> startClusterTopologyManager(brokerCfg, startFuture));
+              } else {
+                startFuture.completeExceptionally(error);
+              }
+            });
+
+    return startFuture;
+  }
+
+  private void startClusterTopologyManager(
+      final BrokerCfg brokerCfg, final CompletableActorFuture<Void> startFuture) {
+    clusterTopologyManager.start(brokerCfg).onComplete(startFuture);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerService.java
@@ -12,13 +12,15 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.nio.file.Path;
 
 public final class ClusterTopologyManagerService extends Actor {
 
   private final ClusterTopologyManager clusterTopologyManager;
 
-  public ClusterTopologyManagerService() {
-    clusterTopologyManager = new ClusterTopologyManager(this, new PersistedClusterTopology());
+  public ClusterTopologyManagerService(final Path topologyFile) {
+    clusterTopologyManager =
+        new ClusterTopologyManager(this, new PersistedClusterTopology(topologyFile));
   }
 
   /**

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/PersistedClusterTopology.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/PersistedClusterTopology.java
@@ -7,11 +7,28 @@
  */
 package io.camunda.zeebe.broker.clustering.topology;
 
-final class PersistedClusterTopology {
-  ClusterTopology clusterTopology;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
-  void initialize() {
-    // TODO read from local persisted storage
+/** Manages reading and updating ClusterTopology in a local persisted file * */
+final class PersistedClusterTopology {
+  private final Path topologyFile;
+  private ClusterTopology clusterTopology;
+
+  PersistedClusterTopology(final Path topologyFile) {
+    this.topologyFile = topologyFile;
+  }
+
+  void initialize() throws IOException {
+    if (Files.exists(topologyFile)) {
+      final var serializedTopology = Files.readAllBytes(topologyFile);
+      if (serializedTopology.length > 0) {
+        clusterTopology = ClusterTopology.decode(serializedTopology);
+      }
+      return;
+    }
     clusterTopology = null;
   }
 
@@ -19,8 +36,15 @@ final class PersistedClusterTopology {
     return clusterTopology;
   }
 
-  void update(final ClusterTopology clusterTopology) {
+  void update(final ClusterTopology clusterTopology) throws IOException {
+    final var serializedTopology = clusterTopology.encode();
+    Files.write(
+        topologyFile,
+        serializedTopology,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.DSYNC);
+
     this.clusterTopology = clusterTopology;
-    // TODO write to file
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/PersistedClusterTopology.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/PersistedClusterTopology.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+final class PersistedClusterTopology {
+  ClusterTopology clusterTopology;
+
+  void initialize() {
+    // TODO read from local persisted storage
+    clusterTopology = null;
+  }
+
+  ClusterTopology getTopology() {
+    return clusterTopology;
+  }
+
+  void update(final ClusterTopology clusterTopology) {
+    this.clusterTopology = clusterTopology;
+    // TODO write to file
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticPartitionDistributionResolver.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticPartitionDistributionResolver.java
@@ -23,12 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-/**
- * Manage how partitions are distributed among the brokers.
- *
- * <p>Note: Do not confuse it with the {@link TopologyManager}. {@link
- * StaticPartitionDistributionResolver} doesn't keep track of the current leader and followers.
- */
+/** Manage how partitions are distributed among the brokers. */
 public class StaticPartitionDistributionResolver {
 
   public PartitionDistribution resolveTopology(

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticPartitionDistributionResolver.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticPartitionDistributionResolver.java
@@ -26,10 +26,10 @@ import java.util.stream.IntStream;
 /**
  * Manage how partitions are distributed among the brokers.
  *
- * <p>Note: Do not confuse it with the {@link TopologyManager}. {@link ClusterTopologyManager}
- * doesn't keep track of the current leader and followers.
+ * <p>Note: Do not confuse it with the {@link TopologyManager}. {@link
+ * StaticPartitionDistributionResolver} doesn't keep track of the current leader and followers.
  */
-public class ClusterTopologyManager {
+public class StaticPartitionDistributionResolver {
 
   public PartitionDistribution resolveTopology(
       final PartitioningCfg partitionCfg, final ClusterCfg clusterCfg) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyAssert.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyAssert.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
 final class ClusterTopologyAssert extends AbstractAssert<ClusterTopologyAssert, ClusterTopology> {
@@ -28,6 +30,13 @@ final class ClusterTopologyAssert extends AbstractAssert<ClusterTopologyAssert, 
     final var memberId = MemberId.from(Integer.toString(member));
     assertThat(actual.members()).containsKey(memberId);
     assertThat(actual.members().get(memberId).partitions()).containsOnlyKeys(partitionIds);
+    return this;
+  }
+
+  ClusterTopologyAssert hasOnlyMembers(final Set<Integer> members) {
+    final var memberIds =
+        members.stream().map(id -> MemberId.from(String.valueOf(id))).collect(Collectors.toSet());
+    assertThat(actual.members()).containsOnlyKeys(memberIds);
     return this;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyAssert.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyAssert.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import java.util.Collection;
+import org.assertj.core.api.AbstractAssert;
+
+final class ClusterTopologyAssert extends AbstractAssert<ClusterTopologyAssert, ClusterTopology> {
+
+  private ClusterTopologyAssert(final ClusterTopology clusterTopology, final Class<?> selfType) {
+    super(clusterTopology, selfType);
+  }
+
+  static ClusterTopologyAssert assertThatClusterTopology(final ClusterTopology actual) {
+    return new ClusterTopologyAssert(actual, ClusterTopologyAssert.class);
+  }
+
+  ClusterTopologyAssert hasMemberWithPartitions(
+      final int member, final Collection<Integer> partitionIds) {
+    final var memberId = MemberId.from(Integer.toString(member));
+    assertThat(actual.members()).containsKey(memberId);
+    assertThat(actual.members().get(memberId).partitions()).containsOnlyKeys(partitionIds);
+    return this;
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering.topology;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class ClusterTopologyManagerTest {
+
+  @Test
+  void shouldInitializeClusterTopologyFromBrokerCfg() {
+    // given
+    final ClusterTopologyManager clusterTopologyManager =
+        new ClusterTopologyManager(new TestConcurrencyControl(), new PersistedClusterTopology());
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setClusterSize(3);
+    brokerCfg.getCluster().setPartitionsCount(3);
+    brokerCfg.getCluster().setReplicationFactor(1);
+
+    // when
+    clusterTopologyManager.start(brokerCfg).join();
+
+    // then
+    final ClusterTopology clusterTopology = clusterTopologyManager.getClusterTopology().join();
+    ClusterTopologyAssert.assertThatClusterTopology(clusterTopology)
+        .hasMemberWithPartitions(0, Set.of(1))
+        .hasMemberWithPartitions(1, Set.of(2))
+        .hasMemberWithPartitions(2, Set.of(3));
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerTest.java
@@ -9,16 +9,19 @@ package io.camunda.zeebe.broker.clustering.topology;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.nio.file.Path;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 final class ClusterTopologyManagerTest {
 
   @Test
-  void shouldInitializeClusterTopologyFromBrokerCfg() {
+  void shouldInitializeClusterTopologyFromBrokerCfg(@TempDir final Path topologyFile) {
     // given
     final ClusterTopologyManager clusterTopologyManager =
-        new ClusterTopologyManager(new TestConcurrencyControl(), new PersistedClusterTopology());
+        new ClusterTopologyManager(
+            new TestConcurrencyControl(), new PersistedClusterTopology(topologyFile));
     final BrokerCfg brokerCfg = new BrokerCfg();
     brokerCfg.getCluster().setClusterSize(3);
     brokerCfg.getCluster().setPartitionsCount(3);

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/topology/ClusterTopologyManagerTest.java
@@ -7,9 +7,17 @@
  */
 package io.camunda.zeebe.broker.clustering.topology;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -21,7 +29,8 @@ final class ClusterTopologyManagerTest {
     // given
     final ClusterTopologyManager clusterTopologyManager =
         new ClusterTopologyManager(
-            new TestConcurrencyControl(), new PersistedClusterTopology(topologyFile));
+            new TestConcurrencyControl(),
+            new PersistedClusterTopology(topologyFile.resolve("topology.temp")));
     final BrokerCfg brokerCfg = new BrokerCfg();
     brokerCfg.getCluster().setClusterSize(3);
     brokerCfg.getCluster().setPartitionsCount(3);
@@ -36,5 +45,46 @@ final class ClusterTopologyManagerTest {
         .hasMemberWithPartitions(0, Set.of(1))
         .hasMemberWithPartitions(1, Set.of(2))
         .hasMemberWithPartitions(2, Set.of(3));
+  }
+
+  @Test
+  void shouldInitializeClusterTopologyFromFile(@TempDir final Path topologyFile)
+      throws IOException {
+    // given
+    final Path existingTopologyFile = topologyFile.resolve("topology.temp");
+    final var existingTopology =
+        ClusterTopology.init()
+            .addMember(
+                MemberId.from("5"),
+                MemberState.initializeAsActive(Map.of(10, PartitionState.active(4))));
+    Files.write(existingTopologyFile, existingTopology.encode());
+    final ClusterTopologyManager clusterTopologyManager =
+        new ClusterTopologyManager(
+            new TestConcurrencyControl(), new PersistedClusterTopology(existingTopologyFile));
+
+    // when
+    clusterTopologyManager.start(new BrokerCfg()).join();
+
+    // then
+    final ClusterTopology clusterTopology = clusterTopologyManager.getClusterTopology().join();
+    ClusterTopologyAssert.assertThatClusterTopology(clusterTopology)
+        .hasOnlyMembers(Set.of(5))
+        .hasMemberWithPartitions(5, Set.of(10));
+  }
+
+  @Test
+  void shouldFailIfTopologyFileIsCorrupted(@TempDir final Path topologyFile) throws IOException {
+    // given
+    final Path existingTopologyFile = topologyFile.resolve("topology.temp");
+    Files.write(existingTopologyFile, new byte[10]); // write random string
+    final ClusterTopologyManager clusterTopologyManager =
+        new ClusterTopologyManager(
+            new TestConcurrencyControl(), new PersistedClusterTopology(existingTopologyFile));
+
+    // when - then
+    assertThat(clusterTopologyManager.start(new BrokerCfg()))
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableThat()
+        .withCauseInstanceOf(JsonParseException.class);
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticPartitionDistributionResolverTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticPartitionDistributionResolverTest.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-class ClusterTopologyManagerTest {
+class StaticPartitionDistributionResolverTest {
 
   @Test
   void shouldGenerateRoundRobinDistribution() {
@@ -49,7 +49,8 @@ class ClusterTopologyManagerTest {
     clusterCfg.setReplicationFactor(3);
 
     // when
-    final var topology = new ClusterTopologyManager().resolveTopology(partitioningCfg, clusterCfg);
+    final var topology =
+        new StaticPartitionDistributionResolver().resolveTopology(partitioningCfg, clusterCfg);
     final Set<PartitionMetadata> partitionDistribution = topology.partitions();
 
     // then
@@ -111,7 +112,8 @@ fixed:
     clusterCfg.setReplicationFactor(3);
 
     // when
-    final var topology = new ClusterTopologyManager().resolveTopology(partitioningCfg, clusterCfg);
+    final var topology =
+        new StaticPartitionDistributionResolver().resolveTopology(partitioningCfg, clusterCfg);
     final Set<PartitionMetadata> partitionDistribution = topology.partitions();
 
     // then

--- a/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -12,7 +12,7 @@ import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.partitioning.RaftPartitionGroupFactory;
-import io.camunda.zeebe.broker.partitioning.topology.ClusterTopologyManager;
+import io.camunda.zeebe.broker.partitioning.topology.StaticPartitionDistributionResolver;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -101,7 +101,7 @@ public class RestoreManager {
 
     final var factory = new RaftPartitionGroupFactory();
     final var clusterTopology =
-        new ClusterTopologyManager()
+        new StaticPartitionDistributionResolver()
             .resolveTopology(
                 configuration.getExperimental().getPartitioning(), configuration.getCluster());
     // snapshot store factory can be null because we are not going start the partitions.


### PR DESCRIPTION
## Description

This PR add a ClusterTopologyManager that is responsible for initializing and managing ClusterTopology. As a first step, it initializes from the local persisted file or from the provided BrokerCfg. Later this will be extended to initialize by querying a coordinator.

As discussed before, this PR writes ClusterTopology to file as Json. This is temporary until we finalize a serialization format. Because of this reason, the new `ClusterTopologyManger` is not integrated with the Broker. Once we start using it, it would be difficult to change the serialization format due to backward compatibility. 

## Related issues

closes #13801 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
