### PR TITLE
[Backport stable/8.2] fix(gateway): close transport client and request manager with the BrokerClient

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -75,8 +75,13 @@ public final class BrokerClientImpl implements BrokerClient {
     }
 
     isClosed = true;
-
     LOG.debug("Closing gateway broker client ...");
+
+    doAndLogException(requestManager::close);
+    LOG.debug("request manager closed");
+
+    doAndLogException(atomixTransportAdapter::close);
+    LOG.debug("transport client closed");
 
     doAndLogException(topologyManager::close);
     LOG.debug("topology manager closed");


### PR DESCRIPTION
# Description
Backport of #14100 to `stable/8.2`.

relates to #7855
original author: @deepthidevaki