### PR TITLE
Send slack when java client issue has been closed

### DIFF
--- a/.github/workflows/java-client-issue.yaml
+++ b/.github/workflows/java-client-issue.yaml
@@ -8,7 +8,7 @@ jobs:
   slack-notify:
     name: Send slack notification if java client issue has been closed
     runs-on: ubuntu-latest
-    if: ${{ github.event.label.name == 'scope/clients-java' }}
+    if: contains(github.event.issue.labels.*.name, 'scope/clients-java')
     steps:
       - id: slack-notify
         name: Send slack notification to DevEx

--- a/.github/workflows/java-client-issue.yaml
+++ b/.github/workflows/java-client-issue.yaml
@@ -1,0 +1,39 @@
+name: Slack notification for Java client issue closed
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  slack-notify:
+    name: Send slack notification if java client issue has been closed
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'scope/clients-java' }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification to DevEx
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":fyi: A java client issue has been closed at the Zeebe repo. :fyi:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the issue: ${{ github.event.issue.html_url }}\n This message has been sent in order to support you in making our other client's feature complete."
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEVEX_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Description

This should support DevEx in making the client's feature complete and improve the pace of when to implement new features. 

This PR adds a new workflow which should be triggered when a issue is closed labeled with `scope/clients-java`. This of course can also be further extended, if needed.

As discussed with @jwulf and @akeller here https://camunda.slack.com/archives/CSQ2E3BT4/p1691779812325079
<!-- Please explain the changes you made here. -->

