### PR TITLE
Not write the entire command for rejection

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -198,7 +198,7 @@ public class Engine implements RecordProcessor {
   }
 
   /**
-   * This method remove unuseful information from rejected records in order to not encounter the
+   * This method removes redundant information from rejected records in order to avoid the
    * {@link ExceededBatchRecordSizeException} when writing the rejection event.
    *
    * <ul>

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -198,8 +198,8 @@ public class Engine implements RecordProcessor {
   }
 
   /**
-   * This method removes redundant information from rejected records in order to avoid the
-   * {@link ExceededBatchRecordSizeException} when writing the rejection event.
+   * This method removes redundant information from rejected records in order to avoid the {@link
+   * ExceededBatchRecordSizeException} when writing the rejection event.
    *
    * <ul>
    *   <li>Commands of type {@link DeploymentRecord}: for those records the resources information

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -154,7 +155,8 @@ public class Engine implements RecordProcessor {
               : processor.tryHandleError(record, processingException);
 
       if (error == ProcessingError.UNEXPECTED_ERROR) {
-        handleUnexpectedError(processingException, record);
+        final var errorRecord = getRejectionRecord(record);
+        handleUnexpectedError(processingException, errorRecord);
       }
     }
     return processingResultBuilder.build();
@@ -193,6 +195,25 @@ public class Engine implements RecordProcessor {
 
       writers.state().appendFollowUpEvent(record.getKey(), ErrorIntent.CREATED, errorRecord);
     }
+  }
+
+  /**
+   * This method remove unuseful information from rejected records in order to not encounter the
+   * {@link ExceededBatchRecordSizeException} when writing the rejection event.
+   *
+   * <ul>
+   *   <li>Commands of type {@link DeploymentRecord}: for those records the resources information
+   *       are not necessary
+   * </ul>
+   *
+   * @param record the record to transform
+   * @return the {@link TypedRecord} with only necessary information
+   */
+  private TypedRecord getRejectionRecord(final TypedRecord record) {
+    if (record.getValue() instanceof final DeploymentRecord deploymentRecord) {
+      deploymentRecord.resetResources();
+    }
+    return record;
   }
 
   private static final class ProcessingResultBuilderMutex

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
@@ -17,7 +17,15 @@ import io.camunda.zeebe.client.api.response.Process;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +44,9 @@ public final class CreateDeploymentTest {
   public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
 
   @Test
   public void shouldDeployProcessModel() {
@@ -152,5 +163,36 @@ public final class CreateDeploymentTest {
     assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
         .hasMessageContaining("rejected with code 'EXCEEDED_BATCH_RECORD_SIZE'");
+  }
+
+  @Test
+  public void shouldNotWriteResourcesInformationInRejectedRecords() {
+    // when
+    final var modelThatFitsJustWithinMaxMessageSize =
+        Bpmn.createExecutableProcess("PROCESS")
+            .startEvent()
+            .documentation("x".repeat((1046900)))
+            .done();
+    final var command =
+        CLIENT_RULE
+            .getClient()
+            .newDeployResourceCommand()
+            .addProcessModel(modelThatFitsJustWithinMaxMessageSize, "too_large_process.bpmn")
+            .send();
+
+    // then
+    final var rejectedRecords = RecordingExporter.records()
+        .filter(record -> RecordType.COMMAND_REJECTION.equals(record.getRecordType()))
+        .toList();
+
+    rejectedRecords.stream()
+        .map(Record::getValue)
+        .forEach(
+            recordValue -> {
+              if (recordValue instanceof DeploymentRecord) {
+                assertThat(((DeploymentRecord) recordValue).getResources()).isEmpty();
+              }
+            }
+        );
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
@@ -20,12 +20,9 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +41,7 @@ public final class CreateDeploymentTest {
   public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
@@ -181,9 +179,10 @@ public final class CreateDeploymentTest {
             .send();
 
     // then
-    final var rejectedRecords = RecordingExporter.records()
-        .filter(record -> RecordType.COMMAND_REJECTION.equals(record.getRecordType()))
-        .toList();
+    final var rejectedRecords =
+        RecordingExporter.records()
+            .filter(record -> RecordType.COMMAND_REJECTION.equals(record.getRecordType()))
+            .toList();
 
     rejectedRecords.stream()
         .map(Record::getValue)
@@ -192,7 +191,6 @@ public final class CreateDeploymentTest {
               if (recordValue instanceof DeploymentRecord) {
                 assertThat(((DeploymentRecord) recordValue).getResources()).isEmpty();
               }
-            }
-        );
+            });
   }
 }


### PR DESCRIPTION
## Description

With this fix we are able to wright a rejection record without encounter `ExceededBatchSize ` error. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12699 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
