### PR TITLE
feat(engine): enable yielding on due date checker by default

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -18,26 +18,26 @@ final class FeatureFlagsCfgTest {
   public final Map<String, String> environment = new HashMap<>();
 
   @Test
-  void shouldSetEnableYieldingDueDateCheckerFromConfig() {
-    // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
-    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
-
-    // then
-    assertThat(featureFlagsCfg.isEnableYieldingDueDateChecker()).isTrue();
-  }
-
-  @Test
-  void shouldSetEnableYieldingDueDateCheckerFromEnv() {
-    // given
-    environment.put("zeebe.broker.experimental.features.enableYieldingDueDateChecker", "false");
-
+  void shouldDisableYieldingDueDateCheckerFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
     final var featureFlagsCfg = cfg.getExperimental().getFeatures();
 
     // then
     assertThat(featureFlagsCfg.isEnableYieldingDueDateChecker()).isFalse();
+  }
+
+  @Test
+  void shouldEnableYieldingDueDateCheckerFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.features.enableYieldingDueDateChecker", "true");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableYieldingDueDateChecker()).isTrue();
   }
 
   @Test

--- a/broker/src/test/resources/system/feature-flags-cfg.yaml
+++ b/broker/src/test/resources/system/feature-flags-cfg.yaml
@@ -2,7 +2,7 @@ zeebe:
   broker:
     experimental:
       features:
-        enableYieldingDueDateChecker: true
+        enableYieldingDueDateChecker: false
         enableActorMetrics: true
         enableMessageTTLCheckerAsync: true
         enableTimerDueDateCheckerAsync: true

--- a/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -46,7 +46,7 @@ public record FeatureFlags(
 
   //  protected static final boolean FOO_DEFAULT = false;
 
-  private static final boolean YIELDING_DUE_DATE_CHECKER = false;
+  private static final boolean YIELDING_DUE_DATE_CHECKER = true;
   private static final boolean ENABLE_ACTOR_METRICS = false;
 
   private static final boolean ENABLE_MSG_TTL_CHECKER_ASYNC = false;

--- a/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -19,7 +19,7 @@ class FeatureFlagsTest {
     final var sut = FeatureFlags.createDefault();
 
     // then
-    assertThat(sut.yieldingDueDateChecker()).isFalse();
+    assertThat(sut.yieldingDueDateChecker()).isTrue();
     assertThat(sut.enableActorMetrics()).isFalse();
     assertThat(sut.enableMessageTTLCheckerAsync()).isFalse();
   }


### PR DESCRIPTION
## Description

Given the feature was used several times successfully already while not surfacing any issues, we want to promote it to be enabled by default. Even with the due date checker now running async to the stream processor https://github.com/camunda/zeebe/pull/13524 enabling the feature allows to prevent the due date checker occupying the async actor on which also other tasks are run on.

## Related issues

closes #14032 
