### PR TITLE
[Backport stable/8.1] Cache parsed DRGs

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+
+public final class CachesCfg implements ConfigurationEntry {
+  private int drgCacheCapacity = EngineConfiguration.DEFAULT_DRG_CACHE_CAPACITY;
+
+  public int getDrgCacheCapacity() {
+    return drgCacheCapacity;
+  }
+
+  public void setDrgCacheCapacity(final int drgCacheCapacity) {
+    this.drgCacheCapacity = drgCacheCapacity;
+  }
+
+  @Override
+  public String toString() {
+    return "CachesCfg{" + "drgCacheCapacity=" + drgCacheCapacity + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -14,10 +14,12 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 public final class EngineCfg implements ConfigurationEntry {
 
   private MessagesCfg messages = new MessagesCfg();
+  private CachesCfg caches = new CachesCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     messages.init(globalConfig, brokerBase);
+    caches.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -28,14 +30,23 @@ public final class EngineCfg implements ConfigurationEntry {
     this.messages = messages;
   }
 
+  public CachesCfg getCaches() {
+    return caches;
+  }
+
+  public void setCaches(final CachesCfg caches) {
+    this.caches = caches;
+  }
+
   @Override
   public String toString() {
-    return "EngineCfg{" + "messages=" + messages + '}';
+    return "EngineCfg{" + "messages=" + messages + ", caches=" + caches + '}';
   }
 
   public EngineConfiguration createEngineConfiguration() {
     return new EngineConfiguration()
         .setMessagesTtlCheckerBatchLimit(messages.getTtlCheckerBatchLimit())
-        .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval());
+        .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval())
+        .setDrgCacheCapacity(caches.getDrgCacheCapacity());
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -29,6 +29,7 @@ final class EngineCfgTest {
     // then
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofMinutes(1));
+    assertThat(configuration.getDrgCacheCapacity()).isEqualTo(1000L);
   }
 
   @Test
@@ -42,5 +43,6 @@ final class EngineCfgTest {
     // then
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(1000);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofSeconds(15));
+    assertThat(configuration.getDrgCacheCapacity()).isEqualTo(2000L);
   }
 }

--- a/broker/src/test/resources/system/engine.yaml
+++ b/broker/src/test/resources/system/engine.yaml
@@ -5,3 +5,5 @@ zeebe:
         messages:
           ttlCheckerBatchLimit: 1000
           ttlCheckerInterval: 15s
+        caches:
+          drgCacheCapacity: 2000

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -833,6 +833,13 @@
           # of messages in a single execution. See `ttlCheckerBatchLimit` to configure the size of these batches.
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERINTERVAL
           # ttlCheckerInterval: 1m
+        
+        # caches:
+          # Allows to configure the Decision Requirements Graph cache size. By default this is set to 1000.
+          # If there are more than 1000 different DRG's actively used in the cluster it is recommended
+          # to increase the size of this cache. The cache prevents having to parse DRG's everytime a
+          # decision is evaluated. If the cache is full, the least used DRG gets evicted.
+          # drgCacheCapacity: 1000
 
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -772,6 +772,13 @@
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MESSAGES_TTLCHECKERINTERVAL
           # ttlCheckerInterval: 1m
 
+        # caches:
+          # Allows to configure the Decision Requirements Graph cache size. By default this is set to 1000.
+          # If there are more than 1000 different DRG's actively used in the cluster it is recommended
+          # to increase the size of this cache. The cache prevents having to parse DRG's everytime a
+          # decision is evaluated. If the cache is full, the least used DRG gets evicted.
+          # drgCacheCapacity: 1000
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -111,6 +111,11 @@
       <artifactId>cron-utils</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -74,7 +74,8 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getPartitionId(),
             zeebeDb,
             recordProcessorContext.getTransactionContext(),
