### PR TITLE
Introduce new checksum interface

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/ImmutableChecksumsSFV.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/ImmutableChecksumsSFV.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots;
+
+import java.io.IOException;
+
+/**
+ * Immutable checksum collection in simple file verification (SFV) file format, which only allows to
+ * read serialized file checksums or a combined checksum.
+ */
+public interface ImmutableChecksumsSFV {
+
+  /**
+   * @return a combined CRC32C checksum over all files (for backwards compatibility)
+   */
+  long getCombinedValue();
+
+  /**
+   * @return the serialized SFV file data
+   */
+  byte[] serializeSfvFileData() throws IOException;
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/MutableChecksumsSFV.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/MutableChecksumsSFV.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** Mutable checksum collection in simple file verification (SFV) file format */
+public interface MutableChecksumsSFV extends ImmutableChecksumsSFV {
+
+  /**
+   * Update the checksum collection, and add a new checksum from a given file path.
+   *
+   * @param filePath the path to a file for which a checksum is created and added to the collection
+   * @throws IOException when reading of given file fails
+   */
+  void updateFromFile(final Path filePath) throws IOException;
+
+  /**
+   * Build the checksum collection from a SFV format string array.
+   *
+   * @param lines the lines (in SFV) to build up the checksum collection
+   */
+  void updateFromSfvFile(final String... lines);
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.scheduler.ActorThread;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
+import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
@@ -512,7 +513,7 @@ public final class FileBasedSnapshotStore extends Actor
       moveToSnapshotDirectory(directory, destination);
 
       final var checksumPath = buildSnapshotsChecksumPath(snapshotId);
-      final SfvChecksum actualChecksum;
+      final MutableChecksumsSFV actualChecksum;
       try {
         // computing the checksum on the final destination also lets us detect any failures during
         // the

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.snapshots.impl;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.SnapshotId;
@@ -38,7 +39,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   private final ActorFuture<Void> takenFuture = new CompletableActorFuture<>();
   private boolean isValid = false;
   private PersistedSnapshot snapshot;
-  private SfvChecksum checksum;
+  private MutableChecksumsSFV checksum;
   private long lastFollowupEventPosition = Long.MAX_VALUE;
 
   FileBasedTransientSnapshot(

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -119,7 +119,7 @@ public class FileBasedSnapshotStoreTest {
   public void shouldNotLoadCorruptedSnapshot() throws Exception {
     // given
     final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
-    SnapshotChecksum.persist(persistedSnapshot.getChecksumPath(), new SfvChecksum(0xCAFEL));
+    SnapshotChecksum.persist(persistedSnapshot.getChecksumPath(), new SfvChecksumImpl(0xCAFEL));
 
     // when
     snapshotStore.close();
@@ -150,7 +150,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
     final var corruptOlderSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumPath(), new SfvChecksum(0xCAFEL));
+    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumPath(), new SfvChecksumImpl(0xCAFEL));
 
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, snapshotStore).persist().join();
@@ -198,7 +198,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
 
     // when - corrupting old snapshot and adding new valid snapshot
-    SnapshotChecksum.persist(olderSnapshot.getChecksumPath(), new SfvChecksum(0xCAFEL));
+    SnapshotChecksum.persist(olderSnapshot.getChecksumPath(), new SfvChecksumImpl(0xCAFEL));
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, otherStore).persist().join();
 
@@ -216,7 +216,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
     final var corruptSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    SnapshotChecksum.persist(corruptSnapshot.getChecksumPath(), new SfvChecksum(0xCAFEL));
+    SnapshotChecksum.persist(corruptSnapshot.getChecksumPath(), new SfvChecksumImpl(0xCAFEL));
 
     // when
     snapshotStore.close();

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SfvChecksumTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SfvChecksumTest.java
@@ -22,11 +22,11 @@ public class SfvChecksumTest {
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  private SfvChecksum sfvChecksum;
+  private SfvChecksumImpl sfvChecksum;
 
   @Before
   public void setUp() throws Exception {
-    sfvChecksum = new SfvChecksum();
+    sfvChecksum = new SfvChecksumImpl();
   }
 
   @Test

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.snapshots.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -167,7 +168,7 @@ public class SnapshotChecksumTest {
     }
 
     // when
-    final SfvChecksum sfvChecksum = SnapshotChecksum.read(tempFile.toPath());
+    final ImmutableChecksumsSFV sfvChecksum = SnapshotChecksum.read(tempFile.toPath());
     final long combinedValue = sfvChecksum.getCombinedValue();
 
     // then
@@ -181,7 +182,7 @@ public class SnapshotChecksumTest {
     createChunk(folder, "file1.txt");
     createChunk(folder, "file2.txt");
     createChunk(folder, "file3.txt");
-    final SfvChecksum sfvChecksum = SnapshotChecksum.calculate(folder);
+    final ImmutableChecksumsSFV sfvChecksum = SnapshotChecksum.calculate(folder);
 
     // when
     final String serialized =
@@ -191,13 +192,14 @@ public class SnapshotChecksumTest {
     assertThat(serialized).contains("; number of files used for combined value = 3");
   }
 
+  @Test
   public void shouldAddChecksumOfMetadataAtTheEnd() throws IOException {
     // given
     final var folder = temporaryFolder.newFolder().toPath();
     createChunk(folder, "file1.txt");
     createChunk(folder, "file2.txt");
     createChunk(folder, "file3.txt");
-    final SfvChecksum checksumCalculatedInSteps = SnapshotChecksum.calculate(folder);
+    final var checksumCalculatedInSteps = SnapshotChecksum.calculate(folder);
 
     // when
     createChunk(folder, FileBasedSnapshotStore.METADATA_FILE_NAME);
@@ -206,7 +208,7 @@ public class SnapshotChecksumTest {
         folder.resolve(FileBasedSnapshotStore.METADATA_FILE_NAME));
 
     // This is how checksum is calculated when verifying
-    final SfvChecksum checksumCalculatedAtOnce = SnapshotChecksum.calculate(folder);
+    final ImmutableChecksumsSFV checksumCalculatedAtOnce = SnapshotChecksum.calculate(folder);
 
     // then
     assertThat(checksumCalculatedInSteps.getCombinedValue())


### PR DESCRIPTION
## Description
Introduce a new interface for SfvChecksum. Split up the interface into mutable and immutable, to
limit access later in upcoming interfaces and usage.

Add missing documentation to interface methods.


The next step for me is to do some more refactoring on the SFV checksum collection (make the class a bit leaner and cleaner
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/zeebe/issues/14045

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
