### PR TITLE
Fix: Broker reestablishes streams on Gateway added to cluster

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -19,9 +19,9 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.impl.ClientStreamServiceImpl;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamApiHandler;
-import io.camunda.zeebe.transport.stream.impl.RemoteStreamEndpoint;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamRegistry;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamServiceImpl;
+import io.camunda.zeebe.transport.stream.impl.RemoteStreamTransport;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamerImpl;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -57,7 +57,7 @@ public final class TransportFactory {
     final RemoteStreamRegistry<M> registry = new RemoteStreamRegistry<>(metrics);
     return new RemoteStreamServiceImpl<>(
         new RemoteStreamerImpl<>(clusterCommunicationService, registry, errorHandler, metrics),
-        new RemoteStreamEndpoint<>(
+        new RemoteStreamTransport<>(
             clusterCommunicationService, new RemoteStreamApiHandler<>(registry, metadataFactory)),
         registry);
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -36,7 +36,7 @@ import org.agrona.DirectBuffer;
  */
 public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
     implements ClientStreamer<M>, ClientStreamService<M> {
-
+  private static final byte[] SUCCESS_RESPONSE = new byte[0];
   private final ClientStreamManager<M> clientStreamManager;
   private final ClusterCommunicationService communicationService;
   private final ClientStreamRegistry<M> registry;
@@ -81,7 +81,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
               });
           return responseFuture;
         },
-        ignore -> new byte[0]);
+        ignore -> SUCCESS_RESPONSE);
 
     communicationService.replyTo(
         StreamTopics.RESTART_STREAMS.topic(),
@@ -89,9 +89,9 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
         (memberId, ignore) -> {
           clientStreamManager.onServerRemoved(MemberId.from(memberId.id()));
           clientStreamManager.onServerJoined(MemberId.from(memberId.id()));
-          return null;
+          return SUCCESS_RESPONSE;
         },
-        ignore -> new byte[0],
+        Function.identity(),
         actor::run);
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.agrona.DirectBuffer;
 
 /**
@@ -81,6 +82,17 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
           return responseFuture;
         },
         ignore -> new byte[0]);
+
+    communicationService.replyTo(
+        StreamTopics.RESTART_STREAMS.topic(),
+        Function.identity(),
+        (memberId, ignore) -> {
+          clientStreamManager.onServerRemoved(MemberId.from(memberId.id()));
+          clientStreamManager.onServerJoined(MemberId.from(memberId.id()));
+          return null;
+        },
+        ignore -> new byte[0],
+        actor::run);
   }
 
   @Override

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
@@ -26,12 +26,12 @@ import java.util.stream.Stream;
 public class RemoteStreamServiceImpl<M extends BufferReader, P extends BufferWriter>
     implements RemoteStreamService<M, P> {
   private final RemoteStreamerImpl<M, P> streamer;
-  private final RemoteStreamEndpoint<M> apiServer;
+  private final RemoteStreamTransport<M> apiServer;
   private final RemoteStreamRegistry<M> registry;
 
   public RemoteStreamServiceImpl(
       final RemoteStreamerImpl<M, P> streamer,
-      final RemoteStreamEndpoint<M> apiServer,
+      final RemoteStreamTransport<M> apiServer,
       final RemoteStreamRegistry<M> registry) {
     this.streamer = streamer;
     this.apiServer = apiServer;
@@ -90,5 +90,8 @@ public class RemoteStreamServiceImpl<M extends BufferReader, P extends BufferWri
   @Override
   public void event(final ClusterMembershipEvent event) {
     apiServer.removeAll(event.subject().id());
+    if (event.type() == Type.MEMBER_ADDED) {
+      apiServer.recreateStreams(event.subject().id());
+    }
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
@@ -11,7 +11,8 @@ public enum StreamTopics {
   ADD("stream-add"),
   PUSH("stream-push"),
   REMOVE("stream-remove"),
-  REMOVE_ALL("stream-remove-all");
+  REMOVE_ALL("stream-remove-all"),
+  RESTART_STREAMS("stream-recreate");
 
   private final String topic;
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -62,10 +61,7 @@ final class StreamIntegrationTest {
           .setIoBoundActorThreadCount(1)
           .build();
   private final List<Node> clusterNodes =
-      List.of(
-          createNode(UUID.randomUUID().toString()),
-          createNode(UUID.randomUUID().toString()),
-          createNode(UUID.randomUUID().toString()));
+      List.of(createNode("server1"), createNode("server2"), createNode("client"));
   private final TestServer server1 =
       new TestServer(createClusterNode(clusterNodes.get(0), clusterNodes));
   private final TestServer server2 =
@@ -401,8 +397,7 @@ final class StreamIntegrationTest {
               cluster.getCommunicationService(),
               TestSerializableData::new,
               dynamicErrorHandler,
-              RemoteStreamMetrics.noop(),
-              cluster.getMembershipService());
+              RemoteStreamMetrics.noop());
     }
 
     private void start() {


### PR DESCRIPTION
## Description

The bug arises when the broker perceives that the gateway is removed from the cluster, but in reality, this was a false positive (the stream was only created when the gateway actually joined the cluster).
This in this pr is a naive solution that when the broker notices the node being added to the cluster, it sends a command to reset the streams.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/14002

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
