### PR TITLE
Add auth data interchange API

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -25,6 +25,21 @@
   <dependencies>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/auth/src/main/java/io/camunda/zeebe/auth/api/AuthorizationDecoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/api/AuthorizationDecoder.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.auth.api;
+
+public interface AuthorizationDecoder<T> {
+
+  /** Returns an instance of <T> containing the user's authorizations. */
+  T getAuthorizations();
+}

--- a/auth/src/main/java/io/camunda/zeebe/auth/api/AuthorizationDecoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/api/AuthorizationDecoder.java
@@ -10,5 +10,5 @@ package io.camunda.zeebe.auth.api;
 public interface AuthorizationDecoder<T> {
 
   /** Returns an instance of <T> containing the user's authorizations. */
-  T getAuthorizations();
+  T decode();
 }

--- a/auth/src/main/java/io/camunda/zeebe/auth/api/AuthorizationEncoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/api/AuthorizationEncoder.java
@@ -10,5 +10,5 @@ package io.camunda.zeebe.auth.api;
 public interface AuthorizationEncoder {
 
   /** Returns a user's authorizations encoded in a String. */
-  String getEncodedString();
+  String encode();
 }

--- a/auth/src/main/java/io/camunda/zeebe/auth/api/AuthorizationEncoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/api/AuthorizationEncoder.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.auth.api;
+
+public interface AuthorizationEncoder {
+
+  /** Returns a user's authorizations encoded in a String. */
+  String getEncodedString();
+}

--- a/auth/src/main/java/io/camunda/zeebe/auth/api/JwtAuthorizationBuilder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/api/JwtAuthorizationBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.auth.api;
+
+/**
+ * A builder interface for implementing token authorization builders.
+ *
+ * @param <T> - The implementation class for the builder
+ * @param <A> - The algorithm class that will be used for signing or validating the token.
+ * @param <U> - The output of the builder
+ */
+public interface JwtAuthorizationBuilder<T extends JwtAuthorizationBuilder<T, A, U>, A, U> {
+
+  public static final String AUTHORIZED_TENANTS_CLAIM = "authorized_tenants";
+
+  /**
+   * Sets the token subject.
+   *
+   * @param subject - the subject String
+   * @return the builder instance
+   */
+  T withSubject(String subject);
+
+  /**
+   * Sets the token issuer.
+   *
+   * @param issuer - the issuer String
+   * @return the builder instance
+   */
+  T withIssuer(String issuer);
+
+  /**
+   * Sets the token audience.
+   *
+   * @param audience - the audience String
+   * @return the builder instance
+   */
+  T withAudience(String audience);
+
+  /**
+   * Sets the signing algorithm for the token. The algorithm may depend on the token library.
+   *
+   * @param signingAlgorithm - the signing algorithm instance
+   * @return the builder instance
+   */
+  T withSigningAlgorithm(A signingAlgorithm);
+
+  U build();
+}

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/Authorization.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/Authorization.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.auth.impl;
+
+public class Authorization {
+
+  public static JwtAuthorizationEncoder encodeWithJwt() {
+    return new JwtAuthorizationEncoder();
+  }
+
+  public static JwtAuthorizationDecoder decodeWithJwt() {
+    return new JwtAuthorizationDecoder();
+  }
+}

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/Authorization.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/Authorization.java
@@ -9,11 +9,11 @@ package io.camunda.zeebe.auth.impl;
 
 public class Authorization {
 
-  public static JwtAuthorizationEncoder encodeWithJwt() {
+  public static JwtAuthorizationEncoder jwtEncoder() {
     return new JwtAuthorizationEncoder();
   }
 
-  public static JwtAuthorizationDecoder decodeWithJwt() {
-    return new JwtAuthorizationDecoder();
+  public static JwtAuthorizationDecoder jwtDecoder(final String jwtToken) {
+    return new JwtAuthorizationDecoder(jwtToken);
   }
 }

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.auth.impl;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.Verification;
+import io.camunda.zeebe.auth.api.AuthorizationDecoder;
+import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
+import io.camunda.zeebe.util.EnsureUtil;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JwtAuthorizationDecoder
+    implements JwtAuthorizationBuilder<JwtAuthorizationDecoder, Algorithm, DecodedJWT>,
+        AuthorizationDecoder<Map<String, Claim>> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthorizationDecoder.class);
+
+  private String issuer = "zeebe-gateway";
+  private String audience = "zeebe-broker";
+  private String subject = "Authorization";
+  private Algorithm signingAlgorithm = Algorithm.none();
+  private final Set<String> claims = new HashSet<>();
+  private String jwtToken;
+
+  public JwtAuthorizationDecoder() {}
+
+  @Override
+  public JwtAuthorizationDecoder withSubject(final String subject) {
+    this.subject = subject;
+    return this;
+  }
+
+  @Override
+  public JwtAuthorizationDecoder withIssuer(final String issuer) {
+    this.issuer = issuer;
+    return this;
+  }
+
+  @Override
+  public JwtAuthorizationDecoder withAudience(final String audience) {
+    this.audience = audience;
+    return this;
+  }
+
+  @Override
+  public JwtAuthorizationDecoder withSigningAlgorithm(final Algorithm signingAlgorithm) {
+    this.signingAlgorithm = signingAlgorithm;
+    return this;
+  }
+
+  /**
+   * Validates the signature and decodes a provided JWT token. It is also possible to pass the names
+   * of the claims that are expected to be contained in the token.
+   *
+   * @return a decoded JWT token
+   */
+  @Override
+  public DecodedJWT build() {
+    final Verification verificationBuilder =
+        JWT.require(signingAlgorithm)
+            .withIssuer(issuer)
+            .withAudience(audience)
+            .withSubject(subject);
+
+    for (final String claim : claims) {
+      verificationBuilder.withClaimPresence(claim);
+    }
+    final JWTVerifier jwtVerification = verificationBuilder.build();
+
+    try {
+      EnsureUtil.ensureNotNullOrEmpty("JWT token", jwtToken);
+      return jwtVerification.verify(jwtToken);
+    } catch (final JWTVerificationException | NullPointerException ex) {
+      LOGGER.error("Authorization data unavailable: {}", ex.getMessage());
+      throw new UnrecoverableException("Authorization data unavailable: " + ex.getMessage(), ex);
+    }
+  }
+
+  @Override
+  public Map<String, Claim> getAuthorizations() {
+    return build().getClaims();
+  }
+
+  /**
+   * Sets the name of a JWT token claim expected to be part of the token. This method can be called
+   * multiple times. The token will be validated agains all the added claims.
+   *
+   * @param claimName - the name of the claim
+   * @return the builder instance
+   */
+  public JwtAuthorizationDecoder withClaim(final String claimName) {
+    claims.add(claimName);
+    return this;
+  }
+
+  /**
+   * Sets the JWT token String that should be validated and decoded.
+   *
+   * @param token - the JWT token String
+   * @return the builder instance
+   */
+  public JwtAuthorizationDecoder withJwtToken(final String token) {
+    jwtToken = token;
+    return this;
+  }
+}

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
@@ -16,7 +16,6 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
 import io.camunda.zeebe.auth.api.AuthorizationDecoder;
 import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
