### PR TITLE
Allow opening an existing DB in snapshot-only mode

### DIFF
--- a/zb-db/pom.xml
+++ b/zb-db/pom.xml
@@ -70,5 +70,11 @@
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDbFactory.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDbFactory.java
@@ -24,4 +24,16 @@ public interface ZeebeDbFactory<ColumnFamilyNames extends Enum<ColumnFamilyNames
    * @return the created zeebe database
    */
   ZeebeDb<ColumnFamilyNames> createDb(File pathName);
+
+  /**
+   * Opens an existing DB in read-only mode for the sole purpose of creating snapshots from it.
+   *
+   * <p>NOTE: if a read-only DB is required in the future that allows actually reading, then this
+   * can be extended to do so. However, keep in mind that you cannot use transactions on such DBs,
+   * and it might be better to do this when we've moved away from the transaction DB family.
+   *
+   * @param path the path to the existing database
+   * @return a snapshot-able DB
+   */
+  ZeebeDb<ColumnFamilyNames> openSnapshotOnlyDb(final File path);
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl.rocksdb;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.DbKey;
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.ZeebeDbException;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.agrona.CloseHelper;
+import org.rocksdb.Checkpoint;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.slf4j.Logger;
+
+final class SnapshotOnlyDb<ColumnFamilyType extends Enum<ColumnFamilyType>>
+    implements ZeebeDb<ColumnFamilyType> {
+  private static final Logger LOG = Loggers.DB_LOGGER;
+
+  private final RocksDB db;
+  private final List<AutoCloseable> managedResources;
+
+  public SnapshotOnlyDb(final RocksDB db, final List<AutoCloseable> managedResources) {
+    this.db = db;
+    this.managedResources = managedResources;
+  }
+
+  @Override
+  public <KeyType extends DbKey, ValueType extends DbValue>
+      ColumnFamily<KeyType, ValueType> createColumnFamily(
+          final ColumnFamilyType columnFamily,
+          final TransactionContext context,
+          final KeyType keyInstance,
+          final ValueType valueInstance) {
+    throw unsupported("createColumnFamily");
+  }
+
+  @Override
+  public void createSnapshot(final File snapshotDir) {
+    try (final var checkpoint = Checkpoint.create(db)) {
+      checkpoint.createCheckpoint(snapshotDir.getAbsolutePath());
+    } catch (final RocksDBException e) {
+      throw new ZeebeDbException(
+          "Failed to take a RocksDB snapshot at '%s'".formatted(snapshotDir), e);
+    }
+  }
+
+  @Override
+  public Optional<String> getProperty(final String propertyName) {
+    throw unsupported("getProperty");
+  }
+
+  @Override
+  public TransactionContext createContext() {
+    throw unsupported("createContext");
+  }
+
+  @Override
+  public boolean isEmpty(final ColumnFamilyType column, final TransactionContext context) {
+    throw unsupported("isEmpty");
+  }
+
+  @Override
+  public void close() {
+    Collections.reverse(managedResources);
+    CloseHelper.closeAll(
+        error ->
+            LOG.error("Failed to close RockDB resource, which may lead to leaked resources", error),
+        managedResources);
+  }
+
+  static <ColumnFamilyType extends Enum<ColumnFamilyType>> ZeebeDb<ColumnFamilyType> openDb(
+      final Options options, final String path, final List<AutoCloseable> managedResources)
+      throws RocksDBException {
+    final RocksDB db = RocksDB.openReadOnly(options, path);
+    managedResources.add(db);
+
+    return new SnapshotOnlyDb<>(db, managedResources);
+  }
+
+  private UnsupportedOperationException unsupported(final String operation) {
+    return new UnsupportedOperationException(
+        "Failed to execute 'ZeebeDb#%s'; this operation is not supported on a snapshot-only DB"
+            .formatted(operation));
+  }
+}

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -19,22 +19,17 @@ import io.camunda.zeebe.util.ByteValue;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Properties;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionPriority;
 
-public final class ZeebeRocksDbFactoryTest {
-
-  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+final class ZeebeRocksDbFactoryTest {
 
   @Test
-  public void shouldCreateNewDb() throws Exception {
+  void shouldCreateNewDb(final @TempDir File pathName) throws Exception {
     // given
     final ZeebeDbFactory<DefaultColumnFamily> dbFactory = DefaultZeebeDbFactory.getDefaultFactory();
-
-    final File pathName = temporaryFolder.newFolder();
 
     // when
     final ZeebeDb<DefaultColumnFamily> db = dbFactory.createDb(pathName);
@@ -45,11 +40,10 @@ public final class ZeebeRocksDbFactoryTest {
   }
 
   @Test
-  public void shouldCreateTwoNewDbs() throws Exception {
+  void shouldCreateTwoNewDbs(final @TempDir File firstPath, final @TempDir File secondPath)
+      throws Exception {
     // given
     final ZeebeDbFactory<DefaultColumnFamily> dbFactory = DefaultZeebeDbFactory.getDefaultFactory();
-    final File firstPath = temporaryFolder.newFolder();
-    final File secondPath = temporaryFolder.newFolder();
 
     // when
     final ZeebeDb<DefaultColumnFamily> firstDb = dbFactory.createDb(firstPath);
@@ -66,12 +60,13 @@ public final class ZeebeRocksDbFactoryTest {
   }
 
   @Test
-  public void shouldOverwriteDefaultColumnFamilyOptions() {
+  void shouldOverwriteDefaultColumnFamilyOptions() {
     // given
     final var customProperties = new Properties();
     customProperties.put("write_buffer_size", String.valueOf(ByteValue.ofMegabytes(16)));
     customProperties.put("compaction_pri", "kByCompensatedSize");
 
+    //noinspection unchecked
     final var factoryWithDefaults =
         (ZeebeRocksDbFactory<DefaultColumnFamily>) DefaultZeebeDbFactory.getDefaultFactory();
     final var factoryWithCustomOptions =
@@ -101,11 +96,10 @@ public final class ZeebeRocksDbFactoryTest {
   }
 
   @Test
-  public void shouldFailIfPropertiesDoesntExist() throws Exception {
+  void shouldFailIfPropertiesDoesNotExist(final @TempDir File pathName) {
     // given
     final var customProperties = new Properties();
     customProperties.put("notExistingProperty", String.valueOf(ByteValue.ofMegabytes(16)));
-    final File pathName = temporaryFolder.newFolder();
 
     final var factoryWithCustomOptions =
         new ZeebeRocksDbFactory<>(
@@ -113,6 +107,7 @@ public final class ZeebeRocksDbFactoryTest {
             new ConsistencyChecksSettings());
 
     // expect
+    //noinspection resource
     assertThatThrownBy(() -> factoryWithCustomOptions.createDb(pathName))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(


### PR DESCRIPTION
## Description

This PR adds a new API call to `ZeebeDbFactory` which allows opening existing databases in a snapshot-only mode. This returns a `ZeebeDb` which can ONLY take snapshots, and will throw a `new UnsupportedOperationException` for any other operations.

While it would be nice to have a proper read-only DB implementation, there are no transactions in a such a DB, and our whole access to the DB is coupled with the transaction API. As we were thinking of switching away from transactions, it will likely be easier after that to implement a read-only DB.

This will be used as part of the fix for #13775 to create the runtime directory faster via hard-links instead of a full copy.

## Related issues

related to #13775 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
