### PR TITLE
Optimize exporters tests

### DIFF
--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -70,7 +70,8 @@ final class ElasticsearchExporterIT {
     config.index.createTemplate = true;
     config.bulk.size = 1; // force flushing on the first record
     // here; enable all indexes that needed during the tests beforehand as they will be created once
-    config.index.jobBatch = true;
+    TestSupport.provideValueTypes()
+        .forEach(valueType -> TestSupport.setIndexingForValueType(config.index, valueType, true));
 
     testClient = new TestClient(config, indexRouter);
 

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -62,8 +61,6 @@ final class ElasticsearchExporterIT {
 
   @BeforeAll
   public void beforeAll() {
-    // as all tests use the same endpoint, we need a per-test unique prefix
-    config.index.prefix = UUID.randomUUID() + "-test-record";
     config.url = CONTAINER.getHttpHostAddress();
     config.index.setNumberOfShards(1);
     config.index.setNumberOfReplicas(1);

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -69,7 +69,8 @@ final class OpensearchExporterIT {
     config.index.createTemplate = true;
     config.bulk.size = 1; // force flushing on the first record
     // here; enable all indexes that needed during the tests beforehand as they will be created once
-    config.index.jobBatch = true;
+    TestSupport.provideValueTypes()
+        .forEach(valueType -> TestSupport.setIndexingForValueType(config.index, valueType, true));
 
     testClient = new TestClient(config, indexRouter);
 

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -61,8 +60,6 @@ final class OpensearchExporterIT {
 
   @BeforeAll
   public void beforeAll() {
-    // as all tests use the same endpoint, we need a per-test unique prefix
-    config.index.prefix = UUID.randomUUID() + "-test-record";
     config.url = CONTAINER.getHttpHostAddress();
     config.index.setNumberOfShards(1);
     config.index.setNumberOfReplicas(1);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
To optimize `ElasticsearchExporterIT` and `OpensearchExporterIT` tests significantly, we use a single test instance `@TestInstance(Lifecycle.PER_CLASS)` and share its resources, including ES/OS configuration exporter among tests. With this approach, tests runtime was improved by 40-60%

**Before:**
```
125.004 s - in io.camunda.zeebe.exporter.ElasticsearchExporterIT
140.801 s - in io.camunda.zeebe.exporter.opensearch.OpensearchExporterIT
```

**After:**
```
83.72 s -- in io.camunda.zeebe.exporter.ElasticsearchExporterIT
50.49 s -- in io.camunda.zeebe.exporter.opensearch.OpensearchExporterIT
```

**Benchmark Data**
> [!NOTE]
> The following Benchmark data was produced by running the following command on a local setup
> ```
> ./mvnw -B -T 2 --no-snapshot-updates -D forkCount=7 -D maven.javadoc.skip=true -D skipUTs -D skipChecks -P parallel-tests -pl ./exporters/elasticsearch-exporter -Dit.test=io.camunda.zeebe.exporter.ElasticsearchExporterIT verify
> ```


| Method                         | Runtime  | Performance Gain |
|--------------------------------|----------|------------------|
| Sequential Execution (current) | 66.079 s |                  |
| Concurrent Execution           | 53.009 s | 19% + flaky tests ⚠️              |
| Nested Classes                 | 55.616 s | 16%              |
| Single Test Class Instance     | 17.33 s  | 74%              |

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12517

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
