### PR TITLE
[Backport stable/8.1] fix: create incident if single outgoing sequence flow has no matching condition

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -89,7 +89,8 @@ public final class ExclusiveGatewayProcessor
       return Either.right(Optional.empty());
     }
 
-    if (element.getOutgoing().size() == 1 && element.getOutgoing().get(0).getCondition() == null) {
+    final var outgoingSequenceFlows = element.getOutgoing();
+    if (outgoingSequenceFlows.size() == 1 && outgoingSequenceFlows.get(0).getCondition() == null) {
       // only one flow without a condition, can just be taken
       return Either.right(Optional.of(element.getOutgoing().get(0)));
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
@@ -93,9 +93,10 @@ public final class InclusiveGatewayProcessor
       return Either.right(null);
     }
 
-    if (element.getOutgoing().size() == 1) {
-      // only one flow can just be taken
-      executableSequenceFlows.add(element.getOutgoing().get(0));
+    final var outgoingSequenceFlows = element.getOutgoing();
+    if (outgoingSequenceFlows.size() == 1 && outgoingSequenceFlows.get(0).getCondition() == null) {
+      // only one flow without a condition, can just be taken
+      executableSequenceFlows.add(outgoingSequenceFlows.get(0));
       return Either.right(executableSequenceFlows);
     }
 


### PR DESCRIPTION
# Description
Backport of #14007 to `stable/8.1`.

relates to #13936 