### PR TITLE
test: fix deadlock in stream processor tests

### DIFF
--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+final class ExtendedProcessingScheduleServiceImplTest {
+  @Test
+  void shouldNotScheduleAsyncIfDisabled() {
+    // given
+    final var sync = mock(SimpleProcessingScheduleService.class);
+    final var async = mock(SimpleProcessingScheduleService.class);
+    final var concurrencyControl = mock(ConcurrencyControl.class);
+    final var schedulingService =
+        new ExtendedProcessingScheduleServiceImpl(sync, async, concurrencyControl, false);
+
+    // when
+    schedulingService.runDelayed(Duration.ZERO, () -> {});
+
+    // then
+    Mockito.verify(sync, Mockito.times(1))
+        .runDelayed(Mockito.eq(Duration.ZERO), Mockito.<Runnable>any());
+  }
+
+  @Test
+  void shouldAlwaysScheduleAsyncIfEnabled() {
+    // given
+    final var sync = mock(SimpleProcessingScheduleService.class);
+    final var async = mock(SimpleProcessingScheduleService.class);
+    final var concurrencyControl = mock(ConcurrencyControl.class);
+    doAnswer(
+            invocation -> {
+              final var runnable = (Runnable) invocation.getArgument(0);
+              runnable.run();
+              return null;
+            })
+        .when(concurrencyControl)
+        .run(Mockito.any());
+
+    final var schedulingService =
+        new ExtendedProcessingScheduleServiceImpl(sync, async, concurrencyControl, true);
+
+    // when
+    schedulingService.runDelayed(Duration.ZERO, () -> {});
+
+    // then
+    Mockito.verify(async, Mockito.times(1))
+        .runDelayed(Mockito.eq(Duration.ZERO), Mockito.<Runnable>any());
+  }
+}

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -459,52 +459,6 @@ public final class StreamProcessorTest {
   }
 
   @Test
-  public void shouldBlockProcessingIfSchedulingBlocks() throws InterruptedException {
-    // given
-    final var mockProcessorLifecycleAware = streamPlatform.getMockProcessorLifecycleAware();
-    final CountDownLatch asyncServiceLatch = new CountDownLatch(1);
-    final CountDownLatch countDownLatch = new CountDownLatch(1);
-    doAnswer(
-            (invocationOnMock) -> {
-              final var context = (ReadonlyStreamProcessorContext) invocationOnMock.getArgument(0);
-
-              context
-                  .getScheduleService()
-                  .runAtFixedRate(
-                      Duration.ZERO,
-                      (taskResultBuilder) -> {
-                        try {
-                          asyncServiceLatch.countDown();
-                          countDownLatch.await();
-                        } catch (final InterruptedException e) {
-                          throw new RuntimeException(e);
-                        }
-                        return taskResultBuilder.build();
-                      });
-
-              return invocationOnMock.callRealMethod();
-            })
-        .when(mockProcessorLifecycleAware)
-        .onRecovered(any());
-
-    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
-    streamPlatform.startStreamProcessor();
-
-    try {
-      // when
-      assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
-      streamPlatform.writeBatch(
-          RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
-
-      // then
-      verify(defaultRecordProcessor, timeout(500).times(0)).process(any(), any());
-    } finally {
-      // free processor
-      countDownLatch.countDown();
-    }
-  }
-
-  @Test
   public void shouldProcessEvenIfAsyncSchedulingBlocks() throws InterruptedException {
     // given
     final var mockProcessorLifecycleAware = streamPlatform.getMockProcessorLifecycleAware();

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -490,15 +490,18 @@ public final class StreamProcessorTest {
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     streamPlatform.startStreamProcessor();
 
-    // when
-    assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
-    streamPlatform.writeBatch(
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+    try {
+      // when
+      assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
+      streamPlatform.writeBatch(
+          RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
 
-    // then
-    verify(defaultRecordProcessor, timeout(500).times(0)).process(any(), any());
-    // free processor
-    countDownLatch.countDown();
+      // then
+      verify(defaultRecordProcessor, timeout(500).times(0)).process(any(), any());
+    } finally {
+      // free processor
+      countDownLatch.countDown();
+    }
   }
 
   @Test
@@ -533,15 +536,19 @@ public final class StreamProcessorTest {
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     streamPlatform.startStreamProcessor();
 
-    // when
-    assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
-    streamPlatform.writeBatch(
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+    try {
+      // when
+      assertThat(asyncServiceLatch.await(10, TimeUnit.SECONDS)).isTrue();
+      streamPlatform.writeBatch(
+          RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
 
-    // then
-    verify(defaultRecordProcessor, TIMEOUT.times(1)).process(any(), any());
-    // free schedule service
-    countDownLatch.countDown();
+      // then
+      verify(defaultRecordProcessor, TIMEOUT.times(1)).process(any(), any());
+
+    } finally {
+      // free schedule service
+      countDownLatch.countDown();
+    }
   }
 
   @Disabled("Should be enabled when https://github.com/camunda/zeebe/issues/11849 is fixed")


### PR DESCRIPTION
This test is broken since we enabled async scheduled tasks by default. It was actually behaving exactly as `shouldProcessEvenIfAsyncSchedulingBlocks` except that the assertion that `RecordProcessor#process` is not being called  would still pass most of the time because the invocation count is observed before the stream processor actor had the chance to run. When it occasionally fails because `RecordProcessor#process` was getting called fast enough, the test would fail but not close correctly because the processing actor is blocked waiting on a countdown latch that the test never decrements (because the assertion failed and the countdown only happens in the happy path).

I've first fixed the deadlock by ensuring that countdown latches are always decremented. Additionally, I suggest to simply remove the test case `shouldBlockProcessingIfSchedulingBlocks` because it tries to observe that a bug can occur when a non-default setting is used. IMO this does not add much value and I'd rather remove it instead of trying to extend `StreamPlatformExtension` to allow configuring `enableAsyncScheduledTasks`.

closes https://github.com/camunda/zeebe/issues/14011