### PR TITLE
Unsubscribe and resubscribe message start events on process deletion

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -91,21 +91,21 @@ public final class DeploymentCreateProcessor
         new DeploymentTransformer(
             stateWriter, processingState, expressionProcessor, keyGenerator, featureFlags);
     startEventSubscriptionManager =
-        new StartEventSubscriptionManager(processingState, keyGenerator);
+        new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
   }
 
   @Override
   public void processNewCommand(final TypedRecord<DeploymentRecord> command) {
     transformAndDistributeDeployment(command);
     // manage the top-level start event subscriptions except for timers
-    startEventSubscriptionManager.tryReOpenStartEventSubscription(command.getValue(), stateWriter);
+    startEventSubscriptionManager.tryReOpenStartEventSubscription(command.getValue());
   }
 
   @Override
   public void processDistributedCommand(final TypedRecord<DeploymentRecord> command) {
     processDistributedRecord(command);
     // manage the top-level start event subscriptions except for timers
-    startEventSubscriptionManager.tryReOpenStartEventSubscription(command.getValue(), stateWriter);
+    startEventSubscriptionManager.tryReOpenStartEventSubscription(command.getValue());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -39,22 +39,25 @@ public class StartEventSubscriptionManager {
   private final MessageStartEventSubscriptionState messageStartEventSubscriptionState;
   private final SignalSubscriptionState signalSubscriptionState;
   private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
 
   public StartEventSubscriptionManager(
-      final ProcessingState processingState, final KeyGenerator keyGenerator) {
+      final ProcessingState processingState,
+      final KeyGenerator keyGenerator,
+      final StateWriter stateWriter) {
     processState = processingState.getProcessState();
     messageStartEventSubscriptionState = processingState.getMessageStartEventSubscriptionState();
     signalSubscriptionState = processingState.getSignalSubscriptionState();
     this.keyGenerator = keyGenerator;
+    this.stateWriter = stateWriter;
   }
 
-  public void tryReOpenStartEventSubscription(
-      final DeploymentRecord deploymentRecord, final StateWriter stateWriter) {
+  public void tryReOpenStartEventSubscription(final DeploymentRecord deploymentRecord) {
 
     for (final ProcessMetadata processRecord : deploymentRecord.processesMetadata()) {
       if (!processRecord.isDuplicate() && isLatestProcess(processRecord)) {
-        closeExistingStartEventSubscriptions(processRecord, stateWriter);
-        openStartEventSubscriptions(processRecord, stateWriter);
+        closeExistingStartEventSubscriptions(processRecord);
+        openStartEventSubscriptions(processRecord);
       }
     }
   }
@@ -66,25 +69,22 @@ public class StartEventSubscriptionManager {
         == processRecord.getVersion();
   }
 
-  private void closeExistingStartEventSubscriptions(
-      final ProcessMetadata processRecord, final StateWriter stateWriter) {
-    closeMessageExistingStartEventSubscriptions(processRecord, stateWriter);
-    closeSignalExistingStartEventSubscriptions(processRecord, stateWriter);
+  private void closeExistingStartEventSubscriptions(final ProcessMetadata processRecord) {
+    closeMessageExistingStartEventSubscriptions(processRecord);
+    closeSignalExistingStartEventSubscriptions(processRecord);
   }
 
-  private void closeMessageExistingStartEventSubscriptions(
-      final ProcessMetadata processRecord, final StateWriter stateWriter) {
+  private void closeMessageExistingStartEventSubscriptions(final ProcessMetadata processRecord) {
     final DeployedProcess lastMsgProcess =
         findLastStartProcess(processRecord, ExecutableCatchEventElement::isMessage);
     if (lastMsgProcess == null) {
       return;
     }
 
-    closeMessageStartEventSubscriptions(lastMsgProcess, stateWriter);
+    closeMessageStartEventSubscriptions(lastMsgProcess);
   }
 
-  public void closeMessageStartEventSubscriptions(
-      final DeployedProcess deployedProcess, final StateWriter stateWriter) {
+  public void closeMessageStartEventSubscriptions(final DeployedProcess deployedProcess) {
     messageStartEventSubscriptionState.visitSubscriptionsByProcessDefinition(
         deployedProcess.getKey(),
         subscription ->
@@ -94,8 +94,7 @@ public class StartEventSubscriptionManager {
                 subscription.getRecord()));
   }
 
-  private void closeSignalExistingStartEventSubscriptions(
-      final ProcessMetadata processRecord, final StateWriter stateWriter) {
+  private void closeSignalExistingStartEventSubscriptions(final ProcessMetadata processRecord) {
     final DeployedProcess lastSignalProcess =
         findLastStartProcess(processRecord, ExecutableCatchEventElement::isSignal);
     if (lastSignalProcess == null) {
@@ -126,25 +125,21 @@ public class StartEventSubscriptionManager {
     return null;
   }
 
-  private void openStartEventSubscriptions(
-      final ProcessMetadata processRecord, final StateWriter stateWriter) {
+  private void openStartEventSubscriptions(final ProcessMetadata processRecord) {
     final long processDefinitionKey = processRecord.getKey();
     final DeployedProcess processDefinition = processState.getProcessByKey(processDefinitionKey);
     final ExecutableProcess process = processDefinition.getProcess();
     final List<ExecutableStartEvent> startEvents = process.getStartEvents();
     for (final ExecutableStartEvent startEvent : startEvents) {
       if (startEvent.isMessage()) {
-        openMessageStartEventSubscription(
-            processDefinition, processDefinitionKey, startEvent, stateWriter);
+        openMessageStartEventSubscription(processDefinition, processDefinitionKey, startEvent);
       } else if (startEvent.isSignal()) {
-        openSignalStartEventSubscription(
-            processDefinition, processDefinitionKey, startEvent, stateWriter);
+        openSignalStartEventSubscription(processDefinition, processDefinitionKey, startEvent);
       }
     }
   }
 
-  public void openStartEventSubscriptions(
-      final DeployedProcess deployedProcess, final StateWriter stateWriter) {
+  public void openStartEventSubscriptions(final DeployedProcess deployedProcess) {
     final var process = deployedProcess.getProcess();
 
     process
@@ -153,7 +148,7 @@ public class StartEventSubscriptionManager {
             startEvent -> {
               if (startEvent.isMessage()) {
                 openMessageStartEventSubscription(
-                    deployedProcess, deployedProcess.getKey(), startEvent, stateWriter);
+                    deployedProcess, deployedProcess.getKey(), startEvent);
               }
             });
   }
@@ -161,8 +156,7 @@ public class StartEventSubscriptionManager {
   private void openMessageStartEventSubscription(
       final DeployedProcess processDefinition,
       final long processDefinitionKey,
-      final ExecutableStartEvent startEvent,
-      final StateWriter stateWriter) {
+      final ExecutableStartEvent startEvent) {
     final ExecutableMessage message = startEvent.getMessage();
 
     message
@@ -188,8 +182,7 @@ public class StartEventSubscriptionManager {
   private void openSignalStartEventSubscription(
       final DeployedProcess processDefinition,
       final long processDefinitionKey,
-      final ExecutableStartEvent startEvent,
-      final StateWriter stateWriter) {
+      final ExecutableStartEvent startEvent) {
     final ExecutableSignal signal = startEvent.getSignal();
 
     signal

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -143,6 +143,21 @@ public class StartEventSubscriptionManager {
     }
   }
 
+  public void openStartEventSubscriptions(
+      final DeployedProcess deployedProcess, final StateWriter stateWriter) {
+    final var process = deployedProcess.getProcess();
+
+    process
+        .getStartEvents()
+        .forEach(
+            startEvent -> {
+              if (startEvent.isMessage()) {
+                openMessageStartEventSubscription(
+                    deployedProcess, deployedProcess.getKey(), startEvent, stateWriter);
+              }
+            });
+  }
+
   private void openMessageStartEventSubscription(
       final DeployedProcess processDefinition,
       final long processDefinitionKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -80,8 +80,13 @@ public class StartEventSubscriptionManager {
       return;
     }
 
+    closeMessageStartEventSubscriptions(lastMsgProcess, stateWriter);
+  }
+
+  public void closeMessageStartEventSubscriptions(
+      final DeployedProcess deployedProcess, final StateWriter stateWriter) {
     messageStartEventSubscriptionState.visitSubscriptionsByProcessDefinition(
-        lastMsgProcess.getKey(),
+        deployedProcess.getKey(),
         subscription ->
             stateWriter.appendFollowUpEvent(
                 subscription.getKey(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
@@ -30,9 +30,9 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
       final Writers writers,
       final KeyGenerator keyGenerator) {
     this.deploymentDistributionCommandSender = deploymentDistributionCommandSender;
-    startEventSubscriptionManager =
-        new StartEventSubscriptionManager(processingState, keyGenerator);
     stateWriter = writers.state();
+    startEventSubscriptionManager =
+        new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
   }
 
   @Override
@@ -43,6 +43,6 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
     stateWriter.appendFollowUpEvent(deploymentKey, DeploymentIntent.DISTRIBUTED, deploymentEvent);
     deploymentDistributionCommandSender.completeOnPartition(deploymentKey);
 
-    startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent, stateWriter);
+    startEventSubscriptionManager.tryReOpenStartEventSubscription(deploymentEvent);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -256,6 +256,8 @@ public class ResourceDeletionProcessor
                     failureOrTimer.get());
               });
     }
+
+    startEventSubscriptionManager.openStartEventSubscriptions(deployedProcess, stateWriter);
   }
 
   private static final class NoSuchResourceException extends IllegalStateException {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -80,7 +80,7 @@ public class ResourceDeletionProcessor
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     expressionProcessor = bpmnBehaviors.expressionBehavior();
     startEventSubscriptionManager =
-        new StartEventSubscriptionManager(processingState, keyGenerator);
+        new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
   }
 
   @Override
@@ -227,8 +227,7 @@ public class ResourceDeletionProcessor
           });
     }
     if (process.hasMessageStartEvent()) {
-      startEventSubscriptionManager.closeMessageStartEventSubscriptions(
-          deployedProcess, stateWriter);
+      startEventSubscriptionManager.closeMessageStartEventSubscriptions(deployedProcess);
     }
   }
 
@@ -257,7 +256,7 @@ public class ResourceDeletionProcessor
               });
     }
 
-    startEventSubscriptionManager.openStartEventSubscriptions(deployedProcess, stateWriter);
+    startEventSubscriptionManager.openStartEventSubscriptions(deployedProcess);
   }
 
   private static final class NoSuchResourceException extends IllegalStateException {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -107,4 +107,10 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
         filter(r -> r.getValueType() == ValueType.PROCESS_MESSAGE_SUBSCRIPTION)
             .map(Record.class::cast));
   }
+
+  public MessageStartEventSubscriptionRecordStream messageStartEventSubscriptionRecords() {
+    return new MessageStartEventSubscriptionRecordStream(
+        filter(r -> r.getValueType() == ValueType.MESSAGE_START_EVENT_SUBSCRIPTION)
+            .map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When we delete the latest version of a process we need to make sure we cancel any active message subscriptions for the start events in this process.
As we want to reactivate the previous version when the latest is deleted, we also have to make sure we create the message subscriptions for the previous version.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9798 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
