### PR TITLE
Resolve flaky `ResourceDeletionMultiPartitionTest`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -195,14 +195,15 @@ public final class DeploymentCreateProcessor
         .forEach(
             decisionRequirementsRecord ->
                 stateWriter.appendFollowUpEvent(
-                    command.getKey(),
+                    decisionRequirementsRecord.getDecisionRequirementsKey(),
                     DecisionRequirementsIntent.CREATED,
                     decisionRequirementsRecord));
     deploymentEvent.decisionsMetadata().stream()
         .filter(not(DecisionRecord::isDuplicate))
         .forEach(
             (record) ->
-                stateWriter.appendFollowUpEvent(command.getKey(), DecisionIntent.CREATED, record));
+                stateWriter.appendFollowUpEvent(
+                    record.getDecisionKey(), DecisionIntent.CREATED, record));
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -164,7 +164,7 @@ public final class DeploymentCreateProcessor
   private void processDistributedRecord(final TypedRecord<DeploymentRecord> command) {
     final var deploymentEvent = command.getValue();
     createBpmnResources(deploymentEvent);
-    createDmnResources(command, deploymentEvent);
+    createDmnResources(deploymentEvent);
     final var recordWithoutResource = createDeploymentWithoutResources(deploymentEvent);
     stateWriter.appendFollowUpEvent(
         command.getKey(), DeploymentIntent.CREATED, recordWithoutResource);
@@ -187,8 +187,7 @@ public final class DeploymentCreateProcessor
             });
   }
 
-  private void createDmnResources(
-      final TypedRecord<DeploymentRecord> command, final DeploymentRecord deploymentEvent) {
+  private void createDmnResources(final DeploymentRecord deploymentEvent) {
     deploymentEvent.decisionRequirementsMetadata().stream()
         .filter(not(DecisionRequirementsMetadataRecord::isDuplicate))
         .map(drg -> createDrgRecord(deploymentEvent, drg))


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Please find the explanation [here](https://github.com/camunda/zeebe/issues/13980#issuecomment-1689451937).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13980 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
