### PR TITLE
Store tenant in `DbDeploymentState`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableBoolean;
@@ -26,7 +27,6 @@ import org.agrona.collections.MutableReference;
 import org.slf4j.Logger;
 
 public final class DbDeploymentState implements MutableDeploymentState {
-
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
 
   private final DbLong deploymentKey;
@@ -140,6 +140,10 @@ public final class DbDeploymentState implements MutableDeploymentState {
               // we ignore this currently
               return;
             }
+            // Any deployments in this state are old as deployment distributions are done using
+            // generalized distribution now. It is safe to assume that they belong to the default
+            // tenant. We do have to set this on the record before distributing it.
+            deploymentRaw.getDeploymentRecord().setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
             lastDeployment.set(BufferUtil.createCopy(deploymentRaw.getDeploymentRecord()));
             lastDeploymentKey.set(deploymentKey);
           }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -14,10 +14,10 @@ import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Before;
@@ -194,7 +194,8 @@ public class DeploymentStateTest {
     assertThat(pendings).extracting(Triple::getMiddle).containsExactly(2, 3);
     assertThat(pendings)
         .extracting(Triple::getRight)
-        .containsOnly(BufferUtil.createCopy(deployment));
+        .containsOnly(
+            BufferUtil.createCopy(deployment.setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)));
   }
 
   @Test
@@ -224,8 +225,9 @@ public class DeploymentStateTest {
         .extracting(Triple::getRight)
         .containsOnly(
             deployments.stream()
+                .map(record -> record.setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
                 .map(BufferUtil::createCopy)
-                .collect(Collectors.toList())
+                .toList()
                 .toArray(new DirectBuffer[deployments.size()]));
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -227,8 +227,7 @@ public class DeploymentStateTest {
             deployments.stream()
                 .map(record -> record.setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
                 .map(BufferUtil::createCopy)
-                .toList()
-                .toArray(new DirectBuffer[deployments.size()]));
+                .toArray(DirectBuffer[]::new));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This state is only used for pending deployment distributions. These are no longer used since the introduction of generalized distribution. It is safe to assume that any data in this state belongs to the default  tenant. Because of this we don't have to do complex stuff to make it  tenant aware. We just have to make sure we add the default tenant to the deployment record on distribution.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #13320 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
