### PR TITLE
Improve cluster topology initialization

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -86,7 +86,9 @@ final class ClusterTopologyManager {
                 startFuture.completeExceptionally(new IllegalStateException(errorMessage));
               } else {
                 try {
-                  persistedClusterTopology.update(topology);
+                  // merge in case there was a concurrent update via gossip
+                  persistedClusterTopology.update(
+                      topology.merge(persistedClusterTopology.getTopology()));
                   topologyGossiper.accept(persistedClusterTopology.getTopology());
                   setStarted();
                 } catch (final IOException e) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -75,18 +75,23 @@ final class ClusterTopologyManager {
     topologyInitializer
         .initialize()
         .onComplete(
-            (initialized, error) -> {
+            (topology, error) -> {
               if (error != null) {
                 LOG.error("Failed to initialize topology", error);
                 startFuture.completeExceptionally(error);
-              } else if (!initialized) {
+              } else if (topology.isUninitialized()) {
                 final String errorMessage =
-                    "Expected to initialize topology, but initializer return false";
+                    "Expected to initialize topology, but got uninitialized topology";
                 LOG.error(errorMessage);
                 startFuture.completeExceptionally(new IllegalStateException(errorMessage));
               } else {
-                topologyGossiper.accept(persistedClusterTopology.getTopology());
-                setStarted();
+                try {
+                  persistedClusterTopology.update(topology);
+                  topologyGossiper.accept(persistedClusterTopology.getTopology());
+                  setStarted();
+                } catch (final IOException e) {
+                  startFuture.completeExceptionally("Failed to start update cluster topology", e);
+                }
               }
             });
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -20,20 +20,9 @@ final class PersistedClusterTopology {
   private final ClusterTopologySerializer serializer;
   private ClusterTopology clusterTopology = ClusterTopology.uninitialized();
 
-  private Listener topologyUpdateListener;
-
   PersistedClusterTopology(final Path topologyFile, final ClusterTopologySerializer serializer) {
     this.topologyFile = topologyFile;
     this.serializer = serializer;
-  }
-
-  void tryInitialize() throws IOException {
-    if (Files.exists(topologyFile)) {
-      final var serializedTopology = Files.readAllBytes(topologyFile);
-      if (serializedTopology.length > 0) {
-        clusterTopology = serializer.decodeClusterTopology(serializedTopology);
-      }
-    }
   }
 
   ClusterTopology getTopology() {
@@ -54,27 +43,9 @@ final class PersistedClusterTopology {
         StandardOpenOption.DSYNC);
 
     this.clusterTopology = clusterTopology;
-    if (topologyUpdateListener != null) {
-      topologyUpdateListener.onTopologyUpdated(clusterTopology);
-    }
   }
 
   public boolean isUninitialized() {
     return clusterTopology.isUninitialized();
-  }
-
-  public void addUpdateListener(final Listener updateListener) {
-    topologyUpdateListener = updateListener;
-  }
-
-  public void removeUpdateListener(final Listener updateListener) {
-    if (topologyUpdateListener == updateListener) {
-      topologyUpdateListener = null;
-    }
-  }
-
-  @FunctionalInterface
-  interface Listener {
-    void onTopologyUpdated(ClusterTopology clusterTopology);
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyUpdateNotifier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyUpdateNotifier.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import io.camunda.zeebe.topology.state.ClusterTopology;
+
+public interface TopologyUpdateNotifier {
+
+  /**
+   * Register topology update listener which is notified when Topology is changed. The listener is
+   * immediately invoked if the current topology is not null.
+   *
+   * @param listener which is notified
+   */
+  void addUpdateListener(TopologyUpdateListener listener);
+
+  /**
+   * Removed the registered listener
+   *
+   * @param listener to be removed
+   */
+  void removeUpdateListener(TopologyUpdateListener listener);
+
+  @FunctionalInterface
+  interface TopologyUpdateListener {
+    void onTopologyUpdated(ClusterTopology clusterTopology);
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -48,7 +48,7 @@ final class ClusterTopologyManagerTest {
         } catch (IOException e) {
           return CompletableActorFuture.completedExceptionally(e);
         }
-        return CompletableActorFuture.completed(true);
+        return CompletableActorFuture.completed(initialTopology);
       };
 
   @BeforeEach
@@ -107,7 +107,8 @@ final class ClusterTopologyManagerTest {
   @Test
   void shouldFailToStartIfTopologyIsNotInitialized() {
     // given
-    final TopologyInitializer failingInitializer = () -> CompletableActorFuture.completed(false);
+    final TopologyInitializer failingInitializer =
+        () -> CompletableActorFuture.completed(ClusterTopology.uninitialized());
     final var startFuture = startTopologyManager(failingInitializer);
 
     // when - then

--- a/topology/src/test/java/io/camunda/zeebe/topology/TopologyInitializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/TopologyInitializerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.topology;
 
+import static io.camunda.zeebe.topology.ClusterTopologyAssert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -66,7 +67,7 @@ final class TopologyInitializerTest {
     final var initializeFuture = fileInitializer.initialize();
 
     // then
-    assertThat(initializeFuture.join()).isTrue();
+    assertThatClusterTopology(initializeFuture.join()).isInitialized();
   }
 
   @Test
@@ -78,7 +79,7 @@ final class TopologyInitializerTest {
     final var initializeFuture = fileInitializer.initialize();
 
     // then
-    assertThat(initializeFuture.join()).isFalse();
+    assertThatClusterTopology(initializeFuture.join()).isUninitialized();
   }
 
   @Test
@@ -106,7 +107,7 @@ final class TopologyInitializerTest {
     final var initializeFuture = initializer.initialize();
 
     // then
-    assertThat(initializeFuture.join()).isTrue();
+    assertThatClusterTopology(initializeFuture.join()).isInitialized();
     assertThat(persistedClusterTopology.getTopology())
         .describedAs("should update persisted topology after initialization")
         .isEqualTo(initialClusterTopology);
@@ -125,7 +126,7 @@ final class TopologyInitializerTest {
     persistedClusterTopology.update(initialClusterTopology);
 
     // then
-    assertThat(initializeFuture.join()).isTrue();
+    assertThatClusterTopology(initializeFuture.join()).isInitialized();
   }
 
   @Test
@@ -147,7 +148,7 @@ final class TopologyInitializerTest {
     persistedClusterTopology.update(initialClusterTopology);
 
     // then
-    assertThat(initializeFuture.join()).isTrue();
+    assertThatClusterTopology(initializeFuture.join()).isInitialized();
     assertThat(persistedClusterTopology.getTopology())
         .describedAs("should update persisted topology after initialization")
         .isEqualTo(initialClusterTopology);
@@ -172,7 +173,7 @@ final class TopologyInitializerTest {
     persistedClusterTopology.update(initialClusterTopology);
 
     // then
-    assertThat(initializeFuture.join()).isFalse();
+    assertThatClusterTopology(initializeFuture.join()).isUninitialized();
   }
 
   private TopologyInitializer getStaticInitializer() {
@@ -198,7 +199,7 @@ final class TopologyInitializerTest {
       final var initializeFuture = fileInitializer.initialize();
 
       // then
-      assertThat(initializeFuture.join()).isTrue();
+      assertThatClusterTopology(initializeFuture.join()).isInitialized();
     }
 
     @Test
@@ -220,7 +221,7 @@ final class TopologyInitializerTest {
       persistedClusterTopology.update(initialClusterTopology);
 
       // then
-      assertThat(initializeFuture.join()).isTrue();
+      assertThatClusterTopology(initializeFuture.join()).isInitialized();
     }
 
     @Test
@@ -245,7 +246,7 @@ final class TopologyInitializerTest {
       persistedClusterTopology.update(initialClusterTopology);
 
       // then
-      assertThat(initializeFuture.join()).isTrue();
+      assertThatClusterTopology(initializeFuture.join()).isInitialized();
     }
 
     @Test
@@ -269,7 +270,7 @@ final class TopologyInitializerTest {
       syncResponseFuture.complete(initialClusterTopology);
 
       // then
-      assertThat(initializeFuture.join()).isTrue();
+      assertThatClusterTopology(initializeFuture.join()).isInitialized();
     }
 
     @Test
@@ -296,7 +297,7 @@ final class TopologyInitializerTest {
       syncResponseFuture.complete(ClusterTopology.uninitialized());
 
       // then
-      assertThat(initializeFuture.join()).isTrue();
+      assertThatClusterTopology(initializeFuture.join()).isInitialized();
     }
   }
 }


### PR DESCRIPTION
## Description

Follow up #13960 
 
- Refactor `TopologyInitializer`s to not directly update `PersistedClusterTopology`
- Speedup initialization by reacting to member added events

## Related issues

related to #13941

