### PR TITLE
Set tenant on records during resource transformation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -287,7 +287,8 @@ public final class DeploymentCreateProcessor
         .setNamespace(drg.getNamespace())
         .setResourceName(drg.getResourceName())
         .setChecksum(wrapArray(drg.getChecksum()))
-        .setResource(resource);
+        .setResource(resource)
+        .setTenantId(drg.getTenantId());
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -158,7 +158,8 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
         processMetadata
             .setBpmnProcessId(BufferUtil.wrapString(process.getId()))
             .setChecksum(resourceDigest)
-            .setResourceName(deploymentResource.getResourceNameBuffer());
+            .setResourceName(deploymentResource.getResourceNameBuffer())
+            .setTenantId(deploymentEvent.getTenantId());
 
         final var isDuplicate =
             isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -168,7 +168,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
         .setDecisionRequirementsName(parsedDrg.getName())
         .setNamespace(parsedDrg.getNamespace())
         .setResourceName(resource.getResourceName())
-        .setChecksum(checksum);
+        .setChecksum(checksum)
+        .setTenantId(deploymentEvent.getTenantId());
 
     decisionState
         .findLatestDecisionRequirementsById(wrapString(parsedDrg.getId()))
@@ -207,7 +208,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                   .setDecisionId(decision.getId())
                   .setDecisionName(decision.getName())
                   .setDecisionRequirementsId(parsedDrg.getId())
-                  .setDecisionRequirementsKey(drgRecord.getDecisionRequirementsKey());
+                  .setDecisionRequirementsKey(drgRecord.getDecisionRequirementsKey())
+                  .setTenantId(drgRecord.getTenantId());
 
               decisionState
                   .findLatestDecisionById(wrapString(decision.getId()))
@@ -281,7 +283,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                         .setNamespace(drg.getNamespace())
                         .setResourceName(drg.getResourceName())
                         .setChecksum(drg.getChecksumBuffer())
-                        .setResource(resource.getResourceBuffer())));
+                        .setResource(resource.getResourceBuffer())
+                        .setTenantId(drg.getTenantId())));
 
     deployment.decisionsMetadata().stream()
         .filter(decision -> decision.getDecisionRequirementsKey() == decisionRequirementsKey)
@@ -297,6 +300,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                         .setDecisionName(decision.getDecisionName())
                         .setVersion(decision.getVersion())
                         .setDecisionRequirementsId(decision.getDecisionRequirementsId())
-                        .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())));
+                        .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
+                        .setTenantId(decision.getTenantId())));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributedApplier.java
@@ -78,7 +78,8 @@ public class DeploymentDistributedApplier
         .setNamespace(drg.getNamespace())
         .setResourceName(drg.getResourceName())
         .setChecksum(wrapArray(drg.getChecksum()))
