### PR TITLE
fix(engine): propagate only defined variables

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
@@ -62,4 +62,11 @@ public class AbstractCallActivityBuilder<B extends AbstractCallActivityBuilder<B
     calledElement.setPropagateAllChildVariablesEnabled(propagateAllChildVariables);
     return myself;
   }
+
+  public B zeebePropagateAllParentVariables(final boolean propagateAllParentVariables) {
+    final ZeebeCalledElement calledElement =
+        getCreateSingleExtensionElement(ZeebeCalledElement.class);
+    calledElement.setPropagateAllParentVariablesEnabled(propagateAllParentVariables);
+    return myself;
+  }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -38,6 +38,8 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_PROCESS_ID = "processId";
   public static final String ATTRIBUTE_PROPAGATE_ALL_CHILD_VARIABLES = "propagateAllChildVariables";
+  public static final String ATTRIBUTE_PROPAGATE_ALL_PARENT_VARIABLES =
+      "propagateAllParentVariables";
 
   public static final String ATTRIBUTE_FORM_KEY = "formKey";
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
@@ -29,6 +29,7 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
 
   private static Attribute<String> processIdAttribute;
   private static Attribute<Boolean> propagateAllChildVariablesAttribute;
+  private static Attribute<Boolean> propagateAllParentVariablesAttribute;
 
   public ZeebeCalledElementImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -55,6 +56,16 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
     propagateAllChildVariablesAttribute.setValue(this, propagateAllChildVariablesEnabled);
   }
 
+  @Override
+  public boolean isPropagateAllParentVariablesEnabled() {
+    return propagateAllParentVariablesAttribute.getValue(this);
+  }
+
+  @Override
+  public void setPropagateAllParentVariablesEnabled(boolean propagateAllParentVariablesEnabled) {
+    propagateAllParentVariablesAttribute.setValue(this, propagateAllParentVariablesEnabled);
+  }
+
   public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
@@ -71,6 +82,13 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
     propagateAllChildVariablesAttribute =
         typeBuilder
             .booleanAttribute(ZeebeConstants.ATTRIBUTE_PROPAGATE_ALL_CHILD_VARIABLES)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .defaultValue(true)
+            .build();
+
+    propagateAllParentVariablesAttribute =
+        typeBuilder
+            .booleanAttribute(ZeebeConstants.ATTRIBUTE_PROPAGATE_ALL_PARENT_VARIABLES)
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .defaultValue(true)
             .build();

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
@@ -26,4 +26,8 @@ public interface ZeebeCalledElement extends BpmnModelElementInstance {
   boolean isPropagateAllChildVariablesEnabled();
 
   void setPropagateAllChildVariablesEnabled(boolean propagateAllChildVariablesEnabled);
+
+  boolean isPropagateAllParentVariablesEnabled();
+
+  void setPropagateAllParentVariablesEnabled(boolean propagateAllParentVariablesEnabled);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -182,11 +182,26 @@ public final class BpmnStateBehavior {
         variablesAsDocument);
   }
 
