### PR TITLE
[Backport stable/8.0] fix: don't retain requests until response is sent

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractServerConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractServerConnection.java
@@ -46,7 +46,7 @@ abstract class AbstractServerConnection implements ServerConnection {
         subjectBytes = StringUtil.getBytes(subject);
       }
 
-      reply(message, ProtocolReply.Status.ERROR_NO_HANDLER, Optional.ofNullable(subjectBytes));
+      reply(message.id(), ProtocolReply.Status.ERROR_NO_HANDLER, Optional.ofNullable(subjectBytes));
     }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalServerConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalServerConnection.java
@@ -16,29 +16,24 @@
  */
 package io.atomix.cluster.messaging.impl;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /** Local server-side connection. */
 final class LocalServerConnection extends AbstractServerConnection {
   private static final byte[] EMPTY_PAYLOAD = new byte[0];
 
-  private volatile LocalClientConnection clientConnection;
+  private final LocalClientConnection clientConnection;
 
   LocalServerConnection(
       final HandlerRegistry handlers, final LocalClientConnection clientConnection) {
     super(handlers);
-    this.clientConnection = clientConnection;
+    this.clientConnection = Objects.requireNonNull(clientConnection);
   }
 
   @Override
   public void reply(
-      final ProtocolRequest message,
-      final ProtocolReply.Status status,
-      final Optional<byte[]> payload) {
-    final LocalClientConnection clientConnection = this.clientConnection;
-    if (clientConnection != null) {
-      clientConnection.dispatch(
-          new ProtocolReply(message.id(), payload.orElse(EMPTY_PAYLOAD), status));
-    }
+      final long messageId, final ProtocolReply.Status status, final Optional<byte[]> payload) {
+    clientConnection.dispatch(new ProtocolReply(messageId, payload.orElse(EMPTY_PAYLOAD), status));
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteServerConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteServerConnection.java
@@ -16,6 +16,7 @@
  */
 package io.atomix.cluster.messaging.impl;
 
+import io.atomix.cluster.messaging.impl.ProtocolReply.Status;
 import io.netty.channel.Channel;
 import java.util.Optional;
 
@@ -31,12 +32,9 @@ final class RemoteServerConnection extends AbstractServerConnection {
   }
 
   @Override
-  public void reply(
-      final ProtocolRequest message,
-      final ProtocolReply.Status status,
-      final Optional<byte[]> payload) {
+  public void reply(final long messageId, final Status status, final Optional<byte[]> payload) {
     final ProtocolReply response =
-        new ProtocolReply(message.id(), payload.orElse(EMPTY_PAYLOAD), status);
+        new ProtocolReply(messageId, payload.orElse(EMPTY_PAYLOAD), status);
     channel.writeAndFlush(response, channel.voidPromise());
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ServerConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ServerConnection.java
@@ -24,12 +24,13 @@ interface ServerConnection extends Connection<ProtocolRequest> {
   /**
    * Sends a reply to the other side of the connection.
    *
-   * @param message the message to which to reply
+   * @param messageId the message to which to reply
    * @param status the reply status
    * @param payload the response payload
    */
-  void reply(ProtocolRequest message, ProtocolReply.Status status, Optional<byte[]> payload);
+  void reply(long messageId, ProtocolReply.Status status, Optional<byte[]> payload);
 
   /** Closes the connection. */
+  @Override
   default void close() {}
 }


### PR DESCRIPTION
# Description
Backport of #14012 to `stable/8.0`.

relates to camunda/zeebe#13948
original author: @oleschoenburg