### PR TITLE
refactor(topology): encapsulate static configuration used by topology manager

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -29,8 +29,6 @@ public class RaftPartitionConfig {
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
-  private static final RoundRobinPartitionDistributor DEFAULT_PARTITION_DISTRIBUTOR =
-      new RoundRobinPartitionDistributor();
   private static final int DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD = 100;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
@@ -42,7 +40,6 @@ public class RaftPartitionConfig {
   private Duration snapshotRequestTimeout = DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
-  private PartitionDistributor partitionDistributor = DEFAULT_PARTITION_DISTRIBUTOR;
   private int preferSnapshotReplicationThreshold = DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD;
   private RaftStorageConfig storageConfig;
   private EntryValidator entryValidator;
@@ -170,14 +167,6 @@ public class RaftPartitionConfig {
     this.maxQuorumResponseTimeout = maxQuorumResponseTimeout;
   }
 
-  public PartitionDistributor getPartitionDistributor() {
-    return partitionDistributor;
-  }
-
-  public void setPartitionDistributor(final PartitionDistributor partitionDistributor) {
-    this.partitionDistributor = partitionDistributor;
-  }
-
   public int getPreferSnapshotReplicationThreshold() {
     return preferSnapshotReplicationThreshold;
   }
@@ -223,8 +212,6 @@ public class RaftPartitionConfig {
         + minStepDownFailureCount
         + ", maxQuorumResponseTimeout="
         + maxQuorumResponseTimeout
-        + ", partitionDistributor="
-        + partitionDistributor
         + ", preferSnapshotReplicationThreshold="
         + preferSnapshotReplicationThreshold
         + '}';

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.partitioning.distribution;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
-import io.atomix.raft.partition.PartitionDistributor;
+import io.camunda.zeebe.topology.PartitionDistributor;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/RoundRobinPartitionDistributor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/RoundRobinPartitionDistributor.java
@@ -1,24 +1,17 @@
 /*
- * Copyright © 2020 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
-package io.atomix.raft.partition;
+package io.camunda.zeebe.broker.partitioning.distribution;
 
 import com.google.common.collect.Sets;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.topology.PartitionDistributor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistributionResolver.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistributionResolver.java
@@ -24,8 +24,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-/** Manage how partitions are distributed among the brokers. */
+/** Utility class to determine partition distribution from the given cluster configuration. */
 public final class PartitionDistributionResolver {
+
+  private PartitionDistributionResolver() {}
 
   public static StaticConfiguration getStaticConfiguration(
       final ClusterCfg clusterCfg,

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistributionResolver.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/PartitionDistributionResolver.java
@@ -12,13 +12,13 @@ import static io.camunda.zeebe.broker.system.configuration.partitioning.Scheme.F
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
-import io.atomix.raft.partition.PartitionDistributor;
-import io.atomix.raft.partition.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.distribution.FixedPartitionDistributor;
 import io.camunda.zeebe.broker.partitioning.distribution.FixedPartitionDistributorBuilder;
+import io.camunda.zeebe.broker.partitioning.distribution.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.PartitioningCfg;
+import io.camunda.zeebe.topology.PartitionDistributor;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import java.util.List;
 import java.util.Map;

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
@@ -21,7 +21,7 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.partition.RaftStorageConfig;
-import io.atomix.raft.partition.RoundRobinPartitionDistributor;
+import io.camunda.zeebe.broker.partitioning.distribution.RoundRobinPartitionDistributor;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/RoundRobinPartitionDistributorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/RoundRobinPartitionDistributorTest.java
@@ -1,19 +1,11 @@
 /*
- * Copyright © 2020 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
-package io.atomix.raft.partition;
+package io.camunda.zeebe.broker.partitioning.distribution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticPartitionDistributionResolverTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticPartitionDistributionResolverTest.java
@@ -12,15 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.atomix.cluster.MemberId;
-import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.PartitioningCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
-import io.camunda.zeebe.topology.state.ClusterTopology;
-import io.camunda.zeebe.topology.state.MemberState;
-import io.camunda.zeebe.topology.state.PartitionState;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
@@ -55,10 +50,10 @@ class StaticPartitionDistributionResolverTest {
     clusterCfg.setReplicationFactor(3);
 
     // when
-    final var topology =
-        new PartitionDistributionResolver()
-            .resolvePartitionDistribution(partitioningCfg, clusterCfg);
-    final Set<PartitionMetadata> partitionDistribution = topology.partitions();
+    final var partitionDistribution =
+        PartitionDistributionResolver.getStaticConfiguration(
+                clusterCfg, partitioningCfg, MemberId.from("1"))
+            .generatePartitionDistribution();
 
     // then
     // RoundRobinPartitionDistributorTest verifies more cases.
@@ -119,99 +114,15 @@ fixed:
     clusterCfg.setReplicationFactor(3);
 
     // when
-    final var topology =
-        new PartitionDistributionResolver()
-            .resolvePartitionDistribution(partitioningCfg, clusterCfg);
-    final Set<PartitionMetadata> partitionDistribution = topology.partitions();
+    final var partitionDistribution =
+        PartitionDistributionResolver.getStaticConfiguration(
+                clusterCfg, partitioningCfg, MemberId.from("1"))
+            .generatePartitionDistribution();
 
     // then
     // FixedPartitionDistributorTest verifies more cases.
     final var actualDistribution = getDistribution(partitionDistribution);
     assertThat(actualDistribution).containsExactlyInAnyOrderEntriesOf(expectedDistribution);
-  }
-
-  @Test
-  void shouldGeneratePartitionDistributionFromTopology() {
-    // given
-    final PartitionMetadata partitionOne =
-        new PartitionMetadata(
-            PartitionId.from(PartitionManagerImpl.GROUP_NAME, 1),
-            Set.of(member(1), member(2), member(0)),
-            Map.of(member(0), 1, member(1), 2, member(2), 3),
-            3,
-            member(2));
-    final PartitionMetadata partitionTwo =
-        new PartitionMetadata(
-            PartitionId.from(PartitionManagerImpl.GROUP_NAME, 2),
-            Set.of(member(1), member(2), member(0)),
-            Map.of(member(2), 1, member(1), 2, member(0), 3),
-            3,
-            member(0));
-
-    final var expected = Set.of(partitionTwo, partitionOne);
-
-    final ClusterTopology topology =
-        ClusterTopology.init()
-            .addMember(
-                member(0),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(3))))
-            .addMember(
-                member(1),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(2), 2, PartitionState.active(2))))
-            .addMember(
-                member(2),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(3), 2, PartitionState.active(1))));
-
-    // when
-    final var partitionDistribution =
-        new PartitionDistributionResolver().resolvePartitionDistribution(topology);
-
-    // then
-    assertThat(partitionDistribution.partitions()).containsExactlyInAnyOrderElementsOf(expected);
-  }
-
-  @Test
-  void shouldGeneratePartitionDistributionFromTopologyWithMemberWithNoPartitions() {
-    // given
-    final PartitionMetadata partitionOne =
-        new PartitionMetadata(
-            PartitionId.from(PartitionManagerImpl.GROUP_NAME, 1),
-            Set.of(member(1), member(0)),
-            Map.of(member(0), 1, member(1), 2),
-            2,
-            member(1));
-
-    final PartitionMetadata partitionTwo =
-        new PartitionMetadata(
-            PartitionId.from(PartitionManagerImpl.GROUP_NAME, 2),
-            Set.of(member(1), member(0)),
-            Map.of(member(1), 2, member(0), 3),
-            3,
-            member(0));
-
-    final var expected = Set.of(partitionTwo, partitionOne);
-
-    final ClusterTopology topology =
-        ClusterTopology.init()
-            .addMember(
-                member(0),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(3))))
-            .addMember(
-                member(1),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(2), 2, PartitionState.active(2))))
-            .addMember(member(2), MemberState.initializeAsActive(Map.of()).toLeaving());
-
-    // when
-    final var partitionDistribution =
-        new PartitionDistributionResolver().resolvePartitionDistribution(topology);
-
-    // then
-    assertThat(partitionDistribution.partitions()).containsExactlyInAnyOrderElementsOf(expected);
   }
 
   private static MemberId member(final int id) {

--- a/restore/pom.xml
+++ b/restore/pom.xml
@@ -49,6 +49,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-topology</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/topology/src/main/java/io/camunda/zeebe/topology/PartitionDistributor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PartitionDistributor.java
@@ -1,19 +1,11 @@
 /*
- * Copyright © 2020 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
-package io.atomix.raft.partition;
+package io.camunda.zeebe.topology;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;

--- a/topology/src/main/java/io/camunda/zeebe/topology/StaticConfiguration.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/StaticConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.util.TopologyUtil;
+import java.util.List;
+import java.util.Set;
+
+public record StaticConfiguration(
+    PartitionDistributor partitionDistributor,
+    Set<MemberId> clusterMembers,
+    MemberId localMemberId,
+    List<PartitionId> partitionIds,
+    int replicationFactor) {
+
+  ClusterTopology generateTopology() {
+    final var sortedPartitionIds = partitionIds.stream().sorted().toList();
+    final Set<PartitionMetadata> partitionDistribution =
+        partitionDistributor.distributePartitions(
+            clusterMembers, sortedPartitionIds, replicationFactor);
+    return TopologyUtil.getClusterTopologyFrom(partitionDistribution);
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/StaticConfiguration.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/StaticConfiguration.java
@@ -22,11 +22,14 @@ public record StaticConfiguration(
     List<PartitionId> partitionIds,
     int replicationFactor) {
 
-  ClusterTopology generateTopology() {
-    final var sortedPartitionIds = partitionIds.stream().sorted().toList();
-    final Set<PartitionMetadata> partitionDistribution =
-        partitionDistributor.distributePartitions(
-            clusterMembers, sortedPartitionIds, replicationFactor);
+  public ClusterTopology generateTopology() {
+    final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
     return TopologyUtil.getClusterTopologyFrom(partitionDistribution);
+  }
+
+  public Set<PartitionMetadata> generatePartitionDistribution() {
+    final var sortedPartitionIds = partitionIds.stream().sorted().toList();
+    return partitionDistributor.distributePartitions(
+        clusterMembers, sortedPartitionIds, replicationFactor);
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
@@ -21,6 +21,8 @@ import java.util.stream.Collectors;
 
 public final class TopologyUtil {
 
+  private TopologyUtil() {}
+
   public static ClusterTopology getClusterTopologyFrom(
       final Set<PartitionMetadata> partitionDistribution) {
     final var partitionsOwnedByMembers =

--- a/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.util;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.topology.state.ClusterChangePlan;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class TopologyUtil {
+
+  public static ClusterTopology getClusterTopologyFrom(
+      final Set<PartitionMetadata> partitionDistribution) {
+    final var partitionsOwnedByMembers =
+        partitionDistribution.stream()
+            .flatMap(
+                p ->
+                    p.members().stream()
+                        .map(m -> Map.entry(m, Map.entry(p.id().id(), p.getPriority(m)))))
+            .collect(
+                Collectors.groupingBy(
+                    Entry::getKey,
+                    Collectors.toMap(
+                        e -> e.getValue().getKey(),
+                        e -> PartitionState.active(e.getValue().getValue()))));
+
+    final var memberStates =
+        partitionsOwnedByMembers.entrySet().stream()
+            .collect(
+                Collectors.toMap(Entry::getKey, e -> MemberState.initializeAsActive(e.getValue())));
+
+    return new io.camunda.zeebe.topology.state.ClusterTopology(
+        0, memberStates, ClusterChangePlan.empty());
+  }
+
+  public static Set<PartitionMetadata> getPartitionDistributionFrom(
+      final ClusterTopology clusterTopology, final String groupName) {
+    if (clusterTopology.isUninitialized()) {
+      throw new IllegalStateException(
+          "Cannot generated partition distribution from uninitialized topology");
+    }
+    final var partitionsToMembersMap =
+        clusterTopology.members().entrySet().stream()
+            .flatMap(
+                memberEntry ->
+                    memberEntry.getValue().partitions().entrySet().stream()
+                        .map(
+                            p ->
+                                Map.entry(
+                                    p.getKey(),
+                                    Map.entry(memberEntry.getKey(), p.getValue().priority()))))
+            .collect(
+                Collectors.groupingBy(
+                    Entry::getKey,
+                    Collectors.toMap(e -> e.getValue().getKey(), e -> e.getValue().getValue())));
+
+    return partitionsToMembersMap.entrySet().stream()
+        .map(e -> getPartitionMetadata(e, groupName))
+        .collect(Collectors.toSet());
+  }
+
+  private static PartitionMetadata getPartitionMetadata(
+      final Entry<Integer, Map<MemberId, Integer>> e, final String groupName) {
+    final Map<MemberId, Integer> memberPriorities = e.getValue();
+    final var optionalPrimary = memberPriorities.entrySet().stream().max(Entry.comparingByValue());
+    if (optionalPrimary.isEmpty()) {
+      throw new IllegalStateException("Found partition with no members");
+    }
+    return new PartitionMetadata(
+        partitionId(e.getKey(), groupName),
+        memberPriorities.keySet(),
+        memberPriorities,
+        optionalPrimary.get().getValue(),
+        optionalPrimary.get().getKey());
+  }
+
+  private static PartitionId partitionId(final Integer key, final String groupName) {
+    return PartitionId.from(groupName, key);
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/ControllablePartitionDistributor.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ControllablePartitionDistributor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import java.util.List;
+import java.util.Set;
+
+public class ControllablePartitionDistributor implements PartitionDistributor {
+
+  private Set<PartitionMetadata> partitions;
+
+  public ControllablePartitionDistributor withPartitions(final Set<PartitionMetadata> partitions) {
+    this.partitions = partitions;
+    return this;
+  }
+
+  @Override
+  public Set<PartitionMetadata> distributePartitions(
+      final Set<MemberId> clusterMembers,
+      final List<PartitionId> sortedPartitionIds,
+      final int replicationFactor) {
+    return partitions;
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/TopologyInitializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/TopologyInitializerTest.java
@@ -178,11 +178,18 @@ final class TopologyInitializerTest {
 
   private TopologyInitializer getStaticInitializer() {
     final MemberId member = MemberId.from("10");
+    final var partitionId = PartitionId.from("test", 1);
     final Set<PartitionMetadata> partitions =
         Set.of(
             new PartitionMetadata(
                 PartitionId.from("test", 1), Set.of(member), Map.of(member, 1), 1, member));
-    return new StaticInitializer(() -> partitions);
+    return new StaticInitializer(
+        new StaticConfiguration(
+            new ControllablePartitionDistributor().withPartitions(partitions),
+            Set.of(member),
+            member,
+            List.of(partitionId),
+            1));
   }
 
   private static class TestTopologyNotifier implements TopologyUpdateNotifier {

--- a/topology/src/test/java/io/camunda/zeebe/topology/util/TopologyUtilTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/util/TopologyUtilTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class TopologyUtilTest {
+
+  private static final String GROUP_NAME = "test";
+
+  @Test
+  void shouldGenerateTopologyFromPartitionDistribution() {
+    // given
+    final PartitionMetadata partitionOne =
+        new PartitionMetadata(
+            PartitionId.from(GROUP_NAME, 1),
+            Set.of(member(1), member(2), member(0)),
+            Map.of(member(0), 1, member(1), 2, member(2), 3),
+            3,
+            member(2));
+    final PartitionMetadata partitionTwo =
+        new PartitionMetadata(
+            PartitionId.from(GROUP_NAME, 2),
+            Set.of(member(1), member(2), member(0)),
+            Map.of(member(2), 1, member(1), 2, member(0), 3),
+            3,
+            member(0));
+
+    final ClusterTopology expectedTopology =
+        ClusterTopology.init()
+            .addMember(
+                member(0),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(3))))
+            .addMember(
+                member(1),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(2), 2, PartitionState.active(2))))
+            .addMember(
+                member(2),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(3), 2, PartitionState.active(1))));
+
+    final var partitionDistribution = Set.of(partitionTwo, partitionOne);
+
+    // when
+    final var topology = TopologyUtil.getClusterTopologyFrom(partitionDistribution);
+
+    // then
+    assertThat(topology).isEqualTo(expectedTopology);
+  }
+
+  @Test
+  void shouldGeneratePartitionDistributionFromTopology() {
+    // given
+    final PartitionMetadata partitionOne =
+        new PartitionMetadata(
+            PartitionId.from(GROUP_NAME, 1),
+            Set.of(member(1), member(2), member(0)),
+            Map.of(member(0), 1, member(1), 2, member(2), 3),
+            3,
+            member(2));
+    final PartitionMetadata partitionTwo =
+        new PartitionMetadata(
+            PartitionId.from(GROUP_NAME, 2),
+            Set.of(member(1), member(2), member(0)),
+            Map.of(member(2), 1, member(1), 2, member(0), 3),
+            3,
+            member(0));
+
+    final var expected = Set.of(partitionTwo, partitionOne);
+
+    final ClusterTopology topology =
+        ClusterTopology.init()
+            .addMember(
+                member(0),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(3))))
+            .addMember(
+                member(1),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(2), 2, PartitionState.active(2))))
+            .addMember(
+                member(2),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(3), 2, PartitionState.active(1))));
+
+    // when
+    final var partitionDistribution =
+        TopologyUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
+
+    // then
+    assertThat(partitionDistribution).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @Test
+  void shouldGeneratePartitionDistributionFromTopologyWithMemberWithNoPartitions() {
+    // given
+    final PartitionMetadata partitionOne =
+        new PartitionMetadata(
+            PartitionId.from(GROUP_NAME, 1),
+            Set.of(member(1), member(0)),
+            Map.of(member(0), 1, member(1), 2),
+            2,
+            member(1));
+
+    final PartitionMetadata partitionTwo =
+        new PartitionMetadata(
+            PartitionId.from(GROUP_NAME, 2),
+            Set.of(member(1), member(0)),
+            Map.of(member(1), 2, member(0), 3),
+            3,
+            member(0));
+
+    final var expected = Set.of(partitionTwo, partitionOne);
+
+    final ClusterTopology topology =
+        ClusterTopology.init()
+            .addMember(
+                member(0),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(3))))
+            .addMember(
+                member(1),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(2), 2, PartitionState.active(2))))
+            .addMember(member(2), MemberState.initializeAsActive(Map.of()).toLeaving());
+
+    // when
+    final var partitionDistribution =
+        TopologyUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
+
+    // then
+    assertThat(partitionDistribution).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  private MemberId member(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+}


### PR DESCRIPTION
## Description

This PR contains some refactoring to move topology related classes to Topology. 
- Defines a `StaticConfiguration` to represent the partition distribution provided in the broker configuration. `ClusterTopologyManager` uses this to initialize topology in `StaticInitializer`.
- Move `PartitionDistributor` interface from raft to topology. 

## Related issues

related to  #13765 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
