### PR TITLE
[Backport stable/8.2] fix: create incident if single outgoing sequence flow has no matching condition

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -89,7 +89,8 @@ public final class ExclusiveGatewayProcessor
       return Either.right(Optional.empty());
     }
 
-    if (element.getOutgoing().size() == 1 && element.getOutgoing().get(0).getCondition() == null) {
+    final var outgoingSequenceFlows = element.getOutgoing();
+    if (outgoingSequenceFlows.size() == 1 && outgoingSequenceFlows.get(0).getCondition() == null) {
       // only one flow without a condition, can just be taken
       return Either.right(Optional.of(element.getOutgoing().get(0)));
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
@@ -93,9 +93,10 @@ public final class InclusiveGatewayProcessor
       return Either.right(null);
     }
 
-    if (element.getOutgoing().size() == 1) {
-      // only one flow can just be taken
-      executableSequenceFlows.add(element.getOutgoing().get(0));
+    final var outgoingSequenceFlows = element.getOutgoing();
+    if (outgoingSequenceFlows.size() == 1 && outgoingSequenceFlows.get(0).getCondition() == null) {
+      // only one flow without a condition, can just be taken
+      executableSequenceFlows.add(outgoingSequenceFlows.get(0));
       return Either.right(executableSequenceFlows);
     }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayTest.java
@@ -14,12 +14,15 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -495,6 +498,47 @@ public final class InclusiveGatewayTest {
             tuple("end", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldCreateIncidentIfInclusiveGatewayWithSingleSequenceFlowHasNoMatchingCondition() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .inclusiveGateway()
+            .condition("= false")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<ProcessInstanceRecordValue> failingEvent =
+        RecordingExporter.processInstanceRecords()
+            .withElementType(BpmnElementType.INCLUSIVE_GATEWAY)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(IncidentIntent.CREATED)
+            .getFirst();
+
+    Assertions.assertThat(incidentEvent.getValue())
+        .hasErrorType(ErrorType.CONDITION_ERROR)
+        .hasErrorMessage(
+            "Expected at least one condition to evaluate to true, or to have a default flow")
+        .hasBpmnProcessId(failingEvent.getValue().getBpmnProcessId())
+        .hasProcessInstanceKey(failingEvent.getValue().getProcessInstanceKey())
+        .hasElementId(failingEvent.getValue().getElementId())
+        .hasElementInstanceKey(failingEvent.getKey())
+        .hasVariableScopeKey(failingEvent.getKey());
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #14007 to `stable/8.2`.

relates to #13936 