### PR TITLE
Reset next segment when async creation failed

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -132,6 +132,7 @@ final class SegmentsManager implements AutoCloseable {
             nextSegment.join().initializeForUse(nextSegmentIndex, lastWrittenAsqn, journalMetrics);
       } catch (final CompletionException e) {
         LOG.error("Failed to acquire next segment, retrying synchronously now.", e);
+        nextSegment = null;
         currentSegment = createSegment(descriptor, lastWrittenAsqn);
       }
     } else {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.journal.record.PersistedJournalRecord;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.util.MockJournalMetastore;
 import io.camunda.zeebe.journal.util.PosixPathAssert;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.ByteArrayOutputStream;
@@ -913,7 +914,7 @@ class SegmentedJournalTest {
         .hasMessage("Nope, no free space.");
   }
 
-  @Test
+  @RegressionTest("https://github.com/camunda/zeebe/issues/13955")
   void shouldPrintAsyncOODOnlyOnceFailed() {
     // given
     // in order to assert output


### PR DESCRIPTION
## Description

See description here https://github.com/camunda/zeebe/issues/13955#issuecomment-1705126246
> I was able to reproduce this issue with a test. When creating the first segment and we reach out of disk, we see the following exception: io.camunda.zeebe.journal.JournalException$OutOfDiskSpace, but after the first creation, the segments are created async. This means the type of exception changes to: java.util.concurrent.CompletionException: io.camunda.zeebe.journal.JournalException$OutOfDiskSpace. This is catched in the [SegmentsManager](https://github.com/camunda/zeebe/blob/main/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java#L134), and retried synchronously. The exception will be logged with the completion exception. If this now fails again with OutOfDisk for example, we will not reset the nextSegment future. This means on the next try we will join on the future again, throw the exception again, log it again, and try it again synchronously. This produces our loop.

This PR contains:

 * A new test to verify that OOD is thrown even when async segment creation is happening.
 * A new test to verify that exception for async segment creation is only written (and happening) once.
 * NextSegment future reset to null when future is exceptionally completed


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/13955

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
