### PR TITLE
Add a foreign key relation from process instance to process definition

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -239,7 +239,8 @@ public class ResourceDeletionDeleteProcessor
 
     final var bannedInstances = bannedInstanceState.getBannedProcessInstanceKeys();
     final var hasRunningInstances =
-        elementInstanceState.hasActiveProcessInstances(process.getKey(), bannedInstances);
+        elementInstanceState.hasActiveProcessInstances(
+            process.getTenantId(), process.getKey(), bannedInstances);
 
     if (!hasRunningInstances) {
       stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETED, processRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
@@ -43,9 +43,9 @@ final class ProcessInstanceElementMigratedApplier
 
     if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
       elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
-          value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
+          value.getTenantId(), value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
       elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
-          value.getProcessInstanceKey(), value.getProcessDefinitionKey());
+          value.getTenantId(), value.getProcessInstanceKey(), value.getProcessDefinitionKey());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -54,17 +54,21 @@ public interface ElementInstanceState {
    *
    * <p>Caution: This will also return the keys of banned process instances!
    *
+   * @param tenantId the tenant identifier
    * @param processDefinitionKey the key of the process definition
    * @return a list of process instance keys
    */
-  List<Long> getProcessInstanceKeysByDefinitionKey(final long processDefinitionKey);
+  List<Long> getProcessInstanceKeysByDefinitionKey(
+      final String tenantId, final long processDefinitionKey);
 
   /**
    * Verifies if there are active process instances for a given process definition
    *
+   * @param tenantId the tenant identifier
    * @param processDefinitionKey the key of the process definition
    * @param bannedInstances a list of banned process instance keys
    * @return a boolean indicating if there are running instances
    */
-  boolean hasActiveProcessInstances(long processDefinitionKey, final List<Long> bannedInstances);
+  boolean hasActiveProcessInstances(
+      final String tenantId, long processDefinitionKey, final List<Long> bannedInstances);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -64,7 +64,8 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   private final MutableVariableState variableState;
 
   private final DbForeignKey<DbLong> processDefinitionKey;
-  private final DbCompositeKey<DbForeignKey<DbLong>, DbLong> processInstanceKeyByProcessDefinitionKey;
+  private final DbCompositeKey<DbForeignKey<DbLong>, DbLong>
+      processInstanceKeyByProcessDefinitionKey;
 
   /** [process definition key | process instance key] => [Nil] */
   private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbLong>, DbNil>
@@ -121,12 +122,12 @@ public final class DbElementInstanceState implements MutableElementInstanceState
             numberOfTakenSequenceFlowsKey,
             numberOfTakenSequenceFlows);
 
