### PR TITLE
ci(e2e): use latest patch generation as template

### DIFF
--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -22,24 +22,37 @@ jobs:
     name: Compute branch matrix
     runs-on: ubuntu-latest
     outputs:
-      latest-version: ${{ env.LATEST_VERSION }}
-      previous-latest-version: ${{ env.PREVIOUS_LATEST_VERSION }}
-      previous-previous-latest-version: ${{ env.PREVIOUS_PREVIOUS_LATEST_VERSION }}
+      latest-major-minor-version: ${{ env.LATEST_MAJOR_MINOR_VERSION }}
+      latest-major-minor-patch-version: ${{ env.LATEST_MAJOR_MINOR_PATCH_VERSION }}
+      previous-latest-major-minor-version: ${{ env.PREVIOUS_LATEST_MAJOR_MINOR_VERSION }}
+      previous-latest-major-minor-patch-version: ${{ env.PREVIOUS_LATEST_MAJOR_MINOR_PATCH_VERSION }}
+      previous-previous-latest-major-minor-version: ${{ env.PREVIOUS_PREVIOUS_LATEST_MINOR_VERSION }}
+      previous-previous-latest-major-minor-patch-version: ${{ env.PREVIOUS_PREVIOUS_LATEST_MINOR_PATCH_VERSION }}
     steps:
       - uses: actions/checkout@v3
       - run: git fetch --tags
       - run: |
-          latest=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sed -E -e 's/\.[0-9]+$//' | sort -Vr | head -n1)
-          previous=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sed -E -e 's/\.[0-9]+$//' | grep -v "${latest}" | sort -Vr | head -n1)
-          previous_previous=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sed -E -e 's/\.[0-9]+$//' | grep -v "${latest}" | grep -v "${previous}" | sort -Vr | head -n1)
-          if [ ! -z $latest ] && [ ! -z $previous ] && [ ! -z $previous_previous ]; then
-            echo "Successfully computed latest versions: ${latest} and ${previous} and ${previous_previous}"
+          latest_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr | head -n1)
+          latest_major_minor=$(echo $latest_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
+          previous_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "${latest_major_minor}" | sort -Vr | head -n1)
+          previous_major_minor=$(echo $previous_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
+          previous_previous_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "${latest_major_minor}" | grep -v "${previous_major_minor}" | sort -Vr | head -n1)
+          previous_previous_major_minor=$(echo $previous_previous_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
+
+          if [ ! -z $latest_major_minor_patch ] && [ ! -z $previous_major_minor_patch ] && [ ! -z $previous_previous_major_minor_patch ]; then
+            echo "Successfully computed latest versions: ${latest_major_minor_patch} and ${previous_major_minor_patch} and ${previous_previous_major_minor_patch}"
           else
             echo "Failed to compute latest versions"
           fi
-          echo "LATEST_VERSION=${latest}" >> $GITHUB_ENV
-          echo "PREVIOUS_LATEST_VERSION=${previous}" >> $GITHUB_ENV
-          echo "PREVIOUS_PREVIOUS_LATEST_VERSION=${previous_previous}" >> $GITHUB_ENV
+
+          echo "LATEST_MAJOR_MINOR_PATCH_VERSION=${latest_major_minor_patch}" >> $GITHUB_ENV
+          echo "LATEST_MAJOR_MINOR_VERSION=${latest_major_minor}" >> $GITHUB_ENV
+
+          echo "PREVIOUS_LATEST_MAJOR_MINOR_PATCH_VERSION=${previous_major_minor_patch}" >> $GITHUB_ENV
+          echo "PREVIOUS_LATEST_MAJOR_MINOR_VERSION=${previous_major_minor}" >> $GITHUB_ENV
+
+          echo "PREVIOUS_PREVIOUS_LATEST_MINOR_PATCH_VERSION=${previous_previous_major_minor_patch}" >> $GITHUB_ENV
+          echo "PREVIOUS_PREVIOUS_LATEST_MINOR_VERSION=${previous_previous_major_minor}" >> $GITHUB_ENV
 
   e2e:
     needs:
@@ -50,14 +63,23 @@ jobs:
       matrix:
         branch:
           - 'main'
-          - ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
-          - ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-version) }}
-          - ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-version) }}
+          - ${{ format('stable/{0}', needs.get-versions.outputs.latest-major-minor-version) }}
+          - ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-major-minor-version) }}
+          - ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
+        include:
+          - branch: 'main'
+            generation_template: 'Zeebe SNAPSHOT'
+          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-major-minor-version) }}
+            generation_template: ${{ format('Camunda Platform {0}', needs.get-versions.outputs.latest-major-minor-patch-version) }}
+          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-major-minor-version) }}
+            generation_template: ${{ format('Camunda Platform {0}', needs.get-versions.outputs.previous-latest-major-minor-patch-version) }}
+          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
+            generation_template: ${{ format('Camunda Platform {0}', needs.get-versions.outputs.previous-previous-latest-major-minor-patch-version) }}
     name: Weekly E2E
     uses: ./.github/workflows/e2e-testbench.yaml
     with:
       branch: ${{ matrix.branch }}
-      generation: Zeebe SNAPSHOT
+      generation: ${{ matrix.generation_template }}
       maxTestDuration: P5D
       clusterPlan: Production - M
     secrets: inherit


### PR DESCRIPTION
## Description

Adjust weekly e2e for stable branches to use the latest Patch generation as a template.
This way we avoid using the latest SNAPSHOTS on testing stable branches.

## Related issues

closes #13923 
