### PR TITLE
docs(topology): add java docs on how cluter topology management works

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -20,7 +20,27 @@ import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Responsible for initializing ClusterTopology and managing ClusterTopology changes. */
+/**
+ * ClusterTopologyManager is responsible for initializing ClusterTopology and managing
+ * ClusterTopology changes.
+ *
+ * <p>On startup, ClusterTopologyManager initializes the topology using {@link
+ * TopologyInitializer}s. The initialized topology is gossiped to other members.
+ *
+ * <p>When a topology is received via gossip, it is merged with the local topology. The merge
+ * operation ensures that any concurrent update to the topology is not lost.
+ *
+ * <h4>Making configuration changes</h4>
+ *
+ * <p>Only a coordinator can start a topology change. The steps to make a configuration change are
+ * added to the {@link ClusterTopology}. To make a topology change, the coordinator update the
+ * topology with a list of operations that needs to be executed to achieve the target topology and
+ * gossip the updated topology. These operations are expected to be executed in the order given.
+ *
+ * <p>When a member receives a topology with pending changes, it applies the change if it is
+ * applicable to the member. Only a member can make changes to its own state in the topology. See
+ * {@link TopologyChangeAppliers} to see how a change is applied locally.
+ */
 final class ClusterTopologyManager {
   private static final Logger LOG = LoggerFactory.getLogger(ClusterTopologyManager.class);
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
@@ -23,7 +23,25 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Initialized topology * */
+/**
+ * Initializes topology using different strategies.
+ *
+ * <h4>Initialization Process</h4>
+ *
+ * Each member is configured with a static configuration with initial set of cluster members and
+ * partition distribution.
+ *
+ * <p>Both coordinator and other members first check the local persisted configuration to determine
+ * the topology. If one exists, that is used to initialize the topology. See {@link
+ * FileInitializer}. On bootstrap of the cluster, the local persisted topology is empty.
+ * <li>When the local topology is empty, the coordinator queries cluster members in the static
+ *     configuration for the current topology. See {@link SyncInitializer}. If any member replies
+ *     with a valid topology, coordinator uses that one. If any member replies with an uninitialized
+ *     topology, coordinator generates a new topology from the provided static configuration. See
+ *     {@link StaticInitializer}.
+ * <li>When the local topology is empty, a non-coordinating member waits until it receives a valid
+ *     topology from the coordinator via gossip. See {@link GossipInitializer}.
+ */
 public interface TopologyInitializer {
 
   /**

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
@@ -13,6 +13,10 @@ import java.util.List;
  * Represents the ongoing cluster topology changes. The pendingOperations are executed sequentially.
  * Only after completing one operation, the next operation is started. Once an operation is
  * completed, it should be removed from the plan, so that the next operation can be picked up.
+ *
+ * <p>version starts at 1 and increments every time an operation is completed and removed from the
+ * pending operations. This helps to choose the latest state of the topology change when receiving
+ * gossip update out of order.
  */
 public record ClusterChangePlan(int version, List<TopologyChangeOperation> pendingOperations) {
   public static ClusterChangePlan empty() {

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -20,8 +20,8 @@ import java.util.stream.Stream;
  * Represents the cluster topology which describes the current active, joining or leaving brokers
  * and the partitions that each broker replicates.
  *
- * <p>version - represents the current version of the topology. It is incremented when new
- * configuration change is triggered.
+ * <p>version - represents the current version of the topology. It is incremented only by the
+ * coordinator when a new configuration change is triggered.
  *
  * <p>members - represents the state of each member
  *

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
@@ -12,6 +12,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
+/**
+ * Represents the state of a member in the cluster.
+ *
+ * <p>Version is incremented every time the state is updated. This is used to resolve conflicts when
+ * the members receive gossip updates out of order. Only a member can update its own state. This
+ * prevents any conflicting concurrent updates.
+ *
+ * @param version version of the state.
+ * @param state current state of the member
+ * @param partitions state of all partitions that the member is replicating
+ */
 public record MemberState(long version, State state, Map<Integer, PartitionState> partitions) {
   public static MemberState initializeAsActive(
       final Map<Integer, PartitionState> initialPartitions) {


### PR DESCRIPTION
## Description

This PR adds some class level documentation on how topology management works. Since we don't have another place for technical docs, this would be the main reference other than discussion notes written during the design/POC phase.



