### PR TITLE
Create `DbTenantAwareKey`

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbTenantAwareKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbTenantAwareKey.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl;
+
+import io.camunda.zeebe.db.ContainsForeignKeys;
+import io.camunda.zeebe.db.DbKey;
+import java.util.Collection;
+import java.util.Collections;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+/**
+ * The DbTenantAwareKey wraps any given key and appends it with the tenantKey.
+ *
+ * <p>We have chosen to append the tenant at the end of the wrapped key because:
+ *
+ * <ul>
+ *   <li>The tenant id must be part of the key to ensure uniqueness (e.g. when storing a process id
+ *       and version we need to include the tenant in the key, otherwise they will start overwriting
+ *       eachother)
+ *   <li>It provides flexibility when doing lookups. We can search for prefixes to ignore the
+ *       tenant. We can search by suffix to find everything belonging to a single tenant.
+ *   <li>We won't have preferential treatment. Keys in RocksDb are sorted. If we take Jobs as an
+ *       example, when activating we iterate over all activateable jobs to return to the worker. We
+ *       don't want to Jobs of tenant AAA to take priority over Jobs of tenant ZZZ.
+ * </ul>
+ */
+public record DbTenantAwareKey<WrappedKey extends DbKey>(DbString tenantKey, WrappedKey wrappedKey)
+    implements DbKey, ContainsForeignKeys {
+
+  @Override
+  public DbString tenantKey() {
+    return tenantKey;
+  }
+
+  @Override
+  public WrappedKey wrappedKey() {
+    return wrappedKey;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    wrappedKey.wrap(buffer, offset, length);
+    final var wrappedKeyLength = wrappedKey.getLength();
+    tenantKey.wrap(buffer, offset + wrappedKeyLength, length - wrappedKeyLength);
+  }
+
+  @Override
+  public int getLength() {
+    return wrappedKey.getLength() + tenantKey.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    wrappedKey.write(buffer, offset);
+    final var wrappedKeyLength = wrappedKey.getLength();
+    tenantKey.write(buffer, offset + wrappedKeyLength);
+  }
+
+  // TODO: To consider: maybe we should introduce a DbTenantAwareForeignKey class instead of saying
+  //  this always contains foreign keys.
+  @Override
+  public Collection<DbForeignKey<DbKey>> containedForeignKeys() {
+    if (wrappedKey instanceof ContainsForeignKeys) {
+      return ((ContainsForeignKeys) wrappedKey).containedForeignKeys();
+    }
+
+    return Collections.emptyList();
+  }
+}

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbTenantAwareKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbTenantAwareKey.java
@@ -54,6 +54,7 @@ public record DbTenantAwareKey<WrappedKey extends DbKey>(
         final var wrappedKeyLength = wrappedKey.getLength();
         tenantKey.wrap(buffer, offset + wrappedKeyLength, length - wrappedKeyLength);
       }
+      default -> throw new IllegalStateException("Unexpected value: " + placementType);
     }
   }
 
@@ -75,6 +76,7 @@ public record DbTenantAwareKey<WrappedKey extends DbKey>(
         final var wrappedKeyLength = wrappedKey.getLength();
         tenantKey.write(buffer, offset + wrappedKeyLength);
       }
+      default -> throw new IllegalStateException("Unexpected value: " + placementType);
     }
   }
 

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbTenantAwareKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbTenantAwareKey.java
@@ -15,22 +15,20 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 /**
- * The DbTenantAwareKey wraps any given key and appends it with the tenantKey.
+ * The DbTenantAwareKey wraps any given key and, depending on the PlacementType, append or prepends
+ * the tenant to it.
  *
- * <p>We have chosen to append the tenant at the end of the wrapped key because:
+ * <p>Depending on the use case you want to choose whether you need to use PREFIX or SUFFIX. PREFIX
+ * is suitable when you want the ability to search values by tenant. Use SUFFIX when you want to
+ * search for values irrelevant of tenant.
  *
- * <ul>
- *   <li>The tenant id must be part of the key to ensure uniqueness (e.g. when storing a process id
- *       and version we need to include the tenant in the key, otherwise they will start overwriting
- *       eachother)
- *   <li>It provides flexibility when doing lookups. We can search for prefixes to ignore the
- *       tenant. We can search by suffix to find everything belonging to a single tenant.
- *   <li>We won't have preferential treatment. Keys in RocksDb are sorted. If we take Jobs as an
- *       example, when activating we iterate over all activateable jobs to return to the worker. We
- *       don't want to Jobs of tenant AAA to take priority over Jobs of tenant ZZZ.
- * </ul>
+ * <p>When using PREFIX it's important to be aware that we could have preferential treatment. Keys
+ * in RocksDb are sorted. If we take Jobs as an example, when activating we iterate over all
+ * activatable jobs to return to the worker. We don't want to Jobs of tenant AAA to take priority
+ * over Jobs of tenant ZZZ. SUFFIX is more suitable for this case.
  */
