### PR TITLE
[Backport stable/8.2] fix: don't retain requests until response is sent

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractServerConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractServerConnection.java
@@ -46,7 +46,7 @@ abstract class AbstractServerConnection implements ServerConnection {
         subjectBytes = StringUtil.getBytes(subject);
       }
 
-      reply(message, ProtocolReply.Status.ERROR_NO_HANDLER, Optional.ofNullable(subjectBytes));
+      reply(message.id(), ProtocolReply.Status.ERROR_NO_HANDLER, Optional.ofNullable(subjectBytes));
     }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalServerConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalServerConnection.java
@@ -16,29 +16,24 @@
  */
 package io.atomix.cluster.messaging.impl;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /** Local server-side connection. */
 final class LocalServerConnection extends AbstractServerConnection {
   private static final byte[] EMPTY_PAYLOAD = new byte[0];
 
-  private volatile LocalClientConnection clientConnection;
+  private final LocalClientConnection clientConnection;
 
   LocalServerConnection(
       final HandlerRegistry handlers, final LocalClientConnection clientConnection) {
     super(handlers);
-    this.clientConnection = clientConnection;
+    this.clientConnection = Objects.requireNonNull(clientConnection);
   }
 
   @Override
   public void reply(
-      final ProtocolRequest message,
-      final ProtocolReply.Status status,
-      final Optional<byte[]> payload) {
-    final LocalClientConnection clientConnection = this.clientConnection;
-    if (clientConnection != null) {
-      clientConnection.dispatch(
-          new ProtocolReply(message.id(), payload.orElse(EMPTY_PAYLOAD), status));
-    }
+      final long messageId, final ProtocolReply.Status status, final Optional<byte[]> payload) {
+    clientConnection.dispatch(new ProtocolReply(messageId, payload.orElse(EMPTY_PAYLOAD), status));
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -295,7 +295,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
                       responsePayload = StringUtil.getBytes(exceptionMessage);
                     }
                   }
-                  connection.reply(message, status, Optional.ofNullable(responsePayload));
+                  connection.reply(message.id(), status, Optional.ofNullable(responsePayload));
                 }));
   }
 
@@ -304,32 +304,40 @@ public final class NettyMessagingService implements ManagedMessagingService {
       final String type, final BiFunction<Address, byte[], CompletableFuture<byte[]>> handler) {
     handlers.register(
         type,
-        (message, connection) ->
-            handler
-                .apply(message.sender(), message.payload())
-                .whenComplete(
-                    (result, error) -> {
-                      byte[] responsePayload = null;
-                      final ProtocolReply.Status status;
+        (message, connection) -> {
+          // Extract message components here to avoid retaining a reference to the entire message.
+          // This means we don't need to retain the message payload until the response callback is
+          // completed.
+          final var id = message.id();
+          final var subject = message.subject();
+          final var sender = message.sender();
+          final var payload = message.payload();
+          handler
+              .apply(sender, payload)
+              .whenComplete(
+                  (result, error) -> {
+                    byte[] responsePayload = null;
+                    final ProtocolReply.Status status;
 
-                      if (error == null) {
-                        status = ProtocolReply.Status.OK;
-                        responsePayload = result;
-                      } else {
-                        log.warn(
-                            "Unexpected error while handling message {} from {}",
-                            message.subject(),
-                            message.sender(),
-                            error);
+                    if (error == null) {
+                      status = ProtocolReply.Status.OK;
+                      responsePayload = result;
+                    } else {
+                      log.warn(
+                          "Unexpected error while handling message {} from {}",
+                          subject,
+                          sender,
+                          error);
 
-                        status = ProtocolReply.Status.ERROR_HANDLER_EXCEPTION;
-                        final String exceptionMessage = error.getMessage();
-                        if (exceptionMessage != null) {
-                          responsePayload = StringUtil.getBytes(error.getMessage());
-                        }
+                      status = ProtocolReply.Status.ERROR_HANDLER_EXCEPTION;
+                      final String exceptionMessage = error.getMessage();
+                      if (exceptionMessage != null) {
+                        responsePayload = StringUtil.getBytes(error.getMessage());
                       }
-                      connection.reply(message, status, Optional.ofNullable(responsePayload));
-                    }));
+                    }
+                    connection.reply(id, status, Optional.ofNullable(responsePayload));
+                  });
+        });
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteServerConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteServerConnection.java
@@ -16,6 +16,7 @@
  */
 package io.atomix.cluster.messaging.impl;
 
+import io.atomix.cluster.messaging.impl.ProtocolReply.Status;
 import io.netty.channel.Channel;
 import java.util.Optional;
 
@@ -31,12 +32,9 @@ final class RemoteServerConnection extends AbstractServerConnection {
   }
 
   @Override
-  public void reply(
-      final ProtocolRequest message,
-      final ProtocolReply.Status status,
-      final Optional<byte[]> payload) {
+  public void reply(final long messageId, final Status status, final Optional<byte[]> payload) {
     final ProtocolReply response =
-        new ProtocolReply(message.id(), payload.orElse(EMPTY_PAYLOAD), status);
+        new ProtocolReply(messageId, payload.orElse(EMPTY_PAYLOAD), status);
     channel.writeAndFlush(response, channel.voidPromise());
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ServerConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ServerConnection.java
@@ -24,12 +24,13 @@ interface ServerConnection extends Connection<ProtocolRequest> {
   /**
    * Sends a reply to the other side of the connection.
    *
-   * @param message the message to which to reply
+   * @param messageId the message to which to reply
    * @param status the reply status
    * @param payload the response payload
    */
-  void reply(ProtocolRequest message, ProtocolReply.Status status, Optional<byte[]> payload);
+  void reply(long messageId, ProtocolReply.Status status, Optional<byte[]> payload);
 
   /** Closes the connection. */
+  @Override
   default void close() {}
 }


### PR DESCRIPTION
# Description
Backport of #14012 to `stable/8.2`.

relates to camunda/zeebe#13948
original author: @oleschoenburg