### PR TITLE
Run daily-qa only on weekdays

### DIFF
--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -8,8 +8,8 @@ name: Daily tests
 on:
   workflow_dispatch: { }
   schedule:
-    # Runs at 01:00 every day; see this link for more: https://crontab.guru/#0_1_*_*_*
-    - cron: '0 1 * * *'
+    # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
+    - cron: '0 1 * * 1-5'
 
 env:
   # This URL is used as the business key for the various QA workflows


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

We see several reasons to run the daily QA only on weekdays:

When the QA fails, it notifies the medic through slack. This means that the medic can also be notified in the weekend. This appears to happen often and the team experiences this as annoying.

It is also a lot of additional work for the medic when they start their shift on Monday. Immediately being confronted with a bunch of QA run failures is demotivating. Finding them during the week would be fast enough, and avoids starting the week with an immediate downer.

Running the QA brings costs, running it less often reduces these costs and reduces the carbon footprint.

In the weekend, it is not expected for the code under test to change. So weekend runs don't add much over weekday runs.

Running them only on weekdays reduces the number of chances these tests have to find bugs from 7 times per week to 5. The team thinks this is still enough chance to find bugs.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Discussed at the [Zeebe Teams Sync](https://docs.google.com/document/d/1TO4Lq0trdFhOhMZwK0aPOMg9_smJu-CW4NUPz4qNXpY/edit#heading=h.8bvdsdltd9z1)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
