### PR TITLE
fix(transport): use unique schema ID

### DIFF
--- a/transport/src/main/resources/stream-protocol.xml
+++ b/transport/src/main/resources/stream-protocol.xml
@@ -8,7 +8,7 @@
   -->
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.transport.stream.impl.messages"
-  id="0" version="1" semanticVersion="${project.version}"
+  id="2" version="1" semanticVersion="${project.version}"
   description="Zeebe Protocol" byteOrder="littleEndian">
 
   <xi:include href="../../../protocol/src/main/resources/common-types.xml"/>


### PR DESCRIPTION
## Description

This PR gives a unique SBE message schema ID to the transport stream protocol.

You can check out all the IDs using [fq](https://github.com/wader/fq):

```sh
for file in $(grep -Ril "<sbe:messageSchema" | grep -v '/target/'); do
  echo -n "Schema ID for file: ${file} = "
  cat "${file}" | fq -d xml '."sbe:messageSchema"["@id"]'
done
```

Ideally we'd have something part of the build to do this, but I'd like to get this in for alpha5 =/

> **Note**
> This means alpha4 will not be able to use streaming with alpha5, but that should only cause temporary issues during update.

## Related issues

closes #14033 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
