### PR TITLE
Prevent rate limiting with Docker Hub account

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -31,6 +31,10 @@ inputs:
   secret_vault_secretId:
     description: 'secret valut secret id'
     required: false
+  docker:
+    description: If true, logs into Docker Hub using our CI account; helpful to prevent rate limiting
+    required: false
+    default: "true"
 
 outputs: {}
 
@@ -63,11 +67,24 @@ runs:
         secrets: |
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
+          secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR;
+          secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW;
     - uses: actions/setup-java@v3
       if: inputs.java == 'true'
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
+    # Logging into Docker Hub will help prevent us being rate limited when using an anonymous account
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: |
+        inputs.docker == 'true'
+        && inputs.secret_vault_address != ''
+        && inputs.secret_vault_roleId != ''
+        && inputs.secret_vault_secretId != ''
+      with:
+        username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
+        password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
     # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: 'Create settings.xml'
       uses: s4u/maven-settings-action@v2.8.0

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -68,7 +68,7 @@ runs:
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
           secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR;
-          secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW;
+          secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW_READ_ONLY;
     - uses: actions/setup-java@v3
       if: inputs.java == 'true'
       with:
@@ -84,7 +84,7 @@ runs:
         && inputs.secret_vault_secretId != ''
       with:
         username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
-        password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+        password: ${{ steps.secrets.outputs. REGISTRY_HUB_DOCKER_COM_PSW_READ_ONLY }}
     # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: 'Create settings.xml'
       uses: s4u/maven-settings-action@v2.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,14 +160,11 @@ jobs:
       matrix:
         os: [ macos, windows, linux ]
         arch: [ amd64 ]
-        docker-login: [ true ]
         include:
           - os: macos
             runner: macos-latest
-            docker-login: false
           - os: windows
             runner: windows-latest
-            docker-login: false
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
           - os: linux
@@ -181,7 +178,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          docker: ${{ matrix.docker-login }}
+          docker: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,14 @@ jobs:
       matrix:
         os: [ macos, windows, linux ]
         arch: [ amd64 ]
+        docker-login: [ true ]
         include:
           - os: macos
             runner: macos-latest
+            docker-login: false
           - os: windows
             runner: windows-latest
+            docker-login: false
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
           - os: linux
@@ -178,6 +181,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          docker: ${{ matrix.docker-login }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:


### PR DESCRIPTION
## Description

This PR logs into Docker Hub on tasks where we build Zeebe to prevent rate limiting from Docker Hub, since logging with an account raises our limit. Anonymous pulls only get 100 pulls per 6 hours, so we can quickly reach the limit.

## Related issues

closes #13947

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
