### PR TITLE
ClusterTopologyManager can apply topology changes

### DIFF
--- a/topology/pom.xml
+++ b/topology/pom.xml
@@ -99,6 +99,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -140,12 +140,13 @@ final class ClusterTopologyManager {
     // operation is triggered locally only when the local topology is changes. However, as
     // an extra precaution we check if there is an ongoing operation before applying
     // one.
-    return !onGoingTopologyChangeOperation && mergedTopology.hasPendingChangesFor(localMemberId);
+    return !onGoingTopologyChangeOperation
+        && mergedTopology.pendingChangesFor(localMemberId).isPresent();
   }
 
   private void applyTopologyChangeOperation(final ClusterTopology mergedTopology) {
     onGoingTopologyChangeOperation = true;
-    final var operation = mergedTopology.pendingChangerFor(localMemberId);
+    final var operation = mergedTopology.pendingChangesFor(localMemberId).orElseThrow();
     LOG.info("Applying topology change operation {}", operation);
     final var operationApplier = changeAppliers.getApplier(operation);
     final var initialized =

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -122,8 +122,7 @@ final class ClusterTopologyManager {
     return result;
   }
 
-  private void applyTopologyChangeOperation(final ClusterTopology mergedTopology)
-      throws IOException {
+  private void applyTopologyChangeOperation(final ClusterTopology mergedTopology) {
     final var operation = mergedTopology.pendingChangerFor(localMemberId);
     final var operationApplier = operationsAppliers.getApplier(operation);
     final var initialized =

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -55,7 +55,7 @@ public final class ClusterTopologyManagerService extends Actor {
     persistedClusterTopology = new PersistedClusterTopology(topologyFile, new ProtoBufSerializer());
     clusterTopologyManager =
         new ClusterTopologyManager(
-            this, localMemberId, persistedClusterTopology, new NoopTopologyChangeApplier());
+            this, localMemberId, persistedClusterTopology, new NoopTopologyChangeAppliers());
     clusterTopologyGossiper =
         new ClusterTopologyGossiper(
             this,

--- a/topology/src/main/java/io/camunda/zeebe/topology/NoopTopologyChangeApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/NoopTopologyChangeApplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * This is temporary implementation for TopologyChangeAppliers. This will be eventually removed or
+ * moved to tests, once concrete implementation for each TopologyChangeOperation is available.
+ */
+public class NoopTopologyChangeApplier implements TopologyChangeAppliers {
+
+  @Override
+  public OperationApplier getApplier(final TopologyChangeOperation operation) {
+    return new NoopApplier();
+  }
+
+  private static class NoopApplier implements OperationApplier {
+
+    @Override
+    public Either<Exception, UnaryOperator<MemberState>> init() {
+      return Either.right(memberState -> memberState);
+    }
+
+    @Override
+    public ActorFuture<UnaryOperator<MemberState>> apply() {
+      return CompletableActorFuture.completed(memberState -> memberState);
+    }
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/NoopTopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/NoopTopologyChangeAppliers.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
  * This is temporary implementation for TopologyChangeAppliers. This will be eventually removed or
  * moved to tests, once concrete implementation for each TopologyChangeOperation is available.
  */
-public class NoopTopologyChangeApplier implements TopologyChangeAppliers {
+public class NoopTopologyChangeAppliers implements TopologyChangeAppliers {
 
   @Override
   public OperationApplier getApplier(final TopologyChangeOperation operation) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyChangeAppliers.java
@@ -24,18 +24,26 @@ public interface TopologyChangeAppliers {
   interface OperationApplier {
 
     /**
-     * Validate and initialize the operation. Returns an Either with an exception if the operation
-     * is not valid, or a function that updates the state of the member in the cluster topology
+     * This method will be called before invoking {@link OperationApplier#apply()}. This method can
+     * be used to validate the operation and to update the ClusterTopology to mark the start of the
+     * operation. For example, an operation for joining a partition can mark the state as JOINING.
      *
-     * @return an either
+     * @return an either which contains an exception if the operation is not valid, or a function to
+     *     update the cluster toplogy
      */
     Either<Exception, UnaryOperator<MemberState>> init();
 
     /**
      * Applies the operation. This can be run asynchronously and should complete the future when the
-     * operation is completed.
+     * operation is completed. The future should be completed with a function that can update the
+     * ClusterTopology to mark the operation as completed. For example, an operation for joining a
+     * partition should mark the state of the partition as ACTIVE.
      *
-     * @return the future when the operation is completed.
+     * <p>It is expected that no other operation is applied until this operation is completed. It is
+     * guaranteed that the MemberState updated by {@link OperationApplier#init()} remains the same
+     * until this operation is completed.
+     *
+     * @return the future which is completed when the operation is completed successfully or failed.
      */
     ActorFuture<UnaryOperator<MemberState>> apply();
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyChangeAppliers.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/** */
+public interface TopologyChangeAppliers {
+
+  /**
+   * @return the operation applier for the given operation
+   */
+  OperationApplier getApplier(TopologyChangeOperation operation);
+
+  interface OperationApplier {
+
+    /**
+     * Validate and initialize the operation. Returns an Either with an exception if the operation
+     * is not valid, or a function that updates the state of the member in the cluster topology
+     *
+     * @return an either
+     */
+    Either<Exception, UnaryOperator<MemberState>> init();
+
+    /**
+     * Applies the operation. This can be run asynchronously and should complete the future when the
+     * operation is completed.
+     *
+     * @return the future when the operation is completed.
+     */
+    ActorFuture<UnaryOperator<MemberState>> apply();
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
@@ -25,8 +25,10 @@ public record ClusterChangePlan(int version, List<TopologyChangeOperation> pendi
 
   /** To be called when the first operation is completed. */
   ClusterChangePlan advance() {
-    return new ClusterChangePlan(
-        version + 1, pendingOperations.subList(1, pendingOperations.size()));
+    // List#subList hold on to the original list. Make a copy to prevent a potential memory leak.
+    final var nextPendingOperations =
+        List.copyOf(pendingOperations.subList(1, pendingOperations.size()));
+    return new ClusterChangePlan(version + 1, nextPendingOperations);
   }
 
   public ClusterChangePlan merge(final ClusterChangePlan other) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
@@ -7,8 +7,36 @@
  */
 package io.camunda.zeebe.topology.state;
 
-public record ClusterChangePlan() {
+import java.util.List;
+
+/**
+ * Represents the ongoing cluster topology changes. The pendingOperations are executed sequentially.
+ * Only after completing one operation, the next operation is started. Once an operation is
+ * completed, it should be removed from the plan, so that the next operation can be picked up.
+ */
+public record ClusterChangePlan(int version, List<TopologyChangeOperation> pendingOperations) {
   public static ClusterChangePlan empty() {
-    return new ClusterChangePlan();
+    return new ClusterChangePlan(0, List.of());
+  }
+
+  public static ClusterChangePlan init(final List<TopologyChangeOperation> operations) {
+    return new ClusterChangePlan(1, List.copyOf(operations));
+  }
+
+  /** To be called when the first operation is completed. */
+  ClusterChangePlan advance() {
+    return new ClusterChangePlan(
+        version + 1, pendingOperations.subList(1, pendingOperations.size()));
+  }
+
+  public ClusterChangePlan merge(final ClusterChangePlan other) {
+    // Pick the highest version
+    if (other == null) {
+      return this;
+    }
+    if (other.version > version) {
+      return other;
+    }
+    return this;
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -11,7 +11,7 @@ import com.google.common.collect.ImmutableMap;
 import io.atomix.cluster.MemberId;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -112,29 +112,27 @@ public record ClusterTopology(
    * @return true if the next operation in pending changes is applicable for the given memberId,
    *     otherwise returns false.
    */
-  public boolean hasPendingChangesFor(final MemberId memberId) {
+  private boolean hasPendingChangesFor(final MemberId memberId) {
     return !changes.pendingOperations().isEmpty()
         && changes.pendingOperations().get(0).memberId().equals(memberId);
   }
 
   /**
    * Returns the next pending operation for the given memberId. If there is no pending operation for
-   * the members, throws NoSuchElementException. It is recommended to call {@link
-   * #hasPendingChangesFor(MemberId)} before calling this method.
+   * this member, then returns an empty optional.
    *
    * @param memberId id of the member
    * @return the next pending operation for the given memberId.
-   * @throws NoSuchElementException if there is no pending operation for the given memberId.
    */
-  public TopologyChangeOperation pendingChangerFor(final MemberId memberId) {
+  public Optional<TopologyChangeOperation> pendingChangesFor(final MemberId memberId) {
     if (!hasPendingChangesFor(memberId)) {
-      throw new NoSuchElementException();
+      return Optional.empty();
     }
-    return changes.pendingOperations().get(0);
+    return Optional.of(changes.pendingOperations().get(0));
   }
 
   /**
-   * When the operation returned by {@link #pendingChangerFor(MemberId)} is completed, the changes
+   * When the operation returned by {@link #pendingChangesFor(MemberId)} is completed, the changes
    * should be reflected in ClusterTopology by invoking this method. This removes the completed
    * operation from the pending changes and update the member state using the given updater.
    *

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.topology.state;
 
 import com.google.common.collect.ImmutableMap;
 import io.atomix.cluster.MemberId;
+import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -21,9 +23,11 @@ import java.util.stream.Stream;
  * <p>version - represents the current version of the topology. It is incremented when new
  * configuration change is triggered.
  *
- * <p>members - represents the state of each members
+ * <p>members - represents the state of each member
  *
  * <p>changes - keeps track of the ongoing configuration changes
+ *
+ * <p>This class is immutable. Each mutable methods returns a new instance with the updated state.
  */
 public record ClusterTopology(
     long version, Map<MemberId, MemberState> members, ClusterChangePlan changes) {
@@ -55,7 +59,7 @@ public record ClusterTopology(
     return new ClusterTopology(version, newMembers, changes);
   }
 
-  ClusterTopology updateMember(
+  public ClusterTopology updateMember(
       final MemberId memberId, final UnaryOperator<MemberState> memberStateUpdater) {
     if (!members.containsKey(memberId)) {
       throw new IllegalStateException(
@@ -70,10 +74,20 @@ public record ClusterTopology(
     return new ClusterTopology(version, newMembers, changes);
   }
 
+  public ClusterTopology startTopologyChange(final List<TopologyChangeOperation> operations) {
+    if (changes.pendingOperations().isEmpty()) {
+      return new ClusterTopology(version + 1, members, ClusterChangePlan.init(operations));
+    } else {
+      throw new IllegalArgumentException(
+          "Expected to start new topology change, but there is a topology change in progress "
+              + changes);
+    }
+  }
+
   /**
    * Returns a new ClusterTopology after merging this and other. This doesn't overwrite this or
    * other. If this.version == other.version then the new ClusterTopology contains merged members
-   * and changes. Otherwise, it returns the one with highest version.
+   * and changes. Otherwise, it returns the one with the highest version.
    *
    * @param other ClusterTopology to merge
    * @return merged ClusterTopology
@@ -89,9 +103,51 @@ public record ClusterTopology(
               .collect(
                   Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, MemberState::merge));
 
-      // TODO: changes also have to be merged. We will do it when we add support for configuration
-      // changes.
-      return new ClusterTopology(version, ImmutableMap.copyOf(mergedMembers), changes);
+      final var mergedChanges = changes.merge(other.changes);
+      return new ClusterTopology(version, ImmutableMap.copyOf(mergedMembers), mergedChanges);
     }
+  }
+
+  /**
+   * @return true if the next operation in pending changes is applicable for the given memberId,
+   *     otherwise returns false.
+   */
+  public boolean hasPendingChangesFor(final MemberId memberId) {
+    return !changes.pendingOperations().isEmpty()
+        && changes.pendingOperations().get(0).memberId().equals(memberId);
+  }
+
+  /**
+   * Returns the next pending operation for the given memberId. If there is no pending operation for
+   * the members, throws NoSuchElementException. It is recommended to call {@link
+   * #hasPendingChangesFor(MemberId)} before calling this method.
+   *
+   * @param memberId id of the member
+   * @return the next pending operation for the given memberId.
+   * @throws NoSuchElementException if there is no pending operation for the given memberId.
+   */
+  public TopologyChangeOperation pendingChangerFor(final MemberId memberId) {
+    if (!hasPendingChangesFor(memberId)) {
+      throw new NoSuchElementException();
+    }
+    return changes.pendingOperations().get(0);
+  }
+
+  /**
+   * When the operation returned by {@link #pendingChangerFor(MemberId)} is completed, the changes
+   * should be reflected in ClusterTopology by invoking this method. This removes the completed
+   * operation from the pending changes and update the member state using the given updater.
+   *
+   * @param memberId id of the member which completed the operation
+   * @param memberStateUpdater the method to update the member state
+   * @return the updated ClusterTopology
+   */
+  public ClusterTopology advanceTopologyChange(
+      final MemberId memberId, final UnaryOperator<MemberState> memberStateUpdater) {
+    return updateMember(memberId, memberStateUpdater).advance();
+  }
+
+  private ClusterTopology advance() {
+    return new ClusterTopology(version, members, changes.advance());
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
@@ -30,7 +30,7 @@ public record MemberState(long version, State state, Map<Integer, PartitionState
     return update(State.JOINING, partitions);
   }
 
-  MemberState toActive() {
+  public MemberState toActive() {
     if (state == State.LEFT || state == State.LEAVING) {
       throw new IllegalStateException(
           String.format("Cannot transition to ACTIVE when current state is %s", state));

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.state;
+
+import io.atomix.cluster.MemberId;
+
+/**
+ * An operation that changes the topology. The operation could be a member join or leave a cluster,
+ * or a member join or leave partition.
+ */
+public interface TopologyChangeOperation {
+
+  MemberId memberId();
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -11,18 +11,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
-final class ClusterTopologyAssert extends AbstractAssert<ClusterTopologyAssert, ClusterTopology> {
+public final class ClusterTopologyAssert
+    extends AbstractAssert<ClusterTopologyAssert, ClusterTopology> {
 
   private ClusterTopologyAssert(final ClusterTopology clusterTopology, final Class<?> selfType) {
     super(clusterTopology, selfType);
   }
 
-  static ClusterTopologyAssert assertThatClusterTopology(final ClusterTopology actual) {
+  public static ClusterTopologyAssert assertThatClusterTopology(final ClusterTopology actual) {
     return new ClusterTopologyAssert(actual, ClusterTopologyAssert.class);
   }
 
@@ -44,10 +46,21 @@ final class ClusterTopologyAssert extends AbstractAssert<ClusterTopologyAssert, 
     return this;
   }
 
+  public ClusterTopologyAssert hasMemberWithState(final int member, final MemberState.State state) {
+    final var memberId = MemberId.from(Integer.toString(member));
+    assertThat(actual.members()).containsKey(memberId);
+    assertThat(actual.members().get(memberId).state()).isEqualTo(state);
+    return this;
+  }
+
   ClusterTopologyAssert hasOnlyMembers(final Set<Integer> members) {
     final var memberIds =
         members.stream().map(id -> MemberId.from(String.valueOf(id))).collect(Collectors.toSet());
     assertThat(actual.members()).containsOnlyKeys(memberIds);
     return this;
+  }
+
+  public void hasPendingOperationsWithSize(final int expectedSize) {
+    assertThat(actual.changes().pendingOperations()).hasSize(expectedSize);
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -60,7 +60,8 @@ public final class ClusterTopologyAssert
     return this;
   }
 
-  public void hasPendingOperationsWithSize(final int expectedSize) {
+  public ClusterTopologyAssert hasPendingOperationsWithSize(final int expectedSize) {
     assertThat(actual.changes().pendingOperations()).hasSize(expectedSize);
+    return this;
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -70,7 +70,11 @@ final class ClusterTopologyManagerTest {
 
   private ClusterTopologyManager createTopologyManager() {
     final ClusterTopologyManager clusterTopologyManager =
-        new ClusterTopologyManager(new TestConcurrencyControl(), persistedClusterTopology);
+        new ClusterTopologyManager(
+            new TestConcurrencyControl(),
+            MemberId.from("1"),
+            persistedClusterTopology,
+            new NoopTopologyChangeApplier());
     clusterTopologyManager.setTopologyGossiper(gossipHandler);
     return clusterTopologyManager;
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -58,7 +58,7 @@ final class ClusterTopologyManagerTest {
 
   private ActorFuture<ClusterTopologyManager> startTopologyManager(
       final TopologyInitializer topologyInitializer) {
-    return startTopologyManager(topologyInitializer, new NoopTopologyChangeApplier());
+    return startTopologyManager(topologyInitializer, new NoopTopologyChangeAppliers());
   }
 
   private ActorFuture<ClusterTopologyManager> startTopologyManager(

--- a/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
@@ -28,7 +28,7 @@ class ClusterTopologyTest {
                 withActivePartition(0, 2),
                 member(3),
                 withActivePartition(0, 3)),
-            new ClusterChangePlan());
+            ClusterChangePlan.empty());
     // when
     final var topology =
         ClusterTopology.init()
@@ -50,7 +50,7 @@ class ClusterTopologyTest {
         new ClusterTopology(
             0,
             Map.of(member(1), withActivePartition(1, 1), member(2), withActivePartition(1, 2)),
-            new ClusterChangePlan());
+            ClusterChangePlan.empty());
     final var topology =
         ClusterTopology.init()
             .addMember(
@@ -87,7 +87,7 @@ class ClusterTopologyTest {
                 withActivePartition(0, 2),
                 member(3),
                 new MemberState(1, State.JOINING, Map.of())),
-            new ClusterChangePlan());
+            ClusterChangePlan.empty());
 
     final var initialTopology =
         ClusterTopology.init()


### PR DESCRIPTION
## Description

- [x] ClusterTopology includes ongoing topology changes
 
To support coordinating topology changes via gossip, `ClusterTopology` supports adding `ClusterChangePlan` with a list of pending operations. These pending operations are expected to be executed sequentially. An operation is only executed by the corresponding member. 

- [x] ClusterTopologyManager applies topology changes received via gossip

`ClusterTopologyManager` is responsible for applying the topology change operation. On receiving gossip, it checks if the next pending operation is applicable to this node. If yes it applies the operation by invoking the relevant `TopologyOperationApplier`.
Once an operation is applied, it will be removed from the pending changes and the relevant member state or partition state in the `ClusterTopology` will be updated. The resulting `ClusterTopology` is also gossiped.

This PR adds "Noop" operation applier. The concrete implementations to support each operation will be added later. Noop applier helps to integrate it with the `ClusterTopologyManager` already. The topology change operation are not yet gossiped because they are not added to the protobuf yet.

## Related issues

related #14159 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
