### PR TITLE
Cancel and reactivate timer start events on deletion

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
@@ -160,7 +161,11 @@ public final class EngineProcessors {
         writers,
         bpmnBehaviors.jobActivationBehavior());
     addResourceDeletionProcessors(
-        typedRecordProcessors, writers, processingState, commandDistributionBehavior);
+        typedRecordProcessors,
+        writers,
+        processingState,
+        commandDistributionBehavior,
+        bpmnBehaviors);
     addSignalBroadcastProcessors(
         typedRecordProcessors,
         bpmnBehaviors,
@@ -313,13 +318,15 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final MutableProcessingState processingState,
-      final CommandDistributionBehavior commandDistributionBehavior) {
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final BpmnBehaviors bpmnBehaviors) {
     final var resourceDeletionProcessor =
         new ResourceDeletionProcessor(
             writers,
             processingState.getKeyGenerator(),
             processingState,
-            commandDistributionBehavior);
+            commandDistributionBehavior,
+            bpmnBehaviors);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -318,10 +318,8 @@ public final class EngineProcessors {
         new ResourceDeletionProcessor(
             writers,
             processingState.getKeyGenerator(),
-            processingState.getDecisionState(),
-            commandDistributionBehavior,
-            processingState.getProcessState(),
-            processingState.getElementInstanceState());
+            processingState,
+            commandDistributionBehavior);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
@@ -48,18 +49,16 @@ public class ResourceDeletionProcessor
   public ResourceDeletionProcessor(
       final Writers writers,
       final KeyGenerator keyGenerator,
-      final DecisionState decisionState,
-      final CommandDistributionBehavior commandDistributionBehavior,
-      final ProcessState processState,
-      final ElementInstanceState elementInstanceState) {
+      final ProcessingState processingState,
+      final CommandDistributionBehavior commandDistributionBehavior) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
-    this.decisionState = decisionState;
+    decisionState = processingState.getDecisionState();
     this.commandDistributionBehavior = commandDistributionBehavior;
-    this.processState = processState;
-    this.elementInstanceState = elementInstanceState;
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -12,6 +12,10 @@ import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_IN
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationException;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -25,6 +29,7 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
+import io.camunda.zeebe.model.bpmn.util.time.Timer;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
@@ -36,6 +41,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
 
@@ -52,6 +58,7 @@ public class ResourceDeletionProcessor
   private final ElementInstanceState elementInstanceState;
   private final TimerInstanceState timerInstanceState;
   private final CatchEventBehavior catchEventBehavior;
+  private final ExpressionProcessor expressionProcessor;
 
   public ResourceDeletionProcessor(
       final Writers writers,
@@ -69,6 +76,7 @@ public class ResourceDeletionProcessor
     elementInstanceState = processingState.getElementInstanceState();
     timerInstanceState = processingState.getTimerState();
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
+    expressionProcessor = bpmnBehaviors.expressionBehavior();
   }
 
   @Override
@@ -168,18 +176,29 @@ public class ResourceDeletionProcessor
   private void deleteProcess(final DeployedProcess process) {
     // We don't add the checksum or resource in this event. The checksum is not easily available
     // and the resources are left out to prevent exceeding the maximum batch size.
+    final var processIdBuffer = process.getBpmnProcessId();
     final var processRecord =
         new ProcessRecord()
-            .setBpmnProcessId(process.getBpmnProcessId())
+            .setBpmnProcessId(processIdBuffer)
             .setVersion(process.getVersion())
             .setKey(process.getKey())
             .setResourceName(process.getResourceName());
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETING, processRecord);
 
-    final var latestVersion =
-        processState.getLatestProcessVersion(processRecord.getBpmnProcessId());
+    final String processId = processRecord.getBpmnProcessId();
+    final var latestVersion = processState.getLatestProcessVersion(processId);
+
+    // If we are deleting the latest version we must unsubscribe the start events
     if (latestVersion == process.getVersion()) {
       unsubscribeStartEvents(process);
+
+      final var previousVersion = processState.findProcessVersionBefore(processId, latestVersion);
+      // If there is a previous version we must resubscribe to the previous version's start events.
+      if (previousVersion.isPresent()) {
+        final var previousProcess =
+            processState.getProcessByProcessIdAndVersion(processIdBuffer, previousVersion.get());
+        resubscribeStartEvents(previousProcess);
+      }
     }
 
     final var hasRunningInstances =