-        .setResource(resource);
+        .setResource(resource)
+        .setTenantId(drg.getTenantId());
   }
 
   private static final class NoSuchResourceException extends IllegalStateException {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -621,6 +621,13 @@ public final class CreateDeploymentTest {
         ENGINE.deployment().withXmlResource(process).withTenantId(tenant2).deploy();
 
     // then
+    assertThat(deployment.getKey())
+        .describedAs("Does two different deployments")
+        .isNotEqualTo(deployment2.getKey());
+    assertThat(deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey())
+        .describedAs("Creates 2 different process definitions")
+        .isNotEqualTo(
+            deployment2.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey());
     assertThat(deployment.getValue().getTenantId()).isEqualTo(tenant);
     assertThat(deployment2.getValue().getTenantId()).isEqualTo(tenant2);
     assertThat(

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/DeploymentClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/DeploymentClient.java
@@ -134,6 +134,11 @@ public final class DeploymentClient {
     return this;
   }
 
+  public DeploymentClient withTenantId(final String tenantId) {
+    deploymentRecord.setTenantId(tenantId);
+    return this;
+  }
+
   public DeploymentClient expectRejection() {
     expectation = REJECTION_EXPECTATION;
     return this;

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -31,6 +31,7 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
       new LongProperty("decisionRequirementsKey");
 
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
 
   public DecisionRecord() {
     declareProperty(decisionIdProp)
@@ -39,7 +40,8 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
         .declareProperty(decisionKeyProp)
         .declareProperty(decisionRequirementsIdProp)
         .declareProperty(decisionRequirementsKeyProp)
-        .declareProperty(isDuplicateProp);
+        .declareProperty(isDuplicateProp)
+        .declareProperty(tenantIdProp);
   }
 
   @Override
@@ -129,7 +131,11 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
 
   @Override
   public String getTenantId() {
-    // todo(#13320): replace dummy implementation
-    return "";
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public DecisionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
@@ -37,6 +37,7 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
 
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
 
   public DecisionRequirementsMetadataRecord() {
     declareProperty(decisionRequirementsIdProp)
@@ -46,7 +47,8 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
         .declareProperty(namespaceProp)
         .declareProperty(resourceNameProp)
         .declareProperty(checksumProp)
-        .declareProperty(isDuplicateProp);
+        .declareProperty(isDuplicateProp)
+        .declareProperty(tenantIdProp);
   }
 
   @Override
@@ -160,7 +162,11 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
 
   @Override
   public String getTenantId() {
-    // todo(#13320): replace dummy implementation
-    return "";
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public DecisionRequirementsMetadataRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -35,6 +35,7 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
   private final BinaryProperty resourceProp = new BinaryProperty("resource");
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
 
   public DecisionRequirementsRecord() {
     declareProperty(decisionRequirementsIdProp)
@@ -44,7 +45,8 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
         .declareProperty(namespaceProp)
         .declareProperty(resourceNameProp)
         .declareProperty(checksumProp)
-        .declareProperty(resourceProp);
+        .declareProperty(resourceProp)
+        .declareProperty(tenantIdProp);
   }
 
   @Override
@@ -166,7 +168,11 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
 
   @Override
   public String getTenantId() {
-    // todo(#13320): replace dummy implementation
-    return "";
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public DecisionRequirementsRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -7,7 +7,10 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.deployment;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
@@ -35,11 +38,14 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
   private final ArrayProperty<DecisionRequirementsMetadataRecord> decisionRequirementsMetadataProp =
       new ArrayProperty<>("decisionRequirementsMetadata", new DecisionRequirementsMetadataRecord());
 
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+
   public DeploymentRecord() {
     declareProperty(resourcesProp)
         .declareProperty(processesMetadataProp)
         .declareProperty(decisionRequirementsMetadataProp)
-        .declareProperty(decisionMetadataProp);
+        .declareProperty(decisionMetadataProp)
+        .declareProperty(tenantIdProp);
   }
 
   public ValueArray<ProcessMetadata> processesMetadata() {
@@ -121,8 +127,12 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
 
   @Override
   public String getTenantId() {
-    // todo(#13320): replace dummy implementation
-    return "";
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public DeploymentRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 
   public boolean hasBpmnResources() {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.deployment;
 import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_BPMN_PROCESS_ID;
 import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_KEY;
 import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_VERSION;
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
@@ -35,6 +36,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   // should be set to true if the process was already deployed - property should not be exported
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
 
   public ProcessMetadata() {
     declareProperty(bpmnProcessIdProp)
@@ -42,7 +44,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
         .declareProperty(keyProp)
         .declareProperty(resourceNameProp)
         .declareProperty(checksumProp)
-        .declareProperty(isDuplicateProp);
+        .declareProperty(isDuplicateProp)
+        .declareProperty(tenantIdProp);
   }
 
   @Override
@@ -155,7 +158,11 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   @Override
   public String getTenantId() {
-    // todo(#13320): replace dummy implementation
-    return "";
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public ProcessMetadata setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -29,6 +29,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
   private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
 
   public ProcessRecord() {
     declareProperty(bpmnProcessIdProp)
@@ -36,7 +37,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(keyProp)
         .declareProperty(resourceNameProp)
         .declareProperty(checksumProp)
-        .declareProperty(resourceProp);
+        .declareProperty(resourceProp)
+        .declareProperty(tenantIdProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -46,6 +48,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     keyProp.setValue(metadata.getKey());
     resourceNameProp.setValue(metadata.getResourceNameBuffer());
     resourceProp.setValue(BufferUtil.wrapArray(resource));
+    tenantIdProp.setValue(metadata.getTenantId());
     return this;
   }
 
@@ -174,7 +177,6 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
 
   @Override
   public String getTenantId() {
-    // todo(#13320): replace dummy implementation
-    return "";
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR will make sure that upon deployment the tenant id is taken from the command and written on the events. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

Part 1 of #13320 
Part 2 will consist of actually storing the tenant in the state

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
