### PR TITLE
Link forms to user tasks by formId

### DIFF
--- a/bpmn-model/ignored-changes.json
+++ b/bpmn-model/ignored-changes.json
@@ -1,0 +1,20 @@
+[
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeFormId(java.lang.String)",
+          "justification": "Adding a new method is not a breaking change, so this is acceptable"
+        }
+      ]
+    }
+  }
+]
+
+
+
+

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -64,6 +64,14 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
   }
 
   @Override
+  public B zeebeFormId(final String formId) {
+    final ZeebeFormDefinition formDefinition =
+        getCreateSingleExtensionElement(ZeebeFormDefinition.class);
+    formDefinition.setFormId(formId);
+    return myself;
+  }
+
+  @Override
   public B zeebeUserTaskForm(final String userTaskForm) {
     final ZeebeUserTaskForm zeebeUserTaskForm = createZeebeUserTaskForm();
     zeebeUserTaskForm.setTextContent(userTaskForm);

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
@@ -134,4 +134,12 @@ public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertie
    * @return the builder object
    */
   B zeebeFollowUpDateExpression(String expression);
+
+  /**
+   * Sets the form id of the build user task.
+   *
+   * @param formId the form id to set
+   * @return the builder object
+   */
+  B zeebeFormId(String formId);
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -42,6 +42,7 @@ public class ZeebeConstants {
       "propagateAllParentVariables";
 
   public static final String ATTRIBUTE_FORM_KEY = "formKey";
+  public static final String ATTRIBUTE_FORM_ID = "formId";
 
   public static final String ATTRIBUTE_ASSIGNEE = "assignee";
   public static final String ATTRIBUTE_CANDIDATE_GROUPS = "candidateGroups";

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeFormDefinitionImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeFormDefinitionImpl.java
@@ -28,6 +28,7 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
     implements ZeebeFormDefinition {
 
   protected static Attribute<String> formKeyAttribute;
+  protected static Attribute<String> formIdAttribute;
 
   public ZeebeFormDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -43,6 +44,16 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
     formKeyAttribute.setValue(this, formKey);
   }
 
+  @Override
+  public String getFormId() {
+    return formIdAttribute.getValue(this);
+  }
+
+  @Override
+  public void setFormId(final String formId) {
+    formIdAttribute.setValue(this, formId);
+  }
+
   public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
@@ -54,7 +65,12 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
         typeBuilder
             .stringAttribute(ZeebeConstants.ATTRIBUTE_FORM_KEY)
             .namespace(BpmnModelConstants.ZEEBE_NS)
-            .required()
+            .build();
+
+    formIdAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_FORM_ID)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 
     typeBuilder.build();

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinition.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinition.java
@@ -22,4 +22,8 @@ public interface ZeebeFormDefinition extends BpmnModelElementInstance {
   String getFormKey();
 
   void setFormKey(String formKey);
+
+  String getFormId();
+
+  void setFormId(String formId);
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -30,7 +30,9 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.function.Function;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 
 public final class ZeebeDesignTimeValidators {
@@ -90,8 +92,13 @@ public final class ZeebeDesignTimeValidators {
                 ZeebeSubscription::getCorrelationKey, ZeebeConstants.ATTRIBUTE_CORRELATION_KEY));
     validators.add(
         ZeebeElementValidator.verifyThat(ZeebeFormDefinition.class)
-            .hasNonEmptyAttribute(
-                ZeebeFormDefinition::getFormKey, ZeebeConstants.ATTRIBUTE_FORM_KEY));
+            .hasOnlyOneAttributeInGroup(
+                new HashMap<String, Function<ZeebeFormDefinition, String>>() {
+                  {
+                    put(ZeebeConstants.ATTRIBUTE_FORM_KEY, ZeebeFormDefinition::getFormKey);
+                    put(ZeebeConstants.ATTRIBUTE_FORM_ID, ZeebeFormDefinition::getFormId);
+                  }
+                }));
     validators.add(new ZeebeUserTaskFormValidator());
     validators.add(
         ZeebeElementValidator.verifyThat(ZeebeCalledDecision.class)

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -34,7 +35,8 @@ public class ZeebeFormDefinitionTest extends BpmnModelElementInstanceTest {
 
   @Override
   public Collection<AttributeAssumption> getAttributesAssumptions() {
-    return Collections.singletonList(
-        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "formKey", false, true));
+    return Arrays.asList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "formKey", false, false),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "formId", false, false));
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeUserTaskValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeUserTaskValidationTest.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.model.bpmn.validation;
 
 import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -36,7 +37,47 @@ public class ZeebeUserTaskValidationTest extends AbstractZeebeValidationTest {
             .endEvent()
             .done(),
         singletonList(
-            expect(ZeebeFormDefinition.class, "Attribute 'formKey' must be present and not empty"))
+            expect(
+                ZeebeFormDefinition.class,
+                "Exactly one of the attributes 'formId, formKey' must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId("")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Exactly one of the attributes 'formId, formKey' must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId("")
+            .zeebeFormKey("")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Exactly one of the attributes 'formId, formKey' must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId("form-id")
+            .zeebeFormKey("form-key")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Exactly one of the attributes 'formId, formKey' must be present and not empty"))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -49,6 +90,24 @@ public class ZeebeUserTaskValidationTest extends AbstractZeebeValidationTest {
             expect(
                 ZeebeUserTaskForm.class,
                 "User task form text content has to be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId("form-id")
+            .endEvent()
+            .done(),
+        EMPTY_LIST
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task")
+            .zeebeFormKey("form-key")
+            .endEvent()
+            .done(),
+        EMPTY_LIST
       }
     };
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR allows forms to be linked to `User Task` by `formId`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14134 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
