### PR TITLE
feat(raft): new members can join existing cluster

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -287,6 +287,15 @@ public interface RaftServer {
   }
 
   /**
+   * Starts this raft server by joining an existing replication group. A {@link
+   * io.atomix.raft.protocol.JoinRequest} is sent to an arbitrary member of the cluster, as provided
+   * by the {@link ClusterMembershipService}.
+   *
+   * @return A completable future to be completed once the server has joined the cluster.
+   */
+  CompletableFuture<RaftServer> join();
+
+  /**
    * Promotes the server to leader if possible.
    *
    * @return a future to be completed once the server has been promoted

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftCluster.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftCluster.java
@@ -135,6 +135,8 @@ public interface RaftCluster {
    */
   CompletableFuture<Void> bootstrap(Collection<MemberId> cluster);
 
+  CompletableFuture<Void> join();
+
   /**
    * Returns a member by ID.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
@@ -47,7 +47,7 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
 
   public DefaultRaftMember(final MemberId id, final Type type, final Instant updated) {
     this.id = checkNotNull(id, "id cannot be null");
-    hash = Hashing.murmur3_32().hashUnencodedChars(id.id()).asInt();
+    hash = Hashing.murmur3_32_fixed().hashUnencodedChars(id.id()).asInt();
     setType(checkNotNull(type, "type cannot be null"));
     this.updated = checkNotNull(updated, "updated cannot be null");
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -95,6 +95,12 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
   }
 
   @Override
+  public CompletableFuture<Void> join() {
+    return raft.join()
+        .thenRunAsync(() -> raft.transition(localMember.getType()), raft.getThreadContext());
+  }
+
+  @Override
   public DefaultRaftMember getMember(final MemberId id) {
     if (localMember.memberId().equals(id)) {
       return localMember;

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -91,6 +91,10 @@ public final class RaftMemberContext {
     }
   }
 
+  public boolean hasReplicationContext() {
+    return reader != null;
+  }
+
   public void openReplicationContext(final RaftLog log) {
     resetState(log);
     openReader(log);

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -99,6 +99,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public CompletableFuture<RaftServer> join() {
+    return start(() -> cluster().join());
+  }
+
+  @Override
   public CompletableFuture<RaftServer> promote() {
     return context.anoint().thenApply(v -> this);
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -28,6 +28,7 @@ class RaftMessageContext {
   final String metadataSubject;
   final String configureSubject;
   final String reconfigureSubject;
+  final String joinSubject;
   final String installSubject;
   final String transferSubject;
   final String pollSubject;
@@ -35,10 +36,8 @@ class RaftMessageContext {
   final String appendV1subject;
   final String appendV2subject;
   final String leaderHeartbeatSubject;
-  private final String prefix;
 
   RaftMessageContext(final String prefix) {
-    this.prefix = prefix;
     heartbeatSubject = getSubject(prefix, "heartbeat");
     openSessionSubject = getSubject(prefix, "open");
     closeSessionSubject = getSubject(prefix, "close");
@@ -48,6 +47,7 @@ class RaftMessageContext {
     metadataSubject = getSubject(prefix, "metadata");
     configureSubject = getSubject(prefix, "configure");
     reconfigureSubject = getSubject(prefix, "reconfigure");
+    joinSubject = getSubject(prefix, "join");
     installSubject = getSubject(prefix, "install");
     transferSubject = getSubject(prefix, "transfer");
     pollSubject = getSubject(prefix, "poll");

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -27,6 +27,8 @@ import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
+import io.atomix.raft.protocol.JoinRequest;
+import io.atomix.raft.protocol.JoinResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
@@ -86,6 +88,8 @@ public final class RaftNamespaces {
           .register(TransferResponse.class)
           .register(VersionedAppendRequest.class)
           .register(ReplicatableJournalRecord.class)
+          .register(JoinRequest.class)
+          .register(JoinResponse.class)
           .name("RaftProtocol")
           .build();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/JoinRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/JoinRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+import static java.util.Objects.requireNonNull;
+
+import io.atomix.raft.cluster.RaftMember;
+import java.util.Objects;
+
+public final class JoinRequest extends AbstractRaftRequest {
+  private final RaftMember joining;
+
+  private JoinRequest(final RaftMember joining) {
+    this.joining = requireNonNull(joining);
+  }
+
+  public RaftMember joiningMember() {
+    return joining;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(joining);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JoinRequest that = (JoinRequest) o;
+    return Objects.equals(joining, that.joining);
+  }
+
+  @Override
+  public String toString() {
+    return "JoinRequest{" + "joining=" + joining + '}';
+  }
+
+  public static final class Builder
+      extends AbstractRaftRequest.Builder<JoinRequest.Builder, JoinRequest> {
+
+    private RaftMember joining;
+
+    private Builder() {}
+
+    public Builder withJoiningMember(final RaftMember joining) {
+      this.joining = joining;
+      return this;
+    }
+
+    @Override
+    public JoinRequest build() {
+      validate();
+      return new JoinRequest(joining);
+    }
+
+    @Override
+    protected void validate() {
+      requireNonNull(joining, "joining member cannot be null");
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/JoinResponse.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/JoinResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+import io.atomix.raft.RaftError;
+
+public final class JoinResponse extends AbstractRaftResponse {
+
+  private JoinResponse(final Status status, final RaftError error) {
+    super(status, error);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder extends AbstractRaftResponse.Builder<Builder, JoinResponse> {
+    private Builder() {}
+
+    @Override
+    public JoinResponse build() {
+      validate();
+      return new JoinResponse(status, error);
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -42,6 +42,15 @@ public interface RaftServerProtocol {
   CompletableFuture<ReconfigureResponse> reconfigure(MemberId memberId, ReconfigureRequest request);
 
   /**
+   * Sends a join request to the given node.
+   *
+   * @param memberId the node to which to send the request
+   * @param request the request to send
+   * @return a future to be completed with the response
+   */
+  CompletableFuture<JoinResponse> join(MemberId memberId, JoinRequest request);
+
+  /**
    * Sends an install request to the given node.
    *
    * @param memberId the node to which to send the request
@@ -120,6 +129,10 @@ public interface RaftServerProtocol {
 
   /** Unregisters the reconfigure request handler. */
   void unregisterReconfigureHandler();
