### PR TITLE
fix: reduce timer resolution to ms

### DIFF
--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -101,7 +101,7 @@ public class ActorControl implements ConcurrencyControl {
     job.onJobAddedToTask(task);
 
     final TimerSubscription timerSubscription =
-        new TimerSubscription(job, delay.toNanos(), TimeUnit.NANOSECONDS, isRecurring);
+        new TimerSubscription(job, delay.toMillis(), TimeUnit.MILLISECONDS, isRecurring);
     job.setSubscription(timerSubscription);
 
     timerSubscription.submit();


### PR DESCRIPTION


## Description

Previously we converted the given delay (for a timer) to nanos which caused issues when the delay was over 290+ years. See the following issues #13879 #13880.

Of course, such delay, in general, doesn't make much sense, but also the converting to Nanos was questionable. We convert later, when scheduling the timer, the [time to milliseconds](https://github.com/camunda/zeebe/blob/main/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTimerQueue.java#L53) since the deadtimewheel we use or implement [only supports milliseconds](https://github.com/camunda/zeebe/blob/main/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTimerQueue.java#L40).

This PR changes that the delay is not converted to nano instead to milliseconds.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #13879
related #13880