-import io.camunda.zeebe.util.EnsureUtil;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import java.util.HashSet;
 import java.util.Map;
@@ -38,6 +37,10 @@ public class JwtAuthorizationDecoder
   private String jwtToken;
 
   public JwtAuthorizationDecoder() {}
+
+  public JwtAuthorizationDecoder(final String jwtToken) {
+    this.jwtToken = jwtToken;
+  }
 
   @Override
   public JwtAuthorizationDecoder withSubject(final String subject) {
@@ -83,7 +86,6 @@ public class JwtAuthorizationDecoder
     final JWTVerifier jwtVerification = verificationBuilder.build();
 
     try {
-      EnsureUtil.ensureNotNullOrEmpty("JWT token", jwtToken);
       return jwtVerification.verify(jwtToken);
     } catch (final JWTVerificationException | NullPointerException ex) {
       LOGGER.error("Authorization data unavailable: {}", ex.getMessage());
@@ -92,7 +94,7 @@ public class JwtAuthorizationDecoder
   }
 
   @Override
-  public Map<String, Claim> getAuthorizations() {
+  public Map<String, Claim> decode() {
     return build().getClaims();
   }
 

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationEncoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationEncoder.java
@@ -79,7 +79,7 @@ public class JwtAuthorizationEncoder
   }
 
   @Override
-  public String getEncodedString() {
+  public String encode() {
     return build();
   }
 }

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationEncoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationEncoder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.auth.impl;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTCreationException;
+import io.camunda.zeebe.auth.api.AuthorizationEncoder;
+import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JwtAuthorizationEncoder
+    implements JwtAuthorizationBuilder<JwtAuthorizationEncoder, Algorithm, String>,
+        AuthorizationEncoder {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthorizationEncoder.class);
+  private String issuer = "zeebe-gateway";
+  private String audience = "zeebe-broker";
+  private String subject = "Authorization";
+  private Algorithm signingAlgorithm = Algorithm.none();
+  private final Map<String, Object> claims = new HashMap<>();
+
+  public JwtAuthorizationEncoder() {}
+
+  @Override
+  public JwtAuthorizationEncoder withSubject(final String subject) {
+    this.subject = subject;
+    return this;
+  }
+
+  @Override
+  public JwtAuthorizationEncoder withIssuer(final String issuer) {
+    this.issuer = issuer;
+    return this;
+  }
+
+  @Override
+  public JwtAuthorizationEncoder withAudience(final String audience) {
+    this.audience = audience;
+    return this;
+  }
+
+  @Override
+  public JwtAuthorizationEncoder withSigningAlgorithm(final Algorithm signingAlgorithm) {
+    this.signingAlgorithm = signingAlgorithm;
+    return this;
+  }
+
+  @Override
+  public String build() {
+    try {
+      return JWT.create()
+          .withIssuer(issuer)
+          .withAudience(audience)
+          .withSubject(subject)
+          .withIssuedAt(Instant.now())
+          .withPayload(claims)
+          .sign(signingAlgorithm);
+    } catch (final IllegalArgumentException | JWTCreationException ex) {
+      LOGGER.error("Authorization data couldn't be encoded: {}", ex.getMessage());
+      throw new UnrecoverableException(
+          "Authorization data couldn't be encoded: " + ex.getMessage(), ex);
+    }
+  }
+
+  public JwtAuthorizationEncoder withClaim(final String claimName, final Object claimValue) {
+    claims.put(claimName, claimValue);
+    return this;
+  }
+
+  @Override
+  public String getEncodedString() {
+    return build();
+  }
+}

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/TenantAuthorizationCheckerImpl.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/TenantAuthorizationCheckerImpl.java
@@ -30,10 +30,7 @@ public class TenantAuthorizationCheckerImpl implements TenantAuthorizationChecke
 
   public static TenantAuthorizationChecker fromJwtDecoder(final JwtAuthorizationDecoder decoder) {
     final List<String> authorizedTenants =
-        decoder
-            .getAuthorizations()
-            .get(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM)
-            .asList(String.class);
+        decoder.decode().get(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM).asList(String.class);
     return new TenantAuthorizationCheckerImpl(authorizedTenants);
   }
 }

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/TenantAuthorizationCheckerImpl.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/TenantAuthorizationCheckerImpl.java
@@ -27,4 +27,13 @@ public class TenantAuthorizationCheckerImpl implements TenantAuthorizationChecke
   public Boolean isFullyAuthorized(final List<String> tenantIds) {
     return authorizedTenants.containsAll(tenantIds);
   }