-public record DbTenantAwareKey<WrappedKey extends DbKey>(DbString tenantKey, WrappedKey wrappedKey)
+public record DbTenantAwareKey<WrappedKey extends DbKey>(
+    DbString tenantKey, WrappedKey wrappedKey, PlacementType placementType)
     implements DbKey, ContainsForeignKeys {
 
   @Override
@@ -45,9 +43,18 @@ public record DbTenantAwareKey<WrappedKey extends DbKey>(DbString tenantKey, Wra
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
-    wrappedKey.wrap(buffer, offset, length);
-    final var wrappedKeyLength = wrappedKey.getLength();
-    tenantKey.wrap(buffer, offset + wrappedKeyLength, length - wrappedKeyLength);
+    switch (placementType) {
+      case PREFIX -> {
+        tenantKey.wrap(buffer, offset, length);
+        final var tenantKeyLength = tenantKey.getLength();
+        wrappedKey.wrap(buffer, offset + tenantKeyLength, length - tenantKeyLength);
+      }
+      case SUFFIX -> {
+        wrappedKey.wrap(buffer, offset, length);
+        final var wrappedKeyLength = wrappedKey.getLength();
+        tenantKey.wrap(buffer, offset + wrappedKeyLength, length - wrappedKeyLength);
+      }
+    }
   }
 
   @Override
@@ -57,9 +64,18 @@ public record DbTenantAwareKey<WrappedKey extends DbKey>(DbString tenantKey, Wra
 
   @Override
   public void write(final MutableDirectBuffer buffer, final int offset) {
-    wrappedKey.write(buffer, offset);
-    final var wrappedKeyLength = wrappedKey.getLength();
-    tenantKey.write(buffer, offset + wrappedKeyLength);
+    switch (placementType) {
+      case PREFIX -> {
+        tenantKey.write(buffer, offset);
+        final var tenantKeyLength = tenantKey.getLength();
+        wrappedKey.write(buffer, offset + tenantKeyLength);
+      }
+      case SUFFIX -> {
+        wrappedKey.write(buffer, offset);
+        final var wrappedKeyLength = wrappedKey.getLength();
+        tenantKey.write(buffer, offset + wrappedKeyLength);
+      }
+    }
   }
 
   // TODO: To consider: maybe we should introduce a DbTenantAwareForeignKey class instead of saying
@@ -71,5 +87,10 @@ public record DbTenantAwareKey<WrappedKey extends DbKey>(DbString tenantKey, Wra
     }
 
     return Collections.emptyList();
+  }
+
+  public enum PlacementType {
+    PREFIX,
+    SUFFIX
   }
 }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