@@ -202,6 +221,32 @@ public class ResourceDeletionProcessor
               catchEventBehavior.unsubscribeFromTimerEvent(timer);
             }
           });
+    }
+  }
+
+  private void resubscribeStartEvents(final DeployedProcess deployedProcess) {
+    final var process = deployedProcess.getProcess();
+    if (process.hasTimerStartEvent()) {
+      process.getStartEvents().stream()
+          .filter(ExecutableCatchEventElement::isTimer)
+          .forEach(
+              timerStartEvent -> {
+                final Either<Failure, Timer> failureOrTimer =
+                    timerStartEvent
+                        .getTimerFactory()
+                        .apply(expressionProcessor, NO_ELEMENT_INSTANCE);
+
+                if (failureOrTimer.isLeft()) {
+                  throw new EvaluationException(failureOrTimer.getLeft().getMessage());
+                }
+
+                catchEventBehavior.subscribeToTimerEvent(
+                    NO_ELEMENT_INSTANCE,
+                    NO_ELEMENT_INSTANCE,
+                    deployedProcess.getKey(),
+                    timerStartEvent.getId(),
+                    failureOrTimer.get());
+              });
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
@@ -320,6 +321,12 @@ public final class DbProcessState implements MutableProcessState {
   @Override
   public int getNextProcessVersion(final String bpmnProcessId) {
     return (int) versionManager.getHighestProcessVersion(bpmnProcessId) + 1;
+  }
+
+  @Override
+  public Optional<Integer> findProcessVersionBefore(
+      final String bpmnProcessId, final long version) {
+    return versionManager.findProcessVersionBefore(bpmnProcessId, version);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionInfo.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionInfo.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 public final class ProcessVersionInfo extends UnpackedObject implements DbValue {
@@ -65,6 +66,17 @@ public final class ProcessVersionInfo extends UnpackedObject implements DbValue 
         .map(LongValue::getValue)
         .sorted()
         .toList();
+  }
+
+  public Optional<Integer> findVersionBefore(final long version) {
+    final var knownVersions = getKnownVersions();
+    final var previousIndex = knownVersions.indexOf(version) - 1;
+
+    if (previousIndex >= knownVersions.size() || previousIndex < 0) {
+      return Optional.empty();
+    }
+
+    return Optional.of(knownVersions.get(previousIndex).intValue());
   }
 
   public void addKnownVersion(final long version) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/ProcessVersionManager.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.Object2ObjectHashMap;
 
@@ -123,5 +124,10 @@ public final class ProcessVersionManager {
 
   private long getHighestProcessVersion() {
     return getVersionInfo().getHighestVersion();
+  }
+
+  public Optional<Integer> findProcessVersionBefore(final String processId, final long version) {
+    processIdKey.wrapString(processId);
+    return getVersionInfo().findVersionBefore(version);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import java.util.Collection;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 
 public interface ProcessState {
@@ -43,6 +44,17 @@ public interface ProcessState {
    * @param bpmnProcessId the id of the process
    */
   int getNextProcessVersion(String bpmnProcessId);
+
+  /**
+   * Finds the previous known version a process. This is used, for example, when a process is
+   * deleted and the timers of the previous process need to be activated.
+   *
+   * <p>If not previous version is found, an empty optional is returned.
+   *
+   * @param bpmnProcessId the id of the process
+   * @param version the version for which we want to find the previous version
+   */
+  Optional<Integer> findProcessVersionBefore(String bpmnProcessId, long version);
 
   <T extends ExecutableFlowElement> T getFlowElement(
       long processDefinitionKey, DirectBuffer elementId, Class<T> elementType);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.resource;
 
+import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.tuple;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -31,6 +33,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.io.IOException;
+import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -261,6 +264,69 @@ public class ResourceDeletionTest {
     verifyInstanceOfProcessWithIdAndVersionIsCompleted(processId, 2, processInstanceKey);
   }
 
+  @Test
+  public void shouldCancelTimerStartEventOnDeletion() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var processDefinitionKey = deployProcessWithTimerStartEvent(processId);
+
+    // when
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // then
+    verifyTimerIsCancelled(processDefinitionKey);
+    verifyProcessIdWithVersionIsDeleted(processId, 1);
+    verifyResourceIsDeleted(processDefinitionKey);
+  }
+
+  @Test
+  public void shouldCancelAllTimerStartEventsOnDeletion() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var processDefinitionKey =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("startEvent1")
+                    .timerWithDuration(Duration.ofDays(1))
+                    .endEvent("endEvent")
+                    .moveToProcess(processId)
+                    .startEvent("startEvent2")
+                    .timerWithDuration(Duration.ofDays(1))
+                    .connectTo("endEvent")
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+
+    // when
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // then
+    verifyTimersAreCancelled(processDefinitionKey, 2);
+    verifyProcessIdWithVersionIsDeleted(processId, 1);
+    verifyResourceIsDeleted(processDefinitionKey);
+  }
+
+  @Test
+  public void shouldNotCancelTimersIfDeletedVersionIsNotLatest() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final long firstProcessDefinitionKey = deployProcess(processId);
+    deployProcessWithTimerStartEvent(processId);
+
+    // when
+    engine.resourceDeletion().withResourceKey(firstProcessDefinitionKey).delete();
+
+    // then
+    verifyProcessIdWithVersionIsDeleted(processId, 1);
+    verifyResourceIsDeleted(firstProcessDefinitionKey);
+    verifyNoTimersAreCancelled();
+  }
+
   private long deployDrg(final String drgResource) {
     return engine
         .deployment()
@@ -291,6 +357,22 @@ public class ResourceDeletionTest {
     return engine
         .deployment()
         .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private long deployProcessWithTimerStartEvent(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .timerWithDuration(Duration.ofDays(1))
+                .endEvent()
+                .done())
         .deploy()
         .getValue()
         .getProcessesMetadata()
@@ -442,5 +524,32 @@ public class ResourceDeletionTest {
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  private void verifyTimerIsCancelled(final long processDefinitionKey) {
+    verifyTimersAreCancelled(processDefinitionKey, 1);
+  }
+
+  private void verifyTimersAreCancelled(final long processDefinitionKey, final long times) {
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CANCELED)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .limit(times))
+        .describedAs("Timer(s) should be cancelled")
+        .extracting(
+            t -> t.getValue().getProcessDefinitionKey(),
+            t -> t.getValue().getProcessInstanceKey(),
+            t -> t.getValue().getElementInstanceKey())
+        .containsOnly(tuple(processDefinitionKey, NO_ELEMENT_INSTANCE, NO_ELEMENT_INSTANCE));
+  }
+
+  private void verifyNoTimersAreCancelled() {
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == ResourceDeletionIntent.DELETED)
+                .timerRecords()
+                .withIntent(TimerIntent.CANCELED)
+                .exists())
+        .isFalse();
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -158,6 +158,48 @@ public final class ProcessStateTest {
   }
 
   @Test
+  public void shouldFindPreviousProcessVersion() {
+    // given
+    final var versionOneRecord = creatingProcessRecord(processingState).setVersion(1);
+    final var versionTwoRecord = creatingProcessRecord(processingState).setVersion(2);
+    processState.putProcess(versionOneRecord.getKey(), versionOneRecord);
+    processState.putProcess(versionTwoRecord.getKey(), versionTwoRecord);
+
+    // when
+    final var processVersion = processState.findProcessVersionBefore("processId", 2);
+
+    // then
+    assertThat(processVersion).isNotEmpty();
+    assertThat(processVersion.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldReturnEmptyOptionalWhenFindingVersionWithoutPrevious() {
+    // given
+    final var versionOneRecord = creatingProcessRecord(processingState).setVersion(1);
+    processState.putProcess(versionOneRecord.getKey(), versionOneRecord);
+
+    // when
+    final var processVersion = processState.findProcessVersionBefore("processId", 1);
+
+    // then
+    assertThat(processVersion).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnEmptyOptionalWhenGivenVersionIsNotKnown() {
+    // given
+    final var versionOneRecord = creatingProcessRecord(processingState).setVersion(1);
+    processState.putProcess(versionOneRecord.getKey(), versionOneRecord);
+
+    // when
+    final var processVersion = processState.findProcessVersionBefore("processId", 2);
+
+    // then
+    assertThat(processVersion).isEmpty();
+  }
+
+  @Test
   public void shouldNotIncrementNextProcessVersionForDifferentProcessId() {
     // given
     final var processRecord = creatingProcessRecord(processingState);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When we delete the latest version of a process we need to make sure we cancel any active timers for the start events in this process.
As we want to reactivate the previous version when the latest is deleted, we also have to make sure we create the timers for the previous version. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9796 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