-    processDefinitionKey = new DbForeignKey<>(
-        new DbLong(),
-        ZbColumnFamilies.PROCESS_CACHE,
-        MatchType.Full,
-        (k) -> k.getValue() == -1
-    );
+    processDefinitionKey =
+        new DbForeignKey<>(
+            new DbLong(),
+            ZbColumnFamilies.PROCESS_CACHE,
+            MatchType.Full,
+            (k) -> k.getValue() == -1);
     processInstanceKeyByProcessDefinitionKey =
         new DbCompositeKey<>(processDefinitionKey, elementInstanceKey);
     processInstanceKeyByProcessDefinitionKeyColumnFamily =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -24,7 +24,7 @@ public interface MutableElementInstanceState extends ElementInstanceState {
 
   void removeInstance(long key);
 
-  void createInstance(ElementInstance instance);
+  void createInstance(String tenantId, ElementInstance instance);
 
   void updateInstance(ElementInstance scopeInstance);
 
@@ -67,10 +67,12 @@ public interface MutableElementInstanceState extends ElementInstanceState {
    * <p>This makes it possible to query for all process instances of a specific process definition
    * using {@link ElementInstanceState#getProcessInstanceKeysByDefinitionKey(long)}.
    *
+   * @param tenantId the tenant identifier
    * @param processInstanceKey the key of the process instance to insert the reference for
    * @param processDefinitionKey the key of the process definition to insert the reference for
    */
-  void insertProcessInstanceKeyByDefinitionKey(long processInstanceKey, long processDefinitionKey);
+  void insertProcessInstanceKeyByDefinitionKey(
+      String tenantId, long processInstanceKey, long processDefinitionKey);
 
   /**
    * Deletes the reference between process instance key and process definition key.
@@ -78,8 +80,10 @@ public interface MutableElementInstanceState extends ElementInstanceState {
    * <p>This makes it possible to query for all process instances of a specific process definition
    * using {@link ElementInstanceState#getProcessInstanceKeysByDefinitionKey(long)}.
    *
+   * @param tenantId the tenant identifier
    * @param processInstanceKey the key of the process instance to delete the reference for
    * @param processDefinitionKey the key of the process definition to delete the reference for
    */
-  void deleteProcessInstanceKeyByDefinitionKey(long processInstanceKey, long processDefinitionKey);
+  void deleteProcessInstanceKeyByDefinitionKey(
+      String tenantId, long processInstanceKey, long processDefinitionKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
@@ -296,7 +297,7 @@ public final class ElementInstanceStateTest {
     // when
     final List<Long> processInstanceKeys =
         elementInstanceState.getProcessInstanceKeysByDefinitionKey(
-            processInstanceRecord.getProcessDefinitionKey());
+            processInstanceRecord.getTenantId(), processInstanceRecord.getProcessDefinitionKey());
 
     // then
     Assertions.assertThat(processInstanceKeys).hasSize(1);
@@ -324,7 +325,8 @@ public final class ElementInstanceStateTest {
 
     // when
     final List<Long> processInstanceKeys =
-        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER, processDefinitionKey);
 
     // then
     Assertions.assertThat(processInstanceKeys).hasSize(2);
@@ -352,7 +354,8 @@ public final class ElementInstanceStateTest {
 
     // when
     final List<Long> processInstanceKeys =
-        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER, processDefinitionKey);
 
     // then
     Assertions.assertThat(processInstanceKeys).hasSize(1);
@@ -373,7 +376,8 @@ public final class ElementInstanceStateTest {
 
     // when
     final List<Long> processInstanceKeys =
-        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER, processDefinitionKey);
 
     // then
     Assertions.assertThat(processInstanceKeys).isEmpty();
@@ -396,11 +400,14 @@ public final class ElementInstanceStateTest {
 
     // then
     final List<Long> processInstanceKeys =
-        elementInstanceState.getProcessInstanceKeysByDefinitionKey(processDefinitionKey);
+        elementInstanceState.getProcessInstanceKeysByDefinitionKey(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER, processDefinitionKey);
     Assertions.assertThat(processInstanceKeys).isEmpty();
     final var hasRunningInstances =
         elementInstanceState.hasActiveProcessInstances(
-            processInstanceRecord.getProcessDefinitionKey(), Collections.emptyList());
+            processInstanceRecord.getTenantId(),
+            processInstanceRecord.getProcessDefinitionKey(),
+            Collections.emptyList());
     assertThat(hasRunningInstances).isFalse();
   }
 
@@ -462,7 +469,9 @@ public final class ElementInstanceStateTest {
     // when
     final var hasRunningInstances =
         elementInstanceState.hasActiveProcessInstances(
-            processInstanceRecord.getProcessDefinitionKey(), Collections.emptyList());
+            processInstanceRecord.getTenantId(),
+            processInstanceRecord.getProcessDefinitionKey(),
+            Collections.emptyList());
 
     // then
     Assertions.assertThat(hasRunningInstances).isTrue();
@@ -477,7 +486,9 @@ public final class ElementInstanceStateTest {
     // when
     final var hasRunningInstances =
         elementInstanceState.hasActiveProcessInstances(
-            processInstanceRecord.getProcessDefinitionKey(), Collections.emptyList());
+            processInstanceRecord.getTenantId(),
+            processInstanceRecord.getProcessDefinitionKey(),
+            Collections.emptyList());
 
     // then
     Assertions.assertThat(hasRunningInstances).isFalse();
@@ -495,6 +506,7 @@ public final class ElementInstanceStateTest {
     // when
     final var hasRunningInstances =
         elementInstanceState.hasActiveProcessInstances(
+            processInstanceRecord.getTenantId(),
             processInstanceRecord.getProcessDefinitionKey(),
             Collections.singletonList(processInstanceKey));
 
@@ -597,12 +609,12 @@ public final class ElementInstanceStateTest {
       final long processInstanceKey,
       final ProcessInstanceRecord processInstanceRecord,
       final ProcessInstanceIntent instanceIntent) {
-    createProcessInstance(processInstanceRecord.getProcessDefinitionKey(), processInstanceRecord);
+    createProcessDefinition(processInstanceRecord.getProcessDefinitionKey(), processInstanceRecord);
     return elementInstanceState.newInstance(
         processInstanceKey, processInstanceRecord, instanceIntent);
   }
 
-  private void createProcessInstance(final long key, final ProcessInstanceRecord record) {
+  private void createProcessDefinition(final long key, final ProcessInstanceRecord record) {
     stateRule.getProcessingState().getProcessState().putProcess(key, createProcessRecord(record));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/IncidentStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/IncidentStateTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -186,6 +187,7 @@ public final class IncidentStateTest {
 
   public IncidentRecord createProcessInstanceIncident() {
     elementInstanceState.createInstance(
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
         new ElementInstance(
             1234, ProcessInstanceIntent.ELEMENT_ACTIVATED, new ProcessInstanceRecord()));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
 import org.assertj.core.api.Assertions;
@@ -217,6 +218,7 @@ public final class TimerInstanceStateTest {
         .getProcessingState()
         .getElementInstanceState()
         .createInstance(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER,
             new ElementInstance(
                 key, ProcessInstanceIntent.ELEMENT_ACTIVATED, new ProcessInstanceRecord()));
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR add a foreign key between process instances and the process definition they belong to

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13495 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
