### PR TITLE
fix(broker): remove existing limiter before adding a new one 

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/PartitionAwareRequestLimiter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/PartitionAwareRequestLimiter.java
@@ -136,6 +136,7 @@ public final class PartitionAwareRequestLimiter {
   }
 
   public void addPartition(final int partitionId) {
+    removePartition(partitionId);
     getOrCreateLimiter(partitionId);
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/PartitionAwareRateLimiterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/PartitionAwareRateLimiterTest.java
@@ -13,16 +13,16 @@ import io.camunda.zeebe.broker.system.configuration.backpressure.BackpressureCfg
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import java.util.stream.IntStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public final class PartitionAwareRateLimiterTest {
+final class PartitionAwareRateLimiterTest {
   private static final int PARTITIONS = 3;
   private final Intent context = ProcessInstanceCreationIntent.CREATE;
   private PartitionAwareRequestLimiter partitionedLimiter;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     final var backpressureCfg = new BackpressureCfg();
     backpressureCfg.setAlgorithm("fixed");
     backpressureCfg.getFixed().setLimit(1);
@@ -33,7 +33,7 @@ public final class PartitionAwareRateLimiterTest {
   }
 
   @Test
-  public void shouldNotBlockRequestsOnOtherPartitionsWhenOnePartitionIsFull() {
+  void shouldNotBlockRequestsOnOtherPartitionsWhenOnePartitionIsFull() {
     // when
     assertThat(partitionedLimiter.tryAcquire(0, 0, 1, context)).isTrue();
     assertThat(partitionedLimiter.tryAcquire(0, 0, 2, context)).isFalse();
@@ -44,7 +44,7 @@ public final class PartitionAwareRateLimiterTest {
   }
 
   @Test
-  public void shouldUpdateOnResponse() {
+  void shouldUpdateOnResponse() {
     // given
     partitionedLimiter.tryAcquire(0, 0, 1, context);
     assertThat(partitionedLimiter.tryAcquire(0, 0, 2, context)).isFalse();
@@ -57,7 +57,7 @@ public final class PartitionAwareRateLimiterTest {
   }
 
   @Test
-  public void shouldNotUpdateOnResponseDifferentPartition() {
+  void shouldNotUpdateOnResponseDifferentPartition() {
     final int mainPartitionId = 0;
     final int otherPartitionId = 1;
     // given

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/PartitionAwareRateLimiterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/PartitionAwareRateLimiterTest.java
@@ -71,4 +71,20 @@ final class PartitionAwareRateLimiterTest {
     // then
     assertThat(partitionedLimiter.tryAcquire(mainPartitionId, 0, 2, context)).isFalse();
   }
+
+  @Test
+  void shouldCreateNewLimiterOnReAddingPartitionWithoutExplicitRemove() {
+    // given
+    final int partitionId = 0;
+    partitionedLimiter.tryAcquire(partitionId, 0, 1, context);
+    assertThat(partitionedLimiter.tryAcquire(partitionId, 0, 2, context)).isFalse();
+
+    // when
+    partitionedLimiter.addPartition(partitionId);
+
+    // then
+    assertThat(partitionedLimiter.tryAcquire(partitionId, 0, 2, context))
+        .describedAs("Should not reject request on re-added partition")
+        .isTrue();
+  }
 }


### PR DESCRIPTION
## Description

The previous assumption was that `CommandApiService#onBecomingFollower` is always invoked before becoming leader again. But recent changes to ZeebePartition resulted in not notifying the listeners if a transition was cancelled in between. When a Leader -> Follower -> Leader transition happened, where follower transitioned was cancelled, then this resulted in the command api using the limiter from the previous leader role. To prevent this, when adding a partition the limiter force create a new one. addPartiton is only used when we want to re-add a partition. So it makes sense to force re-create it.

## Related issues

closes #14044 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
