### PR TITLE
fix: use thread-safe collection of snapshot stores

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.broker.system.partitions.AtomixRecordEntrySupplier;
 import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.StateController;
@@ -52,12 +54,12 @@ public class StateControllerImpl implements StateController {
       final AtomixRecordEntrySupplier entrySupplier,
       final ToLongFunction<ZeebeDb> exporterPositionSupplier,
       final ConcurrencyControl concurrencyControl) {
-    this.constructableSnapshotStore = constructableSnapshotStore;
-    this.runtimeDirectory = runtimeDirectory;
-    this.zeebeDbFactory = zeebeDbFactory;
-    this.exporterPositionSupplier = exporterPositionSupplier;
-    this.entrySupplier = entrySupplier;
-    this.concurrencyControl = concurrencyControl;
+    this.constructableSnapshotStore = requireNonNull(constructableSnapshotStore);
+    this.runtimeDirectory = requireNonNull(runtimeDirectory);
+    this.zeebeDbFactory = requireNonNull(zeebeDbFactory);
+    this.exporterPositionSupplier = requireNonNull(exporterPositionSupplier);
+    this.entrySupplier = requireNonNull(entrySupplier);
+    this.concurrencyControl = requireNonNull(concurrencyControl);
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.NoSuchElementException;
 import org.agrona.collections.Int2ObjectHashMap;
 
 /**
@@ -34,7 +35,6 @@ import org.agrona.collections.Int2ObjectHashMap;
 public final class FileBasedSnapshotStoreFactory implements ReceivableSnapshotStoreFactory {
   public static final String SNAPSHOTS_DIRECTORY = "snapshots";
   public static final String PENDING_DIRECTORY = "pending";
-
   private final Int2ObjectHashMap<FileBasedSnapshotStore> partitionSnapshotStores =
       new Int2ObjectHashMap<>();
   private final ActorSchedulingService actorScheduler;
@@ -105,6 +105,11 @@ public final class FileBasedSnapshotStoreFactory implements ReceivableSnapshotSt
   @Deprecated // This is an intermediate solution to run StateController and SnapshotStore on same
   // actor.
   public ConcurrencyControl getSnapshotStoreConcurrencyControl(final int partitionId) {
-    return partitionSnapshotStores.get(partitionId);
+
+    final var snapshotStore = partitionSnapshotStores.get(partitionId);
+    if (snapshotStore == null) {
+      throw new NoSuchElementException("No snapshot store found for partition " + partitionId);
+    }
+    return snapshotStore;
   }
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.NoSuchElementException;
-import org.agrona.collections.Int2ObjectHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Loads existing snapshots in memory, cleaning out old and/or invalid snapshots if present.
@@ -35,8 +35,8 @@ import org.agrona.collections.Int2ObjectHashMap;
 public final class FileBasedSnapshotStoreFactory implements ReceivableSnapshotStoreFactory {
   public static final String SNAPSHOTS_DIRECTORY = "snapshots";
   public static final String PENDING_DIRECTORY = "pending";
-  private final Int2ObjectHashMap<FileBasedSnapshotStore> partitionSnapshotStores =
-      new Int2ObjectHashMap<>();
+  private final ConcurrentHashMap<Integer, FileBasedSnapshotStore> partitionSnapshotStores =
+      new ConcurrentHashMap<>();
   private final ActorSchedulingService actorScheduler;
   private final int nodeId;
 


### PR DESCRIPTION
Fixes #14207 by using a thread safe data structure to hold onto snapshot stores. This bug was introduced with #13819 but not noticed because it is probabilistic and depends on the number of partitions. Since we usually test with low partition count, the bug wasn't observed during QA.