### PR TITLE
Introduce Operate to medic benchmarks

### DIFF
--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       full-ref: ${{ steps.data.outputs.full-ref }}
       benchmark: ${{ steps.data.outputs.benchmark }}
+      operate: ${{ steps.data.outputs.operate }}
     steps:
       - uses: actions/checkout@v4
       - name: Collect benchmark data
@@ -43,6 +44,8 @@ jobs:
         run: |
           echo "full-ref"=$(git rev-parse HEAD) >> $GITHUB_OUTPUT
           echo "benchmark=medic-y-$(date +%Y)-cw-$(date +%V)-$(git rev-parse --short HEAD)-benchmark" >> $GITHUB_OUTPUT
+          echo "operate=operate-y-$(date +%Y)-cw-$(date +%V)" >> $GITHUB_OUTPUT
+          
 
   setup-normal-benchmark:
     name: Normal Benchmark
@@ -71,11 +74,18 @@ jobs:
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
       measure: false
       benchmark-load: >
-        --set starter.rate=25
+        --set starter.rate=5
+        --set worker.replicas=1
         --set timer.replicas=1
-        --set timer.rate=25
+        --set timer.rate=5
         --set publisher.replicas=1
-        --set publisher.rate=25
+        --set publisher.rate=5
+        --set camunda-platform.operate.enabled=true
+        --set camunda-platform.operate.image.repository=gcr.io/zeebe-io/operate
+        --set camunda-platform.operate.image.tag=${{ needs.benchmark-data.outputs.operate }}    
+        --set camunda-platform.elasticsearch.volumeClaimTemplate.resources.requests.storage=128Gi
+        --set camunda-platform.retentionPolicy.zeebeIndexMaxSize=30
+        --set camunda-platform.retentionPolicy.schedule="0 * * * *"
   setup-latency-benchmark:
     name: Latency Benchmark
     uses: ./.github/workflows/benchmark.yml


### PR DESCRIPTION
## Description

Add Operate to our weekly medic benchmarks. See related slack channel: https://app.slack.com/client/T0PM0P1SA/C05GGP8C214

First Operate will be included in the mixed benchmarks, which is mostly for verifying multiple elements and stability and not really for performance anyway. We reduce the load such the archiver/importer from Operate has no issues with it.

Furthermore, the disk of elastic has been increased for that benchmark, and the curator adjusted so there less potential conflicts with deleting indexes too early.

Operate is building their images on Sundays, see here https://github.com/camunda/operate/blob/master/.github/workflows/weekly-internal-docker-images.yaml such that we can consume it in our benchmarks.

\cc @ralfpuchert 
<!-- Please explain the changes you made here. -->

See example run with same configs https://github.com/camunda/zeebe/actions/runs/6110693620