-  public void copyVariablesToProcessInstance(
+  public void copyAllVariablesToProcessInstance(
       final long sourceScopeKey,
       final long targetProcessInstanceKey,
       final DeployedProcess targetProcess) {
     final var variables = variablesState.getVariablesAsDocument(sourceScopeKey);
+    copyVariablesToProcessInstance(targetProcessInstanceKey, targetProcess, variables);
+  }
+
+  public void copyLocalVariablesToProcessInstance(
+      final long sourceScopeKey,
+      final long targetProcessInstanceKey,
+      final DeployedProcess targetProcess) {
+    final var variables = variablesState.getVariablesLocalAsDocument(sourceScopeKey);
+    copyVariablesToProcessInstance(targetProcessInstanceKey, targetProcess, variables);
+  }
+
+  private void copyVariablesToProcessInstance(
+      final long targetProcessInstanceKey,
+      final DeployedProcess targetProcess,
+      final DirectBuffer variables) {
     variableBehavior.mergeDocument(
         targetProcessInstanceKey,
         targetProcess.getKey(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -72,9 +72,22 @@ public final class CallActivityProcessor
               final var childProcessInstanceKey =
                   stateTransitionBehavior.createChildProcessInstance(process, context);
 
+              final var propagateAllParentVariablesEnabled =
+                  element.isPropagateAllParentVariablesEnabled();
+              final var inputMappings = element.getInputMappings();
               final var callActivityInstanceKey = activated.getElementInstanceKey();
-              stateBehavior.copyVariablesToProcessInstance(
-                  callActivityInstanceKey, childProcessInstanceKey, process);
+
+              if (propagateAllParentVariablesEnabled) {
+                stateBehavior.copyAllVariablesToProcessInstance(
+                    callActivityInstanceKey, childProcessInstanceKey, process);
+              } else if (inputMappings.isPresent()) {
+                // when activating the call activity, the input mappings will be applied.
+                // Resulting in local variables in the (local) call activity scope.
+                // These local variables can simply be propagated to the called child
+                // process instance.
+                stateBehavior.copyLocalVariablesToProcessInstance(
+                    callActivityInstanceKey, childProcessInstanceKey, process);
+              }
             },
             failure -> incidentBehavior.createIncident(failure, context));
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
@@ -14,6 +14,7 @@ public class ExecutableCallActivity extends ExecutableActivity {
   private Expression calledElementProcessId;
 
   private boolean propagateAllChildVariablesEnabled;
+  private boolean propagateAllParentVariablesEnabled;
 
   public ExecutableCallActivity(final String id) {
     super(id);
@@ -34,5 +35,13 @@ public class ExecutableCallActivity extends ExecutableActivity {
   public void setPropagateAllChildVariablesEnabled(
       final boolean propagateAllChildVariablesEnabled) {
     this.propagateAllChildVariablesEnabled = propagateAllChildVariablesEnabled;
+  }
+
+  public boolean isPropagateAllParentVariablesEnabled() {
+    return propagateAllParentVariablesEnabled;
+  }
+
+  public void setPropagateAllParentVariablesEnabled(boolean propagateAllParentVariablesEnabled) {
+    this.propagateAllParentVariablesEnabled = propagateAllParentVariablesEnabled;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
@@ -48,5 +48,9 @@ public final class CallActivityTransformer implements ModelElementTransformer<Ca
     final var propagateAllChildVariablesEnabled =
         calledElement.isPropagateAllChildVariablesEnabled();
     callActivity.setPropagateAllChildVariablesEnabled(propagateAllChildVariablesEnabled);
+
+    final var propagateAllParentVariablesEnabled =
+        calledElement.isPropagateAllParentVariablesEnabled();
+    callActivity.setPropagateAllParentVariablesEnabled(propagateAllParentVariablesEnabled);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
@@ -280,6 +281,37 @@ public final class CallActivityTest {
   }
 
   @Test
+  public void shouldPropagateAllVariablesWhenEnablingPropagateAllParentVariablesExplicitly() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            "wf-parent.bpmn",
+            parentProcess(
+                c -> c.zeebeInputExpression("x", "y").zeebePropagateAllParentVariables(true)))
+        .deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID_PARENT)
+            .withVariables(Map.of("x", 1))
+            .create();
+
+    // then
+    final var childInstance = getChildInstanceOf(processInstanceKey);
+
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(childInstance.getProcessInstanceKey())
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(v -> tuple(v.getName(), v.getValue()))
+        .contains(tuple("x", "1"), tuple("y", "1"));
+  }
+
+  @Test
   public void shouldOnlyPropagateVariablesDefinedViaInputMappings() {
     // given
     ENGINE
@@ -302,13 +334,14 @@ public final class CallActivityTest {
     final var childInstance = getChildInstanceOf(processInstanceKey);
 
     assertThat(
-            RecordingExporter.variableRecords()
-                .withProcessInstanceKey(childInstance.getProcessInstanceKey())
-                .limit(2))
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == JobIntent.CREATED)
+                .variableRecords()
+                .withIntent(VariableIntent.CREATED)
+                .withProcessInstanceKey(childInstance.getProcessInstanceKey()))
         .extracting(Record::getValue)
         .extracting(v -> tuple(v.getName(), v.getValue()))
-        .contains(tuple("y", "1"))
-        .doesNotContain(tuple("x", "1"));
+        .containsExactly(tuple("y", "1"));
   }
 
   @Test
@@ -332,12 +365,12 @@ public final class CallActivityTest {
     final var childInstance = getChildInstanceOf(processInstanceKey);
 
     assertThat(
-            RecordingExporter.variableRecords()
-                .withProcessInstanceKey(childInstance.getProcessInstanceKey())
-                .limit(2))
-        .extracting(Record::getValue)
-        .extracting(v -> tuple(v.getName(), v.getValue()))
-        .doesNotContain(tuple("x", "1"));
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == JobIntent.CREATED)
+                .variableRecords()
+                .withIntent(VariableIntent.CREATED)
+                .withProcessInstanceKey(childInstance.getProcessInstanceKey()))
+        .isEmpty();
   }
 
   @Test


### PR DESCRIPTION
This commit introduces a new property called
`propagateAllParentVariables` to allow a user to control if all variables or just specific ones need to be propagated to a child process instances when activating a call activity.

1. (Default) `propagateAllParentVariables = true`, then Zeebe behaves as currently (i.e., all variables a propagated to the child process instance).
2. `propagateAllParentVariables = false`, only the variables defined via input mappings are propagated to the child process instance (if any).

The property `propagateAllParentVariables` can be set per call activity.

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13959 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [x] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [x] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
