### PR TITLE
[Backport release-8.3.0-alpha5] fix(transport): use unique schema ID

### DIFF
--- a/transport/src/main/resources/stream-protocol.xml
+++ b/transport/src/main/resources/stream-protocol.xml
@@ -8,7 +8,7 @@
   -->
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.transport.stream.impl.messages"
-  id="0" version="1" semanticVersion="${project.version}"
+  id="2" version="1" semanticVersion="${project.version}"
   description="Zeebe Protocol" byteOrder="littleEndian">
 
   <xi:include href="../../../protocol/src/main/resources/common-types.xml"/>


### PR DESCRIPTION
# Description
Backport of #14174 to `release-8.3.0-alpha5`.

relates to #14033
original author: @npepinpe