### PR TITLE
Resolve member's address with NettyMessagingService 

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -90,8 +90,8 @@ class ChannelPool {
    * @return a future to be completed with a channel from the pool
    */
   CompletableFuture<Channel> getChannel(final Address address, final String messageType) {
-    final InetSocketAddress inetAddress = address.socketAddress();
-    if (inetAddress == null) {
+    final InetSocketAddress inetAddress = address.getResolvedSocketAddress();
+    if (inetAddress == null || inetAddress.isUnresolved()) {
       final CompletableFuture<Channel> failedFuture = new OrderedFuture<>();
       failedFuture.completeExceptionally(
           new ConnectException("Failed to resolve address %s".formatted(address)));

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -23,7 +23,7 @@ import io.atomix.utils.net.Address;
 import io.camunda.zeebe.util.collection.Tuple;
 import io.netty.channel.Channel;
 import java.net.ConnectException;
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +38,7 @@ class ChannelPool {
 
   private final Function<Address, CompletableFuture<Channel>> factory;
   private final int size;
-  private final Map<Tuple<Address, InetAddress>, List<CompletableFuture<Channel>>> channels =
+  private final Map<Tuple<Address, InetSocketAddress>, List<CompletableFuture<Channel>>> channels =
       Maps.newConcurrentMap();
 
   ChannelPool(final Function<Address, CompletableFuture<Channel>> factory, final int size) {
@@ -53,8 +53,9 @@ class ChannelPool {
    * @return the channel pool for the given address
    */
   private List<CompletableFuture<Channel>> getChannelPool(
-      final Address address, final InetAddress inetAddress) {
-    final Tuple<Address, InetAddress> channelPoolIdentifier = new Tuple<>(address, inetAddress);
+      final Address address, final InetSocketAddress inetAddress) {
+    final Tuple<Address, InetSocketAddress> channelPoolIdentifier =
+        new Tuple<>(address, inetAddress);
 
     final List<CompletableFuture<Channel>> channelPool = channels.get(channelPoolIdentifier);
     if (channelPool != null) {
@@ -89,7 +90,7 @@ class ChannelPool {
    * @return a future to be completed with a channel from the pool
    */
   CompletableFuture<Channel> getChannel(final Address address, final String messageType) {
-    final InetAddress inetAddress = address.address();
+    final InetSocketAddress inetAddress = address.socketAddress();
     if (inetAddress == null) {
       final CompletableFuture<Channel> failedFuture = new OrderedFuture<>();
       failedFuture.completeExceptionally(

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageEncoderV1.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageEncoderV1.java
@@ -28,7 +28,7 @@ class MessageEncoderV1 extends AbstractMessageEncoder {
 
   @Override
   protected void encodeAddress(final ProtocolMessage message, final ByteBuf buffer) {
-    final InetAddress senderIp = address.address();
+    final InetAddress senderIp = address.tryResolveAngGetAddress();
     final byte[] senderIpBytes = senderIp.getAddress();
     buffer.writeByte(senderIpBytes.length);
     buffer.writeBytes(senderIpBytes);

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageEncoderV1.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageEncoderV1.java
@@ -28,7 +28,7 @@ class MessageEncoderV1 extends AbstractMessageEncoder {
 
   @Override
   protected void encodeAddress(final ProtocolMessage message, final ByteBuf buffer) {
-    final InetAddress senderIp = address.tryResolveAngGetAddress();
+    final InetAddress senderIp = address.tryResolveAddress();
     final byte[] senderIpBytes = senderIp.getAddress();
     buffer.writeByte(senderIpBytes.length);
     buffer.writeBytes(senderIpBytes);

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -62,7 +62,7 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import java.net.ConnectException;
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -690,7 +690,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
    */
   private CompletableFuture<Channel> bootstrapClient(final Address address) {
     final CompletableFuture<Channel> future = new OrderedFuture<>();
-    final InetAddress resolvedAddress = address.address(true);
+    final InetSocketAddress resolvedAddress = address.socketAddress();
     if (resolvedAddress == null) {
       future.completeExceptionally(
           new ConnectException(
@@ -714,7 +714,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     // TODO: Make this faster:
     // http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#37.0
     bootstrap.channel(clientChannelClass);
-    bootstrap.remoteAddress(resolvedAddress, address.port());
+    bootstrap.remoteAddress(resolvedAddress);
     bootstrap.handler(new BasicClientChannelInitializer(future));
     final Channel channel =
         bootstrap
@@ -726,7 +726,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
                         new ConnectException(
                             String.format(
                                 "Failed to connect channel for address %s (resolved: %s) : %s",
-                                address, address.address(), onConnect.cause())));
+                                address, address.getAddress(), onConnect.cause())));
                   }
                 })
             .channel();

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -40,8 +40,6 @@ import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.concurrent.Future;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -96,20 +94,13 @@ public class NettyUnicastService implements ManagedUnicastService {
       return;
     }
 
-    final InetAddress resolvedAddress = address.address();
-    if (resolvedAddress == null) {
-      LOGGER.debug(
-          "Failed sending unicast message (destination address {} cannot be resolved)", address);
-      return;
-    }
-
-    final Message message = new Message(this.advertisedAddress, subject, payload);
+    final Message message = new Message(advertisedAddress, subject, payload);
     final byte[] bytes = SERIALIZER.encode(message);
     final ByteBuf buf = channel.alloc().buffer(Integer.BYTES + Integer.BYTES + bytes.length);
     buf.writeInt(preamble);
     buf.writeInt(bytes.length).writeBytes(bytes);
     channel.writeAndFlush(
-        new DatagramPacket(buf, new InetSocketAddress(resolvedAddress, address.port())));
+        new DatagramPacket(buf,address.socketAddress()));
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -99,8 +99,7 @@ public class NettyUnicastService implements ManagedUnicastService {
     final ByteBuf buf = channel.alloc().buffer(Integer.BYTES + Integer.BYTES + bytes.length);
     buf.writeInt(preamble);
     buf.writeInt(bytes.length).writeBytes(bytes);
-    channel.writeAndFlush(
-        new DatagramPacket(buf,address.socketAddress()));
+    channel.writeAndFlush(new DatagramPacket(buf, address.socketAddress()));
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -40,6 +40,7 @@ import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.concurrent.Future;
+import java.net.InetAddress;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -93,13 +94,18 @@ public class NettyUnicastService implements ManagedUnicastService {
       LOGGER.debug("Failed sending unicast message, unicast service was not started.");
       return;
     }
-
+    final InetAddress resolvedAddress = address.tryResolveAddress();
+    if (resolvedAddress == null) {
+      LOGGER.debug(
+          "Failed sending unicast message (destination address {} cannot be resolved)", address);
+      return;
+    }
     final Message message = new Message(advertisedAddress, subject, payload);
     final byte[] bytes = SERIALIZER.encode(message);
     final ByteBuf buf = channel.alloc().buffer(Integer.BYTES + Integer.BYTES + bytes.length);
     buf.writeInt(preamble);
     buf.writeInt(bytes.length).writeBytes(bytes);
-    channel.writeAndFlush(new DatagramPacket(buf, address.socketAddress()));
+    channel.writeAndFlush(new DatagramPacket(buf, address.getResolvedSocketAddress()));
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -200,7 +200,7 @@ public class NettyMessagingServiceTest {
     assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
     assertTrue(handlerInvoked.get());
     assertTrue(Arrays.equals(request.get(), "hello world".getBytes()));
-    assertEquals(address1.address(), sender.get().address());
+    assertEquals(address1.tryResolveAngGetAddress(), sender.get().tryResolveAngGetAddress());
   }
 
   @Test
@@ -313,7 +313,7 @@ public class NettyMessagingServiceTest {
     assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
     assertTrue(handlerInvoked.get());
     assertTrue(Arrays.equals(request.get(), "hello world".getBytes()));
-    assertEquals(address1.address(), sender.get().address());
+    assertEquals(address1.tryResolveAngGetAddress(), sender.get().tryResolveAngGetAddress());
   }
 
   @Test

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -200,7 +200,7 @@ public class NettyMessagingServiceTest {
     assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
     assertTrue(handlerInvoked.get());
     assertTrue(Arrays.equals(request.get(), "hello world".getBytes()));
-    assertEquals(address1.tryResolveAngGetAddress(), sender.get().tryResolveAngGetAddress());
+    assertEquals(address1.tryResolveAddress(), sender.get().tryResolveAddress());
   }
 
   @Test
@@ -313,7 +313,7 @@ public class NettyMessagingServiceTest {
     assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
     assertTrue(handlerInvoked.get());
     assertTrue(Arrays.equals(request.get(), "hello world".getBytes()));
-    assertEquals(address1.tryResolveAngGetAddress(), sender.get().tryResolveAngGetAddress());
+    assertEquals(address1.tryResolveAddress(), sender.get().tryResolveAddress());
   }
 
   @Test

--- a/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -126,8 +126,8 @@ public final class Address {
    *
    * @return the IP address
    */
-  public InetAddress tryResolveAngGetAddress() {
-    return tryResolveAngGetAddress(false);
+  public InetAddress tryResolveAddress() {
+    return tryResolveAddress(false);
   }
 
   /**
@@ -136,7 +136,7 @@ public final class Address {
    * @param resolve whether to force resolve the hostname
    * @return the IP address
    */
-  public InetAddress tryResolveAngGetAddress(final boolean resolve) {
+  public InetAddress tryResolveAddress(final boolean resolve) {
     if (resolve || socketAddress.isUnresolved()) {
       // the constructor will by default attempt to resolve the host, and will fall back to the
       // unresolved address if it couldn't
@@ -156,7 +156,24 @@ public final class Address {
     return socketAddress.getAddress();
   }
 
+  /**
+   * Returns the socket address.
+   *
+   * @return the socket address
+   */
   public InetSocketAddress socketAddress() {
+    return socketAddress;
+  }
+
+  /**
+   * Returns the resolved socket address.
+   *
+   * @return the resolved socket address
+   */
+  public InetSocketAddress getResolvedSocketAddress() {
+    if (socketAddress.isUnresolved()) {
+      socketAddress = new InetSocketAddress(host, port);
+    }
     return socketAddress;
   }
 

--- a/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -17,7 +17,6 @@
 package io.atomix.utils.net;
 
 import com.google.common.net.HostAndPort;
-import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -28,7 +27,6 @@ public final class Address {
   private static final int DEFAULT_PORT = 5679;
   private final String host;
   private final int port;
-  private transient volatile Type type;
   private volatile InetSocketAddress socketAddress;
 
   public Address(final String host, final int port) {
@@ -39,7 +37,6 @@ public final class Address {
     this.host = host;
     this.port = port;
     if (address != null) {
-      type = address instanceof Inet6Address ? Type.IPV6 : Type.IPV4;
       socketAddress = new InetSocketAddress(address, port);
     } else {
       socketAddress = InetSocketAddress.createUnresolved(host, port);
@@ -129,8 +126,8 @@ public final class Address {
    *
    * @return the IP address
    */
-  public InetAddress address() {
-    return address(false);
+  public InetAddress tryResolveAngGetAddress() {
+    return tryResolveAngGetAddress(false);
   }
 
   /**
@@ -139,14 +136,23 @@ public final class Address {
    * @param resolve whether to force resolve the hostname
    * @return the IP address
    */
-  public InetAddress address(final boolean resolve) {
+  public InetAddress tryResolveAngGetAddress(final boolean resolve) {
     if (resolve || socketAddress.isUnresolved()) {
-      // the constructor will by default attempt to resolve the host, and will fallback to the an
+      // the constructor will by default attempt to resolve the host, and will fall back to the
       // unresolved address if it couldn't
       socketAddress = new InetSocketAddress(host, port);
       return socketAddress.getAddress();
     }
 
+    return socketAddress.getAddress();
+  }
+
+  /**
+   * Returns the IP address or null if it is unresolved.
+   *
+   * @return the IP address
+   */
+  public InetAddress getAddress() {
     return socketAddress.getAddress();
   }
 

--- a/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -154,22 +154,6 @@ public final class Address {
     return socketAddress;
   }
 
-  /**
-   * Returns the address type.
-   *
-   * @return the address type
-   */
-  public Type type() {
-    if (type == null) {
-      synchronized (this) {
-        if (type == null) {
-          type = address() instanceof Inet6Address ? Type.IPV6 : Type.IPV4;
-        }
-      }
-    }
-    return type;
-  }
-
   @Override
   public int hashCode() {
     return Objects.hash(host, port);

--- a/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
+++ b/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
@@ -28,7 +28,7 @@ public class AddressTest {
     final Address address = Address.from("127.0.0.1:5000");
     assertEquals("127.0.0.1", address.host());
     assertEquals(5000, address.port());
-    assertEquals("localhost", address.tryResolveAngGetAddress().getHostName());
+    assertEquals("localhost", address.tryResolveAddress().getHostName());
     assertEquals("127.0.0.1:5000", address.toString());
   }
 
@@ -37,8 +37,7 @@ public class AddressTest {
     final Address address = Address.from("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000");
     assertEquals("fe80:cd00:0000:0cde:1257:0000:211e:729c", address.host());
     assertEquals(5000, address.port());
-    assertEquals(
-        "fe80:cd00:0:cde:1257:0:211e:729c", address.tryResolveAngGetAddress().getHostName());
+    assertEquals("fe80:cd00:0:cde:1257:0:211e:729c", address.tryResolveAddress().getHostName());
     assertEquals("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000", address.toString());
   }
 
@@ -47,7 +46,7 @@ public class AddressTest {
     final Address address = Address.from("localhost", 5000);
     assertEquals(
         InetAddress.getLoopbackAddress().getHostAddress(),
-        address.tryResolveAngGetAddress().getHostAddress());
+        address.tryResolveAddress().getHostAddress());
     assertEquals(5000, address.port());
   }
 }

--- a/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
+++ b/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
@@ -28,7 +28,7 @@ public class AddressTest {
     final Address address = Address.from("127.0.0.1:5000");
     assertEquals("127.0.0.1", address.host());
     assertEquals(5000, address.port());
-    assertEquals("localhost", address.address().getHostName());
+    assertEquals("localhost", address.tryResolveAngGetAddress().getHostName());
     assertEquals("127.0.0.1:5000", address.toString());
   }
 
@@ -37,7 +37,8 @@ public class AddressTest {
     final Address address = Address.from("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000");
     assertEquals("fe80:cd00:0000:0cde:1257:0000:211e:729c", address.host());
     assertEquals(5000, address.port());
-    assertEquals("fe80:cd00:0:cde:1257:0:211e:729c", address.address().getHostName());
+    assertEquals(
+        "fe80:cd00:0:cde:1257:0:211e:729c", address.tryResolveAngGetAddress().getHostName());
     assertEquals("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000", address.toString());
   }
 
@@ -45,7 +46,8 @@ public class AddressTest {
   public void testResolveAddress() throws Exception {
     final Address address = Address.from("localhost", 5000);
     assertEquals(
-        InetAddress.getLoopbackAddress().getHostAddress(), address.address().getHostAddress());
+        InetAddress.getLoopbackAddress().getHostAddress(),
+        address.tryResolveAngGetAddress().getHostAddress());
     assertEquals(5000, address.port());
   }
 }


### PR DESCRIPTION
## Description

The member's address resolution was being performed synchronously which could lead to the thread waiting a long time until the address gets resolved.

This is a problem for our SWIM implementation in particular because it forces DNS resolution on every probe and runs single-threaded.

This solution moves the address resolution to the NettyMessagingService standard address resolution which is performed asynchronously and therefore non-blocking.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13722 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
