### PR TITLE
Speed up state controller recovery from existing snapshot

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
@@ -17,7 +17,6 @@
 package io.atomix.cluster;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
@@ -76,12 +75,6 @@ class NoopSnapshotStore implements ReceivableSnapshotStore {
   @Override
   public Path getPath() {
     return null;
-  }
-
-  @Override
-  public ActorFuture<Void> copySnapshot(
-      final PersistedSnapshot snapshot, final Path targetDirectory) {
-    return CompletableActorFuture.completed(null);
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -113,12 +113,6 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
   }
 
   @Override
-  public ActorFuture<Void> copySnapshot(
-      final PersistedSnapshot snapshot, final Path targetDirectory) {
-    return null;
-  }
-
-  @Override
   public ReceivedSnapshot newReceivedSnapshot(final String snapshotId) {
     final var newSnapshot = new InMemorySnapshot(this, snapshotId);
     receivedSnapshots.add(newSnapshot);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -43,7 +43,7 @@ public class LargeStateControllerPerformanceTest {
   private static final double SIZE_GB =
       Double.parseDouble(
           System.getenv().getOrDefault("LARGE_STATE_CONTROLLER_PERFORMANCE_TEST_SIZE_GB", "0.5"));
-  private static final Map<Double, Double> KNOWN_REFERENCE_SCORES = Map.of(0.5, 3.2, 4.0, 0.55);
+  private static final Map<Double, Double> KNOWN_REFERENCE_SCORES = Map.of(0.5, 10.0, 4.0, 0.55);
 
   private TestState.TestContext context;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -43,7 +43,7 @@ public class LargeStateControllerPerformanceTest {
   private static final double SIZE_GB =
       Double.parseDouble(
           System.getenv().getOrDefault("LARGE_STATE_CONTROLLER_PERFORMANCE_TEST_SIZE_GB", "0.5"));
-  private static final Map<Double, Double> KNOWN_REFERENCE_SCORES = Map.of(0.5, 10.0, 4.0, 0.55);
+  private static final Map<Double, Double> KNOWN_REFERENCE_SCORES = Map.of(0.5, 10.0, 4.0, 9.0);
 
   private TestState.TestContext context;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
@@ -27,11 +27,8 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class TestState {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestState.class);
 
   private static final int BATCH_INSERT_SIZE = 10_000;
   private static final int KEY_VALUE_SIZE = 8096;

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshotStore.java
@@ -83,14 +83,4 @@ public interface PersistedSnapshotStore extends CloseableSilently {
   ActorFuture<Void> delete();
 
   Path getPath();
-
-  /**
-   * Copy snapshot to the given directory
-   *
-   * @param snapshot the snapshot to be copied
-   * @param targetDirectory the directory to which the snapshot files will be copied
-   * @return future which will be completed exceptionally if the snapshot was not copied
-   *     successfully
-   */
-  ActorFuture<Void> copySnapshot(PersistedSnapshot snapshot, Path targetDirectory);
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -343,35 +342,6 @@ public final class FileBasedSnapshotStore extends Actor
   @Override
   public Path getPath() {
     return snapshotsDirectory;
-  }
-
-  @Override
-  public ActorFuture<Void> copySnapshot(
-      final PersistedSnapshot snapshot, final Path targetDirectory) {
-    final CompletableActorFuture<Void> result = new CompletableActorFuture<>();
-    actor.run(
-        () -> {
-          if (!Files.exists(snapshot.getPath())) {
-            result.completeExceptionally(
-                String.format(
-                    "Expected to copy snapshot %s to directory %s, but snapshot directory %s does not exists. Snapshot may have been deleted.",
-                    snapshot.getId(), targetDirectory, snapshot.getPath()),
-                new FileNotFoundException());
-          } else {
-            try {
-              FileUtil.copySnapshot(snapshot.getPath(), targetDirectory);
-              result.complete(null);
-            } catch (final Exception e) {
-              result.completeExceptionally(
-                  String.format(
-                      "Failed to copy snapshot %s to directory %s.",
-                      snapshot.getId(), targetDirectory),
-                  e);
-            }
-          }
-        });
-
-    return result;
   }
 
   @Override

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -16,10 +16,8 @@ import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.test.util.asserts.DirectoryAssert;
 import io.camunda.zeebe.util.FileUtil;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -240,49 +238,6 @@ public class FileBasedSnapshotStoreTest {
 
     // then
     assertThat(pendingSnapshotsDir).isEmptyDirectory();
-  }
-
-  @Test
-  public void shouldCopySnapshot() {
-    // given
-    final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
-    final var target = rootDirectory.resolve("runtime");
-
-    // when
-    snapshotStore.copySnapshot(persistedSnapshot, target).join();
-
-    // then
-    assertThat(target).isNotEmptyDirectory();
-    assertThat(target.toFile().list())
-        .containsExactlyInAnyOrder(persistedSnapshot.getDirectory().toFile().list());
-  }
-
-  @Test
-  public void shouldCompleteWithExceptionWhenCannotCopySnapshot() throws IOException {
-    // given
-    final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
-    final var target = rootDirectory.resolve("runtime");
-    target.toFile().createNewFile();
-
-    // when
-    final var result = snapshotStore.copySnapshot(persistedSnapshot, target);
-
-    // then - should fail because targetDirectory already exists
-    assertThatThrownBy(result::join).hasCauseInstanceOf(FileAlreadyExistsException.class);
-  }
-
-  @Test
-  public void shouldCompleteWithExceptionWhenCopyingIfSnapshotDoesNotExists() {
-    // given
-    final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
-    final var target = rootDirectory.resolve("runtime");
-
-    // when
-    persistedSnapshot.delete();
-    final var result = snapshotStore.copySnapshot(persistedSnapshot, target);
-
-    // then
-    assertThatThrownBy(result::join).hasCauseInstanceOf(FileNotFoundException.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR greatly improves the state recovery time from an existing snapshot, especially when the state grows to be very large. This is done by leveraging RocksDB checkpoint capabilities, which create hard-links for the immutable SST files if the source and target directories are on the same filesystem. This has the additional benefit of reducing disk space usage in most cases.

> **Note**
> When the `runtime` and `snapshot` directories are not on the same filesystem, this will end up doing a normal copy, which is as fast as the previous solution.

## Related issues

closes #13775 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
