### PR TITLE
Resolve member's address with NettyMessagingService 

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -241,6 +241,10 @@
       <artifactId>bcprov-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -250,7 +250,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>4.1.97.Final</version>
     </dependency>
 
   </dependencies>

--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -241,10 +241,18 @@
       <artifactId>bcprov-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver</artifactId>
+      <version>4.1.97.Final</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -18,11 +18,9 @@ package io.atomix.cluster.messaging.impl;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import io.atomix.utils.concurrent.OrderedFuture;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.util.collection.Tuple;
 import io.netty.channel.Channel;
-import java.net.ConnectException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -89,13 +87,8 @@ class ChannelPool {
    * @return a future to be completed with a channel from the pool
    */
   CompletableFuture<Channel> getChannel(final Address address, final String messageType) {
-    final InetAddress inetAddress = address.address();
-    if (inetAddress == null) {
-      final CompletableFuture<Channel> failedFuture = new OrderedFuture<>();
-      failedFuture.completeExceptionally(
-          new ConnectException("Failed to resolve address %s".formatted(address)));
-      return failedFuture;
-    }
+    final InetAddress inetAddress = address.getAddress();
+
     final List<CompletableFuture<Channel>> channelPool = getChannelPool(address, inetAddress);
     final int offset = getChannelOffset(messageType);
 

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageEncoderV1.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageEncoderV1.java
@@ -28,7 +28,7 @@ class MessageEncoderV1 extends AbstractMessageEncoder {
 
   @Override
   protected void encodeAddress(final ProtocolMessage message, final ByteBuf buffer) {
-    final InetAddress senderIp = address.address();
+    final InetAddress senderIp = address.tryResolveAddress();
     final byte[] senderIpBytes = senderIp.getAddress();
     buffer.writeByte(senderIpBytes.length);
     buffer.writeBytes(senderIpBytes);

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -64,6 +64,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.LoggingDnsQueryLifeCycleObserverFactory;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import java.net.ConnectException;
@@ -723,6 +724,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.resolver(
         new DnsAddressResolverGroup(
             new DnsNameResolverBuilder(clientGroup.next())
+                .dnsQueryLifecycleObserverFactory(new LoggingDnsQueryLifeCycleObserverFactory())
                 .channelType(clientDataGramChannelClass)));
     bootstrap.remoteAddress(socketAddress);
     bootstrap.handler(new BasicClientChannelInitializer(future));

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -45,11 +45,14 @@ import io.netty.channel.ServerChannel;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.compression.SnappyFrameDecoder;
@@ -59,10 +62,12 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
+import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import java.net.ConnectException;
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -110,6 +115,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private EventLoopGroup clientGroup;
   private Class<? extends ServerChannel> serverChannelClass;
   private Class<? extends Channel> clientChannelClass;
+  private Class<? extends DatagramChannel> clientDataGramChannelClass;
+
   private Channel serverChannel;
 
   // a single thread executor which silently rejects tasks being submitted when it's shutdown
@@ -490,6 +497,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
         new EpollEventLoopGroup(0, namedThreads("netty-messaging-event-epoll-server-%d", log));
     serverChannelClass = EpollServerSocketChannel.class;
     clientChannelClass = EpollSocketChannel.class;
+    clientDataGramChannelClass = EpollDatagramChannel.class;
   }
 
   private void initNioTransport() {
@@ -499,6 +507,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
         new NioEventLoopGroup(0, namedThreads("netty-messaging-event-nio-server-%d", log));
     serverChannelClass = NioServerSocketChannel.class;
     clientChannelClass = NioSocketChannel.class;
+    clientDataGramChannelClass = NioDatagramChannel.class;
   }
 
   /**
@@ -697,15 +706,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
    */
   private CompletableFuture<Channel> bootstrapClient(final Address address) {
     final CompletableFuture<Channel> future = new OrderedFuture<>();
-    final InetAddress resolvedAddress = address.address(true);
-    if (resolvedAddress == null) {
-      future.completeExceptionally(
-          new ConnectException(
-              "Failed to bootstrap client (address "
-                  + address.toString()
-                  + " cannot be resolved)"));
-      return future;
-    }
+    final InetSocketAddress socketAddress = address.socketAddress();
 
     final Bootstrap bootstrap = new Bootstrap();
     bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
@@ -718,11 +719,14 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.option(ChannelOption.TCP_NODELAY, true);
     bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000);
     bootstrap.group(clientGroup);
-    // TODO: Make this faster:
-    // http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#37.0
     bootstrap.channel(clientChannelClass);
-    bootstrap.remoteAddress(resolvedAddress, address.port());
+    bootstrap.resolver(
+        new DnsAddressResolverGroup(
+            new DnsNameResolverBuilder(clientGroup.next())
+                .channelType(clientDataGramChannelClass)));
+    bootstrap.remoteAddress(socketAddress);
     bootstrap.handler(new BasicClientChannelInitializer(future));
+
     final Channel channel =
         bootstrap
             .connect()
@@ -733,7 +737,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
                         new ConnectException(
                             String.format(
                                 "Failed to connect channel for address %s (resolved: %s) : %s",
-                                address, address.address(), onConnect.cause())));
+                                address, address.getAddress(), onConnect.cause())));
                   }
                 })
             .channel();

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -105,7 +105,7 @@ public class NettyUnicastService implements ManagedUnicastService {
     final ByteBuf buf = channel.alloc().buffer(Integer.BYTES + Integer.BYTES + bytes.length);
     buf.writeInt(preamble);
     buf.writeInt(bytes.length).writeBytes(bytes);
-    channel.writeAndFlush(new DatagramPacket(buf, address.getResolvedSocketAddress()));
+    channel.writeAndFlush(new DatagramPacket(buf, address.socketAddress()));
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.common.util.concurrent.MoreExecutors;
@@ -152,7 +153,12 @@ public class NettyMessagingServiceTest {
     final String subject = nextSubject();
     final CompletableFuture<Void> response =
         netty1.sendAsync(unresolvable, subject, "hello world".getBytes());
-    assertTrue(response.isCompletedExceptionally());
+
+    assertThrows(
+        CompletionException.class,
+        () -> {
+          netty1.sendAsync(unresolvable, subject, "hello world".getBytes()).join();
+        });
   }
 
   @Test
@@ -200,7 +206,7 @@ public class NettyMessagingServiceTest {
     assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
     assertTrue(handlerInvoked.get());
     assertTrue(Arrays.equals(request.get(), "hello world".getBytes()));
-    assertEquals(address1.address(), sender.get().address());
+    assertEquals(address1.tryResolveAddress(), sender.get().tryResolveAddress());
   }
 
   @Test
@@ -313,7 +319,7 @@ public class NettyMessagingServiceTest {
     assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
     assertTrue(handlerInvoked.get());
     assertTrue(Arrays.equals(request.get(), "hello world".getBytes()));
-    assertEquals(address1.address(), sender.get().address());
+    assertEquals(address1.tryResolveAddress(), sender.get().tryResolveAddress());
   }
 
   @Test

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.common.util.concurrent.MoreExecutors;
@@ -154,11 +153,7 @@ public class NettyMessagingServiceTest {
     final CompletableFuture<Void> response =
         netty1.sendAsync(unresolvable, subject, "hello world".getBytes());
 
-    assertThrows(
-        CompletionException.class,
-        () -> {
-          netty1.sendAsync(unresolvable, subject, "hello world".getBytes()).join();
-        });
+    assertThat(response).failsWithin(Duration.ofSeconds(10));
   }
 
   @Test

--- a/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -17,7 +17,6 @@
 package io.atomix.utils.net;
 
 import com.google.common.net.HostAndPort;
-import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -28,7 +27,6 @@ public final class Address {
   private static final int DEFAULT_PORT = 5679;
   private final String host;
   private final int port;
-  private transient volatile Type type;
   private volatile InetSocketAddress socketAddress;
 
   public Address(final String host, final int port) {
@@ -39,7 +37,6 @@ public final class Address {
     this.host = host;
     this.port = port;
     if (address != null) {
-      type = address instanceof Inet6Address ? Type.IPV6 : Type.IPV4;
       socketAddress = new InetSocketAddress(address, port);
     } else {
       socketAddress = InetSocketAddress.createUnresolved(host, port);
@@ -125,23 +122,23 @@ public final class Address {
   }
 
   /**
-   * Returns the IP address.
+   * Tries to resolve and returns the IP address.
    *
    * @return the IP address
    */
-  public InetAddress address() {
-    return address(false);
+  public InetAddress tryResolveAddress() {
+    return tryResolveAddress(false);
   }
 
   /**
-   * Returns the IP address.
+   * Tries to resolve and returns the IP address.
    *
    * @param resolve whether to force resolve the hostname
    * @return the IP address
    */
-  public InetAddress address(final boolean resolve) {
+  public InetAddress tryResolveAddress(final boolean resolve) {
     if (resolve || socketAddress.isUnresolved()) {
-      // the constructor will by default attempt to resolve the host, and will fallback to the an
+      // the constructor will by default attempt to resolve the host, and will fall back to the
       // unresolved address if it couldn't
       socketAddress = new InetSocketAddress(host, port);
       return socketAddress.getAddress();
@@ -150,24 +147,31 @@ public final class Address {
     return socketAddress.getAddress();
   }
 
+  /**
+   * Returns the IP address or null if it is unresolved.
+   *
+   * @return the IP address
+   */
+  public InetAddress getAddress() {
+    return socketAddress.getAddress();
+  }
+
+  /**
+   * Returns the socket address.
+   *
+   * @return the socket address
+   */
   public InetSocketAddress socketAddress() {
     return socketAddress;
   }
 
   /**
-   * Returns the address type.
+   * Returns the resolved socket address.
    *
-   * @return the address type
+   * @return the resolved socket address
    */
-  public Type type() {
-    if (type == null) {
-      synchronized (this) {
-        if (type == null) {
-          type = address() instanceof Inet6Address ? Type.IPV6 : Type.IPV4;
-        }
-      }
-    }
-    return type;
+  public InetSocketAddress getResolvedSocketAddress() {
+    return socketAddress;
   }
 
   @Override

--- a/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -127,17 +127,7 @@ public final class Address {
    * @return the IP address
    */
   public InetAddress tryResolveAddress() {
-    return tryResolveAddress(false);
-  }
-
-  /**
-   * Tries to resolve and returns the IP address.
-   *
-   * @param resolve whether to force resolve the hostname
-   * @return the IP address
-   */
-  public InetAddress tryResolveAddress(final boolean resolve) {
-    if (resolve || socketAddress.isUnresolved()) {
+    if (socketAddress.isUnresolved()) {
       // the constructor will by default attempt to resolve the host, and will fall back to the
       // unresolved address if it couldn't
       socketAddress = new InetSocketAddress(host, port);
@@ -162,15 +152,6 @@ public final class Address {
    * @return the socket address
    */
   public InetSocketAddress socketAddress() {
-    return socketAddress;
-  }
-
-  /**
-   * Returns the resolved socket address.
-   *
-   * @return the resolved socket address
-   */
-  public InetSocketAddress getResolvedSocketAddress() {
     return socketAddress;
   }
 

--- a/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
+++ b/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
@@ -28,7 +28,7 @@ public class AddressTest {
     final Address address = Address.from("127.0.0.1:5000");
     assertEquals("127.0.0.1", address.host());
     assertEquals(5000, address.port());
-    assertEquals("localhost", address.address().getHostName());
+    assertEquals("localhost", address.tryResolveAddress().getHostName());
     assertEquals("127.0.0.1:5000", address.toString());
   }
 
@@ -37,7 +37,7 @@ public class AddressTest {
     final Address address = Address.from("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000");
     assertEquals("fe80:cd00:0000:0cde:1257:0000:211e:729c", address.host());
     assertEquals(5000, address.port());
-    assertEquals("fe80:cd00:0:cde:1257:0:211e:729c", address.address().getHostName());
+    assertEquals("fe80:cd00:0:cde:1257:0:211e:729c", address.tryResolveAddress().getHostName());
     assertEquals("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000", address.toString());
   }
 
@@ -45,7 +45,8 @@ public class AddressTest {
   public void testResolveAddress() throws Exception {
     final Address address = Address.from("localhost", 5000);
     assertEquals(
-        InetAddress.getLoopbackAddress().getHostAddress(), address.address().getHostAddress());
+        InetAddress.getLoopbackAddress().getHostAddress(),
+        address.tryResolveAddress().getHostAddress());
     assertEquals(5000, address.port());
   }
 }


### PR DESCRIPTION
## Description

The member's address resolution was being performed synchronously which could lead to the thread waiting a long time until the address gets resolved.

This is a problem for our NettyMessagingService and SWIM implementation in particular because it forces DNS resolution on every probe and runs single-threaded.

This PR only addresses NettyMessagingService and uses the DNSNameResolver address resolution which is performed asynchronously and therefore non-blocking.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
