### PR TITLE
deps(renovate): custom ubuntu versioning rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,13 @@
         "patch"
       ],
       "enabled": false
+    },
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "packageNames": [ "ubuntu" ],
+      "versioning": "regex:^(?<compatibility>[a-z]+)-(?<patch>\\d+)$"
     }
   ],
   "dockerfile": {


### PR DESCRIPTION
## Description

Renovate cannot handle the date tagging used by ubuntu otherwise. This change instructs renovate to treat every new tag of the same ubuntu release as a patch.

Will require a manual test after merge, luckily there is already a new tag [ubuntu:jammy-20230804](https://hub.docker.com/layers/library/ubuntu/jammy-20230804/images/sha256-56887c5194fddd8db7e36ced1c16b3569d89f74c801dc8a5adbf48236fb34564?context=explore) and we can trigger a run manually right after via the dep dashboard https://github.com/camunda/zeebe/issues/12605

## Related issues

closes #13736 
