### PR TITLE
Reuse already created checksum collections on persist

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/MutableChecksumsSFV.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/MutableChecksumsSFV.java
@@ -22,6 +22,18 @@ public interface MutableChecksumsSFV extends ImmutableChecksumsSFV {
   void updateFromFile(final Path filePath) throws IOException;
 
   /**
+   * Update the checksum collection, and add a new checksum from given bytes, likely a read file or
+   * soon to be written file.
+   *
+   * <p>Useful, if we want to avoid re-reading files etc.
+   *
+   * @param fileName the name of the file (which relates to the given bytes), that is used in the
+   *     checksum collection in SFV file format
+   * @param bytes the bytes for which the checksum should be created
+   */
+  void updateFromBytes(final String fileName, final byte[] bytes);
+
+  /**
    * Build the checksum collection from a SFV format string array.
    *
    * @param lines the lines (in SFV) to build up the checksum collection

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.scheduler.ActorThread;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
+import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -482,6 +483,15 @@ public final class FileBasedSnapshotStore extends Actor
     final var persistedSnapshot = currentPersistedSnapshotRef.get();
     return (persistedSnapshot != null
         && persistedSnapshot.getSnapshotId().compareTo(snapshotId) >= 0);
+  }
+
+  FileBasedSnapshot persistNewSnapshot(
+      final FileBasedSnapshotId snapshotId,
+      final Path directory,
+      final ImmutableChecksumsSFV immutableChecksumsSFV,
+      final FileBasedSnapshotMetadata metadata) {
+    return persistNewSnapshot(
+        snapshotId, directory, immutableChecksumsSFV.getCombinedValue(), metadata);
   }
 
   // TODO(npepinpe): using Either here would allow easy rollback regardless of when or where an

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
-import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
@@ -490,17 +489,6 @@ public final class FileBasedSnapshotStore extends Actor
       final Path directory,
       final ImmutableChecksumsSFV immutableChecksumsSFV,
       final FileBasedSnapshotMetadata metadata) {
-    return persistNewSnapshot(
-        snapshotId, directory, immutableChecksumsSFV.getCombinedValue(), metadata);
-  }
-
-  // TODO(npepinpe): using Either here would allow easy rollback regardless of when or where an
-  // exception is thrown, without having to catch and rollback for every possible case
-  FileBasedSnapshot persistNewSnapshot(
-      final FileBasedSnapshotId snapshotId,
-      final Path directory,
-      final long expectedChecksum,
-      final FileBasedSnapshotMetadata metadata) {
     final var currentPersistedSnapshot = currentPersistedSnapshotRef.get();
 
     if (isCurrentSnapshotNewer(snapshotId)) {
@@ -523,19 +511,8 @@ public final class FileBasedSnapshotStore extends Actor
       moveToSnapshotDirectory(directory, destination);
 
       final var checksumPath = buildSnapshotsChecksumPath(snapshotId);
-      final MutableChecksumsSFV actualChecksum;
       try {
-        // computing the checksum on the final destination also lets us detect any failures during
-        // the
-        // copy/move that could occur
-        actualChecksum = SnapshotChecksum.calculate(destination);
-        if (actualChecksum.getCombinedValue() != expectedChecksum) {
-          rollbackPartialSnapshot(destination);
-          throw new InvalidSnapshotChecksum(
-              directory, expectedChecksum, actualChecksum.getCombinedValue());
-        }
-
-        SnapshotChecksum.persist(checksumPath, actualChecksum);
+        SnapshotChecksum.persist(checksumPath, immutableChecksumsSFV);
       } catch (final IOException e) {
         rollbackPartialSnapshot(destination);
         throw new UncheckedIOException(e);
@@ -545,7 +522,7 @@ public final class FileBasedSnapshotStore extends Actor
           new FileBasedSnapshot(
               destination,
               checksumPath,
-              actualChecksum.getCombinedValue(),
+              immutableChecksumsSFV.getCombinedValue(),
               snapshotId,
               metadata,
               this::onSnapshotDeleted,

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -149,9 +149,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
               snapshotId.getExportedPosition(),
               lastFollowupEventPosition);
       writeMetadataAndUpdateChecksum(metadata);
-      snapshot =
-          snapshotStore.persistNewSnapshot(
-              snapshotId, directory, checksum.getCombinedValue(), metadata);
+      snapshot = snapshotStore.persistNewSnapshot(snapshotId, directory, checksum, metadata);
       future.complete(snapshot);
     } catch (final Exception e) {
       future.completeExceptionally(e);

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
@@ -123,6 +123,15 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
   }
 
   @Override
+  public void updateFromBytes(final String fileName, final byte[] bytes) {
+    combinedChecksum.update(fileName.getBytes(UTF_8));
+    final Checksum checksum = new CRC32C();
+    checksum.update(bytes);
+    combinedChecksum.update(bytes);
+    checksums.put(fileName, checksum.getValue());
+  }
+
+  @Override
   public void updateFromSfvFile(final String... lines) {
     for (String line : lines) {
       line = line.trim();

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
@@ -62,7 +62,7 @@ final class SnapshotChecksum {
 
   public static void persist(final Path checksumPath, final ImmutableChecksumsSFV checksum)
       throws IOException {
-    try(final var stream = new FileOutputStream(checksumPath.toFile())) {
+    try (final var stream = new FileOutputStream(checksumPath.toFile())) {
       checksum.write(stream);
     }
   }


### PR DESCRIPTION
## Description

 * Support to update the checksum collection from bytes, which might be received or read from the file already. This is useful, if we want to avoid re-reading files etc.
 * Support to persist snapshot with given checksum collection. 
 * collection of checksum is no longe recreated and directly written to the directory.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

relate #14045 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
