### PR TITLE
Allow configuration of job streaming via env variables and client properties

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -118,9 +118,9 @@ public final class ClientProperties {
   public static final String CLOUD_REGION = "zeebe.client.cloud.region";
 
   /**
-   * @see ZeebeClientBuilder#streamEnabled(boolean)
+   * @see ZeebeClientBuilder#defaultJobWorkerStreamEnabled(boolean)
    */
-  public static final String ENABLE_STREAMING = "zeebe.client.worker.stream.enable";
+  public static final String STREAM_ENABLED = "zeebe.client.worker.stream.enabled";
 
   private ClientProperties() {}
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -117,5 +117,10 @@ public final class ClientProperties {
    */
   public static final String CLOUD_REGION = "zeebe.client.cloud.region";
 
+  /**
+   * @see ZeebeClientBuilder#streamEnabled(boolean)
+   */
+  public static final String ENABLE_STREAMING = "zeebe.client.worker.stream.enable";
+
   private ClientProperties() {}
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -162,6 +162,12 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder maxMessageSize(int maxSize);
 
   /**
+   * A custom streamEnabled allows the client to use job stream instead of job poll. The default
+   * value is set as enabled.
+   */
+  ZeebeClientBuilder streamEnabled(boolean streamEnabled);
+
+  /**
    * @return a new {@link ZeebeClient} with the provided configuration options.
    */
   ZeebeClient build();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -165,7 +165,7 @@ public interface ZeebeClientBuilder {
    * A custom streamEnabled allows the client to use job stream instead of job poll. The default
    * value is set as enabled.
    */
-  ZeebeClientBuilder streamEnabled(boolean streamEnabled);
+  ZeebeClientBuilder defaultJobWorkerStreamEnabled(boolean streamEnabled);
 
   /**
    * @return a new {@link ZeebeClient} with the provided configuration options.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -113,4 +113,9 @@ public interface ZeebeClientConfiguration {
    * @see ZeebeClientBuilder#jobWorkerExecutor(ScheduledExecutorService, boolean)
    */
   boolean ownsJobWorkerExecutor();
+
+  /**
+   * @see ZeebeClientBuilder#streamEnabled(boolean)
+   */
+  boolean getStreamEnabled();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -115,7 +115,7 @@ public interface ZeebeClientConfiguration {
   boolean ownsJobWorkerExecutor();
 
   /**
-   * @see ZeebeClientBuilder#streamEnabled(boolean)
+   * @see ZeebeClientBuilder#defaultJobWorkerStreamEnabled(boolean)
    */
-  boolean getStreamEnabled();
+  boolean getDefaultJobWorkerStreamEnabled();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -18,10 +18,10 @@ package io.camunda.zeebe.client.impl;
 import static io.camunda.zeebe.client.ClientProperties.CA_CERTIFICATE_PATH;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
-import static io.camunda.zeebe.client.ClientProperties.ENABLE_STREAMING;
 import static io.camunda.zeebe.client.ClientProperties.KEEP_ALIVE;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.OVERRIDE_AUTHORITY;
+import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.BuilderUtils.appendProperty;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
@@ -50,8 +50,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
   public static final String OVERRIDE_AUTHORITY_VAR = "ZEEBE_OVERRIDE_AUTHORITY";
 
-  public static final String ZEEBE_CLIENT_WORKER_STREAM_ENABLE =
-      "ZEEBE_CLIENT_WORKER_STREAM_ENABLE";
+  public static final String ZEEBE_CLIENT_WORKER_STREAM_ENABLED =
+      "ZEEBE_CLIENT_WORKER_STREAM_ENABLED";
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
   public static final String DEFAULT_TENANT_ID_VAR = "ZEEBE_DEFAULT_TENANT_ID";
 
@@ -174,7 +174,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
-  public boolean getStreamEnabled() {
+  public boolean getDefaultJobWorkerStreamEnabled() {
     return streamEnabled;
   }
 
@@ -247,8 +247,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     if (properties.containsKey(MAX_MESSAGE_SIZE)) {
       maxMessageSize(DataSizeUtil.parse(properties.getProperty(MAX_MESSAGE_SIZE)));
     }
-    if (properties.containsKey(ENABLE_STREAMING)) {
-      streamEnabled(Boolean.parseBoolean(properties.getProperty(ENABLE_STREAMING)));
+    if (properties.containsKey(STREAM_ENABLED)) {
+      defaultJobWorkerStreamEnabled(Boolean.parseBoolean(properties.getProperty(STREAM_ENABLED)));
     }
     return this;
   }
@@ -375,7 +375,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
-  public ZeebeClientBuilder streamEnabled(final boolean streamEnabled) {
+  public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
     this.streamEnabled = streamEnabled;
     return this;
   }
@@ -422,9 +422,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       defaultTenantId(Environment.system().get(DEFAULT_TENANT_ID_VAR));
     }
 
-    if (Environment.system().isDefined(ZEEBE_CLIENT_WORKER_STREAM_ENABLE)) {
-      streamEnabled(
-          Boolean.parseBoolean(Environment.system().get(ZEEBE_CLIENT_WORKER_STREAM_ENABLE)));
+    if (Environment.system().isDefined(ZEEBE_CLIENT_WORKER_STREAM_ENABLED)) {
+      defaultJobWorkerStreamEnabled(
+          Boolean.parseBoolean(Environment.system().get(ZEEBE_CLIENT_WORKER_STREAM_ENABLED)));
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -91,9 +91,9 @@ public class ZeebeClientCloudBuilderImpl
     if (properties.containsKey(ClientProperties.CLOUD_REGION)) {
       withRegion(properties.getProperty(ClientProperties.CLOUD_REGION));
     }
-    if (properties.containsKey(ClientProperties.ENABLE_STREAMING)) {
-      streamEnabled(
-          Boolean.parseBoolean(properties.getProperty(ClientProperties.ENABLE_STREAMING)));
+    if (properties.containsKey(ClientProperties.STREAM_ENABLED)) {
+      defaultJobWorkerStreamEnabled(
+          Boolean.parseBoolean(properties.getProperty(ClientProperties.STREAM_ENABLED)));
     }
     innerBuilder.withProperties(properties);
 
@@ -223,8 +223,8 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
-  public ZeebeClientBuilder streamEnabled(final boolean streamEnabled) {
-    innerBuilder.streamEnabled(streamEnabled);
+  public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
+    innerBuilder.defaultJobWorkerStreamEnabled(streamEnabled);
     return null;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -91,6 +91,10 @@ public class ZeebeClientCloudBuilderImpl
     if (properties.containsKey(ClientProperties.CLOUD_REGION)) {
       withRegion(properties.getProperty(ClientProperties.CLOUD_REGION));
     }
+    if (properties.containsKey(ClientProperties.ENABLE_STREAMING)) {
+      streamEnabled(
+          Boolean.parseBoolean(properties.getProperty(ClientProperties.ENABLE_STREAMING)));
+    }
     innerBuilder.withProperties(properties);
 
     // todo(#14106): allow default tenant id setting for cloud client
@@ -216,6 +220,12 @@ public class ZeebeClientCloudBuilderImpl
   public ZeebeClientBuilder maxMessageSize(final int maxMessageSize) {
     innerBuilder.maxMessageSize(maxMessageSize);
     return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder streamEnabled(final boolean streamEnabled) {
+    innerBuilder.streamEnabled(streamEnabled);
+    return null;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -71,7 +71,7 @@ public final class JobWorkerBuilderImpl
     maxJobsActive = configuration.getDefaultJobWorkerMaxJobsActive();
     pollInterval = configuration.getDefaultJobPollInterval();
     requestTimeout = configuration.getDefaultRequestTimeout();
-    enableStreaming = configuration.getStreamEnabled();
+    enableStreaming = configuration.getDefaultJobWorkerStreamEnabled();
     backoffSupplier = DEFAULT_BACKOFF_SUPPLIER;
     streamingTimeout = DEFAULT_STREAMING_TIMEOUT;
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -71,6 +71,7 @@ public final class JobWorkerBuilderImpl
     maxJobsActive = configuration.getDefaultJobWorkerMaxJobsActive();
     pollInterval = configuration.getDefaultJobPollInterval();
     requestTimeout = configuration.getDefaultRequestTimeout();
+    enableStreaming = configuration.getStreamEnabled();
     backoffSupplier = DEFAULT_BACKOFF_SUPPLIER;
     streamingTimeout = DEFAULT_STREAMING_TIMEOUT;
   }

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -50,7 +50,7 @@ zeebe:
 
     network:
       # Controls the default host the broker should bind to. Can be overwritten on a
-      # per binding basis for client, management and replication
+      # per-binding basis for client, management and replication
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HOST.
       host: 0.0.0.0
 


### PR DESCRIPTION
## Description

Allow configuration of job streaming via env variables and client properties.
The Environment variable should override the client properties if `applyEnvironmentVariableOverrides` is true.
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/14152

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
