### PR TITLE
Set default stream timeout and enable stream as default in benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ on:
         default: europe-west1-b
         required: false
       benchmark-load:
-        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitary helm arguments, like --set starter.rate=100'
+        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
       publish:
         description: 'Where to publish the results, can be "slack" or "comment"'
@@ -58,7 +58,7 @@ on:
         type: string
         required: false
       benchmark-load:
-        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitary helm arguments, like --set starter.rate=100'
+        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitrary helm arguments, like --set starter.rate=100'
         type: string
         required: false
       measure:

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -40,6 +40,7 @@ public class Worker extends App {
     final WorkerCfg workerCfg = appCfg.getWorker();
     final String jobType = workerCfg.getJobType();
     final long completionDelay = workerCfg.getCompletionDelay().toMillis();
+    final boolean isStreamEnabled = workerCfg.isStreamEnabled();
     final var variables = readVariables(workerCfg.getPayloadPath());
     final BlockingQueue<Future<?>> requestFutures = new ArrayBlockingQueue<>(10_000);
     final BlockingDeque<DelayedCommand> delayedCommands = new LinkedBlockingDeque<>(10_000);
@@ -67,6 +68,7 @@ public class Worker extends App {
                     requestFutures.add(command.send());
                   }
                 })
+            .streamEnabled(isStreamEnabled)
             .open();
 
     final ResponseChecker responseChecker = new ResponseChecker(requestFutures);

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/config/WorkerCfg.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/config/WorkerCfg.java
@@ -21,21 +21,19 @@ public class WorkerCfg {
 
   private String jobType;
   private String workerName;
-
   private int threads;
-
   private int capacity;
   private Duration pollingDelay;
   private Duration completionDelay;
   private boolean completeJobsAsync;
-
   private String payloadPath;
+  private boolean isStreamEnabled;
 
   public String getJobType() {
     return jobType;
   }
 
-  public void setJobType(String jobType) {
+  public void setJobType(final String jobType) {
     this.jobType = jobType;
   }
 
@@ -43,7 +41,7 @@ public class WorkerCfg {
     return workerName;
   }
 
-  public void setWorkerName(String workerName) {
+  public void setWorkerName(final String workerName) {
     this.workerName = workerName;
   }
 
@@ -51,7 +49,7 @@ public class WorkerCfg {
     return threads;
   }
 
-  public void setThreads(int threads) {
+  public void setThreads(final int threads) {
     this.threads = threads;
   }
 
@@ -59,7 +57,7 @@ public class WorkerCfg {
     return capacity;
   }
 
-  public void setCapacity(int capacity) {
+  public void setCapacity(final int capacity) {
     this.capacity = capacity;
   }
 
@@ -67,7 +65,7 @@ public class WorkerCfg {
     return pollingDelay;
   }
 
-  public void setPollingDelay(Duration pollingDelay) {
+  public void setPollingDelay(final Duration pollingDelay) {
     this.pollingDelay = pollingDelay;
   }
 
@@ -75,7 +73,7 @@ public class WorkerCfg {
     return completionDelay;
   }
 
-  public void setCompletionDelay(Duration completionDelay) {
+  public void setCompletionDelay(final Duration completionDelay) {
     this.completionDelay = completionDelay;
   }
 
@@ -83,7 +81,7 @@ public class WorkerCfg {
     return payloadPath;
   }
 
-  public void setPayloadPath(String payloadPath) {
+  public void setPayloadPath(final String payloadPath) {
     this.payloadPath = payloadPath;
   }
 
@@ -91,7 +89,15 @@ public class WorkerCfg {
     return completeJobsAsync;
   }
 
-  public void setCompleteJobsAsync(boolean completeJobsAsync) {
+  public void setCompleteJobsAsync(final boolean completeJobsAsync) {
     this.completeJobsAsync = completeJobsAsync;
+  }
+
+  public boolean isStreamEnabled() {
+    return isStreamEnabled;
+  }
+
+  public void setStreamEnabled(final boolean isStreamEnabled) {
+    this.isStreamEnabled = isStreamEnabled;
   }
 }

--- a/benchmarks/project/src/main/resources/application.conf
+++ b/benchmarks/project/src/main/resources/application.conf
@@ -26,5 +26,6 @@ app {
     completionDelay = 300ms
     completeJobsAsync = false
     payloadPath = "bpmn/big_payload.json"
+    streamEnabled = true
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorker.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorker.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.worker;
 
 /**
- * Represents an active job worker that perfors jobs of a certain type. While a registration is
+ * Represents an active job worker that performs jobs of a certain type. While a registration is
  * open, the client continuously receives jobs from the broker and hands them to a registered {@link
  * JobHandler}.
  */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
@@ -197,10 +197,10 @@ public interface JobWorkerBuilderStep1 {
     JobWorkerBuilderStep3 backoffSupplier(BackoffSupplier backoffSupplier);
 
     /**
-     * Opt-in feature flag to enable job streaming. If called, the job worker will use a mix of
-     * streaming and polling to activate jobs. A long living stream will be opened onto which jobs
-     * will be eagerly pushed, and the polling mechanism will be used strictly to fetch jobs created
-     * <em>before</em> any streams were opened.
+     * Opt-in feature flag to enable job streaming. If set as enabled, the job worker will use a mix
+     * of streaming and polling to activate jobs. A long living stream will be opened onto which
+     * jobs will be eagerly pushed, and the polling mechanism will be used strictly to fetch jobs
+     * created <em>before</em> any streams were opened.
      *
      * <p>If the stream is closed, e.g. the server closed the connection, was restarted, etc., it
      * will be immediately recreated as long as the worker is opened.
@@ -211,21 +211,7 @@ public interface JobWorkerBuilderStep1 {
      * @return the builder for this worker
      */
     @ExperimentalApi("https://github.com/camunda/zeebe/issues/11231")
-    JobWorkerBuilderStep3 enableStreaming();
-
-    /**
-     * Opt-in feature flag to disable job streaming.
-     *
-     * <p>If the stream is closed, e.g. the server closed the connection, was restarted, etc., it
-     * will be immediately recreated as long as the worker is opened.
-     *
-     * <p>NOTE: Job streaming is still under active development, and should be disabled if you
-     * notice any issues.
-     *
-     * @return the builder for this worker
-     */
-    @ExperimentalApi("https://github.com/camunda/zeebe/issues/11231")
-    JobWorkerBuilderStep3 disableStreaming();
+    JobWorkerBuilderStep3 streamEnabled(boolean isStreamEnabled);
 
     /**
      * If streaming is enabled, sets a maximum lifetime for a given stream. Once this timeout is

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
@@ -214,6 +214,20 @@ public interface JobWorkerBuilderStep1 {
     JobWorkerBuilderStep3 enableStreaming();
 
     /**
+     * Opt-in feature flag to disable job streaming.
+     *
+     * <p>If the stream is closed, e.g. the server closed the connection, was restarted, etc., it
+     * will be immediately recreated as long as the worker is opened.
+     *
+     * <p>NOTE: Job streaming is still under active development, and should be disabled if you
+     * notice any issues.
+     *
+     * @return the builder for this worker
+     */
+    @ExperimentalApi("https://github.com/camunda/zeebe/issues/11231")
+    JobWorkerBuilderStep3 disableStreaming();
+
+    /**
      * If streaming is enabled, sets a maximum lifetime for a given stream. Once this timeout is
      * reached, the stream is closed, such that no more jobs are activated and received. If the
      * worker is still open, then it will immediately open a new stream.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -140,14 +140,8 @@ public final class JobWorkerBuilderImpl
   }
 
   @Override
-  public JobWorkerBuilderStep3 enableStreaming() {
-    enableStreaming = true;
-    return this;
-  }
-
-  @Override
-  public JobWorkerBuilderStep3 disableStreaming() {
-    enableStreaming = false;
+  public JobWorkerBuilderStep3 streamEnabled(final boolean isStreamEnabled) {
+    enableStreaming = isStreamEnabled;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -40,6 +40,7 @@ public final class JobWorkerBuilderImpl
 
   public static final BackoffSupplier DEFAULT_BACKOFF_SUPPLIER =
       BackoffSupplier.newBackoffBuilder().build();
+  public static final Duration DEFAULT_STREAMING_TIMEOUT = Duration.ofHours(8);
   private final JobClient jobClient;
   private final ScheduledExecutorService executorService;
   private final List<Closeable> closeables;
@@ -71,6 +72,7 @@ public final class JobWorkerBuilderImpl
     pollInterval = configuration.getDefaultJobPollInterval();
     requestTimeout = configuration.getDefaultRequestTimeout();
     backoffSupplier = DEFAULT_BACKOFF_SUPPLIER;
+    streamingTimeout = DEFAULT_STREAMING_TIMEOUT;
   }
 
   @Override
@@ -140,6 +142,12 @@ public final class JobWorkerBuilderImpl
   @Override
   public JobWorkerBuilderStep3 enableStreaming() {
     enableStreaming = true;
+    return this;
+  }
+
+  @Override
+  public JobWorkerBuilderStep3 disableStreaming() {
+    enableStreaming = false;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -150,4 +150,26 @@ class JobWorkerBuilderImplTest {
     // then
     verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(5));
   }
+
+  @Test
+  void shouldTimeoutStreamAfterEightHours() {
+    // given
+    final StreamJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
+    Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
+        .thenReturn(lastStep);
+    Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
+
+    // when
+    jobWorkerBuilder
+        .jobType("type")
+        .handler((c, j) -> {})
+        .timeout(1)
+        .name("test")
+        .maxJobsActive(30)
+        .enableStreaming()
+        .open();
+
+    // then
+    verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(8));
+  }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -121,7 +121,7 @@ class JobWorkerBuilderImplTest {
             .maxJobsActive(30);
 
     // when
-    builder.enableStreaming().open();
+    builder.streamEnabled(true).open();
 
     // then
     verify(jobClient, atLeast(1)).newStreamJobsCommand();
@@ -144,7 +144,7 @@ class JobWorkerBuilderImplTest {
         .timeout(1)
         .name("test")
         .maxJobsActive(30)
-        .enableStreaming()
+        .streamEnabled(true)
         .open();
 
     // then
@@ -166,7 +166,7 @@ class JobWorkerBuilderImplTest {
         .timeout(1)
         .name("test")
         .maxJobsActive(30)
-        .enableStreaming()
+        .streamEnabled(true)
         .open();
 
     // then

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java
@@ -125,7 +125,7 @@ public final class JobWorkerImplTest {
   public void shouldOpenStreamIfOptedIn() {
     // given
     final JobWorkerBuilderStep3 builder =
-        client.newWorker().jobType("test").handler(NOOP_JOB_HANDLER).enableStreaming();
+        client.newWorker().jobType("test").handler(NOOP_JOB_HANDLER).streamEnabled(true);
 
     // when
     try (final JobWorker ignored = builder.open()) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/JobWorkerTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/JobWorkerTest.java
@@ -162,7 +162,7 @@ final class JobWorkerTest {
     // when - create a worker that streams, and create a new job after the stream is registered
     final var jobHandler = new RecordingJobHandler();
     final var builder =
-        client.getClient().newWorker().jobType(jobType).handler(jobHandler).enableStreaming();
+        client.getClient().newWorker().jobType(jobType).handler(jobHandler).streamEnabled(true);
     try (final var ignored = builder.open()) {
       awaitStreamRegistered(jobType);
       client.createSingleJob(jobType, b -> {});
@@ -178,7 +178,7 @@ final class JobWorkerTest {
     // given
     final var jobHandler = new RecordingJobHandler();
     final var builder =
-        client.getClient().newWorker().jobType(jobType).handler(jobHandler).enableStreaming();
+        client.getClient().newWorker().jobType(jobType).handler(jobHandler).streamEnabled(true);
 
     // when
     try (final var ignored = builder.open()) {
@@ -209,7 +209,7 @@ final class JobWorkerTest {
 
   private static JobWorker prepareStreamingWorker(
       final String jobType, final JobWorkerBuilderStep3 builder) {
-    final var worker = builder.enableStreaming().open();
+    final var worker = builder.streamEnabled(true).open();
     awaitStreamRegistered(jobType);
     return worker;
   }


### PR DESCRIPTION
## Description

This PR enables streaming as default in all benchmarks (can be changed in application.conf) and sets the default stream timeout as 8 hours.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #13914

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
