### PR TITLE
Add auth data to RecordMetadata

### DIFF
--- a/auth/src/main/java/io/camunda/zeebe/auth/api/JwtAuthorizationBuilder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/api/JwtAuthorizationBuilder.java
@@ -17,6 +17,9 @@ package io.camunda.zeebe.auth.api;
 public interface JwtAuthorizationBuilder<T extends JwtAuthorizationBuilder<T, A, U>, A, U> {
 
   public static final String AUTHORIZED_TENANTS_CLAIM = "authorized_tenants";
+  public static String DEFAULT_ISSUER = "zeebe-gateway";
+  public static String DEFAULT_AUDIENCE = "zeebe-broker";
+  public static String DEFAULT_SUBJECT = "zeebe-client";
 
   /**
    * Sets the token subject.

--- a/auth/src/main/java/io/camunda/zeebe/auth/api/JwtAuthorizationBuilder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/api/JwtAuthorizationBuilder.java
@@ -16,7 +16,6 @@ package io.camunda.zeebe.auth.api;
  */
 public interface JwtAuthorizationBuilder<T extends JwtAuthorizationBuilder<T, A, U>, A, U> {
 
-  public static final String AUTHORIZED_TENANTS_CLAIM = "authorized_tenants";
   public static String DEFAULT_ISSUER = "zeebe-gateway";
   public static String DEFAULT_AUDIENCE = "zeebe-broker";
   public static String DEFAULT_SUBJECT = "zeebe-client";

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/Authorization.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/Authorization.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.auth.impl;
 
 public class Authorization {
 
+  public static final String AUTHORIZED_TENANTS = "authorized_tenants";
+
   public static JwtAuthorizationEncoder jwtEncoder() {
     return new JwtAuthorizationEncoder();
   }

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
@@ -29,9 +29,9 @@ public class JwtAuthorizationDecoder
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthorizationDecoder.class);
 
-  private String issuer = "zeebe-gateway";
-  private String audience = "zeebe-broker";
-  private String subject = "Authorization";
+  private String issuer = DEFAULT_ISSUER;
+  private String audience = DEFAULT_AUDIENCE;
+  private String subject = DEFAULT_SUBJECT;
   private Algorithm signingAlgorithm = Algorithm.none();
   private final Set<String> claims = new HashSet<>();
   private String jwtToken;

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
@@ -11,7 +11,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.Verification;
 import io.camunda.zeebe.auth.api.AuthorizationDecoder;
@@ -25,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 public class JwtAuthorizationDecoder
     implements JwtAuthorizationBuilder<JwtAuthorizationDecoder, Algorithm, DecodedJWT>,
-        AuthorizationDecoder<Map<String, Claim>> {
+        AuthorizationDecoder<Map<String, Object>> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthorizationDecoder.class);
 
@@ -94,8 +93,11 @@ public class JwtAuthorizationDecoder
   }
 
   @Override
-  public Map<String, Claim> decode() {
-    return build().getClaims();
+  public Map<String, Object> decode() {
+    final DecodedJWT decodedJWT = withClaim(Authorization.AUTHORIZED_TENANTS).build();
+    return Map.of(
+        Authorization.AUTHORIZED_TENANTS,
+        decodedJWT.getClaim(Authorization.AUTHORIZED_TENANTS).asList(String.class));
   }
 
   /**

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationEncoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationEncoder.java
@@ -24,9 +24,9 @@ public class JwtAuthorizationEncoder
         AuthorizationEncoder {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthorizationEncoder.class);
-  private String issuer = "zeebe-gateway";
-  private String audience = "zeebe-broker";
-  private String subject = "Authorization";
+  private String issuer = DEFAULT_ISSUER;
+  private String audience = DEFAULT_AUDIENCE;
+  private String subject = DEFAULT_SUBJECT;
   private Algorithm signingAlgorithm = Algorithm.none();
   private final Map<String, Object> claims = new HashMap<>();
 

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/TenantAuthorizationCheckerImpl.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/TenantAuthorizationCheckerImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.auth.impl;
 
 import io.camunda.zeebe.auth.api.TenantAuthorizationChecker;
 import java.util.List;
+import java.util.Map;
 
 public class TenantAuthorizationCheckerImpl implements TenantAuthorizationChecker {
 
@@ -28,9 +29,9 @@ public class TenantAuthorizationCheckerImpl implements TenantAuthorizationChecke
     return authorizedTenants.containsAll(tenantIds);
   }
 
-  public static TenantAuthorizationChecker fromJwtDecoder(final JwtAuthorizationDecoder decoder) {
+  public static TenantAuthorizationChecker fromAuthorizationMap(final Map<String, Object> authMap) {
     final List<String> authorizedTenants =
-        decoder.decode().get(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM).asList(String.class);
+        (List) authMap.getOrDefault(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM, List.of());
     return new TenantAuthorizationCheckerImpl(authorizedTenants);
   }
 }

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/TenantAuthorizationCheckerImpl.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/TenantAuthorizationCheckerImpl.java
@@ -31,7 +31,7 @@ public class TenantAuthorizationCheckerImpl implements TenantAuthorizationChecke
 
   public static TenantAuthorizationChecker fromAuthorizationMap(final Map<String, Object> authMap) {
     final List<String> authorizedTenants =
-        (List) authMap.getOrDefault(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM, List.of());
+        (List) authMap.getOrDefault(Authorization.AUTHORIZED_TENANTS, List.of());
     return new TenantAuthorizationCheckerImpl(authorizedTenants);
   }
 }

--- a/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
+++ b/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
@@ -19,7 +19,6 @@ import com.auth0.jwt.interfaces.Claim;
 import io.camunda.zeebe.auth.api.AuthorizationEncoder;
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.auth.impl.JwtAuthorizationDecoder;
-import io.camunda.zeebe.auth.impl.JwtAuthorizationEncoder;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import java.util.List;
 import java.util.Map;
@@ -45,8 +44,7 @@ public class JwtAuthorizationTest {
 
     // when
     final AuthorizationEncoder encoder =
-        Authorization.jwtEncoder()
-            .withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM, authorizedTenants);
+        Authorization.jwtEncoder().withClaim(Authorization.AUTHORIZED_TENANTS, authorizedTenants);
     final String jwtToken = encoder.encode();
 
     // then
@@ -54,9 +52,9 @@ public class JwtAuthorizationTest {
     // assert default claims are also present
     assertDefaultClaims(claims);
     // and authorized tenants claim is present
-    assertThat(claims).containsKey(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM);
+    assertThat(claims).containsKey(Authorization.AUTHORIZED_TENANTS);
     final List<String> authorizedTenantClaim =
-        claims.get(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM).as(List.class);
+        claims.get(Authorization.AUTHORIZED_TENANTS).as(List.class);
     assertThat(authorizedTenantClaim).containsExactlyElementsOf(authorizedTenants);
   }
 
@@ -72,7 +70,7 @@ public class JwtAuthorizationTest {
 
     // when
     final JwtAuthorizationDecoder decoder = Authorization.jwtDecoder(jwtToken);
-    final Map<String, Claim> claims = decoder.decode();
+    final Map<String, Claim> claims = decoder.build().getClaims();
 
     // then
     assertDefaultClaims(claims);
@@ -87,19 +85,18 @@ public class JwtAuthorizationTest {
             .withIssuer(DEFAULT_ISSUER)
             .withAudience(DEFAULT_AUDIENCE)
             .withSubject(DEFAULT_SUBJECT)
-            .withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM, authorizedTenants)
+            .withClaim(Authorization.AUTHORIZED_TENANTS, authorizedTenants)
             .sign(Algorithm.none());
 
     // when
     final JwtAuthorizationDecoder decoder =
-        Authorization.jwtDecoder(jwtToken)
-            .withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM);
-    final Map<String, Claim> claims = decoder.decode();
+        Authorization.jwtDecoder(jwtToken).withClaim(Authorization.AUTHORIZED_TENANTS);
+    final Map<String, Claim> claims = decoder.build().getClaims();
 
     // then
     assertDefaultClaims(claims);
     final List<String> authorizedTenantClaim =
-        claims.get(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM).as(List.class);
+        claims.get(Authorization.AUTHORIZED_TENANTS).as(List.class);
     assertThat(authorizedTenantClaim).containsExactlyElementsOf(authorizedTenants);
   }
 
@@ -115,8 +112,7 @@ public class JwtAuthorizationTest {
 
     // when
     final JwtAuthorizationDecoder decoder =
-        Authorization.jwtDecoder(jwtToken)
-            .withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM);
+        Authorization.jwtDecoder(jwtToken).withClaim(Authorization.AUTHORIZED_TENANTS);
 
     // then
     assertThatThrownBy(() -> decoder.decode())
@@ -144,7 +140,7 @@ public class JwtAuthorizationTest {
   public void shouldFailJwtTokenDecodingWithoutJwtToken() {
     // when
     final JwtAuthorizationDecoder decoder =
-        Authorization.jwtDecoder(null).withClaim(JwtAuthorizationEncoder.AUTHORIZED_TENANTS_CLAIM);
+        Authorization.jwtDecoder(null).withClaim(Authorization.AUTHORIZED_TENANTS);
 
     // then
     assertThatThrownBy(() -> decoder.decode())

--- a/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
+++ b/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.auth;
 
+import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.DEFAULT_AUDIENCE;
+import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.DEFAULT_ISSUER;
+import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.DEFAULT_SUBJECT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -23,10 +26,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class JwtAuthorizationTest {
-
-  private static final String DEFAULT_ISSUER = "zeebe-gateway";
-  private static final String DEFAULT_AUDIENCE = "zeebe-broker";
-  private static final String DEFAULT_SUBJECT = "Authorization";
 
   @Test
   public void shouldEncodeJwtTokenWithDefaultClaims() {

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Map;
 
 record MockTypedCheckpointRecord(
     long position,
@@ -65,6 +66,11 @@ record MockTypedCheckpointRecord(
   @Override
   public String getBrokerVersion() {
     return null;
+  }
+
+  @Override
+  public Map<String, Object> getAuthorizations() {
+    return Map.of();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Map;
 
 final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> {
 
@@ -77,6 +78,11 @@ final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> 
   @Override
   public String getBrokerVersion() {
     return null;
+  }
+
+  @Override
+  public Map<String, Object> getAuthorizations() {
+    return Map.of();
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Map;
 
 public final class MockTypedRecord<T extends UnifiedRecordValue> implements TypedRecord<T> {
 
@@ -111,6 +112,11 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   @Override
   public String getBrokerVersion() {
     return metadata.getBrokerVersion().toString();
+  }
+
+  @Override
+  public Map<String, Object> getAuthorizations() {
+    return metadata.getAuthorization().toDecodedMap();
   }
 
   @Override

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -36,6 +36,9 @@
         "rejectionReason": {
           "type": "text"
         },
+        "authorizations": {
+          "enabled": false
+        },
         "valueType": {
           "type": "keyword"
         },

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -36,6 +36,9 @@
         "rejectionReason": {
           "type": "text"
         },
+        "authorizations": {
+          "enabled": false
+        },
         "valueType": {
           "type": "keyword"
         },

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -127,7 +127,6 @@
     <version.jackson-annotations>2.15.2</version.jackson-annotations>
     <version.swagger-annotations>2.2.15</version.swagger-annotations>
     <version.checker-qual>3.38.0</version.checker-qual>
-    <!-- java-jwt version is aligned with the one in identity-sdk -->
     <version.java-jwt>4.4.0</version.java-jwt>
 
     <!-- maven plugins -->

--- a/protocol-impl/pom.xml
+++ b/protocol-impl/pom.xml
@@ -32,6 +32,16 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-auth</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>

--- a/protocol-impl/pom.xml
+++ b/protocol-impl/pom.xml
@@ -36,11 +36,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.auth0</groupId>
-      <artifactId>java-jwt</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -7,14 +7,11 @@
  */
 package io.camunda.zeebe.protocol.impl.encoding;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
 import io.camunda.zeebe.auth.impl.Authorization;
-import io.camunda.zeebe.auth.impl.JwtAuthorizationDecoder;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -76,15 +73,9 @@ public class AuthInfo extends UnpackedObject {
     switch (getFormat()) {
       case JWT -> {
         final String jwtToken = getAuthData();
-        final DecodedJWT decodedJWT =
-            Authorization.jwtDecoder(jwtToken)
-                .withClaim(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM)
-                .build();
-        final List<String> authorizedTenants =
-            decodedJWT
-                .getClaim(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM)
-                .asList(String.class);
-        return Map.of(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM, authorizedTenants);
+        return Authorization.jwtDecoder(jwtToken)
+            .withClaim(Authorization.AUTHORIZED_TENANTS)
+            .decode();
       }
       default -> {
         return Map.of();

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.auth.impl.JwtAuthorizationDecoder;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/** */
+public class AuthInfo extends UnpackedObject {
+
+  private final EnumProperty<AuthDataFormat> formatProp =
+      new EnumProperty<>("format", AuthDataFormat.class, AuthDataFormat.UNKNOWN);
+
+  private final StringProperty authDataProp = new StringProperty("authData", "");
+
+  public AuthInfo() {
+    declareProperty(formatProp).declareProperty(authDataProp);
+  }
+
+  public AuthDataFormat getFormat() {
+    return formatProp.getValue();
+  }
+
+  public AuthInfo setFormatProp(final AuthDataFormat format) {
+    formatProp.setValue(format);
+    return this;
+  }
+
+  public DirectBuffer getAuthDataBuffer() {
+    return authDataProp.getValue();
+  }
+
+  public String getAuthData() {
+    return BufferUtil.bufferAsString(authDataProp.getValue());
+  }
+
+  public AuthInfo setAuthData(final String authData) {
+    authDataProp.setValue(authData);
+    return this;
+  }
+
+  public void wrap(final AuthInfo authInfo) {
+    formatProp.setValue(authInfo.getFormat());
+    authDataProp.setValue(authInfo.getAuthData());
+  }
+
+  @Override
+  public void reset() {
+    formatProp.setValue(AuthDataFormat.UNKNOWN);
+    authDataProp.setValue("");
+  }
+
+  public DirectBuffer toDirectBuffer() {
+    final var bytes = new byte[getLength()];
+    final var buffer = new UnsafeBuffer(bytes);
+    write(buffer, 0);
+
+    return buffer;
+  }
+
+  public Map<String, Object> toDecodedMap() {
+    switch (getFormat()) {
+      case JWT -> {
+        final String jwtToken = getAuthData();
+        final DecodedJWT decodedJWT =
+            Authorization.jwtDecoder(jwtToken)
+                .withClaim(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM)
+                .build();
+        final List<String> authorizedTenants =
+            decodedJWT
+                .getClaim(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM)
+                .asList(String.class);
+        return Map.of(JwtAuthorizationDecoder.AUTHORIZED_TENANTS_CLAIM, authorizedTenants);
+      }
+      default -> {
+        return Map.of();
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    String data = getAuthData();
+    data = data.isEmpty() ? "" : "." + data;
+    return formatProp.getValue().toString() + data;
+  }
+
+  public enum AuthDataFormat {
+    UNKNOWN((short) 0),
+    JWT((short) 1);
+
+    public final short id;
+
+    AuthDataFormat(final short id) {
+      this.id = id;
+    }
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -14,6 +15,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.StringUtil;
+import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<T> {
@@ -30,6 +32,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final RejectionType rejectionType;
   private final String rejectionReason;
   private final String brokerVersion;
+  private final AuthInfo authorization;
   private final int recordVersion;
 
   public CopiedRecord(
@@ -53,6 +56,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     rejectionReason = metadata.getRejectionReason();
     valueType = metadata.getValueType();
     brokerVersion = metadata.getBrokerVersion().toString();
+    authorization = metadata.getAuthorization();
     recordVersion = metadata.getRecordVersion();
   }
 
@@ -86,6 +90,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     rejectionReason = copiedRecord.rejectionReason;
     valueType = copiedRecord.valueType;
     brokerVersion = copiedRecord.brokerVersion;
+    authorization = copiedRecord.authorization;
     recordVersion = copiedRecord.recordVersion;
   }
 
@@ -137,6 +142,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public String getBrokerVersion() {
     return brokerVersion;
+  }
+
+  @Override
+  public Map<String, Object> getAuthorizations() {
+    return authorization.toDecodedMap();
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -101,13 +101,17 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     final int rejectionReasonLength = decoder.rejectionReasonLength();
     if (rejectionReasonLength > 0) {
       decoder.wrapRejectionReason(rejectionReason);
+    } else {
+      decoder.skipRejectionReason();
     }
 
     final int authorizationLength = decoder.authorizationLength();
     if (authorizationLength > 0) {
-      final DirectBuffer authBuffer = new UnsafeBuffer(new byte[authorizationLength]);
+      final DirectBuffer authBuffer = new UnsafeBuffer();
       decoder.wrapAuthorization(authBuffer);
       authorization.wrap(authBuffer);
+    } else {
+      decoder.skipAuthorization();
     }
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
@@ -32,7 +33,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       MessageHeaderEncoder.ENCODED_LENGTH + RecordMetadataEncoder.BLOCK_LENGTH;
   public static final int DEFAULT_RECORD_VERSION = 1;
 
-  private static final VersionInfo CURRENT_BROKER_VERSION =
+  public static final VersionInfo CURRENT_BROKER_VERSION =
       VersionInfo.parse(VersionUtil.getVersion());
 
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
@@ -46,6 +47,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private long requestId;
   private short intentValue = Intent.NULL_VAL;
   private int requestStreamId;
+  private final AuthInfo authorization = new AuthInfo();
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
 
@@ -68,6 +70,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     decoder.wrap(buffer, offset, headerDecoder.blockLength(), headerDecoder.version());
 
+    // working with fixed-length fields
     recordType = decoder.recordType();
     requestStreamId = decoder.requestStreamId();
     requestId = decoder.requestId();
@@ -94,13 +97,17 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       recordVersion = decodedRecordVersion;
     }
 
+    // working with variable-length fields
     final int rejectionReasonLength = decoder.rejectionReasonLength();
-
     if (rejectionReasonLength > 0) {
-      offset += headerDecoder.blockLength();
-      offset += RecordMetadataDecoder.rejectionReasonHeaderLength();
+      decoder.wrapRejectionReason(rejectionReason);
+    }
 
-      rejectionReason.wrap(buffer, offset, rejectionReasonLength);
+    final int authorizationLength = decoder.authorizationLength();
+    if (authorizationLength > 0) {
+      final DirectBuffer authBuffer = new UnsafeBuffer(new byte[authorizationLength]);
+      decoder.wrapAuthorization(authBuffer);
+      authorization.wrap(authBuffer);
     }
   }
 
@@ -108,7 +115,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   public int getLength() {
     return BLOCK_LENGTH
         + RecordMetadataEncoder.rejectionReasonHeaderLength()
-        + rejectionReason.capacity();
+        + rejectionReason.capacity()
+        + RecordMetadataEncoder.authorizationHeaderLength()
+        + authorization.getLength();
   }
 
   @Override
@@ -122,9 +131,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         .version(encoder.sbeSchemaVersion());
 
     offset += headerEncoder.encodedLength();
-
     encoder.wrap(buffer, offset);
 
+    // working with fixed-length fields
     encoder
         .recordType(recordType)
         .requestStreamId(requestStreamId)
@@ -141,13 +150,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         .minorVersion(brokerVersion.getMinorVersion())
         .patchVersion(brokerVersion.getPatchVersion());
 
-    offset += RecordMetadataEncoder.BLOCK_LENGTH;
-
-    if (rejectionReason.capacity() > 0) {
-      encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
-    } else {
-      buffer.putInt(offset, 0);
-    }
+    // working with variable-length fields
+    encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
+    encoder.putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
   }
 
   public long getRequestId() {
@@ -229,6 +234,20 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     return BufferUtil.bufferAsString(rejectionReason);
   }
 
+  public RecordMetadata authorization(final AuthInfo authorization) {
+    this.authorization.wrap(authorization);
+    return this;
+  }
+
+  public RecordMetadata authorization(final DirectBuffer buffer) {
+    authorization.wrap(buffer);
+    return this;
+  }
+
+  public AuthInfo getAuthorization() {
+    return authorization;
+  }
+
   public RecordMetadata brokerVersion(final VersionInfo brokerVersion) {
     this.brokerVersion = brokerVersion;
     return this;
@@ -257,6 +276,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
+    authorization.reset();
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
     return this;
@@ -272,6 +292,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         requestStreamId,
         rejectionType,
         rejectionReason,
+        authorization,
         protocolVersion,
         brokerVersion,
         recordVersion);
@@ -294,6 +315,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && recordType == that.recordType
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
+        && authorization.equals(that.authorization)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion;
   }
@@ -318,6 +340,10 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     }
     if (rejectionReason.capacity() > 0) {
       builder.append(", rejectionReason=").append(BufferUtil.bufferAsString(rejectionReason));
+    }
+
+    if (!authorization.isEmpty()) {
+      builder.append(", authorization=").append(authorization);
     }
 
     builder.append('}');

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo.AuthDataFormat;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class AuthInfoTest {
+
+  @Test
+  void shouldEncodeDecodeAuthInfo() {
+    // given
+    final String testData = "test-data";
+    final AuthInfo authInfo = new AuthInfo();
+    authInfo.setFormatProp(AuthDataFormat.JWT).setAuthData(testData);
+
+    // when
+    encodeDecode(authInfo);
+
+    // then
+    assertThat(authInfo.getFormat()).isEqualTo(AuthDataFormat.JWT);
+    assertThat(authInfo.getAuthData()).isEqualTo(testData);
+  }
+
+  @Test
+  void shouldEncodeDecodeEmptyAuthInfo() {
+    // given
+    final AuthInfo authInfo = new AuthInfo();
+
+    // when
+    encodeDecode(authInfo);
+
+    // then
+    assertThat(authInfo.getFormat()).isEqualTo(AuthDataFormat.UNKNOWN);
+    assertThat(authInfo.getAuthData()).isEqualTo("");
+  }
+
+  private void encodeDecode(final AuthInfo authInfo) {
+    // encode
+    final UnsafeBuffer buffer = new UnsafeBuffer(new byte[authInfo.getLength()]);
+    authInfo.write(buffer, 0);
+
+    // decode
+    authInfo.reset();
+    authInfo.wrap(buffer, 0, buffer.capacity());
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -134,7 +134,7 @@ final class JsonSerializableToJsonTest {
                   new AuthInfo()
                       .setFormatProp(AuthDataFormat.JWT)
                       .setAuthData(
-                          "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJ6ZWViZS1nYXRld2F5IiwiYXVkIjoiemVlYmUtYnJva2VyIiwic3ViIjoiQXV0aG9yaXphdGlvbiIsImlhdCI6MTY5MzIxNTc1NiwiYXV0aG9yaXplZF90ZW5hbnRzIjpbInRlbmFudC0xIiwidGVuYW50LTIiLCJ0ZW5hbnQtMyJdfQ.");
+                          "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJ6ZWViZS1nYXRld2F5IiwiYXVkIjoiemVlYmUtYnJva2VyIiwic3ViIjoiemVlYmUtY2xpZW50IiwiYXV0aG9yaXplZF90ZW5hbnRzIjpbInRlbmFudC0xIiwidGVuYW50LTIiLCJ0ZW5hbnQtMyJdfQ.");
 
               recordMetadata
                   .intent(intent)

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -12,6 +12,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo.AuthDataFormat;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
@@ -128,6 +130,12 @@ final class JsonSerializableToJsonTest {
               final int requestId = 23;
               final int requestStreamId = 1;
 
+              final AuthInfo authInfo =
+                  new AuthInfo()
+                      .setFormatProp(AuthDataFormat.JWT)
+                      .setAuthData(
+                          "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJ6ZWViZS1nYXRld2F5IiwiYXVkIjoiemVlYmUtYnJva2VyIiwic3ViIjoiQXV0aG9yaXphdGlvbiIsImlhdCI6MTY5MzIxNTc1NiwiYXV0aG9yaXplZF90ZW5hbnRzIjpbInRlbmFudC0xIiwidGVuYW50LTIiLCJ0ZW5hbnQtMyJdfQ.");
+
               recordMetadata
                   .intent(intent)
                   .protocolVersion(protocolVersion)
@@ -138,7 +146,8 @@ final class JsonSerializableToJsonTest {
                   .rejectionReason(rejectionReason)
                   .rejectionType(rejectionType)
                   .requestId(requestId)
-                  .requestStreamId(requestStreamId);
+                  .requestStreamId(requestStreamId)
+                  .authorization(authInfo);
 
               final String resourceName = "resource";
               final DirectBuffer resource = wrapString("contents");
@@ -182,6 +191,13 @@ final class JsonSerializableToJsonTest {
           "rejectionType": "INVALID_ARGUMENT",
           "rejectionReason": "fails",
           "brokerVersion": "1.2.3",
+          "authorizations": {
+            "authorized_tenants":[
+              "tenant-1",
+              "tenant-2",
+              "tenant-3"
+            ]
+          },
           "recordVersion": 10,
           "sourceRecordPosition": 231,
           "value": {
@@ -239,6 +255,7 @@ final class JsonSerializableToJsonTest {
           "rejectionType": "NULL_VAL",
           "rejectionReason": "",
           "brokerVersion": "0.0.0",
+          "authorizations": {},
           "recordVersion": 1,
           "value": {
               "resources": [],

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class RecordMetadataTest {
+
+  @Test
+  void shouldEncodeDecodeMetadataWithNullValues() {
+    // given
+    final RecordMetadata metadata = new RecordMetadata();
+
+    // when
+    encodeDecode(metadata);
+
+    // then
+    assertThat(metadata.getRecordType()).isEqualTo(RecordType.NULL_VAL);
+    assertThat(metadata.getRequestId()).isEqualTo(RecordMetadataEncoder.requestIdNullValue());
+    assertThat(metadata.getRequestStreamId())
+        .isEqualTo(RecordMetadataEncoder.requestStreamIdNullValue());
+    assertThat(metadata.getValueType()).isEqualTo(ValueType.NULL_VAL);
+    assertThat(metadata.getIntent()).isEqualTo(Intent.UNKNOWN);
+    assertThat(metadata.getRejectionType()).isEqualTo(RejectionType.NULL_VAL);
+    assertThat(metadata.getRejectionReason()).isEmpty();
+    assertThat(metadata.getAuthorization()).isEqualTo(new AuthInfo());
+    assertThat(metadata.getBrokerVersion()).isEqualTo(RecordMetadata.CURRENT_BROKER_VERSION);
+    assertThat(metadata.getRecordVersion()).isEqualTo(RecordMetadata.DEFAULT_RECORD_VERSION);
+  }
+
+  private void encodeDecode(final RecordMetadata metadata) {
+    // encode
+    final UnsafeBuffer buffer = new UnsafeBuffer(new byte[metadata.getLength()]);
+    metadata.write(buffer, 0);
+
+    // decode
+    metadata.reset();
+    metadata.wrap(buffer, 0, buffer.capacity());
+  }
+}

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.test.broker.protocol.commandapi;
 import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.keyNullValue;
 import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.partitionIdNullValue;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -40,6 +41,7 @@ public final class ExecuteCommandRequest implements ClientRequest {
   private byte[] encodedCmd;
   private ActorFuture<DirectBuffer> responseFuture;
   private Intent intent = null;
+  private final AuthInfo authorization = new AuthInfo();
 
   public ExecuteCommandRequest(
       final ClientTransport output, final String targetAddress, final MsgPackHelper msgPackHelper) {
@@ -65,6 +67,15 @@ public final class ExecuteCommandRequest implements ClientRequest {
 
   public ExecuteCommandRequest intent(final Intent intent) {
     this.intent = intent;
+    return this;
+  }
+
+  public AuthInfo getAuthorization() {
+    return authorization;
+  }
+
+  public ExecuteCommandRequest setAuthorization(final AuthInfo authorization) {
+    this.authorization.wrap(authorization);
     return this;
   }
 

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequestBuilder.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequestBuilder.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.test.broker.protocol.commandapi;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.test.broker.protocol.MsgPackHelper;
@@ -49,6 +50,11 @@ public final class ExecuteCommandRequestBuilder {
 
   public ExecuteCommandRequestBuilder intent(final Intent intent) {
     request.intent(intent);
+    return this;
+  }
+
+  public ExecuteCommandRequestBuilder authorization(final AuthInfo authorization) {
+    request.setAuthorization(authorization);
     return this;
   }
 

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <version.java>8</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <protocol.version>3</protocol.version>
+    <protocol.version>4</protocol.version>
   </properties>
 
   <dependencies>

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -31,6 +31,22 @@
           "classQualifiedName": "io.camunda.zeebe.protocol.record.value.BpmnElementType"
         },
         {
+          "justification": "Ignore changes to the constant version when we bump it",
+          "code": "java.field.constantValueChanged",
+          "new": {
+            "matcher": "java",
+            "match": "type * { * io.camunda.zeebe.protocol.**::^SCHEMA_VERSION; }"
+          }
+        },
+        {
+          "justification": "Ignore changes to the constant version when we bump it",
+          "code": "java.field.constantValueChanged",
+          "new": {
+            "matcher": "java",
+            "match": "type * { * io.camunda.zeebe.protocol.**::^PROTOCOL_VERSION; }"
+          }
+        },
+        {
           "justification": "Ignore new methods for Protocol Record interfaces, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
           "code": "java.method.addedToInterface",
           "new": {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -89,6 +89,14 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
   String getBrokerVersion();
 
   /**
+   * Provides the authorization data of the user the triggered the creation of this record. The
+   * following entries may be available:
+   *
+   * <ul>
+   *   <li>Key: <code>authorized_tenants</code>; Value: a List of Strings defining the user's
+   *       authorized tenants.
+   * </ul>
+   *
    * @return a Map of authorization data for this record or an empty Map if not set.
    */
   Map<String, Object> getAuthorizations();

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.protocol.record;
 
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.Map;
 import org.immutables.value.Value;
 
 /** Represents a record published to the log stream. */
@@ -86,6 +87,11 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
    * @return the version of the broker that wrote this record
    */
   String getBrokerVersion();
+
+  /**
+   * @return a Map of authorization data for this record or an empty Map if not set.
+   */
+  Map<String, Object> getAuthorizations();
 
   /**
    * A record version is an integer starting from 1. The version of a record is defined when it is

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantOwned.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantOwned.java
@@ -18,6 +18,12 @@ package io.camunda.zeebe.protocol.record.value;
 /** Concerns an entity that is owned by a tenant. */
 public interface TenantOwned {
 
+  /**
+   * The default tenant identifier. When multi-tenancy is disabled, entities are owned by this
+   * tenant. This is done in case multi-tenancy is enabled in the future.
+   */
+  String DEFAULT_TENANT_IDENTIFIER = "<default>";
+
   /** Returns the identifier of the tenant that owns this entity. */
   String getTenantId();
 }

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -103,6 +103,8 @@
     <field name="valueType" id="5" type="ValueType"/>
     <field name="intent" id="6" type="uint8"/>
     <data name="value" id="7" type="varDataEncoding"/>
+    <!-- populated when RecordType is COMMAND -->
+    <data name="authorization" id="8" type="varDataEncoding" sinceVersion="3"/>
   </sbe:message>
 
   <sbe:message name="ExecuteCommandResponse" id="21">
@@ -144,6 +146,8 @@
     <field name="rejectionType" id="7" type="RejectionType"/>
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
+    <!-- populated when RecordType is COMMAND -->
+    <data name="authorization" id="11" type="varDataEncoding" sinceVersion="3"/>
   </sbe:message>
 
   <sbe:message name="BrokerInfo" id="201" description="Broker topology information">

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -104,7 +104,7 @@
     <field name="intent" id="6" type="uint8"/>
     <data name="value" id="7" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->
-    <data name="authorization" id="8" type="varDataEncoding" sinceVersion="3"/>
+    <data name="authorization" id="8" type="varDataEncoding" sinceVersion="4"/>
   </sbe:message>
 
   <sbe:message name="ExecuteCommandResponse" id="21">
@@ -147,7 +147,7 @@
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->
-    <data name="authorization" id="11" type="varDataEncoding" sinceVersion="3"/>
+    <data name="authorization" id="11" type="varDataEncoding" sinceVersion="4"/>
   </sbe:message>
 
   <sbe:message name="BrokerInfo" id="201" description="Broker topology information">

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.StringUtil;
+import java.util.Map;
 
 public final class TypedRecordImpl implements TypedRecord {
   private final int partitionId;
@@ -80,6 +81,11 @@ public final class TypedRecordImpl implements TypedRecord {
   @Override
   public String getBrokerVersion() {
     return metadata.getBrokerVersion().toString();
+  }
+
+  @Override
+  public Map<String, Object> getAuthorizations() {
+    return metadata.getAuthorization().toDecodedMap();
   }
 
   @Override

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Map;
 
 public class UnwrittenRecord implements TypedRecord {
   private final long key;
@@ -23,7 +24,7 @@ public class UnwrittenRecord implements TypedRecord {
 
   public UnwrittenRecord(
       final long key,
-      int partitionId,
+      final int partitionId,
       final UnifiedRecordValue value,
       final RecordMetadata metadata) {
     this.key = key;
@@ -75,6 +76,11 @@ public class UnwrittenRecord implements TypedRecord {
   @Override
   public String getBrokerVersion() {
     return metadata.getBrokerVersion().toString();
+  }
+
+  @Override
+  public Map<String, Object> getAuthorizations() {
+    return metadata.getAuthorization().toDecodedMap();
   }
 
   @Override

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 277]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 307]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 300);
+    final var recordBatch = new RecordBatch((count, size) -> size < 330);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);

--- a/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,6 +103,11 @@ public final class RecordingExporterTest {
     @Override
     public String getBrokerVersion() {
       return null;
+    }
+
+    @Override
+    public Map<String, Object> getAuthorizations() {
+      return Map.of();
     }
 
     @Override


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Includes (encoded) auth data in the `RecordMetadata` and `ExecuteCommandRequest` classes.

:information_source: 
* This PR is based on #13992. Any changes made there should be reflected here before this PR is merged with the `main` branch.
* Commit 9da69d2f is not fully related to this PR. It adds a static field for the default tenant identifier that will be useful in further multi-tenancy development.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13989 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