@@ -13,13 +13,14 @@ import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import java.io.File;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public final class DbTenantAwareKeyColumnFamilyTest {
-  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @TempDir public File temporaryFolder;
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory();
   private ZeebeDb<DefaultColumnFamily> zeebeDb;
@@ -36,10 +37,9 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   private DbTenantAwareKey<DbLong> tenantAwareKey;
   private DbTenantAwareKey<DbCompositeKey<DbLong, DbLong>> compositeTenantAwareKey;
 
-  @Before
-  public void setup() throws Exception {
-    final File pathName = temporaryFolder.newFolder();
-    zeebeDb = dbFactory.createDb(pathName);
+  @BeforeEach
+  void beforeEach() throws Exception {
+    zeebeDb = dbFactory.createDb(temporaryFolder);
 
     tenantKey = new DbString();
     firstKey = new DbLong();
@@ -59,7 +59,7 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   }
 
   @Test
-  public void shouldInsertValue() {
+  void shouldInsertValue() {
     // given
     tenantKey.wrapString("tenant");
     firstKey.wrapLong(1);
@@ -80,7 +80,7 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   }
 
   @Test
-  public void shouldUpsertValue() {
+  void shouldUpsertValue() {
     // given
     tenantKey.wrapString("tenant");
     firstKey.wrapLong(1);
@@ -124,12 +124,9 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   }
 
   @Test
-  public void shouldDeleteValue() {
+  void shouldDeleteValue() {
     // given
-    tenantKey.wrapString("tenant");
-    firstKey.wrapLong(1);
-    value.wrapString("foo");
-    columnFamily.insert(tenantAwareKey, value);
+    upsertKeyValuePair(123L, "foo", "tenantId");
 
     // when
     columnFamily.deleteExisting(tenantAwareKey);

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
@@ -76,7 +76,7 @@ public final class DbTenantAwareKeyColumnFamilyTest {
     assertThat(zbString).isNotNull();
     assertThat(zbString.toString()).isEqualTo("foo");
 
-    // zbLong and value are referencing the same object
+    // zbString and value are referencing the same object
     assertThat(value.toString()).isEqualTo("foo");
   }
 
@@ -97,8 +97,40 @@ public final class DbTenantAwareKeyColumnFamilyTest {
     assertThat(zbString).isNotNull();
     assertThat(zbString.toString()).isEqualTo("foo");
 
-    // zbLong and value are referencing the same object
+    // zbString and value are referencing the same object
     assertThat(value.toString()).isEqualTo("foo");
+  }
+
+  @Test
+  void shouldUpsertValueForMultipleTenants() {
+    // given
+    final String tenant = "tenant";
+    final String otherTenant = "otherTenant";
+    tenantKey.wrapString(tenant);
+    firstKey.wrapLong(1);
+    value.wrapString("foo");
+
+    // when
+    columnFamily.upsert(tenantAwareKey, value);
+    tenantKey.wrapString(otherTenant);
+    columnFamily.upsert(tenantAwareKey, value);
+    value.wrapString("bar");
+
+    // then
+    final var keys = new ArrayList<>();
+    final var values = new ArrayList<>();
+    final var tenants = new ArrayList<>();
+    columnFamily.forEach(
+        (key, value) -> {
+          keys.add(key.wrappedKey().getValue());
+          values.add(value.toString());
+          tenants.add(key.tenantKey().toString());
+        });
+
+    // then
+    assertThat(keys).containsOnly(1L);
+    assertThat(tenants).containsExactly("tenant", "otherTenant");
+    assertThat(values).containsOnly("foo");
   }
 
   @Test
@@ -120,7 +152,7 @@ public final class DbTenantAwareKeyColumnFamilyTest {
     assertThat(zbString).isNotNull();
     assertThat(zbString.toString()).isEqualTo("bar");
 
-    // zbLong and value are referencing the same object
+    // zbString and value are referencing the same object
     assertThat(value.toString()).isEqualTo("bar");
   }
 

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
 import java.io.File;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,11 +44,11 @@ public final class DbTenantAwareKeyColumnFamilyTest {
 
     tenantKey = new DbString();
     firstKey = new DbLong();
-    tenantAwareKey = new DbTenantAwareKey<>(tenantKey, firstKey);
+    tenantAwareKey = new DbTenantAwareKey<>(tenantKey, firstKey, PlacementType.SUFFIX);
 
     secondKey = new DbLong();
     compositeKey = new DbCompositeKey<>(firstKey, secondKey);
-    compositeTenantAwareKey = new DbTenantAwareKey<>(tenantKey, compositeKey);
+    compositeTenantAwareKey = new DbTenantAwareKey<>(tenantKey, compositeKey, PlacementType.SUFFIX);
 
     value = new DbString();
     columnFamily =
@@ -220,7 +221,7 @@ public final class DbTenantAwareKeyColumnFamilyTest {
     final var startAtWrappedKey = new DbLong();
     startAtWrappedKey.wrapLong(124L);
     tenantKey.wrapString("tenantId");
-    final var startAt = new DbTenantAwareKey<>(tenantKey, startAtWrappedKey);
+    final var startAt = new DbTenantAwareKey<>(tenantKey, startAtWrappedKey, PlacementType.SUFFIX);
 
     // when
     final var keys = new ArrayList<>();

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
@@ -127,7 +127,7 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   @Test
   void shouldDeleteValue() {
     // given
-    upsertKeyValuePair(123L, "foo", "tenantId");
+    upsertKeyValuePair(123L, "tenantId", "foo");
 
     // when
     columnFamily.deleteExisting(tenantAwareKey);
@@ -141,11 +141,11 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   @Test
   void shouldUseForeachValue() {
     // given
-    upsertKeyValuePair(123L, "foo", "tenantId");
-    upsertKeyValuePair(124L, "bar", "tenantId");
-    upsertKeyValuePair(125L, "baz", "otherTenantId");
-    upsertKeyValuePair(777L, "jackpot", "tenantId");
-    upsertKeyValuePair(888L, "lastOne", "otherTenantId");
+    upsertKeyValuePair(123L, "tenantId", "foo");
+    upsertKeyValuePair(124L, "tenantId", "bar");
+    upsertKeyValuePair(125L, "otherTenantId", "baz");
+    upsertKeyValuePair(777L, "tenantId", "jackpot");
+    upsertKeyValuePair(888L, "otherTenantId", "lastOne");
 
     // when
     final var values = new ArrayList<>();
@@ -158,11 +158,11 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   @Test
   void shouldUseForeachPair() {
     // given
-    upsertKeyValuePair(123L, "foo", "tenantId");
-    upsertKeyValuePair(124L, "bar", "tenantId");
-    upsertKeyValuePair(125L, "baz", "otherTenantId");
-    upsertKeyValuePair(777L, "jackpot", "tenantId");
-    upsertKeyValuePair(888L, "lastOne", "otherTenantId");
+    upsertKeyValuePair(123L, "tenantId", "foo");
+    upsertKeyValuePair(124L, "tenantId", "bar");
+    upsertKeyValuePair(125L, "otherTenantId", "baz");
+    upsertKeyValuePair(777L, "tenantId", "jackpot");
+    upsertKeyValuePair(888L, "otherTenantId", "lastOne");
 
     // when
     final var keys = new ArrayList<>();
@@ -185,11 +185,11 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   @Test
   void shouldUseWhileTrue() {
     // given
-    upsertKeyValuePair(123L, "foo", "tenantId");
-    upsertKeyValuePair(777L, "jackpot", "tenantId");
-    upsertKeyValuePair(124L, "bar", "tenantId");
-    upsertKeyValuePair(888L, "lastOne", "otherTenantId");
-    upsertKeyValuePair(125L, "baz", "otherTenantId");
+    upsertKeyValuePair(123L, "tenantId", "foo");
+    upsertKeyValuePair(777L, "tenantId", "jackpot");
+    upsertKeyValuePair(124L, "tenantId", "bar");
+    upsertKeyValuePair(888L, "otherTenantId", "lastOne");
+    upsertKeyValuePair(125L, "otherTenantId", "baz");
 
     // when
     final var keys = new ArrayList<>();
@@ -213,11 +213,11 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   @Test
   void shouldUseWhileTrueWithStartAt() {
     // given
-    upsertKeyValuePair(123L, "foo", "tenantId");
-    upsertKeyValuePair(777L, "jackpot", "tenantId");
-    upsertKeyValuePair(124L, "bar", "tenantId");
-    upsertKeyValuePair(888L, "lastOne", "otherTenantId");
-    upsertKeyValuePair(125L, "baz", "otherTenantId");
+    upsertKeyValuePair(123L, "tenantId", "foo");
+    upsertKeyValuePair(777L, "tenantId", "jackpot");
+    upsertKeyValuePair(124L, "tenantId", "bar");
+    upsertKeyValuePair(888L, "otherTenantId", "lastOne");
+    upsertKeyValuePair(125L, "otherTenantId", "baz");
     final var startAtWrappedKey = new DbLong();
     startAtWrappedKey.wrapLong(124L);
     tenantKey.wrapString("tenantId");
@@ -246,11 +246,11 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   @Test
   void shouldUseWhileEqualPrefix() {
     // given
-    upsertCompositeKeyValuePair(123L, 111L, "foo", "tenantId");
-    upsertCompositeKeyValuePair(321L, 333L, "jackpot", "tenantId");
-    upsertCompositeKeyValuePair(123L, 333L, "bar", "tenantId");
-    upsertCompositeKeyValuePair(321L, 222L, "lastOne", "otherTenantId");
-    upsertCompositeKeyValuePair(123L, 222L, "baz", "otherTenantId");
+    upsertCompositeKeyValuePair(123L, 111L, "tenantId", "foo");
+    upsertCompositeKeyValuePair(321L, 333L, "tenantId", "jackpot");
+    upsertCompositeKeyValuePair(123L, 333L, "tenantId", "bar");
+    upsertCompositeKeyValuePair(321L, 222L, "otherTenantId", "lastOne");
+    upsertCompositeKeyValuePair(123L, 222L, "otherTenantId", "baz");
     final var prefix = new DbLong();
     prefix.wrapLong(123L);
 
@@ -275,7 +275,7 @@ public final class DbTenantAwareKeyColumnFamilyTest {
     assertThat(tenants).containsExactly("tenantId", "otherTenantId", "tenantId");
   }
 
-  private void upsertKeyValuePair(final long key, final String value, final String tenantId) {
+  private void upsertKeyValuePair(final long key, final String tenantId, final String value) {
     firstKey.wrapLong(key);
     this.value.wrapString(value);
     tenantKey.wrapString(tenantId);
@@ -283,7 +283,7 @@ public final class DbTenantAwareKeyColumnFamilyTest {
   }
 
   private void upsertCompositeKeyValuePair(
-      final long firstKey, final long secondKey, final String value, final String tenantId) {
+      final long firstKey, final long secondKey, final String tenantId, final String value) {
     this.firstKey.wrapLong(firstKey);
     this.secondKey.wrapLong(secondKey);
     this.value.wrapString(value);

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyColumnFamilyTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.ZeebeDbFactory;
+import java.io.File;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public final class DbTenantAwareKeyColumnFamilyTest {
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
+      DefaultZeebeDbFactory.getDefaultFactory();
+  private ZeebeDb<DefaultColumnFamily> zeebeDb;
+  private ColumnFamily<DbTenantAwareKey<DbLong>, DbString> columnFamily;
+  private ColumnFamily<DbTenantAwareKey<DbCompositeKey<DbLong, DbLong>>, DbString>
+      compositeColumnFamily;
+  private DbString tenantKey;
+  private DbLong firstKey;
+  private DbLong secondKey;
+  private DbCompositeKey<DbLong, DbLong> compositeKey;
+
+  private DbString value;
+
+  private DbTenantAwareKey<DbLong> tenantAwareKey;
+  private DbTenantAwareKey<DbCompositeKey<DbLong, DbLong>> compositeTenantAwareKey;
+
+  @Before
+  public void setup() throws Exception {
+    final File pathName = temporaryFolder.newFolder();
+    zeebeDb = dbFactory.createDb(pathName);
+
+    tenantKey = new DbString();
+    firstKey = new DbLong();
+    tenantAwareKey = new DbTenantAwareKey<>(tenantKey, firstKey);
+
+    secondKey = new DbLong();
+    compositeKey = new DbCompositeKey<>(firstKey, secondKey);
+    compositeTenantAwareKey = new DbTenantAwareKey<>(tenantKey, compositeKey);
+
+    value = new DbString();
+    columnFamily =
+        zeebeDb.createColumnFamily(
+            DefaultColumnFamily.DEFAULT, zeebeDb.createContext(), tenantAwareKey, value);
+    compositeColumnFamily =
+        zeebeDb.createColumnFamily(
+            DefaultColumnFamily.DEFAULT, zeebeDb.createContext(), compositeTenantAwareKey, value);
+  }
+
+  @Test
+  public void shouldInsertValue() {
+    // given
+    tenantKey.wrapString("tenant");
+    firstKey.wrapLong(1);
+    value.wrapString("foo");
+
+    // when
+    columnFamily.insert(tenantAwareKey, value);
+    value.wrapString("bar");
+
+    // then
+    final DbString zbString = columnFamily.get(tenantAwareKey);
+
+    assertThat(zbString).isNotNull();
+    assertThat(zbString.toString()).isEqualTo("foo");
+
+    // zbLong and value are referencing the same object
+    assertThat(value.toString()).isEqualTo("foo");
+  }
+
+  @Test
+  public void shouldUpsertValue() {
+    // given
+    tenantKey.wrapString("tenant");
+    firstKey.wrapLong(1);
+    value.wrapString("foo");
+
+    // when
+    columnFamily.upsert(tenantAwareKey, value);
+    value.wrapString("bar");
+
+    // then
+    final DbString zbString = columnFamily.get(tenantAwareKey);
+
+    assertThat(zbString).isNotNull();
+    assertThat(zbString.toString()).isEqualTo("foo");
+
+    // zbLong and value are referencing the same object
+    assertThat(value.toString()).isEqualTo("foo");
+  }
+
+  @Test
+  public void shouldUpdateValue() {
+    // given
+    tenantKey.wrapString("tenant");
+    firstKey.wrapLong(1);
+    value.wrapString("foo");
+    columnFamily.insert(tenantAwareKey, value);
+
+    // when
+    value.wrapString("bar");
+    columnFamily.upsert(tenantAwareKey, value);
+    value.wrapString("baz");
+
+    // then
+    final DbString zbString = columnFamily.get(tenantAwareKey);
+
+    assertThat(zbString).isNotNull();
+    assertThat(zbString.toString()).isEqualTo("bar");
+
+    // zbLong and value are referencing the same object
+    assertThat(value.toString()).isEqualTo("bar");
+  }
+
+  @Test
+  public void shouldDeleteValue() {
+    // given
+    tenantKey.wrapString("tenant");
+    firstKey.wrapLong(1);
+    value.wrapString("foo");
+    columnFamily.insert(tenantAwareKey, value);
+
+    // when
+    columnFamily.deleteExisting(tenantAwareKey);
+
+    // then
+    final DbString zbString = columnFamily.get(tenantAwareKey);
+
+    assertThat(zbString).isNull();
+  }
+}

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl;
+
+import static io.camunda.zeebe.db.impl.ZeebeDbConstants.ZB_DB_BYTE_ORDER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.agrona.ExpandableArrayBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DbTenantAwareKeyTest {
+
+  private static final DbString TENANT_KEY = new DbString();
+  private static final String TENANT_ID = "tenantId";
+
+  @BeforeEach
+  void beforeEach() {
+    TENANT_KEY.wrapString(TENANT_ID);
+  }
+
+  @AfterEach
+  void afterEach() {
+    TENANT_KEY.wrapString("");
+  }
+
+  @Test
+  void shouldWriteDbString() {
+    // given
+    final var wrappedKey = new DbString();
+    final var value = "foo";
+    wrappedKey.wrapString(value);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    tenantAwareKey.write(buffer, 0);
+
+    // then
+    // The total length is the amount of bytes in each string (= amount of characters) + 2 times the
+    // amount of bytes in an Integer. This is what's used in a buffer to determine the length of the
+    // String that's coming.
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(value.length() + TENANT_ID.length() + (Integer.BYTES * 2));
+
+    // The first integer is the length of the first part of the key (foo)
+    assertThat(buffer.getInt(0, ZB_DB_BYTE_ORDER)).isEqualTo(value.length());
+    byte[] bytes = new byte[value.length()];
+    // We get the 3 bytes from the buffer and verify it matches foo. We start at index Integer.BYTES
+    // to skip the length.
+    buffer.getBytes(Integer.BYTES, bytes);
+    assertThat(bytes).isEqualTo(value.getBytes());
+
+    // The second integer is the length of the second part of the key (tenantId)
+    assertThat(buffer.getInt(value.length() + Integer.BYTES, ZB_DB_BYTE_ORDER))
+        .isEqualTo(TENANT_ID.length());
+    bytes = new byte[TENANT_ID.length()];
+    // We get the 8 bytes from the buffer and verify it matches tenantId. We start at an index that
+    // skips foo and its length, as well as the length of tenantId.
+    buffer.getBytes(value.length() + (Integer.BYTES * 2), bytes);
+    assertThat(bytes).isEqualTo(TENANT_ID.getBytes());
+  }
+
+  @Test
+  void shouldWrapDbString() {
+    // given
+    final var wrappedKey = new DbString();
+    final var value = "foo";
+    wrappedKey.wrapString(value);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+
+    // when
+    final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+    final int length = tenantAwareKey.getLength();
+    tenantAwareKey.write(buffer, 0);
+    tenantAwareKey.wrap(buffer, 0, length);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(value.length() + TENANT_ID.length() + (Integer.BYTES * 2));
+    assertThat(tenantAwareKey.wrappedKey().toString()).isEqualTo(value);
+    assertThat(wrappedKey.toString()).isEqualTo(value);
+    assertThat(tenantAwareKey.tenantKey().toString()).isEqualTo(TENANT_ID);
+    assertThat(TENANT_KEY.toString()).isEqualTo(TENANT_ID);
+  }
+
+  @Test
+  void shouldWriteDbLong() {
+    // given
+    final var wrappedKey = new DbLong();
+    final var value = 123L;
+    wrappedKey.wrapLong(value);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    tenantAwareKey.write(buffer, 0);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + TENANT_ID.length() + Integer.BYTES);
+
+    assertThat(buffer.getLong(0, ZB_DB_BYTE_ORDER)).isEqualTo(value);
+
+    assertThat(buffer.getInt(Long.BYTES, ZB_DB_BYTE_ORDER)).isEqualTo(TENANT_ID.length());
+    final var bytes = new byte[TENANT_ID.length()];
+    buffer.getBytes(Long.BYTES + Integer.BYTES, bytes);
+    assertThat(bytes).isEqualTo(TENANT_ID.getBytes());
+  }
+
+  @Test
+  void shouldWrapDbLong() {
+    // given
+    final var wrappedKey = new DbLong();
+    final var value = 123L;
+    wrappedKey.wrapLong(value);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+
+    // when
+    final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+    final int length = tenantAwareKey.getLength();
+    tenantAwareKey.write(buffer, 0);
+    tenantAwareKey.wrap(buffer, 0, length);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + TENANT_ID.length() + Integer.BYTES);
+    assertThat(tenantAwareKey.wrappedKey().getValue()).isEqualTo(value);
+    assertThat(wrappedKey.getValue()).isEqualTo(value);
+    assertThat(tenantAwareKey.tenantKey().toString()).isEqualTo(TENANT_ID);
+    assertThat(TENANT_KEY.toString()).isEqualTo(TENANT_ID);
+  }
+
+  @Test
+  void shouldWriteDbCompositeKey() {
+    // given
+    final var stringKey = new DbString();
+    final var longKey = new DbLong();
+    final var wrappedKey = new DbCompositeKey<>(stringKey, longKey);
+    final var stringValue = "foo";
+    final var longValue = 123L;
+    stringKey.wrapString(stringValue);
+    longKey.wrapLong(longValue);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    tenantAwareKey.write(buffer, 0);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + stringValue.length() + TENANT_ID.length() + (Integer.BYTES * 2));
+
+    var offset = 0;
+    assertThat(buffer.getInt(offset, ZB_DB_BYTE_ORDER)).isEqualTo(stringValue.length());
+    byte[] bytes = new byte[stringValue.length()];
+    offset += Integer.BYTES;
+    buffer.getBytes(offset, bytes);
+    assertThat(bytes).isEqualTo(stringValue.getBytes());
+    offset += stringValue.length();
+
+    assertThat(buffer.getLong(offset, ZB_DB_BYTE_ORDER)).isEqualTo(longValue);
+    offset += Long.BYTES;
+
+    assertThat(buffer.getInt(offset, ZB_DB_BYTE_ORDER)).isEqualTo(TENANT_ID.length());
+    offset += Integer.BYTES;
+    bytes = new byte[TENANT_ID.length()];
+    buffer.getBytes(offset, bytes);
+    assertThat(bytes).isEqualTo(TENANT_ID.getBytes());
+  }
+
+  @Test
+  void shouldWrapDbCompositeKey() {
+    // given
+    final var stringKey = new DbString();
+    final var longKey = new DbLong();
+    final var wrappedKey = new DbCompositeKey<>(stringKey, longKey);
+    final var stringValue = "foo";
+    final var longValue = 123L;
+    stringKey.wrapString(stringValue);
+    longKey.wrapLong(longValue);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    final var length = tenantAwareKey.getLength();
+    tenantAwareKey.write(buffer, 0);
+    tenantAwareKey.wrap(buffer, 0, length);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + stringValue.length() + TENANT_ID.length() + (Integer.BYTES * 2));
+
+    final var firstKey = tenantAwareKey.wrappedKey().first();
+    final var secondKey = tenantAwareKey.wrappedKey().second();
+    final var tenantKey = tenantAwareKey.tenantKey();
+    assertThat(firstKey.toString()).isEqualTo(stringValue);
+    assertThat(secondKey.getValue()).isEqualTo(longValue);
+    assertThat(tenantKey.toString()).isEqualTo(TENANT_ID);
+  }
+
+  @Test
+  void shouldWriteDbForeignKey() {
+    // given
+    final var longKey = new DbLong();
+    final var foreignKey = new DbForeignKey<>(longKey, DefaultColumnFamily.DEFAULT);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, foreignKey);
+    final var longValue = 123L;
+    longKey.wrapLong(longValue);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    tenantAwareKey.write(buffer, 0);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + TENANT_ID.length() + Integer.BYTES);
+
+    assertThat(buffer.getLong(0, ZB_DB_BYTE_ORDER)).isEqualTo(longValue);
+
+    assertThat(buffer.getInt(Long.BYTES, ZB_DB_BYTE_ORDER)).isEqualTo(TENANT_ID.length());
+    final var bytes = new byte[TENANT_ID.length()];
+    buffer.getBytes(Long.BYTES + Integer.BYTES, bytes);
+    assertThat(bytes).isEqualTo(TENANT_ID.getBytes());
+  }
+
+  @Test
+  void shouldWrapDbForeignKey() {
+    // given
+    final var longKey = new DbLong();
+    final var foreignKey = new DbForeignKey<>(longKey, DefaultColumnFamily.DEFAULT);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, foreignKey);
+    final var longValue = 123L;
+    longKey.wrapLong(longValue);
+
+    // when
+    final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+    final int length = tenantAwareKey.getLength();
+    tenantAwareKey.write(buffer, 0);
+    tenantAwareKey.wrap(buffer, 0, length);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + TENANT_ID.length() + Integer.BYTES);
+    assertThat(tenantAwareKey.wrappedKey().inner().getValue()).isEqualTo(longValue);
+    assertThat(longKey.getValue()).isEqualTo(longValue);
+    assertThat(tenantAwareKey.tenantKey().toString()).isEqualTo(TENANT_ID);
+    assertThat(TENANT_KEY.toString()).isEqualTo(TENANT_ID);
+  }
+}

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.db.impl;
 import static io.camunda.zeebe.db.impl.ZeebeDbConstants.ZB_DB_BYTE_ORDER;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
 import org.agrona.ExpandableArrayBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,7 @@ public class DbTenantAwareKeyTest {
     final var wrappedKey = new DbString();
     final var value = "foo";
     wrappedKey.wrapString(value);
-    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.SUFFIX);
 
     // when
     final var buffer = new ExpandableArrayBuffer();
@@ -73,7 +74,7 @@ public class DbTenantAwareKeyTest {
     final var wrappedKey = new DbString();
     final var value = "foo";
     wrappedKey.wrapString(value);
-    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.SUFFIX);
 
     // when
     final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
@@ -96,7 +97,7 @@ public class DbTenantAwareKeyTest {
     final var wrappedKey = new DbLong();
     final var value = 123L;
     wrappedKey.wrapLong(value);
-    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.SUFFIX);
 
     // when
     final var buffer = new ExpandableArrayBuffer();
@@ -120,7 +121,7 @@ public class DbTenantAwareKeyTest {
     final var wrappedKey = new DbLong();
     final var value = 123L;
     wrappedKey.wrapLong(value);
-    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.SUFFIX);
 
     // when
     final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
@@ -147,7 +148,7 @@ public class DbTenantAwareKeyTest {
     final var longValue = 123L;
     stringKey.wrapString(stringValue);
     longKey.wrapLong(longValue);
-    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.SUFFIX);
 
     // when
     final var buffer = new ExpandableArrayBuffer();
@@ -185,7 +186,7 @@ public class DbTenantAwareKeyTest {
     final var longValue = 123L;
     stringKey.wrapString(stringValue);
     longKey.wrapLong(longValue);
-    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.SUFFIX);
 
     // when
     final var buffer = new ExpandableArrayBuffer();
@@ -210,7 +211,7 @@ public class DbTenantAwareKeyTest {
     // given
     final var longKey = new DbLong();
     final var foreignKey = new DbForeignKey<>(longKey, DefaultColumnFamily.DEFAULT);
-    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, foreignKey);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, foreignKey, PlacementType.SUFFIX);
     final var longValue = 123L;
     longKey.wrapLong(longValue);
 
@@ -235,7 +236,7 @@ public class DbTenantAwareKeyTest {
     // given
     final var longKey = new DbLong();
     final var foreignKey = new DbForeignKey<>(longKey, DefaultColumnFamily.DEFAULT);
-    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, foreignKey);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, foreignKey, PlacementType.SUFFIX);
     final var longValue = 123L;
     longKey.wrapLong(longValue);
 

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTenantAwareKeyTest.java
@@ -32,7 +32,58 @@ public class DbTenantAwareKeyTest {
   }
 
   @Test
-  void shouldWriteDbString() {
+  void shouldWriteDbStringPrefixed() {
+    // given
+    final var wrappedKey = new DbString();
+    final var value = "foo";
+    wrappedKey.wrapString(value);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.PREFIX);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    tenantAwareKey.write(buffer, 0);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(value.length() + TENANT_ID.length() + (Integer.BYTES * 2));
+
+    assertThat(buffer.getInt(0, ZB_DB_BYTE_ORDER)).isEqualTo(TENANT_ID.length());
+    byte[] bytes = new byte[TENANT_ID.length()];
+    buffer.getBytes(Integer.BYTES, bytes);
+    assertThat(bytes).isEqualTo(TENANT_ID.getBytes());
+
+    assertThat(buffer.getInt(TENANT_ID.length() + Integer.BYTES, ZB_DB_BYTE_ORDER))
+        .isEqualTo(value.length());
+    bytes = new byte[value.length()];
+    buffer.getBytes(TENANT_ID.length() + (Integer.BYTES * 2), bytes);
+    assertThat(bytes).isEqualTo(value.getBytes());
+  }
+
+  @Test
+  void shouldWrapDbStringPrefixed() {
+    // given
+    final var wrappedKey = new DbString();
+    final var value = "foo";
+    wrappedKey.wrapString(value);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.PREFIX);
+
+    // when
+    final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+    final int length = tenantAwareKey.getLength();
+    tenantAwareKey.write(buffer, 0);
+    tenantAwareKey.wrap(buffer, 0, length);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(value.length() + TENANT_ID.length() + (Integer.BYTES * 2));
+    assertThat(tenantAwareKey.wrappedKey().toString()).isEqualTo(value);
+    assertThat(wrappedKey.toString()).isEqualTo(value);
+    assertThat(tenantAwareKey.tenantKey().toString()).isEqualTo(TENANT_ID);
+    assertThat(TENANT_KEY.toString()).isEqualTo(TENANT_ID);
+  }
+
+  @Test
+  void shouldWriteDbStringSuffixed() {
     // given
     final var wrappedKey = new DbString();
     final var value = "foo";
@@ -69,7 +120,7 @@ public class DbTenantAwareKeyTest {
   }
 
   @Test
-  void shouldWrapDbString() {
+  void shouldWrapDbStringSuffixed() {
     // given
     final var wrappedKey = new DbString();
     final var value = "foo";
@@ -92,7 +143,55 @@ public class DbTenantAwareKeyTest {
   }
 
   @Test
-  void shouldWriteDbLong() {
+  void shouldWriteDbLongPrefixed() {
+    // given
+    final var wrappedKey = new DbLong();
+    final var value = 123L;
+    wrappedKey.wrapLong(value);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.PREFIX);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    tenantAwareKey.write(buffer, 0);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + TENANT_ID.length() + Integer.BYTES);
+
+    assertThat(buffer.getInt(0, ZB_DB_BYTE_ORDER)).isEqualTo(TENANT_ID.length());
+    final var bytes = new byte[TENANT_ID.length()];
+    buffer.getBytes(Integer.BYTES, bytes);
+    assertThat(bytes).isEqualTo(TENANT_ID.getBytes());
+
+    assertThat(buffer.getLong(Integer.BYTES + TENANT_ID.length(), ZB_DB_BYTE_ORDER))
+        .isEqualTo(value);
+  }
+
+  @Test
+  void shouldWrapDbLongPrefixed() {
+    // given
+    final var wrappedKey = new DbLong();
+    final var value = 123L;
+    wrappedKey.wrapLong(value);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.PREFIX);
+
+    // when
+    final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+    final int length = tenantAwareKey.getLength();
+    tenantAwareKey.write(buffer, 0);
+    tenantAwareKey.wrap(buffer, 0, length);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + TENANT_ID.length() + Integer.BYTES);
+    assertThat(tenantAwareKey.wrappedKey().getValue()).isEqualTo(value);
+    assertThat(wrappedKey.getValue()).isEqualTo(value);
+    assertThat(tenantAwareKey.tenantKey().toString()).isEqualTo(TENANT_ID);
+    assertThat(TENANT_KEY.toString()).isEqualTo(TENANT_ID);
+  }
+
+  @Test
+  void shouldWriteDbLongSuffixed() {
     // given
     final var wrappedKey = new DbLong();
     final var value = 123L;
@@ -116,7 +215,7 @@ public class DbTenantAwareKeyTest {
   }
 
   @Test
-  void shouldWrapDbLong() {
+  void shouldWrapDbLongSuffixed() {
     // given
     final var wrappedKey = new DbLong();
     final var value = 123L;
@@ -139,7 +238,75 @@ public class DbTenantAwareKeyTest {
   }
 
   @Test
-  void shouldWriteDbCompositeKey() {
+  void shouldWriteDbCompositeKeyPrefixed() {
+    // given
+    final var stringKey = new DbString();
+    final var longKey = new DbLong();
+    final var wrappedKey = new DbCompositeKey<>(stringKey, longKey);
+    final var stringValue = "foo";
+    final var longValue = 123L;
+    stringKey.wrapString(stringValue);
+    longKey.wrapLong(longValue);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.PREFIX);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    tenantAwareKey.write(buffer, 0);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + stringValue.length() + TENANT_ID.length() + (Integer.BYTES * 2));
+
+    var offset = 0;
+    assertThat(buffer.getInt(offset, ZB_DB_BYTE_ORDER)).isEqualTo(TENANT_ID.length());
+    offset += Integer.BYTES;
+    byte[] bytes = new byte[TENANT_ID.length()];
+    buffer.getBytes(offset, bytes);
+    assertThat(bytes).isEqualTo(TENANT_ID.getBytes());
+    offset += TENANT_ID.length();
+
+    assertThat(buffer.getInt(offset, ZB_DB_BYTE_ORDER)).isEqualTo(stringValue.length());
+    bytes = new byte[stringValue.length()];
+    offset += Integer.BYTES;
+    buffer.getBytes(offset, bytes);
+    assertThat(bytes).isEqualTo(stringValue.getBytes());
+    offset += stringValue.length();
+
+    assertThat(buffer.getLong(offset, ZB_DB_BYTE_ORDER)).isEqualTo(longValue);
+  }
+
+  @Test
+  void shouldWrapDbCompositeKeyPrefixed() {
+    // given
+    final var stringKey = new DbString();
+    final var longKey = new DbLong();
+    final var wrappedKey = new DbCompositeKey<>(stringKey, longKey);
+    final var stringValue = "foo";
+    final var longValue = 123L;
+    stringKey.wrapString(stringValue);
+    longKey.wrapLong(longValue);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, wrappedKey, PlacementType.PREFIX);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    final var length = tenantAwareKey.getLength();
+    tenantAwareKey.write(buffer, 0);
+    tenantAwareKey.wrap(buffer, 0, length);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + stringValue.length() + TENANT_ID.length() + (Integer.BYTES * 2));
+
+    final var firstKey = tenantAwareKey.wrappedKey().first();
+    final var secondKey = tenantAwareKey.wrappedKey().second();
+    final var tenantKey = tenantAwareKey.tenantKey();
+    assertThat(firstKey.toString()).isEqualTo(stringValue);
+    assertThat(secondKey.getValue()).isEqualTo(longValue);
+    assertThat(tenantKey.toString()).isEqualTo(TENANT_ID);
+  }
+
+  @Test
+  void shouldWriteDbCompositeKeySuffixed() {
     // given
     final var stringKey = new DbString();
     final var longKey = new DbLong();
@@ -177,7 +344,7 @@ public class DbTenantAwareKeyTest {
   }
 
   @Test
-  void shouldWrapDbCompositeKey() {
+  void shouldWrapDbCompositeKeySuffixed() {
     // given
     final var stringKey = new DbString();
     final var longKey = new DbLong();
@@ -207,7 +374,57 @@ public class DbTenantAwareKeyTest {
   }
 
   @Test
-  void shouldWriteDbForeignKey() {
+  void shouldWriteDbForeignKeyPrefixed() {
+    // given
+    final var longKey = new DbLong();
+    final var foreignKey = new DbForeignKey<>(longKey, DefaultColumnFamily.DEFAULT);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, foreignKey, PlacementType.PREFIX);
+    final var longValue = 123L;
+    longKey.wrapLong(longValue);
+
+    // when
+    final var buffer = new ExpandableArrayBuffer();
+    tenantAwareKey.write(buffer, 0);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + TENANT_ID.length() + Integer.BYTES);
+
+    assertThat(buffer.getInt(0, ZB_DB_BYTE_ORDER)).isEqualTo(TENANT_ID.length());
+    final var bytes = new byte[TENANT_ID.length()];
+    buffer.getBytes(Integer.BYTES, bytes);
+    assertThat(bytes).isEqualTo(TENANT_ID.getBytes());
+
+    assertThat(buffer.getLong(Integer.BYTES + TENANT_ID.length(), ZB_DB_BYTE_ORDER))
+        .isEqualTo(longValue);
+  }
+
+  @Test
+  void shouldWrapDbForeignKeyPrefixed() {
+    // given
+    final var longKey = new DbLong();
+    final var foreignKey = new DbForeignKey<>(longKey, DefaultColumnFamily.DEFAULT);
+    final var tenantAwareKey = new DbTenantAwareKey<>(TENANT_KEY, foreignKey, PlacementType.PREFIX);
+    final var longValue = 123L;
+    longKey.wrapLong(longValue);
+
+    // when
+    final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+    final int length = tenantAwareKey.getLength();
+    tenantAwareKey.write(buffer, 0);
+    tenantAwareKey.wrap(buffer, 0, length);
+
+    // then
+    assertThat(tenantAwareKey.getLength())
+        .isEqualTo(Long.BYTES + TENANT_ID.length() + Integer.BYTES);
+    assertThat(tenantAwareKey.wrappedKey().inner().getValue()).isEqualTo(longValue);
+    assertThat(longKey.getValue()).isEqualTo(longValue);
+    assertThat(tenantAwareKey.tenantKey().toString()).isEqualTo(TENANT_ID);
+    assertThat(TENANT_KEY.toString()).isEqualTo(TENANT_ID);
+  }
+
+  @Test
+  void shouldWriteDbForeignKeySuffixed() {
     // given
     final var longKey = new DbLong();
     final var foreignKey = new DbForeignKey<>(longKey, DefaultColumnFamily.DEFAULT);
@@ -232,7 +449,7 @@ public class DbTenantAwareKeyTest {
   }
 
   @Test
-  void shouldWrapDbForeignKey() {
+  void shouldWrapDbForeignKeySuffixed() {
     // given
     final var longKey = new DbLong();
     final var foreignKey = new DbForeignKey<>(longKey, DefaultColumnFamily.DEFAULT);

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ForeignKeyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ForeignKeyTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.zeebe.db.DbKey;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
 import org.junit.jupiter.api.Test;
 
 final class ForeignKeyTest {
@@ -51,7 +52,8 @@ final class ForeignKeyTest {
     // given
     final var foreignKey =
         new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
-    final var tenantAwareKey = new DbTenantAwareKey<>(mock(DbString.class), foreignKey);
+    final var tenantAwareKey =
+        new DbTenantAwareKey<>(mock(DbString.class), foreignKey, PlacementType.SUFFIX);
 
     // then
     assertThat(tenantAwareKey.containedForeignKeys()).singleElement().isEqualTo(foreignKey);
@@ -63,7 +65,8 @@ final class ForeignKeyTest {
     final var key1 = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
     final var key2 = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
     final var compositeKey = new DbCompositeKey<>(key1, key2);
-    final var tenantAwareKey = new DbTenantAwareKey<>(mock(DbString.class), compositeKey);
+    final var tenantAwareKey =
+        new DbTenantAwareKey<>(mock(DbString.class), compositeKey, PlacementType.SUFFIX);
 
     // then
     assertThat(tenantAwareKey.containedForeignKeys()).containsExactly(key1, key2);

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ForeignKeyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ForeignKeyTest.java
@@ -46,6 +46,29 @@ final class ForeignKeyTest {
     assertThat(composite.containedForeignKeys()).containsExactly(key1, key2, key3);
   }
 
+  @Test
+  void shouldCollectForeignKeysFromTenantAwareKey() {
+    // given
+    final var foreignKey =
+        new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
+    final var tenantAwareKey = new DbTenantAwareKey<>(mock(DbString.class), foreignKey);
+
+    // then
+    assertThat(tenantAwareKey.containedForeignKeys()).singleElement().isEqualTo(foreignKey);
+  }
+
+  @Test
+  void shouldCollectForeignKeysFromTenantAwareComposite() {
+    // given
+    final var key1 = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
+    final var key2 = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
+    final var compositeKey = new DbCompositeKey<>(key1, key2);
+    final var tenantAwareKey = new DbTenantAwareKey<>(mock(DbString.class), compositeKey);
+
+    // then
+    assertThat(tenantAwareKey.containedForeignKeys()).containsExactly(key1, key2);
+  }
+
   private enum TestColumnFamilies {
     TEST_COLUMN_FAMILY
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
To support multi-tenancy (#12653) we need to make sure we can store `tenantIds` in our state. 

We have chosen to append the `tenantId` to the end of the key of a ColumnFamily. This is because:

- The `tenantId` must be part of the key to ensure uniqueness (e.g. when storing a `processId` and `version` we need to include the tenant in the key, otherwise they will start overwriting eachother)
- It provides flexibility when doing lookups. We can search for prefixes to ignore the tenant. We can search by suffix to find everything belonging to a single tenant.
- We won't have preferential treatment. Keys in RocksDb are sorted. If we take Jobs as an example, when activating we iterate over all `activateableJobs` to return to the worker. We don't want to Jobs of tenant `AAA` to take priority over Jobs of tenant `ZZZ`.

In order to achieve this I've created `DbTenantAwareKey`. This is a new key we can use in our `ColumnFamilies`. It is quite similar to the `DbCompositeKey` we already have. It can wrap any existing `DbKey`. It will also always contains a `DbString` within in which the `tenantId` is stored. This key will take care of making the the `tenantId` gets appended to whatever key it wraps.

---------------


This PR seems large, but honestly, most of it is just testcases 😄 


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14019 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
