### PR TITLE
Unsubscribe and resubscribe signal start events on process deletion

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -153,6 +153,9 @@ public class StartEventSubscriptionManager {
               if (startEvent.isMessage()) {
                 openMessageStartEventSubscription(
                     deployedProcess, deployedProcess.getKey(), startEvent);
+              } else if (startEvent.isSignal()) {
+                openSignalStartEventSubscription(
+                    deployedProcess, deployedProcess.getKey(), startEvent);
               }
             });
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -101,8 +101,12 @@ public class StartEventSubscriptionManager {
       return;
     }
 
+    closeSignalStartEventSubscriptions(lastSignalProcess);
+  }
+
+  public void closeSignalStartEventSubscriptions(final DeployedProcess deployedProcess) {
     signalSubscriptionState.visitStartEventSubscriptionsByProcessDefinitionKey(
-        lastSignalProcess.getKey(),
+        deployedProcess.getKey(),
         subscription ->
             stateWriter.appendFollowUpEvent(
                 subscription.getKey(), SignalSubscriptionIntent.DELETED, subscription.getRecord()));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -74,6 +74,15 @@ public class StartEventSubscriptionManager {
     closeSignalExistingStartEventSubscriptions(processRecord);
   }
 
+  public void closeStartEventSubscriptions(final DeployedProcess deployedProcess) {
+    if (deployedProcess.getProcess().hasMessageStartEvent()) {
+      closeMessageStartEventSubscriptions(deployedProcess);
+    }
+    if (deployedProcess.getProcess().hasSignalStartEvent()) {
+      closeSignalStartEventSubscriptions(deployedProcess);
+    }
+  }
+
   private void closeMessageExistingStartEventSubscriptions(final ProcessMetadata processRecord) {
     final DeployedProcess lastMsgProcess =
         findLastStartProcess(processRecord, ExecutableCatchEventElement::isMessage);
@@ -84,7 +93,7 @@ public class StartEventSubscriptionManager {
     closeMessageStartEventSubscriptions(lastMsgProcess);
   }
 
-  public void closeMessageStartEventSubscriptions(final DeployedProcess deployedProcess) {
+  private void closeMessageStartEventSubscriptions(final DeployedProcess deployedProcess) {
     messageStartEventSubscriptionState.visitSubscriptionsByProcessDefinition(
         deployedProcess.getKey(),
         subscription ->
@@ -104,7 +113,7 @@ public class StartEventSubscriptionManager {
     closeSignalStartEventSubscriptions(lastSignalProcess);
   }
 
-  public void closeSignalStartEventSubscriptions(final DeployedProcess deployedProcess) {
+  private void closeSignalStartEventSubscriptions(final DeployedProcess deployedProcess) {
     signalSubscriptionState.visitStartEventSubscriptionsByProcessDefinitionKey(
         deployedProcess.getKey(),
         subscription ->

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -136,9 +136,9 @@ public class StartEventSubscriptionManager {
     final List<ExecutableStartEvent> startEvents = process.getStartEvents();
     for (final ExecutableStartEvent startEvent : startEvents) {
       if (startEvent.isMessage()) {
-        openMessageStartEventSubscription(processDefinition, processDefinitionKey, startEvent);
+        openMessageStartEventSubscription(processDefinition, startEvent);
       } else if (startEvent.isSignal()) {
-        openSignalStartEventSubscription(processDefinition, processDefinitionKey, startEvent);
+        openSignalStartEventSubscription(processDefinition, startEvent);
       }
     }
   }
@@ -151,19 +151,15 @@ public class StartEventSubscriptionManager {
         .forEach(
             startEvent -> {
               if (startEvent.isMessage()) {
-                openMessageStartEventSubscription(
-                    deployedProcess, deployedProcess.getKey(), startEvent);
+                openMessageStartEventSubscription(deployedProcess, startEvent);
               } else if (startEvent.isSignal()) {
-                openSignalStartEventSubscription(
-                    deployedProcess, deployedProcess.getKey(), startEvent);
+                openSignalStartEventSubscription(deployedProcess, startEvent);
               }
             });
   }
 
   private void openMessageStartEventSubscription(
-      final DeployedProcess processDefinition,
-      final long processDefinitionKey,
-      final ExecutableStartEvent startEvent) {
+      final DeployedProcess processDefinition, final ExecutableStartEvent startEvent) {
     final ExecutableMessage message = startEvent.getMessage();
 
     message
@@ -174,7 +170,7 @@ public class StartEventSubscriptionManager {
               messageSubscriptionRecord.reset();
               messageSubscriptionRecord
                   .setMessageName(messageNameBuffer)
-                  .setProcessDefinitionKey(processDefinitionKey)
+                  .setProcessDefinitionKey(processDefinition.getKey())
                   .setBpmnProcessId(processDefinition.getBpmnProcessId())
                   .setStartEventId(startEvent.getId());
 
@@ -187,9 +183,7 @@ public class StartEventSubscriptionManager {
   }
 
   private void openSignalStartEventSubscription(
-      final DeployedProcess processDefinition,
-      final long processDefinitionKey,
-      final ExecutableStartEvent startEvent) {
+      final DeployedProcess processDefinition, final ExecutableStartEvent startEvent) {
     final ExecutableSignal signal = startEvent.getSignal();
 
     signal
@@ -200,7 +194,7 @@ public class StartEventSubscriptionManager {
               signalSubscriptionRecord.reset();
               signalSubscriptionRecord
                   .setSignalName(signalNameBuffer)
-                  .setProcessDefinitionKey(processDefinitionKey)
+                  .setProcessDefinitionKey(processDefinition.getKey())
                   .setBpmnProcessId(processDefinition.getBpmnProcessId())
                   .setCatchEventId(startEvent.getId());
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -226,12 +226,8 @@ public class ResourceDeletionProcessor
             }
           });
     }
-    if (process.hasMessageStartEvent()) {
-      startEventSubscriptionManager.closeMessageStartEventSubscriptions(deployedProcess);
-    }
-    if (process.hasSignalStartEvent()) {
-      startEventSubscriptionManager.closeSignalStartEventSubscriptions(deployedProcess);
-    }
+
+    startEventSubscriptionManager.closeStartEventSubscriptions(deployedProcess);
   }
 
   private void resubscribeStartEvents(final DeployedProcess deployedProcess) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -229,6 +229,9 @@ public class ResourceDeletionProcessor
     if (process.hasMessageStartEvent()) {
       startEventSubscriptionManager.closeMessageStartEventSubscriptions(deployedProcess);
     }
+    if (process.hasSignalStartEvent()) {
+      startEventSubscriptionManager.closeSignalStartEventSubscriptions(deployedProcess);
+    }
   }
 
   private void resubscribeStartEvents(final DeployedProcess deployedProcess) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -113,4 +113,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
         filter(r -> r.getValueType() == ValueType.MESSAGE_START_EVENT_SUBSCRIPTION)
             .map(Record.class::cast));
   }
+
+  public SignalSubscriptionRecordStream signalSubscriptionRecords() {
+    return new SignalSubscriptionRecordStream(
+        filter(r -> r.getValueType() == ValueType.SIGNAL_SUBSCRIPTION).map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When we delete the latest version of a process we need to make sure we cancel any active signal subscriptions for the start events in this process.
As we want to reactivate the previous version when the latest is deleted, we also have to make sure we create the signal subscriptions for the previous version.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13354 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
