### PR TITLE
feat(test-util): add junit 5 extension to auto close resources

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/junit/AutoCloseResourceExtension.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/junit/AutoCloseResourceExtension.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ModifierSupport;
+import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+final class AutoCloseResourceExtension implements BeforeEachCallback, BeforeAllCallback {
+  @Override
+  public void beforeAll(final ExtensionContext extensionContext) {
+    final var store = store(extensionContext);
+    lookupAnnotatedFields(extensionContext, null, ModifierSupport::isStatic)
+        .forEach(resource -> store.put(resource, resource));
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext extensionContext) {
+    final var store = store(extensionContext);
+    final var testInstance = extensionContext.getRequiredTestInstance();
+    lookupAnnotatedFields(extensionContext, testInstance, ModifierSupport::isNotStatic)
+        .forEach(resource -> store.put(resource, resource));
+  }
+
+  private Iterable<CloseableResource> lookupAnnotatedFields(
+      final ExtensionContext extensionContext,
+      final Object testInstance,
+      final Predicate<Field> fieldType) {
+    return AnnotationSupport.findAnnotatedFields(
+            extensionContext.getRequiredTestClass(),
+            AutoCloseResource.class,
+            fieldType,
+            HierarchyTraversalMode.TOP_DOWN)
+        .stream()
+        .map(field -> ofAnnotatedCloseable(testInstance, field))
+        .toList();
+  }
+
+  private CloseableResource ofAnnotatedCloseable(final Object testInstance, final Field field) {
+    final var annotation = field.getAnnotation(AutoCloseResource.class);
+    final var method =
+        ReflectionSupport.findMethod(field.getType(), annotation.closeMethod())
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        "No close method '%s' for object of type '%s'; did you forget to set a custom close method?"
+                            .formatted(annotation.closeMethod(), field.getType().getName())));
+
+    ReflectionUtils.makeAccessible(field);
+    ReflectionUtils.makeAccessible(method);
+
+    return new AnnotatedCloseable(testInstance, field, method);
+  }
+
+  private Store store(final ExtensionContext extensionContext) {
+    return extensionContext.getStore(Namespace.create(AutoCloseResourceExtension.class));
+  }
+
+  private record AnnotatedCloseable(Object testInstance, Field objectField, Method method)
+      implements CloseableResource {
+
+    @Override
+    public void close() throws Exception {
+      final var value = objectField.get(testInstance);
+      if (value != null) {
+        method.invoke(value);
+      }
+    }
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/junit/AutoCloseResources.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/junit/AutoCloseResources.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Registers the {@link AutoCloseResourceExtension} extension, which will all fields annotated with
+ * {@link AutoCloseResource} and ensure they closed after their lifecycle is finished.
+ *
+ * <p>This means, instance fields are closed after every test, and static fields after all tests.
+ * The order in which the fields are closed is undefined.
+ */
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ExtendWith(AutoCloseResourceExtension.class)
+public @interface AutoCloseResources {
+
+  /**
+   * Indicates a resource which may be closed by the {@link AutoCloseResourceExtension} extension.
+   */
+  @Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+  @Retention(RetentionPolicy.RUNTIME)
+  @Documented
+  @Inherited
+  @interface AutoCloseResource {
+    String closeMethod() default "close";
+  }
+}

--- a/test-util/src/test/java/io/camunda/zeebe/test/util/junit/AutoCloseResourcesTest.java
+++ b/test-util/src/test/java/io/camunda/zeebe/test/util/junit/AutoCloseResourcesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.collections.MutableBoolean;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This tests that all instance fields are correctly closed by closing on their references and
+ * adding one assertion for each to a final {@link AfterAll} callback. The structure is a bit
+ * strange: given-when is in the test themselves, and the `then` is in the {@link AfterAll}
+ * callback.
+ *
+ * <p>I'm not sure how we could test that all static fields are correctly closed, but considering
+ * the code paths are almost identical, this is hopefully enough.
+ */
+@AutoCloseResources
+final class AutoCloseResourcesTest {
+  private static final List<Runnable> ASSERTIONS = new ArrayList<>();
+
+  @AutoCloseResource
+  private final MyCloseable closeable = new MyCloseable(new MutableBoolean(false));
+
+  @AutoCloseResource(closeMethod = "myCustomClose")
+  private final MyCustomCloseable customCloseable =
+      new MyCustomCloseable(new MutableBoolean(false));
+
+  // not closed as not annotated
+  private final MyCloseable notClosed = new MyCloseable(new MutableBoolean(false));
+
+  @AfterAll
+  static void ensureInstanceFieldsAreClosed() {
+    // then
+    ASSERTIONS.forEach(Runnable::run);
+  }
+
+  @Test
+  void shouldCloseAutoCloseable() {
+    // given
+    final var closeableRef = closeable;
+
+    // when
+    ASSERTIONS.add(() -> assertThat(closeableRef.isClosed().get()).isTrue());
+  }
+
+  @Test
+  void shouldCloseCustomCloseable() {
+    // given
+    final var customCloseableRef = customCloseable;
+
+    // when
+    ASSERTIONS.add(() -> assertThat(customCloseableRef.isClosed().get()).isTrue());
+  }
+
+  @Test
+  void shouldNotClosedNonAnnotatedAutoCloseable() {
+    // given
+    final var notClosedRef = notClosed;
+
+    // when
+    ASSERTIONS.add(() -> assertThat(notClosedRef.isClosed().get()).isFalse());
+  }
+
+  private record MyCloseable(MutableBoolean isClosed) implements AutoCloseable {
+
+    @Override
+    public void close() {
+      isClosed.set(true);
+    }
+  }
+
+  private record MyCustomCloseable(MutableBoolean isClosed) {
+    @SuppressWarnings("unused")
+    public void myCustomClose() {
+      isClosed.set(true);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new JUnit 5 extension which auto closes all static and instance fields annotated with `@AutoCloseResource`. Static fields are closed after all tests (i.e. following `AfterAll` semantics) and instance fields are closed after every tests (i.e. following `AfterEach` semantics).

You can customize the close method via `@AutoCloseResource(closeMethod = "mySuperClose")` to also annotate non standard `AutoCloseable` objects.

> **Note**
> I added tests for the instance fields. The tests are a little bit strange, in that the assertion is done in a final `AfterAll` callback. I'm not sure how to test the static fields, but considering the code paths are almost identical, I think this is good enough.

## Related issues

closes #13965 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
