### PR TITLE
deps(renovate): enable ubuntu updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,9 @@
       "matchManagers": [
         "dockerfile"
       ],
+      "excludePackageNames": [
+        "ubuntu"
+      ],
       "matchUpdateTypes": [
         "major",
         "minor",
@@ -28,7 +31,9 @@
       "matchManagers": [
         "dockerfile"
       ],
-      "packageNames": [ "ubuntu" ],
+      "packageNames": [
+        "ubuntu"
+      ],
       "versioning": "regex:^(?<compatibility>[a-z]+)-(?<patch>\\d+)$"
     }
   ],


### PR DESCRIPTION
## Description

Missed to enable the update with the previous PR https://github.com/camunda/zeebe/pull/14061 .
As we have the general rule that disables all major/minor/patch updates, we need to exclude ubuntu there.

## Related issues

closes #13736