### PR TITLE
Remove deleted DRG from cache

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -380,6 +380,7 @@ public final class DbDecisionState implements MutableDecisionState {
 
     decisionRequirementsByKey.deleteExisting(dbDecisionRequirementsKey);
     decisionRequirementsKeyByIdAndVersion.deleteExisting(decisionRequirementsIdAndVersion);
+    drgCache.invalidate(record.getDecisionRequirementsKey());
   }
 
   private void updateLatestDecisionVersion(final DecisionRecord record) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -394,7 +394,7 @@ public final class DecisionStateTest {
     decisionState.deleteDecision(decisionRecord);
 
     // then
-    assertThat(decisionState.findDecisionByKey(decisionRecord.getDecisionKey()).isEmpty());
+    assertThat(decisionState.findDecisionByKey(decisionRecord.getDecisionKey())).isEmpty();
     assertThat(decisionState.findLatestDecisionById(decisionRecord.getDecisionIdBuffer()))
         .isEmpty();
     assertThat(
@@ -426,7 +426,7 @@ public final class DecisionStateTest {
     decisionState.deleteDecision(decisionRecord1);
 
     // then
-    assertThat(decisionState.findDecisionByKey(decisionRecord1.getDecisionKey()).isEmpty());
+    assertThat(decisionState.findDecisionByKey(decisionRecord1.getDecisionKey())).isEmpty();
     final var latestDecisionById =
         decisionState.findLatestDecisionById(decisionRecord1.getDecisionIdBuffer());
     assertThat(latestDecisionById).isNotEmpty();
@@ -458,7 +458,7 @@ public final class DecisionStateTest {
     decisionState.deleteDecision(decisionRecord2);
 
     // then
-    assertThat(decisionState.findDecisionByKey(decisionRecord2.getDecisionKey()).isEmpty());
+    assertThat(decisionState.findDecisionByKey(decisionRecord2.getDecisionKey())).isEmpty();
     final var latestDecisionById =
         decisionState.findLatestDecisionById(decisionRecord2.getDecisionIdBuffer());
     assertThat(latestDecisionById).isNotEmpty();
@@ -492,7 +492,7 @@ public final class DecisionStateTest {
     decisionState.deleteDecision(decisionRecord3);
 
     // then
-    assertThat(decisionState.findDecisionByKey(decisionRecord3.getDecisionKey()).isEmpty());
+    assertThat(decisionState.findDecisionByKey(decisionRecord3.getDecisionKey())).isEmpty();
     final var latestDecisionById =
         decisionState.findLatestDecisionById(decisionRecord3.getDecisionIdBuffer());
     assertThat(latestDecisionById).isNotEmpty();
@@ -512,8 +512,8 @@ public final class DecisionStateTest {
     decisionState.deleteDecisionRequirements(drg);
 
     // then
-    assertThat(
-        decisionState.findDecisionRequirementsByKey(drg.getDecisionRequirementsKey()).isEmpty());
+    assertThat(decisionState.findDecisionRequirementsByKey(drg.getDecisionRequirementsKey()))
+        .isEmpty();
     assertThat(decisionState.findLatestDecisionById(drg.getDecisionRequirementsIdBuffer()))
         .isEmpty();
   }
@@ -538,9 +538,8 @@ public final class DecisionStateTest {
 
     // then
     assertThat(
-        decisionState
-            .findDecisionsByDecisionRequirementsKey(drg1.getDecisionRequirementsKey())
-            .isEmpty());
+            decisionState.findDecisionsByDecisionRequirementsKey(drg1.getDecisionRequirementsKey()))
+        .isEmpty();
     final var latestDrg =
         decisionState.findLatestDecisionRequirementsById(drg1.getDecisionRequirementsIdBuffer());
     assertThat(latestDrg).isNotEmpty();
@@ -569,7 +568,7 @@ public final class DecisionStateTest {
     decisionState.deleteDecisionRequirements(drg2);
 
     // then
-    assertThat(decisionState.findDecisionByKey(drg2.getDecisionRequirementsKey()).isEmpty());
+    assertThat(decisionState.findDecisionByKey(drg2.getDecisionRequirementsKey())).isEmpty();
     final var latestDrg =
         decisionState.findLatestDecisionRequirementsById(drg2.getDecisionRequirementsIdBuffer());
     assertThat(latestDrg).isNotEmpty();
@@ -598,7 +597,7 @@ public final class DecisionStateTest {
     decisionState.deleteDecisionRequirements(drg3);
 
     // then
-    assertThat(decisionState.findDecisionByKey(drg3.getDecisionRequirementsKey()).isEmpty());
+    assertThat(decisionState.findDecisionByKey(drg3.getDecisionRequirementsKey())).isEmpty();
     final var latestDrg =
         decisionState.findLatestDecisionRequirementsById(drg3.getDecisionRequirementsIdBuffer());
     assertThat(latestDrg).isNotEmpty();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When we delete a DRG we must also delete it from the cache, otherwise it remains available. Due to a bug in our tests assertion we didn't catch this earlier.

No backport required as resource deletion is part of the 8.3 release.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14146 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