+
+  void registerJoinHandler(Function<JoinRequest, CompletableFuture<JoinResponse>> handler);
+
+  void unregisterJoinHandler();
 
   /**
    * Registers a install request callback.

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -17,6 +17,7 @@
 package io.atomix.raft.roles;
 
 import io.atomix.raft.RaftError;
+import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.protocol.AppendResponse;
@@ -25,6 +26,8 @@ import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
+import io.atomix.raft.protocol.JoinRequest;
+import io.atomix.raft.protocol.JoinResponse;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftResponse;
@@ -101,6 +104,15 @@ public class InactiveRole extends AbstractRole {
                 .withStatus(Status.ERROR)
                 .withError(RaftError.Type.UNAVAILABLE)
                 .build());
+    return CompletableFuture.completedFuture(result);
+  }
+
+  @Override
+  public CompletableFuture<JoinResponse> onJoin(final JoinRequest request) {
+    logRequest(request);
+    final var result =
+        logResponse(
+            JoinResponse.builder().withStatus(Status.ERROR).withError(Type.UNAVAILABLE).build());
     return CompletableFuture.completedFuture(result);
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -23,6 +23,8 @@ import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
+import io.atomix.raft.protocol.JoinRequest;
+import io.atomix.raft.protocol.JoinResponse;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.ReconfigureRequest;
@@ -67,6 +69,9 @@ public interface RaftRole extends Managed<RaftRole> {
    * @return A completable future to be completed with the request response.
    */
   CompletableFuture<ReconfigureResponse> onReconfigure(ReconfigureRequest request);
