### PR TITLE
fix(gateway): rethrow exception to ensure push is retried

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/ClientStreamAdapter.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/ClientStreamAdapter.java
@@ -19,9 +19,11 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
 import io.camunda.zeebe.transport.stream.api.ClientStreamer;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.agrona.DirectBuffer;
@@ -78,13 +80,13 @@ public class ClientStreamAdapter {
         new StatusRuntimeException(Status.INVALID_ARGUMENT.withDescription(errorMessage)));
   }
 
-  @SuppressWarnings("ClassCanBeRecord")
-  private static final class ClientStreamConsumerImpl implements ClientStreamConsumer {
-    private final ServerCallStreamObserver<ActivatedJob> responseObserver;
+  @VisibleForTesting("Allow unit testing behavior job handling behavior")
+  static final class ClientStreamConsumerImpl implements ClientStreamConsumer {
+    private final StreamObserver<ActivatedJob> responseObserver;
     private final Executor executor;
 
     public ClientStreamConsumerImpl(
-        final ServerCallStreamObserver<ActivatedJob> responseObserver, final Executor executor) {
+        final StreamObserver<ActivatedJob> responseObserver, final Executor executor) {
       this.responseObserver = responseObserver;
       this.executor = executor;
     }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/ClientStreamAdapter.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/ClientStreamAdapter.java
@@ -103,7 +103,7 @@ public class ClientStreamAdapter {
         responseObserver.onNext(activatedJob);
       } catch (final Exception e) {
         responseObserver.onError(e);
-        CompletableFuture.failedFuture(e);
+        throw e;
       }
     }
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
@@ -181,10 +181,6 @@ public class StreamActivatedJobsTest extends GatewayTest {
             "INVALID_ARGUMENT: Expected to stream activated jobs with timeout to be greater than zero, but it was 0");
   }
 
-  // TODO add test for onClose
-  // How to test onClose? it seems the graceful way to close a stream from the client side is
-  // simply to cancel it, as per the gRPC docs. So is onClose only for when we close it server side?
-
   private TestStreamObserver getStreamActivatedJobsRequestUnblocking(
       final String jobType,
       final String worker,

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/stream/ClientStreamConsumerImplTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/stream/ClientStreamConsumerImplTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.impl.stream.ClientStreamAdapter.ClientStreamConsumerImpl;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import org.agrona.LangUtil;
+import org.junit.jupiter.api.Test;
+
+final class ClientStreamConsumerImplTest {
+  @Test
+  void shouldRethrowExceptionOnPushFailure() {
+    // given
+    final var failure = new RuntimeException("failed");
+    final var failingObserver = new FailingStreamObserver(failure);
+    final var consumer = new ClientStreamConsumerImpl(failingObserver, Runnable::run);
+
+    // when
+    final var result = consumer.push(BufferUtil.createCopy(new ActivatedJobImpl()));
+
+    // then
+    assertThat(failingObserver.error).isSameAs(failure);
+    assertThat(result)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .havingRootCause()
+        .isSameAs(failure);
+  }
+
+  private static final class FailingStreamObserver implements StreamObserver<ActivatedJob> {
+    private final Throwable failure;
+    private Throwable error;
+
+    private FailingStreamObserver(final Throwable failure) {
+      this.failure = failure;
+    }
+
+    @Override
+    public void onNext(final ActivatedJob value) {
+      LangUtil.rethrowUnchecked(failure);
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+      error = t;
+    }
+
+    @Override
+    public void onCompleted() {}
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes retrying failed pushes in the gateway. It seems we were silently swallowing the exception, meaning pushes that failed to be forwarded to a client were not retried to the next client.

I couldn't figure out a way to test this at the integration level - that is, two streams are registered, the first one fails, the second one receives the job, because:

1. How to make sure the first one fails specifically when its response observer `onNext` is called, and not before? Closing it risks removing it and thus it would never be tried...
2. Clients are picked at random, so how to guarantee which is picked first/second?

So in the end I went with a unit test that guarantees the future returned by `push` is always failed. It's not ideal, but better than nothing, and would've caught the issue here.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