+
+  public static TenantAuthorizationChecker fromJwtDecoder(final JwtAuthorizationDecoder decoder) {
+    final List<String> authorizedTenants =
+        decoder
+            .getAuthorizations()
+            .get(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM)
+            .asList(String.class);
+    return new TenantAuthorizationCheckerImpl(authorizedTenants);
+  }
 }

--- a/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
+++ b/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.auth.impl.JwtAuthorizationEncoder;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JwtAuthorizationTest {
 

--- a/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
+++ b/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Claim;
+import io.camunda.zeebe.auth.api.AuthorizationEncoder;
+import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.auth.impl.JwtAuthorizationDecoder;
+import io.camunda.zeebe.auth.impl.JwtAuthorizationEncoder;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class JwtAuthorizationTest {
+
+  private final String defaultIssuer = "zeebe-gateway";
+  private final String defaultAudience = "zeebe-broker";
+  private final String defaultSubject = "Authorization";
+
+  @Test
+  public void shouldEncodeJwtTokenWithDefaultClaims() {
+    // when
+    final AuthorizationEncoder encoder = Authorization.encodeWithJwt();
+    final String jwtToken = encoder.getEncodedString();
+
+    // then
+    final Map<String, Claim> claims = JWT.decode(jwtToken).getClaims();
+    assertDefaultClaims(claims);
+  }
+
+  @Test
+  public void shouldEncodeJwtTokenWithAuthorizedTenants() {
+    // given
+    final List<String> authorizedTenants = List.of("tenant-1", "tenant-2", "tenant-3");
+
+    // when
+    final AuthorizationEncoder encoder =
+        Authorization.encodeWithJwt()
+            .withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM, authorizedTenants);
+    final String jwtToken = encoder.getEncodedString();
+
+    // then
+    final Map<String, Claim> claims = JWT.decode(jwtToken).getClaims();
+    // assert default claims are also present
+    assertDefaultClaims(claims);
+    // and authorized tenants claim is present
+    assertThat(claims).containsKey(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM);
+    final List<String> authorizedTenantClaim =
+        claims.get(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM).as(List.class);
+    assertThat(authorizedTenantClaim).containsExactlyElementsOf(authorizedTenants);
+  }
+
+  @Test
+  public void shouldValidateAndDecodeJwtTokenWithDefaultClaims() {
+    // given
+    final String jwtToken =
+        JWT.create()
+            .withIssuer(defaultIssuer)
+            .withAudience(defaultAudience)
+            .withSubject(defaultSubject)
+            .sign(Algorithm.none());
+
+    // when
+    final JwtAuthorizationDecoder decoder = Authorization.decodeWithJwt().withJwtToken(jwtToken);
+    final Map<String, Claim> claims = decoder.getAuthorizations();
+
+    // then
+    assertDefaultClaims(claims);
+  }
+
+  @Test
+  public void shouldValidateAndDecodeJwtTokenWithAuthorizedTenantsClaim() {
+    // given
+    final List<String> authorizedTenants = List.of("tenant-1", "tenant-2", "tenant-3");
+    final String jwtToken =
+        JWT.create()
+            .withIssuer(defaultIssuer)
+            .withAudience(defaultAudience)
+            .withSubject(defaultSubject)
+            .withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM, authorizedTenants)
+            .sign(Algorithm.none());
+
+    // when
+    final JwtAuthorizationDecoder decoder =
+        Authorization.decodeWithJwt()
+            .withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM)
+            .withJwtToken(jwtToken);
+    final Map<String, Claim> claims = decoder.getAuthorizations();
+
+    // then
+    assertDefaultClaims(claims);
+    final List<String> authorizedTenantClaim =
+        claims.get(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM).as(List.class);
+    assertThat(authorizedTenantClaim).containsExactlyElementsOf(authorizedTenants);
+  }
+
+  @Test
+  public void shouldFailJwtTokenValidationWithNoAuthorizedTenants() {
+    // given
+    final String jwtToken =
+        JWT.create()
+            .withIssuer(defaultIssuer)
+            .withAudience(defaultAudience)
+            .withSubject(defaultSubject)
+            .sign(Algorithm.none());
+
+    // when
+    final JwtAuthorizationDecoder decoder =
+        Authorization.decodeWithJwt()
+            .withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM)
+            .withJwtToken(jwtToken);
+
+    // then
+    assertThatThrownBy(() -> decoder.getAuthorizations())
+        .isInstanceOf(UnrecoverableException.class)
+        .hasMessage(
+            "Authorization data unavailable: The Claim 'authorized_tenants' is not present in the JWT.");
+  }
+
+  @Test
+  public void shouldFailJwtTokenDecodingWithoutJwtToken() {
+    // when
+    final JwtAuthorizationDecoder decoder =
+        Authorization.decodeWithJwt().withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM);
+
+    // then
+    assertThatThrownBy(() -> decoder.getAuthorizations())
+        .isInstanceOf(UnrecoverableException.class)
+        .hasMessage("Authorization data unavailable: JWT token");
+  }
+
+  private void assertDefaultClaims(final Map<String, Claim> claims) {
+    assertThat(claims).containsKey("iss");
+    assertThat(claims.get("iss").as(String.class)).isEqualTo(defaultIssuer);
+    assertThat(claims).containsKey("aud");
+    assertThat(claims.get("aud").as(String.class)).isEqualTo(defaultAudience);
+    assertThat(claims).containsKey("sub");
+    assertThat(claims.get("sub").as(String.class)).isEqualTo(defaultSubject);
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -127,6 +127,8 @@
     <version.jackson-annotations>2.15.2</version.jackson-annotations>
     <version.swagger-annotations>2.2.15</version.swagger-annotations>
     <version.checker-qual>3.37.0</version.checker-qual>
+    <!-- java-jwt version is aligned with the one in identity-sdk -->
+    <version.java-jwt>4.4.0</version.java-jwt>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.1.0</plugin.version.antrun>
@@ -1061,6 +1063,12 @@
         <groupId>io.github.acm19</groupId>
         <artifactId>aws-request-signing-apache-interceptor</artifactId>
         <version>2.3.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.auth0</groupId>
+        <artifactId>java-jwt</artifactId>
+        <version>${version.java-jwt}</version>
       </dependency>
 
       <!-- Dependencies present for convergence only -->


### PR DESCRIPTION
## Description

Implements an API for interchange of auth data. This will be used to encode the tenant access list from the Zeebe gateway to the broker.

:information_source: The PR is based on #13991 so any changes made there should be rebased here before it's merged with the `main` branch.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13988 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
