### PR TITLE
fix: don't attempt to close request future if already completed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -747,12 +747,15 @@ public final class NettyMessagingService implements ManagedMessagingService {
     channel
         .closeFuture()
         .addListener(
-            onClose ->
+            onClose -> {
+              if (!future.isDone()) {
                 future.completeExceptionally(
                     new ConnectException(
                         String.format(
                             "Channel %s for address %s was closed unexpectedly before the request was handled",
-                            channel, address))));
+                            channel, address)));
+              }
+            });
 
     return future;
   }


### PR DESCRIPTION
Check first if the request future was already completed before trying to complete it exceptionally. In most cases the future was already completed so we don't have to create an exception which is fairly expensive (collecting stack trace + exception message formatting).