+
+  /** Handles a request to join the cluster. */
+  CompletableFuture<JoinResponse> onJoin(JoinRequest request);
 
   /**
    * Handles a transfer request.

--- a/atomix/cluster/src/test/java/io/atomix/raft/MemberJoinTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/MemberJoinTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.ClusterMembershipEventListener;
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember.Type;
+import io.atomix.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.protocol.TestRaftProtocolFactory;
+import io.atomix.raft.snapshot.TestSnapshotStore;
+import io.atomix.raft.storage.RaftStorage;
+import io.atomix.utils.concurrent.SingleThreadContext;
+import io.atomix.utils.net.Address;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class MemberJoinTest {
+  final SingleThreadContext context = new SingleThreadContext("raft-%d");
+
+  final TestRaftProtocolFactory protocolFactory = new TestRaftProtocolFactory(context);
+
+  @Test
+  void shouldJoinExistingMembers(@TempDir final Path tmp) {
+    // given - a cluster with 3 members
+    final var id1 = MemberId.from("1");
+    final var id2 = MemberId.from("2");
+    final var id3 = MemberId.from("3");
+
+    final var m1 = createServer(tmp, createMembershipService(id1, id2, id3));
+    final var m2 = createServer(tmp, createMembershipService(id2, id1, id3));
+    final var m3 = createServer(tmp, createMembershipService(id3, id1, id2));
+
+    CompletableFuture.allOf(
+            m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
+        .join();
+
+    // when - a new member joins
+    final var id4 = MemberId.from("4");
+    final var m4 = createServer(tmp, createMembershipService(id4, id1, id2, id3));
+    m4.join().join();
+
+    // then - all members show a configuration with 4 active members
+    final var expected =
+        List.of(
+            new DefaultRaftMember(id1, Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(id2, Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(id3, Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(id4, Type.ACTIVE, Instant.now()));
+
+    assertThat(m1.cluster().getMembers()).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(m2.cluster().getMembers()).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(m3.cluster().getMembers()).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(m4.cluster().getMembers()).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  private ClusterMembershipService createMembershipService(
+      final MemberId localId, final MemberId... remoteIds) {
+    final var localMember = Member.member(localId, Address.local());
+    final var remoteMembers =
+        Arrays.stream(remoteIds).map(id -> Member.member(id, Address.local()));
+    final var members = new HashMap<MemberId, Member>();
+    members.put(localId, localMember);
+    remoteMembers.forEach(member -> members.put(member.id(), member));
+    return new ClusterMembershipService() {
+      @Override
+      public Member getLocalMember() {
+        return localMember;
+      }
+
+      @Override
+      public Set<Member> getMembers() {
+        return Set.copyOf(members.values());
+      }
+
+      @Override
+      public Member getMember(final MemberId memberId) {
+        return members.get(memberId);
+      }
+
+      @Override
+      public void addListener(final ClusterMembershipEventListener listener) {}
+
+      @Override
+      public void removeListener(final ClusterMembershipEventListener listener) {}
+    };
+  }
+
+  private RaftServer createServer(
+      final Path dir, final ClusterMembershipService membershipService) {
+    final var memberId = membershipService.getLocalMember().id();
+    final var protocol = protocolFactory.newServerProtocol(memberId);
+    final var storage =
+        RaftStorage.builder()
+            .withDirectory(dir.resolve(memberId.toString()).toFile())
+            .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
+            .withMaxSegmentSize(1024 * 10)
+            .build();
+    return RaftServer.builder(memberId)
+        .withMembershipService(membershipService)
+        .withProtocol(protocol)
+        .withStorage(storage)
+        .withPartitionConfig(
+            new RaftPartitionConfig()
+                .setElectionTimeout(Duration.ofMillis(1000))
+                .setHeartbeatInterval(Duration.ofMillis(500)))
+        .build();
+  }
+}


### PR DESCRIPTION
This adds support for a new raft server operation, `join` as an alternative to `bootstrap`. Whereas `bootstrap` starts the server and then creates an initial configuration based on a provided member list, `join` picks any member from the membership service and sends it a `JoinRequest` with the new member id and desired member type (e.g. `ACTIVE` or `PROMOTABLE`). The request is forwarded to the current leader.

When a leader receives a `JoinRequest`, it is translated to a `ReconfigureRequest` from `currentMembers` to `currentMembers + newMember`. This part is a bit hacky - there's no reason to use `ReconfigureRequest` as long as we are only adding or removing a single member at a time - but it also doesn't hurt anything but readability.
The `JoinRequest` is completed once the `ReconfigureRequest` is completed. This happens after leaving the joint consensus phase, on commit of the new configuration. 
Waiting for the completion of the reconfiguration may fail, leading to a failed `join` from the perspective of the new member, even if the configuration was actually committed.

As an example, here is an excerpt from a test where a fourth member joins a three node cluster:
```
23:00:50.697 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{1}{role=FOLLOWER} - Received JoinRequest{joining=DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693058896Z}}
23:00:50.702 [] TRACE io.atomix.raft.roles.LeaderRole - RaftServer{2}{role=LEADER} - Received ReconfigureRequest{index=0, term=0, members=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693058896Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}]}
23:00:50.710 [] TRACE io.atomix.raft.roles.LeaderRole - RaftServer{2}{role=LEADER} - Appended IndexedRaftLogEntryImpl[index=2, term=1, entry=ConfigurationEntry[timestamp=1693429250702, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693058896Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}], oldMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}]], record=PersistedJournalRecord[metadata=RecordMetadata[checksum=4101772789, length=165], record=RecordData[index=2, asqn=-1, data=UnsafeBuffer{addressOffset=140658703323308, capacity=137, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=309 lim=10240 cap=10240]}], serializedRecord=UnsafeBuffer{addressOffset=140658703323280, capacity=165, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=309 lim=10240 cap=10240]}]]
23:00:50.717 [] DEBUG io.atomix.raft.roles.LeaderAppender - RaftServer{2} - Configuring 4
23:00:50.718 [] TRACE io.atomix.raft.roles.LeaderAppender - RaftServer{2} - Sending ConfigureRequest{term=1, leader='2', index=2, timestamp=1693429250702, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693058896Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}], oldMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}]} to 4
23:00:50.720 [] TRACE io.atomix.raft.roles.InactiveRole - RaftServer{null}{role=INACTIVE} - Received ConfigureRequest{term=1, leader='2', index=2, timestamp=1693429250702, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693058896Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}], oldMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}]}
23:00:50.721 [] DEBUG io.atomix.raft.impl.RaftContext - RaftServer{4} - Set term 1
23:00:50.721 [] TRACE io.atomix.raft.impl.RaftContext - RaftServer{4} - Set leader null
23:00:50.722 [] INFO  io.atomix.raft.impl.RaftContext - RaftServer{4} - Transitioning to FOLLOWER
23:00:50.730 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Received InternalAppendRequest[term=1, leader=2, prevLogIndex=2, prevLogTerm=1, commitIndex=1, entries=[]]
23:00:50.730 [] INFO  io.atomix.raft.impl.RaftContext - RaftServer{4} - Found leader 2
23:00:50.731 [] DEBUG io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Rejected InternalAppendRequest[term=1, leader=2, prevLogIndex=2, prevLogTerm=1, commitIndex=1, entries=[]]: Previous index (2) is greater than the local log's last index (0)
23:00:50.731 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Sending AppendResponse{status=OK, term=1, succeeded=false, lastLogIndex=0, lastSnapshotIndex=0}
23:00:50.732 [] TRACE io.atomix.raft.roles.LeaderAppender - RaftServer{2} - Received AppendResponse{status=OK, term=1, succeeded=false, lastLogIndex=0, lastSnapshotIndex=0} from 4
23:00:50.732 [] TRACE io.atomix.raft.roles.LeaderAppender - RaftServer{2} - Reset next index for RaftMemberContext{member=4, term=1, configIndex=2, snapshotIndex=0, nextSnapshotIndex=0, nextSnapshotChunk=null, matchIndex=0, heartbeatTime=1693429250717, appending=0, appendSucceeded=false, appendTime=1693429250728, configuring=false, installing=false, failures=0} to 1
23:00:50.733 [] TRACE io.atomix.raft.roles.LeaderAppender - RaftServer{2} - Sending VersionedAppendRequest{version=2, term=1, leader=2, prevLogIndex=0, prevLogTerm=0, entries=2, commitIndex=2} to 4
23:00:50.735 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Received InternalAppendRequest[term=1, leader=2, prevLogIndex=0, prevLogTerm=0, commitIndex=2, entries=[...]
23:00:50.735 [] DEBUG io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Reset first index to 1
23:00:50.737 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Appended IndexedRaftLogEntryImpl[index=1, term=1, entry=InitialEntry[], record=PersistedJournalRecord[metadata=RecordMetadata[checksum=4252175043, length=45], record=RecordData[index=1, asqn=-1, data=UnsafeBuffer{addressOffset=140658702557290, capacity=17, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=123 lim=10240 cap=10240]}], serializedRecord=UnsafeBuffer{addressOffset=140658702557262, capacity=45, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=123 lim=10240 cap=10240]}]]
23:00:50.739 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Appended IndexedRaftLogEntryImpl[index=2, term=1, entry=ConfigurationEntry[timestamp=1693429250702, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461Z}, DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461Z}], oldMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461Z}]], record=PersistedJournalRecord[metadata=RecordMetadata[checksum=4101772789, length=165], record=RecordData[index=2, asqn=-1, data=UnsafeBuffer{addressOffset=140658702557356, capacity=137, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=309 lim=10240 cap=10240]}], serializedRecord=UnsafeBuffer{addressOffset=140658702557328, capacity=165, byteArray=null, byteBuffer=java.nio.DirectByteBuffer[pos=309 lim=10240 cap=10240]}]]
23:00:50.739 [] INFO  io.atomix.raft.impl.RaftContext - RaftServer{4} - Setting firstCommitIndex to 2. RaftServer is ready only after it has committed events upto this index
23:00:50.740 [] INFO  io.atomix.raft.impl.RaftContext - RaftServer{4} - Commit index is 2. RaftServer is ready
23:00:50.741 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Sending AppendResponse{status=OK, term=1, succeeded=true, lastLogIndex=2, lastSnapshotIndex=0}
23:00:50.741 [] TRACE io.atomix.raft.roles.LeaderAppender - RaftServer{2} - Sending ConfigureRequest{term=1, leader='2', index=3, timestamp=1693429250735, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693058896Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}], oldMembers=[]} to 4
23:00:50.742 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Received ConfigureRequest{term=1, leader='2', index=3, timestamp=1693429250735, newMembers=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693058896Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}], oldMembers=[]}
23:00:50.743 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{4}{role=FOLLOWER} - Sending ConfigureResponse{status=OK}
23:00:50.753 [] TRACE io.atomix.raft.roles.LeaderRole - RaftServer{2}{role=LEADER} - Sending ReconfigureResponse{status=OK, index=3, term=1, timestamp=1693429250735, members=[DefaultRaftMember{id=2, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=1, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}, DefaultRaftMember{id=4, type=ACTIVE, updated=2023-08-30T21:00:50.693058896Z}, DefaultRaftMember{id=3, type=ACTIVE, updated=2023-08-30T21:00:49.461902559Z}]}
23:00:50.754 [] TRACE io.atomix.raft.roles.LeaderAppender - RaftServer{2} - Received AppendResponse{status=OK, term=1, succeeded=true, lastLogIndex=3, lastSnapshotIndex=0} from 4
23:00:50.754 [] TRACE io.atomix.raft.roles.FollowerRole - RaftServer{1}{role=FOLLOWER} - Sending JoinResponse{status=OK}
23:00:50.754 [] INFO  io.atomix.raft.impl.DefaultRaftServer - RaftServer{4} - Server join completed. Waiting for the server to be READY
23:00:50.755 [] DEBUG io.atomix.raft.impl.DefaultRaftServer - RaftServer{4} - Server started successfully!
```

relates to #13906 

