### PR TITLE
Topology manager send and receive topology via gossip

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -60,7 +60,7 @@ final class ClusterTopologyManager {
   private void initialize(final Supplier<Set<PartitionMetadata>> staticPartitionResolver)
       throws IOException {
     persistedClusterTopology.initialize();
-    if (persistedClusterTopology.getTopology() == null) {
+    if (persistedClusterTopology.isUninitialized()) {
       final var topology = initializeFromConfig(staticPartitionResolver);
       persistedClusterTopology.update(topology);
       LOG.info(

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -86,7 +86,7 @@ final class ClusterTopologyManager {
 
   private void initialize(final Supplier<Set<PartitionMetadata>> staticPartitionResolver)
       throws IOException {
-    persistedClusterTopology.initialize();
+    persistedClusterTopology.tryInitialize();
     if (persistedClusterTopology.isUninitialized()) {
       final var topology = initializeFromConfig(staticPartitionResolver);
       persistedClusterTopology.update(topology);

--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -22,7 +22,7 @@ final class PersistedClusterTopology {
     this.topologyFile = topologyFile;
   }
 
-  void initialize() throws IOException {
+  void tryInitialize() throws IOException {
     if (Files.exists(topologyFile)) {
       final var serializedTopology = Files.readAllBytes(topologyFile);
       if (serializedTopology.length > 0) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -16,7 +16,7 @@ import java.nio.file.StandardOpenOption;
 /** Manages reading and updating ClusterTopology in a local persisted file * */
 final class PersistedClusterTopology {
   private final Path topologyFile;
-  private ClusterTopology clusterTopology;
+  private ClusterTopology clusterTopology = ClusterTopology.uninitialized();
 
   PersistedClusterTopology(final Path topologyFile) {
     this.topologyFile = topologyFile;
@@ -28,9 +28,7 @@ final class PersistedClusterTopology {
       if (serializedTopology.length > 0) {
         clusterTopology = ClusterTopology.decode(serializedTopology);
       }
-      return;
     }
-    clusterTopology = null;
   }
 
   ClusterTopology getTopology() {
@@ -47,5 +45,9 @@ final class PersistedClusterTopology {
         StandardOpenOption.DSYNC);
 
     this.clusterTopology = clusterTopology;
+  }
+
+  public boolean isUninitialized() {
+    return clusterTopology.isUninitialized();
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -33,6 +33,16 @@ import java.util.stream.Stream;
 public record ClusterTopology(
     long version, Map<MemberId, MemberState> members, ClusterChangePlan changes) {
 
+  private static final int UNINITIALIZED_VERSION = -1;
+
+  public static ClusterTopology uninitialized() {
+    return new ClusterTopology(UNINITIALIZED_VERSION, Map.of(), ClusterChangePlan.empty());
+  }
+
+  public boolean isUninitialized() {
+    return version == UNINITIALIZED_VERSION;
+  }
+
   public static ClusterTopology init() {
     return new ClusterTopology(0, Map.of(), ClusterChangePlan.empty());
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiperTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiperTest.java
@@ -16,6 +16,8 @@ import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
@@ -144,9 +146,9 @@ final class ClusterTopologyGossiperTest {
       gossiper.updateClusterTopology(clusterTopology);
     }
 
-    private ClusterTopology mergeTopology(final ClusterTopology t) {
+    private ActorFuture<ClusterTopology> mergeTopology(final ClusterTopology t) {
       clusterTopology = clusterTopology == null ? t : t.merge(clusterTopology);
-      return clusterTopology;
+      return TestActorFuture.completedFuture(clusterTopology);
     }
 
     public MemberId id() {


### PR DESCRIPTION
## Description

This PR integrates `ClusterTopologyManager` with the gossiper. When topology is initialized, it is gossiped so that other members can receive it. When Gossiper receives a new event, it is forwarded to ClusterTopologyManager which updates the local topology.

## Related issues

closes #13862

