### PR TITLE
Link forms to start events by formId

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractStartEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractStartEventBuilder.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 
 /**
  * @author Sebastian Menski
@@ -132,6 +133,20 @@ public abstract class AbstractStartEventBuilder<B extends AbstractStartEventBuil
   public B interrupting(final boolean interrupting) {
     element.setInterrupting(interrupting);
 
+    return myself;
+  }
+
+  public B zeebeFormKey(final String formKey) {
+    final ZeebeFormDefinition formDefinition =
+        getCreateSingleExtensionElement(ZeebeFormDefinition.class);
+    formDefinition.setFormKey(formKey);
+    return myself;
+  }
+
+  public B zeebeFormId(final String formId) {
+    final ZeebeFormDefinition formDefinition =
+        getCreateSingleExtensionElement(ZeebeFormDefinition.class);
+    formDefinition.setFormId(formId);
     return myself;
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeStartEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeStartEventValidationTest.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.model.bpmn.validation;
 
 import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.runners.Parameterized.Parameters;
@@ -68,6 +70,53 @@ public class ZeebeStartEventValidationTest extends AbstractZeebeValidationTest {
             expect(SubProcess.class, "Interrupting timer event with time cycle is not allowed.")),
       },
       {processWithNoneStartEventAndMultipleOtherStartEvents(), valid()},
+      // Form Deployment validation
+      {
+        Bpmn.createExecutableProcess().startEvent().zeebeFormKey("").endEvent().done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Exactly one of the attributes 'formId, formKey' must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess().startEvent().zeebeFormId("").endEvent().done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Exactly one of the attributes 'formId, formKey' must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .zeebeFormKey("")
+            .zeebeFormId("")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Exactly one of the attributes 'formId, formKey' must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .zeebeFormKey("form-key")
+            .zeebeFormId("form-id")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Exactly one of the attributes 'formId, formKey' must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess().startEvent().zeebeFormId("form-id").endEvent().done(),
+        EMPTY_LIST
+      },
+      {
+        Bpmn.createExecutableProcess().startEvent().zeebeFormKey("form-key").endEvent().done(),
+        EMPTY_LIST
+      },
     };
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR allows forms to be linked to `Start Event` by formId

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14135 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
