### PR TITLE
fix(gateway): close transport client and request manager with the BrokerClient

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -73,8 +73,13 @@ public final class BrokerClientImpl implements BrokerClient {
     }
 
     isClosed = true;
-
     LOG.debug("Closing gateway broker client ...");
+
+    doAndLogException(requestManager::close);
+    LOG.debug("request manager closed");
+
+    doAndLogException(atomixTransportAdapter::close);
+    LOG.debug("transport client closed");
 
     doAndLogException(topologyManager::close);
     LOG.debug("topology manager closed");


### PR DESCRIPTION
## Description

Both transport client and request manager are started by `BrokerClient`. But they were never closed, causing noisy logs because the dependent components are closed.

## Related issues

closes #7855 

