### PR TITLE
Support tenant-aware deployments in the java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -31,6 +31,11 @@ public final class ClientProperties {
   public static final String GATEWAY_ADDRESS = "zeebe.client.gateway.address";
 
   /**
+   * @see ZeebeClientBuilder#defaultTenantId(String)
+   */
+  public static final String DEFAULT_TENANT_ID = "zeebe.client.tenantId";
+
+  /**
    * @see ZeebeClientBuilder#numJobWorkerExecutionThreads(int)
    */
   public static final String JOB_WORKER_EXECUTION_THREADS = "zeebe.client.worker.threads";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -50,6 +50,13 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder gatewayAddress(String gatewayAddress);
 
   /**
+   * @param tenantId the tenant identifier which is used for tenant-aware deployments when no tenant
+   *     identifier is set for a command. Default value is an empty String since the property isn't
+   *     allowed when multi-tenancy is disabled in the Zeebe gateway.
+   */
+  ZeebeClientBuilder defaultTenantId(String tenantId);
+
+  /**
    * @param maxJobsActive Default value for {@link JobWorkerBuilderStep3#maxJobsActive(int)}.
    *     Default value is 32.
    */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -50,9 +50,9 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder gatewayAddress(String gatewayAddress);
 
   /**
-   * @param tenantId the tenant identifier which is used for tenant-aware deployments when no tenant
-   *     identifier is set for a command. Default value is an empty String since the property isn't
-   *     allowed when multi-tenancy is disabled in the Zeebe gateway.
+   * @param tenantId the tenant identifier which is used for tenant-aware commands when no tenant
+   *     identifier is set. The default value is {@link
+   *     io.camunda.zeebe.client.api.command.CommandWithTenantStep#DEFAULT_TENANT_IDENTIFIER}.
    */
   ZeebeClientBuilder defaultTenantId(String tenantId);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -28,6 +28,12 @@ public interface ZeebeClientConfiguration {
   String getGatewayAddress();
 
   /**
+   * @see ZeebeClientBuilder#defaultTenantId(String)
+   * @return
+   */
+  String getDefaultTenantId();
+
+  /**
    * @see ZeebeClientBuilder#numJobWorkerExecutionThreads(int)
    */
   int getNumJobWorkerExecutionThreads();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -29,7 +29,6 @@ public interface ZeebeClientConfiguration {
 
   /**
    * @see ZeebeClientBuilder#defaultTenantId(String)
-   * @return
    */
   String getDefaultTenantId();
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Decision.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Decision.java
@@ -48,4 +48,9 @@ public interface Decision {
    * @return the assigned key of the decision requirements graph that this decision is part of
    */
   long getDecisionRequirementsKey();
+
+  /**
+   * @return the tenant identifier that owns this decision
+   */
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DecisionRequirements.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DecisionRequirements.java
@@ -43,4 +43,9 @@ public interface DecisionRequirements {
    * @return the resource name (i.e. filename) from which this decision requirements was parsed
    */
   String getResourceName();
+
+  /**
+   * @return the tenant identifier that owns this decision requirements
+   */
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeploymentEvent.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeploymentEvent.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client.api.response;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
 import java.util.List;
 
 public interface DeploymentEvent {
@@ -42,6 +41,5 @@ public interface DeploymentEvent {
   /**
    * @return the tenant identifier that owns this deployment
    */
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13321")
   String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Process.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Process.java
@@ -35,4 +35,9 @@ public interface Process {
    * @return the name of the deployment resource which contains the process
    */
   String getResourceName();
+
+  /**
+   * @return the tenant identifier that owns this process
+   */
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -49,6 +49,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
   public static final String OVERRIDE_AUTHORITY_VAR = "ZEEBE_OVERRIDE_AUTHORITY";
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
+  public static final String DEFAULT_TENANT_ID_VAR = "ZEEBE_DEFAULT_TENANT_ID";
 
   private boolean applyEnvironmentVariableOverrides = true;
 
@@ -396,6 +397,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
     if (Environment.system().isDefined(MAX_MESSAGE_SIZE)) {
       maxMessageSize(DataSizeUtil.parse(Environment.system().get(MAX_MESSAGE_SIZE)));
+    }
+
+    if (Environment.system().isDefined(DEFAULT_TENANT_ID_VAR)) {
+      defaultTenantId(Environment.system().get(DEFAULT_TENANT_ID_VAR));
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -53,6 +53,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   private String gatewayAddress = DEFAULT_GATEWAY_ADDRESS;
+  private String defaultTenantId = "";
   private int jobWorkerMaxJobsActive = 32;
   private int numJobWorkerExecutionThreads = 1;
   private String defaultJobWorkerName = "default";
@@ -73,6 +74,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public String getGatewayAddress() {
     return gatewayAddress;
+  }
+
+  @Override
+  public String getDefaultTenantId() {
+    return defaultTenantId;
   }
 
   @Override
@@ -170,6 +176,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     if (properties.containsKey(ClientProperties.GATEWAY_ADDRESS)) {
       gatewayAddress(properties.getProperty(ClientProperties.GATEWAY_ADDRESS));
     }
+    if (properties.containsKey(ClientProperties.DEFAULT_TENANT_ID)) {
+      defaultTenantId(properties.getProperty(ClientProperties.DEFAULT_TENANT_ID));
+    }
 
     if (properties.containsKey(ClientProperties.JOB_WORKER_EXECUTION_THREADS)) {
       numJobWorkerExecutionThreads(
@@ -239,6 +248,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public ZeebeClientBuilder gatewayAddress(final String gatewayAddress) {
     this.gatewayAddress = gatewayAddress;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder defaultTenantId(final String tenantId) {
+    defaultTenantId = tenantId;
     return this;
   }
 
@@ -388,6 +403,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     final StringBuilder sb = new StringBuilder();
 
     appendProperty(sb, "gatewayAddress", gatewayAddress);
+    appendProperty(sb, "defaultTenantId", defaultTenantId);
     appendProperty(sb, "jobWorkerMaxJobsActive", jobWorkerMaxJobsActive);
     appendProperty(sb, "numJobWorkerExecutionThreads", numJobWorkerExecutionThreads);
     appendProperty(sb, "defaultJobWorkerName", defaultJobWorkerName);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.zeebe.client.impl.util.DataSizeUtil;
 import io.camunda.zeebe.client.impl.util.Environment;
@@ -53,7 +54,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   private String gatewayAddress = DEFAULT_GATEWAY_ADDRESS;
-  private String defaultTenantId = "";
+  private String defaultTenantId = CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER;
   private int jobWorkerMaxJobsActive = 32;
   private int numJobWorkerExecutionThreads = 1;
   private String defaultJobWorkerName = "default";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -93,7 +93,7 @@ public class ZeebeClientCloudBuilderImpl
     }
     innerBuilder.withProperties(properties);
 
-    // todo(#13321): allow default tenant id setting for cloud client
+    // todo(#14106): allow default tenant id setting for cloud client
     innerBuilder.defaultTenantId("");
 
     return this;
@@ -115,7 +115,8 @@ public class ZeebeClientCloudBuilderImpl
   @Override
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/14106")
   public ZeebeClientCloudBuilderStep4 defaultTenantId(final String tenantId) {
-    Loggers.LOGGER.debug("Multi-tenancy is currently not supported in Camunda Cloud.");
+    Loggers.LOGGER.debug(
+        "Multi-tenancy in Camunda 8 SaaS will be supported with https://github.com/camunda/zeebe/issues/14106.");
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4;
+import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.grpc.ClientInterceptor;
@@ -91,6 +92,10 @@ public class ZeebeClientCloudBuilderImpl
       withRegion(properties.getProperty(ClientProperties.CLOUD_REGION));
     }
     innerBuilder.withProperties(properties);
+
+    // todo(#13321): allow default tenant id setting for cloud client
+    innerBuilder.defaultTenantId("");
+
     return this;
   }
 
@@ -104,6 +109,13 @@ public class ZeebeClientCloudBuilderImpl
   @Override
   public ZeebeClientCloudBuilderStep4 gatewayAddress(final String gatewayAddress) {
     innerBuilder.gatewayAddress(gatewayAddress);
+    return this;
+  }
+
+  @Override
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/14106")
+  public ZeebeClientCloudBuilderStep4 defaultTenantId(final String tenantId) {
+    Loggers.LOGGER.debug("Multi-tenancy is currently not supported in Camunda Cloud.");
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -249,7 +249,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public DeployResourceCommandStep1 newDeployResourceCommand() {
     return new DeployResourceCommandImpl(
-        asyncStub, config.getDefaultRequestTimeout(), credentialsProvider::shouldRetryRequest);
+        asyncStub, config, credentialsProvider::shouldRetryRequest);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
@@ -22,6 +22,7 @@ import com.google.protobuf.ByteString;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
@@ -62,6 +63,28 @@ public final class DeployResourceCommandImpl
     requestTimeout = config.getDefaultRequestTimeout();
     this.retryPredicate = retryPredicate;
     tenantId(config.getDefaultTenantId());
+  }
+
+  /**
+   * A constructor that provides an instance with the <code><default></code> tenantId set.
+   *
+   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
+   * the <code>tenantId</code> property to be defined. This constructor is only intended for
+   * backwards compatibility in tests.
+   *
+   * @deprecated since 8.3.0, use {@link
+   *     DeployResourceCommandImpl#DeployResourceCommandImpl(GatewayStub asyncStub,
+   *     ZeebeClientConfiguration config, Predicate retryPredicate)}
+   */
+  @Deprecated
+  public DeployResourceCommandImpl(
+      final GatewayStub asyncStub,
+      final Duration requestTimeout,
+      final Predicate<Throwable> retryPredicate) {
+    this.asyncStub = asyncStub;
+    this.requestTimeout = requestTimeout;
+    this.retryPredicate = retryPredicate;
+    tenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
 import static io.camunda.zeebe.client.impl.command.StreamUtil.readInputStream;
 
 import com.google.protobuf.ByteString;
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1;
@@ -55,11 +56,12 @@ public final class DeployResourceCommandImpl
 
   public DeployResourceCommandImpl(
       final GatewayStub asyncStub,
-      final Duration requestTimeout,
+      final ZeebeClientConfiguration config,
       final Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
-    this.requestTimeout = requestTimeout;
+    requestTimeout = config.getDefaultRequestTimeout();
     this.retryPredicate = retryPredicate;
+    tenantId(config.getDefaultTenantId());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
@@ -169,7 +169,7 @@ public final class DeployResourceCommandImpl
 
   @Override
   public DeployResourceCommandStep2 tenantId(final String tenantId) {
-    // todo(#13321): replace dummy implementation
+    requestBuilder.setTenantId(tenantId);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.response;
 
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.response.Decision;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
 import java.util.Objects;
@@ -51,6 +52,7 @@ public final class DecisionImpl implements Decision {
    *     dmnDecisionName, int version, long decisionKey, String dmnDecisionRequirementsId, long
    *     decisionRequirementsKey, String tenantId)}
    */
+  @Deprecated
   public DecisionImpl(
       final String dmnDecisionId,
       final String dmnDecisionName,
@@ -65,7 +67,7 @@ public final class DecisionImpl implements Decision {
         decisionKey,
         dmnDecisionRequirementsId,
         decisionRequirementsKey,
-        "");
+        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public DecisionImpl(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionImpl.java
@@ -42,7 +42,7 @@ public final class DecisionImpl implements Decision {
   }
 
   /**
-   * A constructor that provides an instance with an empty String for a tenantId.
+   * A constructor that provides an instance with the <code><default></code> tenantId set.
    *
    * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
    * the <code>tenantId</code> property to be defined. This constructor is only intended for

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionImpl.java
@@ -40,6 +40,34 @@ public final class DecisionImpl implements Decision {
         metadata.getTenantId());
   }
 
+  /**
+   * A constructor that provides an instance with an empty String for a tenantId.
+   *
+   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
+   * the <code>tenantId</code> property to be defined. This constructor is only intended for
+   * backwards compatibility in tests.
+   *
+   * @deprecated since 8.3.0, use {@link DecisionImpl#DecisionImpl(String dmnDecisionId, String
+   *     dmnDecisionName, int version, long decisionKey, String dmnDecisionRequirementsId, long
+   *     decisionRequirementsKey, String tenantId)}
+   */
+  public DecisionImpl(
+      final String dmnDecisionId,
+      final String dmnDecisionName,
+      final int version,
+      final long decisionKey,
+      final String dmnDecisionRequirementsId,
+      final long decisionRequirementsKey) {
+    this(
+        dmnDecisionId,
+        dmnDecisionName,
+        version,
+        decisionKey,
+        dmnDecisionRequirementsId,
+        decisionRequirementsKey,
+        "");
+  }
+
   public DecisionImpl(
       final String dmnDecisionId,
       final String dmnDecisionName,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionImpl.java
@@ -27,6 +27,7 @@ public final class DecisionImpl implements Decision {
   private final long decisionKey;
   private final String dmnDecisionRequirementsId;
   private final long decisionRequirementsKey;
+  private final String tenantId;
 
   public DecisionImpl(final DecisionMetadata metadata) {
     this(
@@ -35,7 +36,8 @@ public final class DecisionImpl implements Decision {
         metadata.getVersion(),
         metadata.getDecisionKey(),
         metadata.getDmnDecisionRequirementsId(),
-        metadata.getDecisionRequirementsKey());
+        metadata.getDecisionRequirementsKey(),
+        metadata.getTenantId());
   }
 
   public DecisionImpl(
@@ -44,13 +46,15 @@ public final class DecisionImpl implements Decision {
       final int version,
       final long decisionKey,
       final String dmnDecisionRequirementsId,
-      final long decisionRequirementsKey) {
+      final long decisionRequirementsKey,
+      final String tenantId) {
     this.dmnDecisionId = dmnDecisionId;
     this.dmnDecisionName = dmnDecisionName;
     this.version = version;
     this.decisionKey = decisionKey;
     this.dmnDecisionRequirementsId = dmnDecisionRequirementsId;
     this.decisionRequirementsKey = decisionRequirementsKey;
+    this.tenantId = tenantId;
   }
 
   @Override
@@ -84,6 +88,11 @@ public final class DecisionImpl implements Decision {
   }
 
   @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
         dmnDecisionId,
@@ -91,7 +100,8 @@ public final class DecisionImpl implements Decision {
         version,
         decisionKey,
         dmnDecisionRequirementsId,
-        decisionRequirementsKey);
+        decisionRequirementsKey,
+        tenantId);
   }
 
   @Override
@@ -108,7 +118,8 @@ public final class DecisionImpl implements Decision {
         && decisionRequirementsKey == decision.decisionRequirementsKey
         && Objects.equals(dmnDecisionId, decision.dmnDecisionId)
         && Objects.equals(dmnDecisionName, decision.dmnDecisionName)
-        && Objects.equals(dmnDecisionRequirementsId, decision.dmnDecisionRequirementsId);
+        && Objects.equals(dmnDecisionRequirementsId, decision.dmnDecisionRequirementsId)
+        && Objects.equals(tenantId, decision.tenantId);
   }
 
   @Override
@@ -129,6 +140,9 @@ public final class DecisionImpl implements Decision {
         + '\''
         + ", decisionRequirementsKey="
         + decisionRequirementsKey
+        + ", tenantId='"
+        + tenantId
+        + '\''
         + '}';
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionRequirementsImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionRequirementsImpl.java
@@ -38,6 +38,32 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
         metadata.getTenantId());
   }
 
+  /**
+   * A constructor that provides an instance with an empty String for a tenantId.
+   *
+   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
+   * the <code>tenantId</code> property to be defined. This constructor is only intended for
+   * backwards compatibility in tests.
+   *
+   * @deprecated since 8.3.0, use {@link DecisionRequirementsImpl#DecisionRequirementsImpl(String
+   *     dmnDecisionRequirementsId, String dmnDecisionRequirementsName, int version, long
+   *     decisionRequirementsKey, String resourceName, String tenantId)}
+   */
+  public DecisionRequirementsImpl(
+      final String dmnDecisionRequirementsId,
+      final String dmnDecisionRequirementsName,
+      final int version,
+      final long decisionRequirementsKey,
+      final String resourceName) {
+    this(
+        dmnDecisionRequirementsId,
+        dmnDecisionRequirementsName,
+        version,
+        decisionRequirementsKey,
+        resourceName,
+        "");
+  }
+
   public DecisionRequirementsImpl(
       final String dmnDecisionRequirementsId,
       final String dmnDecisionRequirementsName,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionRequirementsImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionRequirementsImpl.java
@@ -40,7 +40,7 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
   }
 
   /**
-   * A constructor that provides an instance with an empty String for a tenantId.
+   * A constructor that provides an instance with the <code><default></code> tenantId set.
    *
    * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
    * the <code>tenantId</code> property to be defined. This constructor is only intended for

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionRequirementsImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionRequirementsImpl.java
@@ -26,6 +26,7 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
   private final int version;
   private final long decisionRequirementsKey;
   private final String resourceName;
+  private final String tenantId;
 
   public DecisionRequirementsImpl(final DecisionRequirementsMetadata metadata) {
     this(
@@ -33,7 +34,8 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
         metadata.getDmnDecisionRequirementsName(),
         metadata.getVersion(),
         metadata.getDecisionRequirementsKey(),
-        metadata.getResourceName());
+        metadata.getResourceName(),
+        metadata.getTenantId());
   }
 
   public DecisionRequirementsImpl(
@@ -41,12 +43,14 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
       final String dmnDecisionRequirementsName,
       final int version,
       final long decisionRequirementsKey,
-      final String resourceName) {
+      final String resourceName,
+      final String tenantId) {
     this.dmnDecisionRequirementsId = dmnDecisionRequirementsId;
     this.dmnDecisionRequirementsName = dmnDecisionRequirementsName;
     this.version = version;
     this.decisionRequirementsKey = decisionRequirementsKey;
     this.resourceName = resourceName;
+    this.tenantId = tenantId;
   }
 
   @Override
@@ -75,13 +79,19 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
   }
 
   @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
         dmnDecisionRequirementsId,
         dmnDecisionRequirementsName,
         version,
         decisionRequirementsKey,
-        resourceName);
+        resourceName,
+        tenantId);
   }
 
   @Override
@@ -97,7 +107,8 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
         && decisionRequirementsKey == that.decisionRequirementsKey
         && Objects.equals(dmnDecisionRequirementsId, that.dmnDecisionRequirementsId)
         && Objects.equals(dmnDecisionRequirementsName, that.dmnDecisionRequirementsName)
-        && Objects.equals(resourceName, that.resourceName);
+        && Objects.equals(resourceName, that.resourceName)
+        && Objects.equals(tenantId, that.tenantId);
   }
 
   @Override
@@ -115,6 +126,9 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
         + decisionRequirementsKey
         + ", resourceName='"
         + resourceName
+        + '\''
+        + ", tenantId='"
+        + tenantId
         + '\''
         + '}';
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionRequirementsImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DecisionRequirementsImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.response;
 
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.response.DecisionRequirements;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsMetadata;
 import java.util.Objects;
@@ -49,6 +50,7 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
    *     dmnDecisionRequirementsId, String dmnDecisionRequirementsName, int version, long
    *     decisionRequirementsKey, String resourceName, String tenantId)}
    */
+  @Deprecated
   public DecisionRequirementsImpl(
       final String dmnDecisionRequirementsId,
       final String dmnDecisionRequirementsName,
@@ -61,7 +63,7 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
         version,
         decisionRequirementsKey,
         resourceName,
-        "");
+        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public DecisionRequirementsImpl(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DeploymentEventImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DeploymentEventImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.response;
 
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.response.Decision;
 import io.camunda.zeebe.client.api.response.DecisionRequirements;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
@@ -36,17 +37,20 @@ public final class DeploymentEventImpl implements DeploymentEvent {
           + " You may have to update the version of your zeebe-client-java dependency to resolve the issue.";
 
   private final long key;
+  private final String tenantId;
   private final List<Process> processes = new ArrayList<>();
   private final List<Decision> decisions = new ArrayList<>();
   private final List<DecisionRequirements> decisionRequirements = new ArrayList<>();
 
   public DeploymentEventImpl(final DeployProcessResponse response) {
     key = response.getKey();
+    tenantId = CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER;
     response.getProcessesList().stream().map(ProcessImpl::new).forEach(processes::add);
   }
 
   public DeploymentEventImpl(final DeployResourceResponse response) {
     key = response.getKey();
+    tenantId = response.getTenantId();
     for (final Deployment deployment : response.getDeploymentsList()) {
       switch (deployment.getMetadataCase()) {
         case PROCESS:
@@ -89,8 +93,7 @@ public final class DeploymentEventImpl implements DeploymentEvent {
 
   @Override
   public String getTenantId() {
-    // todo(#13321): replace dummy implementation
-    return "";
+    return tenantId;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DeploymentEventImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DeploymentEventImpl.java
@@ -107,6 +107,9 @@ public final class DeploymentEventImpl implements DeploymentEvent {
         + decisions
         + ", decisionRequirements="
         + decisionRequirements
+        + ", tenantId='"
+        + tenantId
+        + '\''
         + '}';
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ProcessImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ProcessImpl.java
@@ -36,6 +36,25 @@ public final class ProcessImpl implements Process {
         process.getTenantId());
   }
 
+  /**
+   * A constructor that provides an instance with an empty String for a tenantId.
+   *
+   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
+   * the <code>tenantId</code> property to be defined. This constructor is only intended for
+   * backwards compatibility in tests.
+   *
+   * @deprecated since 8.3.0, use {@link ProcessImpl#ProcessImpl(long processDefinitionKey, String
+   *     bpmnProcessId, int version, String resourceName, String tenantId)}
+   */
+  @Deprecated
+  public ProcessImpl(
+      final long processDefinitionKey,
+      final String bpmnProcessId,
+      final int version,
+      final String resourceName) {
+    this(processDefinitionKey, bpmnProcessId, version, resourceName, "");
+  }
+
   public ProcessImpl(
       final long processDefinitionKey,
       final String bpmnProcessId,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ProcessImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ProcessImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.response;
 
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.response.Process;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
 import java.util.Objects;
@@ -52,7 +53,12 @@ public final class ProcessImpl implements Process {
       final String bpmnProcessId,
       final int version,
       final String resourceName) {
-    this(processDefinitionKey, bpmnProcessId, version, resourceName, "");
+    this(
+        processDefinitionKey,
+        bpmnProcessId,
+        version,
+        resourceName,
+        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public ProcessImpl(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ProcessImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ProcessImpl.java
@@ -38,7 +38,7 @@ public final class ProcessImpl implements Process {
   }
 
   /**
-   * A constructor that provides an instance with an empty String for a tenantId.
+   * A constructor that provides an instance with the <code><default></code> tenantId set.
    *
    * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
    * the <code>tenantId</code> property to be defined. This constructor is only intended for

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ProcessImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ProcessImpl.java
@@ -25,24 +25,28 @@ public final class ProcessImpl implements Process {
   private final String bpmnProcessId;
   private final int version;
   private final String resourceName;
+  private final String tenantId;
 
   public ProcessImpl(final ProcessMetadata process) {
     this(
         process.getProcessDefinitionKey(),
         process.getBpmnProcessId(),
         process.getVersion(),
-        process.getResourceName());
+        process.getResourceName(),
+        process.getTenantId());
   }
 
   public ProcessImpl(
       final long processDefinitionKey,
       final String bpmnProcessId,
       final int version,
-      final String resourceName) {
+      final String resourceName,
+      final String tenantId) {
     this.processDefinitionKey = processDefinitionKey;
     this.bpmnProcessId = bpmnProcessId;
     this.version = version;
     this.resourceName = resourceName;
+    this.tenantId = tenantId;
   }
 
   @Override
@@ -66,8 +70,13 @@ public final class ProcessImpl implements Process {
   }
 
   @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
   public int hashCode() {
-    return Objects.hash(processDefinitionKey, bpmnProcessId, version, resourceName);
+    return Objects.hash(processDefinitionKey, bpmnProcessId, version, resourceName, tenantId);
   }
 
   @Override
@@ -82,7 +91,8 @@ public final class ProcessImpl implements Process {
     return processDefinitionKey == process.processDefinitionKey
         && version == process.version
         && Objects.equals(bpmnProcessId, process.bpmnProcessId)
-        && Objects.equals(resourceName, process.resourceName);
+        && Objects.equals(resourceName, process.resourceName)
+        && Objects.equals(tenantId, process.tenantId);
   }
 
   @Override
@@ -97,6 +107,9 @@ public final class ProcessImpl implements Process {
         + version
         + ", resourceName='"
         + resourceName
+        + '\''
+        + ", tenantId='"
+        + tenantId
         + '\''
         + '}';
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/DeployProcessTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/DeployProcessTest.java
@@ -197,9 +197,10 @@ public final class DeployProcessTest extends ClientTest {
   public void shouldReceiveDeployedProcessMetadataInResponse() {
     // given
     final long key = 123L;
+    final String testTenantId = "test-tenant";
     final String filename = DeployProcessTest.class.getResource(BPMN_1_FILENAME).getPath();
     gatewayService.onDeployProcessRequest(
-        key, deployedProcess(BPMN_1_PROCESS_ID, 12, 423, filename));
+        key, deployedProcess(BPMN_1_PROCESS_ID, 12, 423, filename, testTenantId));
 
     // when
     final DeploymentEvent response =
@@ -208,7 +209,7 @@ public final class DeployProcessTest extends ClientTest {
     // then
     assertThat(response.getKey()).isEqualTo(key);
     assertThat(response.getProcesses())
-        .containsExactly(new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename));
+        .containsExactly(new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename, testTenantId));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client.util;
 
 import com.google.protobuf.GeneratedMessageV3;
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
@@ -164,7 +165,12 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final int version,
       final long processDefinitionKey,
       final String resourceName) {
-    return deployedProcess(bpmnProcessId, version, processDefinitionKey, resourceName, "");
+    return deployedProcess(
+        bpmnProcessId,
+        version,
+        processDefinitionKey,
+        resourceName,
+        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public static ProcessMetadata deployedProcess(
@@ -196,7 +202,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
         decisionKey,
         dmnDecisionRequirementsId,
         decisionRequirementsKey,
-        "");
+        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public static DecisionMetadata deployedDecision(
@@ -230,7 +236,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
         version,
         decisionRequirementsKey,
         resourceName,
-        "");
+        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public static DecisionRequirementsMetadata deployedDecisionRequirements(

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
@@ -164,11 +164,21 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final int version,
       final long processDefinitionKey,
       final String resourceName) {
+    return deployedProcess(bpmnProcessId, version, processDefinitionKey, resourceName, "");
+  }
+
+  public static ProcessMetadata deployedProcess(
+      final String bpmnProcessId,
+      final int version,
+      final long processDefinitionKey,
+      final String resourceName,
+      final String tenantId) {
     return ProcessMetadata.newBuilder()
         .setBpmnProcessId(bpmnProcessId)
         .setVersion(version)
         .setProcessDefinitionKey(processDefinitionKey)
         .setResourceName(resourceName)
+        .setTenantId(tenantId)
         .build();
   }
 
@@ -179,6 +189,24 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final long decisionKey,
       final String dmnDecisionRequirementsId,
       final long decisionRequirementsKey) {
+    return deployedDecision(
+        dmnDecisionId,
+        dmnDecisionName,
+        version,
+        decisionKey,
+        dmnDecisionRequirementsId,
+        decisionRequirementsKey,
+        "");
+  }
+
+  public static DecisionMetadata deployedDecision(
+      final String dmnDecisionId,
+      final String dmnDecisionName,
+      final int version,
+      final long decisionKey,
+      final String dmnDecisionRequirementsId,
+      final long decisionRequirementsKey,
+      final String tenantId) {
     return DecisionMetadata.newBuilder()
         .setDmnDecisionId(dmnDecisionId)
         .setDmnDecisionName(dmnDecisionName)
@@ -186,6 +214,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
         .setDecisionKey(decisionKey)
         .setDmnDecisionRequirementsId(dmnDecisionRequirementsId)
         .setDecisionRequirementsKey(decisionRequirementsKey)
+        .setTenantId(tenantId)
         .build();
   }
 
@@ -195,12 +224,29 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final int version,
       final long decisionRequirementsKey,
       final String resourceName) {
+    return deployedDecisionRequirements(
+        dmnDecisionRequirementsId,
+        dmnDecisionRequirementsName,
+        version,
+        decisionRequirementsKey,
+        resourceName,
+        "");
+  }
+
+  public static DecisionRequirementsMetadata deployedDecisionRequirements(
+      final String dmnDecisionRequirementsId,
+      final String dmnDecisionRequirementsName,
+      final int version,
+      final long decisionRequirementsKey,
+      final String resourceName,
+      final String tenantId) {
     return DecisionRequirementsMetadata.newBuilder()
         .setDmnDecisionRequirementsId(dmnDecisionRequirementsId)
         .setDmnDecisionRequirementsName(dmnDecisionRequirementsName)
         .setVersion(version)
         .setDecisionRequirementsKey(decisionRequirementsKey)
         .setResourceName(resourceName)
+        .setTenantId(tenantId)
         .build();
   }
 
@@ -374,12 +420,14 @@ public final class RecordingGatewayService extends GatewayImplBase {
                 .build());
   }
 
-  public void onDeployResourceRequest(final long key, final Deployment... deployments) {
+  public void onDeployResourceRequest(
+      final long key, final String tenantId, final Deployment... deployments) {
     addRequestHandler(
         DeployResourceRequest.class,
         request ->
             DeployResourceResponse.newBuilder()
                 .setKey(key)
+                .setTenantId(tenantId)
                 .addAllDeployments(Arrays.asList(deployments))
                 .build());
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceTest.java
@@ -93,6 +93,7 @@ public final class DeployResourceTest extends GatewayTest {
   @Test
   @Ignore("https://github.com/camunda/zeebe/issues/14041")
   public void shouldMapRequestAndResponseWithCustomTenantId() {
+    // given
     final var stub = new DeployResourceStub();
     stub.registerWith(brokerClient);
 
@@ -111,33 +112,16 @@ public final class DeployResourceTest extends GatewayTest {
     final var response = client.deployResource(request);
 
     // then
-    assertThat(response.getKey()).isEqualTo(stub.getKey());
-    assertThat(response.getDeploymentsCount()).isEqualTo(3);
     assertThat(response.getTenantId()).isEqualTo(tenantId);
 
-    final Deployment firstDeployment = response.getDeployments(0);
-    assertThat(firstDeployment.hasProcess()).isTrue();
-    assertThat(firstDeployment.hasDecision()).isFalse();
-    assertThat(firstDeployment.hasDecisionRequirements()).isFalse();
-    final ProcessMetadata process = firstDeployment.getProcess();
+    assertThat(response.getDeploymentsCount()).isEqualTo(3);
+    final ProcessMetadata process = response.getDeployments(0).getProcess();
     assertThat(process.getTenantId()).isEqualTo(tenantId);
 
-    final Deployment secondDeployment = response.getDeployments(1);
-    assertThat(secondDeployment.hasProcess()).isFalse();
-    assertThat(secondDeployment.hasDecision()).isTrue();
-    assertThat(secondDeployment.hasDecisionRequirements()).isFalse();
-    final DecisionMetadata decision = secondDeployment.getDecision();
+    final DecisionMetadata decision = response.getDeployments(1).getDecision();
     assertThat(decision.getTenantId()).isEqualTo(tenantId);
 
-    final Deployment thirdDeployment = response.getDeployments(2);
-    assertThat(thirdDeployment.hasProcess()).isFalse();
-    assertThat(thirdDeployment.hasDecision()).isFalse();
-    assertThat(thirdDeployment.hasDecisionRequirements()).isTrue();
-    final DecisionRequirementsMetadata drg = thirdDeployment.getDecisionRequirements();
+    final DecisionRequirementsMetadata drg = response.getDeployments(2).getDecisionRequirements();
     assertThat(drg.getTenantId()).isEqualTo(tenantId);
-
-    final BrokerDeployResourceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
-    assertThat(brokerRequest.getIntent()).isEqualTo(DeploymentIntent.CREATE);
-    assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.DEPLOYMENT);
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceTest.java
@@ -19,12 +19,13 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Deployment;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public final class DeployResourceTest extends GatewayTest {
 
   @Test
-  public void shouldMapRequestAndResponse() {
+  public void shouldMapRequestAndResponseWithDefaultTenantId() {
     // given
     final var stub = new DeployResourceStub();
     stub.registerWith(brokerClient);
@@ -83,6 +84,57 @@ public final class DeployResourceTest extends GatewayTest {
     assertThat(drg.getDecisionRequirementsKey()).isEqualTo(678);
     assertThat(drg.getResourceName()).isEqualTo(dmnName);
     assertThat(drg.getTenantId()).isEqualTo(defaultTenantId);
+
+    final BrokerDeployResourceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getIntent()).isEqualTo(DeploymentIntent.CREATE);
+    assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.DEPLOYMENT);
+  }
+
+  @Test
+  @Ignore("https://github.com/camunda/zeebe/issues/14041")
+  public void shouldMapRequestAndResponseWithCustomTenantId() {
+    final var stub = new DeployResourceStub();
+    stub.registerWith(brokerClient);
+
+    final String bpmnName = "testProcess.bpmn";
+    final String dmnName = "testDecision.dmn";
+    final String tenantId = "test-tenant";
+
+    final var builder = DeployResourceRequest.newBuilder();
+    builder.addResourcesBuilder().setName(bpmnName).setContent(ByteString.copyFromUtf8("<xml/>"));
+    builder.addResourcesBuilder().setName(dmnName).setContent(ByteString.copyFromUtf8("test"));
+    builder.setTenantId(tenantId);
+
+    final var request = builder.build();
+
+    // when
+    final var response = client.deployResource(request);
+
+    // then
+    assertThat(response.getKey()).isEqualTo(stub.getKey());
+    assertThat(response.getDeploymentsCount()).isEqualTo(3);
+    assertThat(response.getTenantId()).isEqualTo(tenantId);
+
+    final Deployment firstDeployment = response.getDeployments(0);
+    assertThat(firstDeployment.hasProcess()).isTrue();
+    assertThat(firstDeployment.hasDecision()).isFalse();
+    assertThat(firstDeployment.hasDecisionRequirements()).isFalse();
+    final ProcessMetadata process = firstDeployment.getProcess();
+    assertThat(process.getTenantId()).isEqualTo(tenantId);
+
+    final Deployment secondDeployment = response.getDeployments(1);
+    assertThat(secondDeployment.hasProcess()).isFalse();
+    assertThat(secondDeployment.hasDecision()).isTrue();
+    assertThat(secondDeployment.hasDecisionRequirements()).isFalse();
+    final DecisionMetadata decision = secondDeployment.getDecision();
+    assertThat(decision.getTenantId()).isEqualTo(tenantId);
+
+    final Deployment thirdDeployment = response.getDeployments(2);
+    assertThat(thirdDeployment.hasProcess()).isFalse();
+    assertThat(thirdDeployment.hasDecision()).isFalse();
+    assertThat(thirdDeployment.hasDecisionRequirements()).isTrue();
+    final DecisionRequirementsMetadata drg = thirdDeployment.getDecisionRequirements();
+    assertThat(drg.getTenantId()).isEqualTo(tenantId);
 
     final BrokerDeployResourceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(DeploymentIntent.CREATE);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* Support tenant-aware deployments in the java client.
* Implement a `defaultTenantId` configuration property for setting a tenant id to all commands.

Note: Since C8 SaaS won't support multi-tenancy in this iteration, the ZeebeCloudClientBuilder doesn't support setting a `defaultTenantId`.

:information_source: This PR is based on #14089 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13321 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
