### PR TITLE
feat(raft): configure request supports joint consensus

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -36,6 +36,7 @@ import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.system.Configuration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /** Inactive state. */
@@ -57,7 +58,12 @@ public class InactiveRole extends AbstractRole {
     updateTermAndLeader(request.term(), request.leader());
 
     final Configuration configuration =
-        new Configuration(request.index(), request.term(), request.timestamp(), request.members());
+        new Configuration(
+            request.index(),
+            request.term(),
+            request.timestamp(),
+            request.newMembers(),
+            request.oldMembers() != null ? request.oldMembers() : List.of());
 
     // Configure the cluster membership. This will cause this server to transition to the
     // appropriate state if its type has changed.

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -286,13 +286,15 @@ final class LeaderAppender {
 
   /** Builds a configure request for the given member. */
   private ConfigureRequest buildConfigureRequest() {
-    final DefaultRaftMember leader = raft.getLeader();
+    final var leader = raft.getLeader();
+    final var configuration = raft.getCluster().getConfiguration();
     return ConfigureRequest.builder()
         .withTerm(raft.getTerm())
         .withLeader(leader.memberId())
-        .withIndex(raft.getCluster().getConfiguration().index())
-        .withTime(raft.getCluster().getConfiguration().time())
-        .withMembers(raft.getCluster().getConfiguration().newMembers())
+        .withIndex(configuration.index())
+        .withTime(configuration.time())
+        .withNewMembers(configuration.newMembers())
+        .withOldMembers(configuration.oldMembers())
         .build();
   }
 


### PR DESCRIPTION
This adds support for joint consensus to `ConfigureRequest`s.

Backwards compatibility is maintained because we are only adding a new field without changing existing ones. This means that 
1. New leaders might send `ConfigureRequest`s with old and new member lists to older followers which do no support joint consensus yet. These will skip the new, unknown field and treat the configuration as normal and not joint consensus. 
2. New followers might receive `ConfigureRequest`s from old leaders. These are handled as if the old member list is always empty which is okay since an old leader doesn't support joint consensus yet.

The first case is a bit problematic but IMO okay since we can assume that no joint consensus configuration is entered while the cluster is upgrading from a pre-joint-consensus version.

relates to https://github.com/camunda/zeebe/issues/13906