### PR TITLE
Differentiate coordinator and non-coordinator ClusterTopologyManager

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -20,6 +20,8 @@ final class PersistedClusterTopology {
   private final ClusterTopologySerializer serializer;
   private ClusterTopology clusterTopology = ClusterTopology.uninitialized();
 
+  private Listener topologyUpdateListener;
+
   PersistedClusterTopology(final Path topologyFile, final ClusterTopologySerializer serializer) {
     this.topologyFile = topologyFile;
     this.serializer = serializer;
@@ -48,9 +50,27 @@ final class PersistedClusterTopology {
         StandardOpenOption.DSYNC);
 
     this.clusterTopology = clusterTopology;
+    if (topologyUpdateListener != null) {
+      topologyUpdateListener.onTopologyUpdated(clusterTopology);
+    }
   }
 
   public boolean isUninitialized() {
     return clusterTopology.isUninitialized();
+  }
+
+  public void addUpdateListener(final Listener updateListener) {
+    topologyUpdateListener = updateListener;
+  }
+
+  public void removeInitializeListener(final Listener updateListener) {
+    if (topologyUpdateListener == updateListener) {
+      topologyUpdateListener = null;
+    }
+  }
+
+  @FunctionalInterface
+  interface Listener {
+    void onTopologyUpdated(ClusterTopology clusterTopology);
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -41,6 +41,10 @@ final class PersistedClusterTopology {
   }
 
   void update(final ClusterTopology clusterTopology) throws IOException {
+    if (this.clusterTopology.equals(clusterTopology)) {
+      return;
+    }
+
     final var serializedTopology = serializer.encode(clusterTopology);
     Files.write(
         topologyFile,

--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -67,7 +67,7 @@ final class PersistedClusterTopology {
     topologyUpdateListener = updateListener;
   }
 
-  public void removeInitializeListener(final Listener updateListener) {
+  public void removeUpdateListener(final Listener updateListener) {
     if (topologyUpdateListener == updateListener) {
       topologyUpdateListener = null;
     }

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.PersistedClusterTopology.Listener;
+import io.camunda.zeebe.topology.state.ClusterChangePlan;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Initialized topology * */
+public interface TopologyInitializer {
+
+  /**
+   * Initializes the cluster topology.
+   *
+   * @return a future when completed with true indicates that the cluster topology is initialized
+   *     successfully. Otherwise, the topology is not initialized.
+   */
+  ActorFuture<Boolean> initialize();
+
+  /**
+   * Chain initializers in oder. If this.initialize did not successfully initialize, then the
+   * topology is initialized using the provided initializer
+   *
+   * @param after the next initializer used to initialize topology if the current one did not
+   *     succeed.
+   * @return a chained TopologyInitializer
+   */
+  default TopologyInitializer orThen(final TopologyInitializer after) {
+    final TopologyInitializer actual = this;
+    return () -> {
+      final ActorFuture<Boolean> chainedInitialize = new CompletableActorFuture<>();
+      actual
+          .initialize()
+          .onComplete(
+              (initialized, error) -> {
+                if (error != null || !initialized) {
+                  after.initialize().onComplete(chainedInitialize);
+                } else {
+                  chainedInitialize.complete(initialized);
+                }
+              });
+      return chainedInitialize;
+    };
+  }
+
+  /** Initialized topology from the locally persisted topology */
+  class FileInitializer implements TopologyInitializer {
+
+    private final PersistedClusterTopology persistedClusterTopology;
+
+    public FileInitializer(final PersistedClusterTopology persistedClusterTopology) {
+      this.persistedClusterTopology = persistedClusterTopology;
+    }
+
+    @Override
+    public ActorFuture<Boolean> initialize() {
+      try {
+        persistedClusterTopology.tryInitialize();
+        return CompletableActorFuture.completed(!persistedClusterTopology.isUninitialized());
+      } catch (final Exception e) {
+        return CompletableActorFuture.completedExceptionally(e);
+      }
+    }
+  }
+
+  /**
+   * Initializes local topology from the topology received from other members via gossip.
+   * Initialization completes successfully, when it receives a valid initialized topology from any
+   * member. The future returned by initialize is never completed until a valid topology is
+   * received.
+   */
+  class GossipInitializer implements TopologyInitializer, Listener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GossipInitializer.class);
+    private final PersistedClusterTopology persistedClusterTopology;
+    private final Consumer<ClusterTopology> topologyGossiper;
+    private final ActorFuture<Boolean> initialized;
+
+    public GossipInitializer(
+        final PersistedClusterTopology persistedClusterTopology,
+        final Consumer<ClusterTopology> topologyGossiper) {
+      this.persistedClusterTopology = persistedClusterTopology;
+      this.topologyGossiper = topologyGossiper;
+      initialized = new CompletableActorFuture<>();
+    }
+
+    @Override
+    public ActorFuture<Boolean> initialize() {
+      persistedClusterTopology.addUpdateListener(this);
+      onTopologyUpdated(persistedClusterTopology.getTopology());
+      if (persistedClusterTopology.isUninitialized()) {
+        // When uninitialized, the member should gossip uninitialized topology so that the
+        // coordinator is not waiting in SyncInitializer forever.
+        topologyGossiper.accept(persistedClusterTopology.getTopology());
+      }
+      return initialized;
+    }
+
+    @Override
+    public void onTopologyUpdated(final ClusterTopology clusterTopology) {
+      if (!clusterTopology.isUninitialized()) {
+        LOGGER.debug("Received cluster topology {} via gossip.", clusterTopology);
+        initialized.complete(true);
+        persistedClusterTopology.removeInitializeListener(this);
+      }
+    }
+  }
+
+  /**
+   * Initializes topology by sending sync requests to other members. If any of them return a valid
+   * topology, it will be initialized. If any of them returns an uninitialized topology, the future
+   * returned by initialize completes as failed.
+   */
+  class SyncInitializer implements TopologyInitializer, Listener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SyncInitializer.class);
+    private static final Duration SYNC_QUERY_RETRY_DELAY = Duration.ofSeconds(5);
+    private final PersistedClusterTopology persistedClusterTopology;
+    private final ActorFuture<Boolean> initialized;
+    private final List<MemberId> knownMembersToSync;
+    private final ConcurrencyControl executor;
+    private final Function<MemberId, ActorFuture<ClusterTopology>> syncRequester;
+
+    public SyncInitializer(
+        final PersistedClusterTopology persistedClusterTopology,
+        final List<MemberId> knownMembersToSync,
+        final ConcurrencyControl executor,
+        final Function<MemberId, ActorFuture<ClusterTopology>> syncRequester) {
+      this.persistedClusterTopology = persistedClusterTopology;
+      this.knownMembersToSync = knownMembersToSync;
+      this.executor = executor;
+      this.syncRequester = syncRequester;
+      initialized = new CompletableActorFuture<>();
+    }
+
+    @Override
+    public ActorFuture<Boolean> initialize() {
+      if (knownMembersToSync.isEmpty()) {
+        initialized.complete(false);
+      } else {
+        LOGGER.debug("Querying members {} before initializing ClusterTopology", knownMembersToSync);
+        persistedClusterTopology.addUpdateListener(this);
+        onTopologyUpdated(persistedClusterTopology.getTopology());
+        knownMembersToSync.forEach(this::tryInitializeFrom);
+      }
+      return initialized;
+    }
+
+    private void tryInitializeFrom(final MemberId memberId) {
+      requestSync(memberId)
+          .onComplete(
+              (topology, error) -> {
+                if (initialized.isDone()) {
+                  return;
+                }
+                if (error == null && topology != null) {
+                  if (topology.isUninitialized()) {
+                    LOGGER.trace("Cluster topology is uninitialized in {}", memberId);
+                    initialized.complete(false);
+                    return;
+                  }
+                  try {
+                    LOGGER.debug(
+                        "Received cluster topology {} from {}", knownMembersToSync, memberId);
+                    persistedClusterTopology.update(topology);
+                    onTopologyUpdated(topology);
+                    return;
+                  } catch (final IOException e) {
+                    LOGGER.warn("Failed to persist received topology");
+                  }
+                }
+                // retry
+                if (!initialized.isDone()) {
+                  LOGGER.trace(
+                      "Failed to get a response for cluster topology sync query to {}. Will retry.",
+                      memberId);
+
+                  executor.schedule(SYNC_QUERY_RETRY_DELAY, () -> tryInitializeFrom(memberId));
+                }
+              });
+    }
+
+    private ActorFuture<ClusterTopology> requestSync(final MemberId memberId) {
+      return syncRequester.apply(memberId);
+    }
+
+    @Override
+    public void onTopologyUpdated(final ClusterTopology clusterTopology) {
+      if (initialized.isDone()) {
+        return;
+      }
+      if (!clusterTopology.isUninitialized()) {
+        initialized.complete(true);
+        persistedClusterTopology.removeInitializeListener(this);
+      }
+    }
+  }
+
+  /** Initialized topology from the given static partition distribution */
+  class StaticInitializer implements TopologyInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StaticInitializer.class);
+    private final Supplier<Set<PartitionMetadata>> staticPartitionResolver;
+    private final PersistedClusterTopology persistedClusterTopology;
+
+    public StaticInitializer(
+        final Supplier<Set<PartitionMetadata>> staticPartitionResolver,
+        final PersistedClusterTopology persistedClusterTopology) {
+      this.staticPartitionResolver = staticPartitionResolver;
+      this.persistedClusterTopology = persistedClusterTopology;
+    }
+
+    @Override
+    public ActorFuture<Boolean> initialize() {
+      final var partitionDistribution = staticPartitionResolver.get();
+
+      final var partitionsOwnedByMembers =
+          partitionDistribution.stream()
+              .flatMap(
+                  p ->
+                      p.members().stream()
+                          .map(m -> Map.entry(m, Map.entry(p.id().id(), p.getPriority(m)))))
+              .collect(
+                  Collectors.groupingBy(
+                      Entry::getKey,
+                      Collectors.toMap(
+                          e -> e.getValue().getKey(),
+                          e -> PartitionState.active(e.getValue().getValue()))));
+
+      final var memberStates =
+          partitionsOwnedByMembers.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Entry::getKey, e -> MemberState.initializeAsActive(e.getValue())));
+
+      final var topology = new ClusterTopology(0, memberStates, ClusterChangePlan.empty());
+      LOGGER.debug("Generated cluster topology from provided configuration. {}", topology);
+      try {
+        persistedClusterTopology.update(topology);
+      } catch (final IOException e) {
+        return CompletableActorFuture.completedExceptionally(e);
+      }
+
+      return CompletableActorFuture.completed(true);
+    }
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
@@ -125,7 +125,7 @@ public interface TopologyInitializer {
       if (!clusterTopology.isUninitialized()) {
         LOGGER.debug("Received cluster topology {} via gossip.", clusterTopology);
         initialized.complete(true);
-        persistedClusterTopology.removeInitializeListener(this);
+        persistedClusterTopology.removeUpdateListener(this);
       }
     }
   }