-            recordProcessorContext.getKeyGenerator());
+            recordProcessorContext.getKeyGenerator(),
+            config);
 
     eventApplier = recordProcessorContext.getEventApplierFactory().apply(processingState);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -20,8 +20,11 @@ public final class EngineConfiguration {
   // message size.
   public static final int BATCH_SIZE_CALCULATION_BUFFER = 1024 * 8;
 
+  public static final int DEFAULT_DRG_CACHE_CAPACITY = 1000;
+
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
+  private int drgCacheCapacity = DEFAULT_DRG_CACHE_CAPACITY;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -40,6 +43,15 @@ public final class EngineConfiguration {
   public EngineConfiguration setMessagesTtlCheckerInterval(
       final Duration messagesTtlCheckerInterval) {
     this.messagesTtlCheckerInterval = messagesTtlCheckerInterval;
+    return this;
+  }
+
+  public int getDrgCacheCapacity() {
+    return drgCacheCapacity;
+  }
+
+  public EngineConfiguration setDrgCacheCapacity(final int drgCacheCapacity) {
+    this.drgCacheCapacity = drgCacheCapacity;
     return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -25,8 +25,8 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCalledDecision;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.KeyGenerator;
+import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
@@ -93,7 +93,6 @@ public final class BpmnDecisionBehavior {
     }
 
     final var decisionId = decisionIdOrFailure.get();
-    // todo(#8571): avoid parsing drg every time
     final var decisionOrFailure = findDecisionById(decisionId);
     final var resultOrFailure =
         decisionOrFailure
@@ -103,7 +102,6 @@ public final class BpmnDecisionBehavior {
                     new Failure(
                         "Expected to evaluate decision '%s', but %s"
                             .formatted(decisionId, failure.getMessage())))
-            .flatMap(drg -> parseDrg(drg.getResource()))
             // all the above failures have the same error type and the correct scope
             .mapLeft(f -> new Failure(f.getMessage(), ErrorType.CALLED_DECISION_ERROR, scopeKey))
             .flatMap(
@@ -152,8 +150,12 @@ public final class BpmnDecisionBehavior {
         .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)));
   }
 
-  private Either<Failure, PersistedDecisionRequirements> findParsedDrgByDecision(
-      final PersistedDecision decision) {
+  public Either<Failure, ParsedDecisionRequirementsGraph> findParsedDrgByDecision(
+      final PersistedDecision persistedDecision) {
+    return findDrgByDecision(persistedDecision).map(DeployedDrg::getParsedDecisionRequirements);
+  }
+
+  private Either<Failure, DeployedDrg> findDrgByDecision(final PersistedDecision decision) {
     final var key = decision.getDecisionRequirementsKey();
     final var id = decision.getDecisionRequirementsId();
     return Either.ofOptional(decisionState.findDecisionRequirementsByKey(key))

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -97,7 +97,7 @@ public final class BpmnDecisionBehavior {
     final var decisionOrFailure = findDecisionById(decisionId);
     final var resultOrFailure =
         decisionOrFailure
-            .flatMap(this::findDrgByDecision)
+            .flatMap(this::findParsedDrgByDecision)
             .mapLeft(
                 failure ->
                     new Failure(
@@ -152,7 +152,7 @@ public final class BpmnDecisionBehavior {
         .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)));
   }
 
-  private Either<Failure, PersistedDecisionRequirements> findDrgByDecision(
+  private Either<Failure, PersistedDecisionRequirements> findParsedDrgByDecision(
       final PersistedDecision decision) {
     final var key = decision.getDecisionRequirementsKey();
     final var id = decision.getDecisionRequirementsId();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -17,8 +17,8 @@ import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.KeyGenerator;
+import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsMetadataRecord;
@@ -237,18 +237,16 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
     return drgRecord.getDecisionRequirementsKey();
   }
 
-  private boolean hasSameResourceNameAs(
-      final DeploymentResource resource, final PersistedDecisionRequirements drg) {
+  private boolean hasSameResourceNameAs(final DeploymentResource resource, final DeployedDrg drg) {
     return drg.getResourceName().equals(resource.getResourceNameBuffer());
   }
 
-  private boolean hasSameChecksumAs(
-      final DirectBuffer checksum, final PersistedDecisionRequirements drg) {
+  private boolean hasSameChecksumAs(final DirectBuffer checksum, final DeployedDrg drg) {
     return drg.getChecksum().equals(checksum);
   }
 
   private boolean hasSameDecisionRequirementsKeyAs(
-      final Collection<ParsedDecision> decisions, final PersistedDecisionRequirements drg) {
+      final Collection<ParsedDecision> decisions, final DeployedDrg drg) {
     return decisions.stream()
         .map(ParsedDecision::getId)
         .map(BufferUtil::wrapString)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.state.deployment.DbDecisionState;
 import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
@@ -74,7 +75,8 @@ public class ProcessingDbState implements MutableProcessingState {
       final int partitionId,
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final EngineConfiguration config) {
     this.partitionId = partitionId;
     this.zeebeDb = zeebeDb;
     this.keyGenerator = keyGenerator;
@@ -95,7 +97,8 @@ public class ProcessingDbState implements MutableProcessingState {
         new DbProcessMessageSubscriptionState(zeebeDb, transactionContext);
     incidentState = new DbIncidentState(zeebeDb, transactionContext, partitionId);
     bannedInstanceState = new DbBannedInstanceState(zeebeDb, transactionContext, partitionId);
-    decisionState = new DbDecisionState(zeebeDb, transactionContext);
+    decisionState = new DbDecisionState(zeebeDb, transactionContext, config);
+
     mutableMigrationState = new DbMigrationState(zeebeDb, transactionContext);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -112,7 +112,7 @@ public final class DbDecisionState implements MutableDecisionState {
     // TODO get maximum size from configuration
     drgCache =
         CacheBuilder.newBuilder()
-            .maximumSize(10000L)
+            .maximumSize(config.getDrgCacheCapacity())
             .build(
                 new CacheLoader<>() {
                   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
@@ -61,7 +62,9 @@ public final class DbDecisionState implements MutableDecisionState {
   private final LoadingCache<Long, DeployedDrg> drgCache;
 
   public DbDecisionState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final TransactionContext transactionContext,
+      final EngineConfiguration config) {
     dbDecisionKey = new DbLong();
     fkDecision = new DbForeignKey<>(dbDecisionKey, ZbColumnFamilies.DMN_DECISIONS);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -161,6 +161,11 @@ public final class DbDecisionState implements MutableDecisionState {
     return decisions;
   }
 
+  @Override
+  public void clearCache() {
+    drgCache.invalidateAll();
+  }
+
   private DeployedDrg findAndParseDecisionRequirementsByKeyFromDb(
       final long decisionRequirementsKey) throws DrgNotFoundException {
     dbDecisionRequirementsKey.wrapLong(decisionRequirementsKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.engine.state.deployment;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -15,16 +18,24 @@ import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.dmn.DecisionEngine;
+import io.camunda.zeebe.dmn.DecisionEngineFactory;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import org.agrona.DirectBuffer;
 
 public final class DbDecisionState implements MutableDecisionState {
+
+  private final DecisionEngine decisionEngine = DecisionEngineFactory.createDecisionEngine();
 
   private final DbLong dbDecisionKey;
   private final DbForeignKey<DbLong> fkDecision;
@@ -46,6 +57,8 @@ public final class DbDecisionState implements MutableDecisionState {
 
   private final ColumnFamily<DbLong, PersistedDecisionRequirements> decisionRequirementsByKey;
   private final ColumnFamily<DbString, DbForeignKey<DbLong>> latestDecisionRequirementsKeysById;
+
+  private final LoadingCache<Long, DeployedDrg> drgCache;
 
   public DbDecisionState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -92,6 +105,18 @@ public final class DbDecisionState implements MutableDecisionState {
             transactionContext,
             dbDecisionRequirementsKeyAndDecisionKey,
             DbNil.INSTANCE);
+
+    // TODO get maximum size from configuration
+    drgCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(10000L)
+            .build(
+                new CacheLoader<>() {
+                  @Override
+                  public DeployedDrg load(final Long key) throws DrgNotFoundException {
+                    return findAndParseDecisionRequirementsByKeyFromDb(key);
+                  }
+                });
   }
 
   @Override
@@ -103,7 +128,7 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
-  public Optional<PersistedDecisionRequirements> findLatestDecisionRequirementsById(
+  public Optional<DeployedDrg> findLatestDecisionRequirementsById(
       final DirectBuffer decisionRequirementsId) {
     dbDecisionRequirementsId.wrapBuffer(decisionRequirementsId);
 
@@ -113,12 +138,8 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
-  public Optional<PersistedDecisionRequirements> findDecisionRequirementsByKey(
-      final long decisionRequirementsKey) {
-    dbDecisionRequirementsKey.wrapLong(decisionRequirementsKey);
-
-    return Optional.ofNullable(decisionRequirementsByKey.get(dbDecisionRequirementsKey))
-        .map(PersistedDecisionRequirements::copy);
+  public Optional<DeployedDrg> findDecisionRequirementsByKey(final long decisionRequirementsKey) {
+    return findDeployedDrg(decisionRequirementsKey);
   }
 
   @Override
@@ -135,6 +156,35 @@ public final class DbDecisionState implements MutableDecisionState {
         }));
 
     return decisions;
+  }
+
+  private DeployedDrg findAndParseDecisionRequirementsByKeyFromDb(
+      final long decisionRequirementsKey) throws DrgNotFoundException {
+    dbDecisionRequirementsKey.wrapLong(decisionRequirementsKey);
+
+    final PersistedDecisionRequirements persistedDrg =
+        decisionRequirementsByKey.get(dbDecisionRequirementsKey);
+    if (persistedDrg == null) {
+      throw new DrgNotFoundException();
+    }
+
+    final PersistedDecisionRequirements copiedDrg = persistedDrg.copy();
+
+    final var resourceBytes = BufferUtil.bufferAsArray(copiedDrg.getResource());
+    final ParsedDecisionRequirementsGraph parsedDrg =
+        decisionEngine.parse(new ByteArrayInputStream(resourceBytes));
+
+    return new DeployedDrg(parsedDrg, copiedDrg);
+  }
+
+  private Optional<DeployedDrg> findDeployedDrg(final long decisionRequirementsKey) {
+    try {
+      // The cache automatically fetches it from the state if the key does not exist.
+      return Optional.of(drgCache.get(decisionRequirementsKey));
+    } catch (final ExecutionException e) {
+      // We reach this when we couldn't load the DRG from the state.
+      return Optional.empty();
+    }
   }
 
   private Optional<PersistedDecision> findDecisionByKey(final long decisionKey) {
@@ -211,4 +261,10 @@ public final class DbDecisionState implements MutableDecisionState {
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
     latestDecisionRequirementsKeysById.upsert(dbDecisionRequirementsId, fkDecisionRequirements);
   }
+
+  /**
+   * This exception is thrown when the drgCache can't find a DRG in the state for a given key. This
+   * must be a checked exception, because of the way the {@link LoadingCache} works.
+   */
+  private static final class DrgNotFoundException extends Exception {}
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedDrg.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedDrg.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.deployment;
+
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import org.agrona.DirectBuffer;
+
+/**
+ * This class is a similar to the {@link DeployedProcess} class. It is a wrapper that contains both
+ * the parsed DRG and the persisted DRG. This object is cached upon retrieving a DRG from the state.
+ */
+public final class DeployedDrg {
+  private final ParsedDecisionRequirementsGraph parsedDecisionRequirements;
+
+  private final PersistedDecisionRequirements persistedDecisionRequirements;
+
+  public DeployedDrg(
+      final ParsedDecisionRequirementsGraph parsedDecisionRequirements,
+      final PersistedDecisionRequirements persistedDecisionRequirements) {
+    this.parsedDecisionRequirements = parsedDecisionRequirements;
+    this.persistedDecisionRequirements = persistedDecisionRequirements;
+  }
+
+  public ParsedDecisionRequirementsGraph getParsedDecisionRequirements() {
+    return parsedDecisionRequirements;
+  }
+
+  public int getDecisionRequirementsVersion() {
+    return persistedDecisionRequirements.getDecisionRequirementsVersion();
+  }
+
+  public DirectBuffer getResourceName() {
+    return persistedDecisionRequirements.getResourceName();
+  }
+
+  public DirectBuffer getChecksum() {
+    return persistedDecisionRequirements.getChecksum();
+  }
+
+  public long getDecisionRequirementsKey() {
+    return persistedDecisionRequirements.getDecisionRequirementsKey();
+  }
+
+  public DirectBuffer getDecisionRequirementsId() {
+    return persistedDecisionRequirements.getDecisionRequirementsId();
+  }
+
+  public DirectBuffer getDecisionRequirementsName() {
+    return persistedDecisionRequirements.getDecisionRequirementsName();
+  }
+
+  public DirectBuffer getResource() {
+    return persistedDecisionRequirements.getResource();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -32,8 +32,7 @@ public interface DecisionState {
    * @return the latest version of the DRG, or {@link Optional#empty()} if no DRG is deployed with
    *     the given id
    */
-  Optional<PersistedDecisionRequirements> findLatestDecisionRequirementsById(
-      DirectBuffer decisionRequirementsId);
+  Optional<DeployedDrg> findLatestDecisionRequirementsById(DirectBuffer decisionRequirementsId);
 
   /**
    * Query decision requirements (DRGs) by the given decision requirements key.
@@ -41,8 +40,7 @@ public interface DecisionState {
    * @param decisionRequirementsKey the key of the DRG
    * @return the DRG, or {@link Optional#empty()} if no DRG is deployed with the given key
    */
-  Optional<PersistedDecisionRequirements> findDecisionRequirementsByKey(
-      long decisionRequirementsKey);
+  Optional<DeployedDrg> findDecisionRequirementsByKey(long decisionRequirementsKey);
 
   /**
    * Query decisions by the given decision requirements (DRG) key.

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -50,4 +50,7 @@ public interface DecisionState {
    *     it
    */
   List<PersistedDecision> findDecisionsByDecisionRequirementsKey(long decisionRequirementsKey);
+
+  /** Completely clears all caches. */
+  void clearCache();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.query;
 
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
@@ -68,7 +69,11 @@ public final class StateQueryService implements QueryService {
       // we don't need a key generator here, so we set it to null
       state =
           new ProcessingDbState(
-              Protocol.DEPLOYMENT_PARTITION, zeebeDb, zeebeDb.createContext(), null);
+              Protocol.DEPLOYMENT_PARTITION,
+              zeebeDb,
+              zeebeDb.createContext(),
+              null,
+              new EngineConfiguration());
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -13,6 +13,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
@@ -157,7 +158,11 @@ public class ProcessingStateExtension implements BeforeEachCallback {
             new DbKeyGenerator(Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext);
         processingState =
             new ProcessingDbState(
-                Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext, keyGenerator);
+                Protocol.DEPLOYMENT_PARTITION,
+                zeebeDb,
+                transactionContext,
+                keyGenerator,
+                new EngineConfiguration());
       } catch (final Exception e) {
         ExceptionUtils.throwAsUncheckedException(e);
       }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
@@ -39,7 +40,8 @@ public final class ProcessingStateRule extends ExternalResource {
 
     final var context = db.createContext();
     final var keyGenerator = new DbKeyGenerator(partition, db, context);
-    processingState = new ProcessingDbState(partition, db, context, keyGenerator);
+    processingState =
+        new ProcessingDbState(partition, db, context, keyGenerator, new EngineConfiguration());
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -114,4 +114,16 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
 
     return metadataList;
   }
+
+  public boolean hasBpmnResources() {
+    return getResources().stream()
+        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
+        .anyMatch(x -> x.endsWith(".bpmn") || x.endsWith(".xml"));
+  }
+
+  public boolean hasDmnResources() {
+    return getResources().stream()
+        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
+        .anyMatch(x -> x.endsWith(".dmn"));
+  }
 }


### PR DESCRIPTION
# Description
Backport of #13831 to `stable/8.1`.

relates to #8571 

---------

This one was some effort to backport as at some point we extracted some functionality of the `BpmnDecisionBehavior` to a more generic `DecisionBehavior` which is used for standalone decision evaluation. This doesn't exist on 8.1 so I had to recreate some of the changes in the `BpmnDecisionBehavior` instead.