### PR TITLE
Arch-agnostic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,33 +5,17 @@
 # Both ubuntu and eclipse-temurin are pinned via digest and not by a strict version tag, as Renovate
 # has trouble with custom versioning schemes
 ARG BASE_IMAGE="ubuntu:jammy"
-ARG BASE_DIGEST_AMD64="sha256:b492494d8e0113c4ad3fe4528a4b5ff89faa5331f7d52c5c138196f69ce176a6"
-ARG BASE_DIGEST_ARM64="sha256:94d12db896d07af18a04319f1023edd091629f558dcc29f84208a7cf5ca040ec"
+ARG BASE_DIGEST="sha256:aabed3296a3d45cede1dc866a24476c4d7e093aa806263c27ddaadbdce3c1054"
 ARG JDK_IMAGE="eclipse-temurin:17-jdk-jammy"
-ARG JDK_DIGEST_AMD64="sha256:0dfd9830fdf7851876aa6f830c9050eedcc9a25921eff64b03259589d3083d9f"
-ARG JDK_DIGEST_ARM64="sha256:0e0cd6c795872211420e4a1cf9468ad607543ef7c14d0c12d01eb93c7ccf1d15"
+ARG JDK_DIGEST="sha256:cf2e1d79e3d430b5277a1ff04cedb521706a053a2adc17b384e9a9bb4b1e79ee"
 
 # set to "build" to build zeebe from scratch instead of using a distball
 ARG DIST="distball"
 
-### AMD64 base image ###
-# BASE_DIGEST_AMD64 is defined at the top of the Dockerfile
-# hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST_AMD64} as base-amd64
-ARG BASE_DIGEST_AMD64
-ARG BASE_DIGEST="${BASE_DIGEST_AMD64}"
-
-### ARM64 base image ##
-# BASE_DIGEST_ARM64 is defined at the top of the Dockerfile
-# hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST_ARM64} as base-arm64
-ARG BASE_DIGEST_ARM64
-ARG BASE_DIGEST="${BASE_DIGEST_ARM64}"
-
-### Base image ##
+### Base image ###
 # All package installation, updates, etc., anything with APT should be done here in a single step
 # hadolint ignore=DL3006
-FROM base-${TARGETARCH} as base
+FROM ${BASE_IMAGE}@${BASE_DIGEST} as base
 WORKDIR /
 
 # Upgrade all outdated packages and install missing ones (e.g. locales, tini)
@@ -47,20 +31,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get install -yqq --no-install-recommends tini ca-certificates && \
     apt-get upgrade -yqq --no-install-recommends
 
-
-### AMD64 JDK image ###
-# JDK_DIGEST_AMD64 is defined at the top of the Dockerfile
-# hadolint ignore=DL3006
-FROM ${JDK_IMAGE}@${JDK_DIGEST_AMD64} as jdk-amd64
-
-### ARM64 JDK image ##
-# JDK_DIGEST_ARM64 is defined at the top of the Dockerfile
-# hadolint ignore=DL3006
-FROM ${JDK_IMAGE}@${JDK_DIGEST_ARM64} as jdk-arm64
-
 ### Build custom JRE using the base JDK image
 # hadolint ignore=DL3006
-FROM jdk-${TARGETARCH} as jre-build
+FROM ${JDK_IMAGE}@${JDK_DIGEST} as jre-build
 
 # Build a custom JRE which will strip down and compress modules to end up with a smaller Java \
 # distribution than the official JRE. This will also include useful debugging tools like
@@ -68,6 +41,9 @@ FROM jdk-${TARGETARCH} as jre-build
 # 10ms to the start up time, which is negligible considering our application takes ~10s to start up.
 # See https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/
 # hadolint ignore=DL3018
+# required to compile a JRE on ARM64
+# see https://github.com/openzipkin/docker-java/issues/34
+ENV JAVA_TOOL_OPTIONS "-Djdk.lang.Process.launchMechanism=vfork"
 RUN jlink \
      --add-modules ALL-MODULE-PATH \
      --strip-debug \
@@ -125,7 +101,6 @@ RUN mkdir camunda-zeebe && \
 FROM ${DIST} as dist
 
 ### Application Image ###
-# TARGETARCH is provided by buildkit
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # hadolint ignore=DL3006
 FROM java as app

--- a/docker/test/verify.sh
+++ b/docker/test/verify.sh
@@ -56,11 +56,11 @@ if [ "$actualArchitecture" != "\"$arch\"" ]; then
   exit 1
 fi
 
-DIGEST_REGEX="BASE_DIGEST_$(echo "$arch" | tr '[:lower:]' '[:upper:]')=\"(sha256\:[a-f0-9\:]+)\""
+DIGEST_REGEX="BASE_DIGEST=\"(sha256\:[a-f0-9\:]+)\""
 DOCKERFILE=$(<"${BASH_SOURCE%/*}/../../Dockerfile")
 if [[ $DOCKERFILE =~ $DIGEST_REGEX ]]; then
     DIGEST="${BASH_REMATCH[1]}"
-    echo "Digest found for architecture $arch: $DIGEST"
+    echo "Digest found: $DIGEST"
 else
     echo >&2 "Docker image digest can not be found in the Dockerfile"
     exit 1


### PR DESCRIPTION
## Description

Refactors the `Dockerfile` to be architecture/platform agnostic. Since images have a general digests, separate from their platform-specific digests, we can simply target that one. When building that image on the specific platform (or even cross-building) the appropriate image will be selected anyway, so we don't need to keep track of platform specific digests.

One caveat is that it seems the ARM64 JDK image fails to build a custom JRE without specifying a different process launching mechanism. It's a bit unclear to me why, but apparently it's not an uncommon problem, and the simplest option is to change the launch mechanism. Naja, not perfect, but works.

## Related issues

related to all the Renovate issues we've been having lately :smile: 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