@@ -215,7 +215,7 @@ public interface TopologyInitializer {
       }
       if (!clusterTopology.isUninitialized()) {
         initialized.complete(true);
-        persistedClusterTopology.removeInitializeListener(this);
+        persistedClusterTopology.removeUpdateListener(this);
       }
     }
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
@@ -184,8 +184,7 @@ public interface TopologyInitializer {
                     return;
                   }
                   try {
-                    LOGGER.debug(
-                        "Received cluster topology {} from {}", knownMembersToSync, memberId);
+                    LOGGER.debug("Received cluster topology {} from {}", topology, memberId);
                     persistedClusterTopology.update(topology);
                     onTopologyUpdated(topology);
                     return;

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -26,6 +26,16 @@ final class ClusterTopologyAssert extends AbstractAssert<ClusterTopologyAssert, 
     return new ClusterTopologyAssert(actual, ClusterTopologyAssert.class);
   }
 
+  ClusterTopologyAssert isUninitialized() {
+    assertThat(actual.isUninitialized()).isTrue();
+    return this;
+  }
+
+  ClusterTopologyAssert isInitialized() {
+    assertThat(actual.isUninitialized()).isFalse();
+    return this;
+  }
+
   ClusterTopologyAssert hasMemberWithPartitions(
       final int member, final Collection<Integer> partitionIds) {
     final var memberId = MemberId.from(Integer.toString(member));

--- a/topology/src/test/java/io/camunda/zeebe/topology/TopologyInitializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/TopologyInitializerTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.topology.TopologyInitializer.FileInitializer;
+import io.camunda.zeebe.topology.TopologyInitializer.GossipInitializer;
+import io.camunda.zeebe.topology.TopologyInitializer.StaticInitializer;
+import io.camunda.zeebe.topology.TopologyInitializer.SyncInitializer;
+import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class TopologyInitializerTest {
+  @TempDir Path rootDir;
+  private final ClusterTopology initialClusterTopology =
+      ClusterTopology.init()
+          .addMember(
+              MemberId.from("10"),
+              MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+
+  private PersistedClusterTopology persistedClusterTopology;
+  private Path topologyFile;
+
+  @BeforeEach
+  void init() {
+    topologyFile = rootDir.resolve("topology.temp");
+    persistedClusterTopology = new PersistedClusterTopology(topologyFile, new ProtoBufSerializer());
+  }
+
+  @Test
+  void shouldInitializeFromExistingFile() throws IOException {
+    // given
+    final var fileInitializer = new FileInitializer(persistedClusterTopology);
+    // write initial topology to the file
+    persistedClusterTopology.update(initialClusterTopology);
+    // when
+    final var initializeFuture = fileInitializer.initialize();
+
+    // then
+    assertThat(initializeFuture.join()).isTrue();
+  }
+
+  @Test
+  void shouldNotInitializeFromEmptyFile() {
+    // given
+    final var fileInitializer = new FileInitializer(persistedClusterTopology);
+
+    // when
+    final var initializeFuture = fileInitializer.initialize();
+
+    // then
+    assertThat(initializeFuture.join()).isFalse();
+  }
+
+  @Test
+  void shouldNotInitializeFromCorruptedFile() throws IOException {
+    // given
+    final var fileInitializer = new FileInitializer(persistedClusterTopology);
+    // Corrupt file
+    Files.write(
+        topologyFile, "random".getBytes(), StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+    // when
+    final var initializeFuture = fileInitializer.initialize();
+
+    // then
+    assertThat(initializeFuture)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class);
+  }
+
+  @Test
+  void shouldInitializeFromStaticConfig() {
+    // given
+    final var initializer = getStaticInitializer();
+
+    // when
+    final var initializeFuture = initializer.initialize();
+
+    // then
+    assertThat(initializeFuture.join()).isTrue();
+    assertThat(persistedClusterTopology.getTopology())
+        .describedAs("should update persisted topology after initialization")
+        .isEqualTo(initialClusterTopology);
+  }
+
+  @Test
+  void shouldInitializeFromGossip() throws IOException {
+    // given
+    final var initializer = new GossipInitializer(persistedClusterTopology, ignore -> {});
+
+    // when
+    final var initializeFuture = initializer.initialize();
+    assertThat(initializeFuture.isDone()).isFalse();
+
+    // Simulate gossip received
+    persistedClusterTopology.update(initialClusterTopology);
+
+    // then
+    assertThat(initializeFuture.join()).isTrue();
+  }
+
+  @Test
+  void shouldInitializeFromSync() throws IOException {
+    // given
+    final var knownMembers = List.of(MemberId.from("1"));
+    final ActorFuture<ClusterTopology> syncResponseFuture = new TestActorFuture<>();
+    final Function<MemberId, ActorFuture<ClusterTopology>> syncRequester = id -> syncResponseFuture;
+    final var initializer =
+        new SyncInitializer(
+            persistedClusterTopology, knownMembers, new TestConcurrencyControl(), syncRequester);
+
+    // when
+    final var initializeFuture = initializer.initialize();
+    assertThat(initializeFuture.isDone()).isFalse();
+    syncResponseFuture.complete(initialClusterTopology);
+
+    // Simulate gossip received
+    persistedClusterTopology.update(initialClusterTopology);
+
+    // then
+    assertThat(initializeFuture.join()).isTrue();
+    assertThat(persistedClusterTopology.getTopology())
+        .describedAs("should update persisted topology after initialization")
+        .isEqualTo(initialClusterTopology);
+  }
+
+  @Test
+  void shouldCompleteFutureButNotInitializeWhenSyncReturnsUninitialized() throws IOException {
+    // given
+    final var knownMembers = List.of(MemberId.from("1"));
+    final ActorFuture<ClusterTopology> syncResponseFuture = new TestActorFuture<>();
+    final Function<MemberId, ActorFuture<ClusterTopology>> syncRequester = id -> syncResponseFuture;
+    final var initializer =
+        new SyncInitializer(
+            persistedClusterTopology, knownMembers, new TestConcurrencyControl(), syncRequester);
+
+    // when
+    final var initializeFuture = initializer.initialize();
+    assertThat(initializeFuture.isDone()).isFalse();
+    syncResponseFuture.complete(ClusterTopology.uninitialized());
+
+    // Simulate gossip received
+    persistedClusterTopology.update(initialClusterTopology);
+
+    // then
+    assertThat(initializeFuture.join()).isFalse();
+  }
+
+  private TopologyInitializer getStaticInitializer() {
+    final MemberId member = MemberId.from("10");
+    final Set<PartitionMetadata> partitions =
+        Set.of(
+            new PartitionMetadata(
+                PartitionId.from("test", 1), Set.of(member), Map.of(member, 1), 1, member));
+    return new StaticInitializer(() -> partitions, persistedClusterTopology);
+  }
+
+  @Nested
+  class ChainedInitializerTest {
+    @Test
+    void shouldInitializeFromFileWhenNotEmpty() throws IOException {
+      // given
+      final var fileInitializer =
+          new FileInitializer(persistedClusterTopology)
+              .orThen(new GossipInitializer(persistedClusterTopology, ignore -> {}));
+      // write initial topology to the file
+      persistedClusterTopology.update(initialClusterTopology);
+      // when
+      final var initializeFuture = fileInitializer.initialize();
+
+      // then
+      assertThat(initializeFuture.join()).isTrue();
+    }
+
+    @Test
+    void shouldInitializeFromGossipWhenFileIsEmpty() throws IOException {
+      // given
+      final AtomicReference<ClusterTopology> gossipedTopology = new AtomicReference<>();
+      final var initializer =
+          new FileInitializer(persistedClusterTopology)
+              .orThen(new GossipInitializer(persistedClusterTopology, gossipedTopology::set));
+
+      // when
+      final var initializeFuture = initializer.initialize();
+      assertThat(initializeFuture.isDone()).isFalse();
+      assertThat(gossipedTopology.get())
+          .describedAs("Should gossip uninitialized topology")
+          .isEqualTo(ClusterTopology.uninitialized());
+
+      // Simulate gossip received
+      persistedClusterTopology.update(initialClusterTopology);
+
+      // then
+      assertThat(initializeFuture.join()).isTrue();
+    }
+
+    @Test
+    void shouldInitializeFromGossipWhenFileIsCorrupted() throws IOException {
+      // given
+      final AtomicReference<ClusterTopology> gossipedTopology = new AtomicReference<>();
+      final var initializer =
+          new FileInitializer(persistedClusterTopology)
+              .orThen(new GossipInitializer(persistedClusterTopology, gossipedTopology::set));
+      // Corrupt file
+      Files.write(
+          topologyFile, "random".getBytes(), StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+
+      // when
+      final var initializeFuture = initializer.initialize();
+      assertThat(initializeFuture.isDone()).isFalse();
+      assertThat(gossipedTopology.get())
+          .describedAs("Should gossip uninitialized topology")
+          .isEqualTo(ClusterTopology.uninitialized());
+
+      // Simulate gossip received
+      persistedClusterTopology.update(initialClusterTopology);
+
+      // then
+      assertThat(initializeFuture.join()).isTrue();
+    }
+
+    @Test
+    void shouldInitializeFromSyncWhenFileIsEmpty() {
+      // given
+      final var knownMembers = List.of(MemberId.from("1"));
+      final ActorFuture<ClusterTopology> syncResponseFuture = new TestActorFuture<>();
+      final Function<MemberId, ActorFuture<ClusterTopology>> syncRequester =
+          id -> syncResponseFuture;
+      final var syncInitializer =
+          new SyncInitializer(
+              persistedClusterTopology, knownMembers, new TestConcurrencyControl(), syncRequester);
+
+      final var initializer = new FileInitializer(persistedClusterTopology).orThen(syncInitializer);
+
+      // when
+      final var initializeFuture = initializer.initialize();
+      assertThat(initializeFuture.isDone()).isFalse();
+
+      // Simulate gossip received
+      syncResponseFuture.complete(initialClusterTopology);
+
+      // then
+      assertThat(initializeFuture.join()).isTrue();
+    }
+
+    @Test
+    void shouldInitializeFromStaticWhenFileAndSyncFails() {
+      // given
+      final var knownMembers = List.of(MemberId.from("1"));
+      final ActorFuture<ClusterTopology> syncResponseFuture = new TestActorFuture<>();
+      final Function<MemberId, ActorFuture<ClusterTopology>> syncRequester =
+          id -> syncResponseFuture;
+      final var syncInitializer =
+          new SyncInitializer(
+              persistedClusterTopology, knownMembers, new TestConcurrencyControl(), syncRequester);
+
+      final var initializer =
+          new FileInitializer(persistedClusterTopology)
+              .orThen(syncInitializer)
+              .orThen(getStaticInitializer());
+
+      // when
+      final var initializeFuture = initializer.initialize();
+      assertThat(initializeFuture.isDone()).isFalse();
+
+      // Simulate gossip received
+      syncResponseFuture.complete(ClusterTopology.uninitialized());
+
+      // then
+      assertThat(initializeFuture.join()).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
## Description

- Add different strategies to initialize cluster topology. Depending on whether the node is a coordinator or not, it can use the combination of these strategies.
- Non-coordinator members first check the local persisted topology. When it is not available, it waits until a valid topology is received via gossip.
- Coordinator first check the local persisted topology, then queries known members, and when no valid ClusterTopology is found, it generates one from the static configuration.


## Related issues

closes #13941 #13956 

