### PR TITLE
ClusterTopologyManager can apply partition join and leave operation

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.topology;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -172,7 +172,7 @@ final class ClusterTopologyManager {
     final var operationApplier = changeAppliers.getApplier(operation);
     final var initialized =
         operationApplier
-            .init()
+            .init(mergedTopology)
             .map(transformer -> mergedTopology.updateMember(localMemberId, transformer))
             .map(this::updateLocalTopology);
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.topology.TopologyInitializer.FileInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.GossipInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.StaticInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.SyncInitializer;
+import io.camunda.zeebe.topology.changes.NoopTopologyChangeAppliers;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiper;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
 import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopTopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopTopologyChangeAppliers.java
@@ -5,10 +5,11 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.topology;
+package io.camunda.zeebe.topology.changes;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.util.Either;
@@ -25,10 +26,11 @@ public class NoopTopologyChangeAppliers implements TopologyChangeAppliers {
     return new NoopApplier();
   }
 
-  private static class NoopApplier implements OperationApplier {
+  public static class NoopApplier implements OperationApplier {
 
     @Override
-    public Either<Exception, UnaryOperator<MemberState>> init() {
+    public Either<Exception, UnaryOperator<MemberState>> init(
+        final ClusterTopology currentClusterTopology) {
       return Either.right(memberState -> memberState);
     }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionChangeExecutor.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * implementation of this interface is expected to be a call back to the system component that can
  * start or stop partition. This is typically the PartitionManager in the Broker.
  */
-public interface PartitionTopologyChangeExecutor {
+public interface PartitionChangeExecutor {
 
   /**
    * The implementation of this method must start the partition on this member. The partition must

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
@@ -66,10 +66,6 @@ final class PartitionJoinApplier implements OperationApplier {
                   + localMemberState.partitions().get(partitionId).state()));
     }
 
-    if (priority < 0) {
-      return Either.left(new IllegalArgumentException("Priority is required for partition join"));
-    }
-
     // Collect the priority of each member, including the local member. This is needed to generate
     // PartitionMetadata when joining the partition.
     partitionMembersWithPriority = collectPriorityByMembers(currentClusterTopology);

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
@@ -20,6 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
+/**
+ * A Partition Join operation is executed when a member wants to start replicating a partition. This
+ * is allowed only when the member is active, and the partition is not already active.
+ */
 final class PartitionJoinApplier implements OperationApplier {
   private final int partitionId;
   private final int priority;
@@ -71,7 +75,9 @@ final class PartitionJoinApplier implements OperationApplier {
     partitionMembersWithPriority = collectPriorityByMembers(currentClusterTopology);
 
     if (partitionExistsInLocalMember) {
-      // The state is already JOINING, so we don't need to do anything
+      // The state is already JOINING, so we don't need to change it. This can happen when the node
+      // was restarted while applying the join operation. To ensure that the topology change can
+      // make progress, we do not treat this as an error.
       return Either.right(memberState -> memberState);
     } else {
       return Either.right(

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
@@ -27,7 +27,7 @@ import java.util.function.UnaryOperator;
 final class PartitionJoinApplier implements OperationApplier {
   private final int partitionId;
   private final int priority;
-  private final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor;
+  private final PartitionChangeExecutor partitionChangeExecutor;
   private final MemberId localMemberId;
   private Map<MemberId, Integer> partitionMembersWithPriority;
 
@@ -35,11 +35,11 @@ final class PartitionJoinApplier implements OperationApplier {
       final int partitionId,
       final int priority,
       final MemberId localMemberId,
-      final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor) {
+      final PartitionChangeExecutor partitionChangeExecutor) {
     this.partitionId = partitionId;
     this.priority = priority;
     this.localMemberId = localMemberId;
-    this.partitionTopologyChangeExecutor = partitionTopologyChangeExecutor;
+    this.partitionChangeExecutor = partitionChangeExecutor;
   }
 
   @Override
@@ -90,7 +90,7 @@ final class PartitionJoinApplier implements OperationApplier {
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
 
-    partitionTopologyChangeExecutor
+    partitionChangeExecutor
         .join(partitionId, partitionMembersWithPriority)
         .onComplete(
             (ignore, error) -> {

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.MemberState.State;
+import io.camunda.zeebe.topology.state.PartitionState;
+import io.camunda.zeebe.util.Either;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+final class PartitionJoinApplier implements OperationApplier {
+  private final int partitionId;
+  private final int priority;
+  private final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor;
+  private final MemberId localMemberId;
+  private Map<MemberId, Integer> partitionMembersWithPriority;
+
+  PartitionJoinApplier(
+      final int partitionId,
+      final int priority,
+      final MemberId localMemberId,
+      final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor) {
+    this.partitionId = partitionId;
+    this.priority = priority;
+    this.localMemberId = localMemberId;
+    this.partitionTopologyChangeExecutor = partitionTopologyChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> init(
+      final ClusterTopology currentClusterTopology) {
+
+    final boolean localMemberIsActive =
+        currentClusterTopology.members().containsKey(localMemberId)
+            && currentClusterTopology.members().get(localMemberId).state() == State.ACTIVE;
+    if (!localMemberIsActive) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to join partition, but the local member is not active"));
+    }
+
+    final MemberState localMemberState = currentClusterTopology.members().get(localMemberId);
+    final boolean partitionExistsInLocalMember =
+        localMemberState.partitions().containsKey(partitionId);
+    if (partitionExistsInLocalMember
+        && localMemberState.partitions().get(partitionId).state() != PartitionState.State.JOINING) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to join partition, but the local member already has the partition at state "
+                  + localMemberState.partitions().get(partitionId).state()));
+    }
+
+    if (priority < 0) {
+      return Either.left(new IllegalArgumentException("Priority is required for partition join"));
+    }
+
+    // Collect the priority of each member, including the local member. This is needed to generate
+    // PartitionMetadata when joining the partition.
+    partitionMembersWithPriority = collectPriorityByMembers(currentClusterTopology);
+
+    if (partitionExistsInLocalMember) {
+      // The state is already JOINING, so we don't need to do anything
+      return Either.right(memberState -> memberState);
+    } else {
+      return Either.right(
+          memberState -> memberState.addPartition(partitionId, PartitionState.joining(priority)));
+    }
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<MemberState>> apply() {
+    final CompletableActorFuture<UnaryOperator<MemberState>> result =
+        new CompletableActorFuture<>();
+
+    partitionTopologyChangeExecutor
+        .join(partitionId, partitionMembersWithPriority)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                result.complete(
+                    memberState ->
+                        memberState.updatePartition(partitionId, PartitionState::toActive));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+    return result;
+  }
+
+  private HashMap<MemberId, Integer> collectPriorityByMembers(
+      final ClusterTopology currentClusterTopology) {
+    final var priorityMap = new HashMap<MemberId, Integer>();
+    currentClusterTopology
+        .members()
+        .forEach(
+            (memberId, memberState) -> {
+              if (memberState.partitions().containsKey(partitionId)) {
+                final var partitionState = memberState.partitions().get(partitionId);
+                priorityMap.put(memberId, partitionState.priority());
+              }
+            });
+
+    priorityMap.put(localMemberId, priority);
+    return priorityMap;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplier.java
@@ -23,9 +23,7 @@ import java.util.function.UnaryOperator;
  * is allowed only when the member is already replicating the partition.
  */
 record PartitionLeaveApplier(
-    int partitionId,
-    MemberId localMemberId,
-    PartitionTopologyChangeExecutor partitionTopologyChangeExecutor)
+    int partitionId, MemberId localMemberId, PartitionChangeExecutor partitionChangeExecutor)
     implements OperationApplier {
 
   @Override
@@ -60,7 +58,7 @@ record PartitionLeaveApplier(
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
 
-    partitionTopologyChangeExecutor
+    partitionChangeExecutor
         .leave(partitionId)
         .onComplete(
             (ignore, error) -> {

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplier.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import io.camunda.zeebe.util.Either;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+record PartitionLeaveApplier(
+    int partitionId,
+    MemberId localMemberId,
+    PartitionTopologyChangeExecutor partitionTopologyChangeExecutor)
+    implements OperationApplier {
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> init(
+      final ClusterTopology currentClusterTopology) {
+
+    final Map<Integer, PartitionState> localPartitions =
+        currentClusterTopology.members().get(localMemberId).partitions();
+    final boolean partitionExistsInLocalMember = localPartitions.containsKey(partitionId);
+
+    if (!partitionExistsInLocalMember) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to leave partition, but the local member does not have the partition"));
+    }
+
+    final boolean partitionIsLeaving =
+        localPartitions.get(partitionId).state() == PartitionState.State.LEAVING;
+    if (partitionIsLeaving) {
+      // If partition state is already set to leaving, then we don't need to set it again
+      return Either.right(m -> m);
+    } else {
+      return Either.right(
+          memberState -> memberState.updatePartition(partitionId, PartitionState::toLeaving));
+    }
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<MemberState>> apply() {
+    final CompletableActorFuture<UnaryOperator<MemberState>> result =
+        new CompletableActorFuture<>();
+
+    partitionTopologyChangeExecutor
+        .leave(partitionId)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                result.complete(memberState -> memberState.removePartition(partitionId));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+
+    return result;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionTopologyChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionTopologyChangeExecutor.java
@@ -18,9 +18,26 @@ import java.util.Map;
  */
 public interface PartitionTopologyChangeExecutor {
 
-  // The implementation should be able to build new PartitionMetadata from the given partitionId and
-  // priorities.
+  /**
+   * The implementation of this method must start the partition on this member. The partition must
+   * join the replication group formed by the members given in the {@code membersWithPriority}. The
+   * implementation must be idempotent. If the node restarts after this method was called, but
+   * before marking the operation as completed, it will be retried after the restart.
+   *
+   * @param partitionId id of the partition
+   * @param membersWithPriority priority of each replicas used of leader election
+   * @return a future that completes when the partition is started and joined the replication group
+   */
   ActorFuture<Void> join(int partitionId, Map<MemberId, Integer> membersWithPriority);
 
+  /**
+   * The implementation of this method must remove the member from the replication group of the
+   * given partition and stops the partition on this member. The implementation must be idempotent.
+   * If the node restarts after this method was called, but before marking the operation as
+   * completed, it will be retried after the restart.
+   *
+   * @param partitionId id of the partition
+   * @return a future that completes when the partition is stopped and removed from the replication.
+   */
   ActorFuture<Void> leave(int partitionId);
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionTopologyChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionTopologyChangeExecutor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.Map;
+
+/**
+ * Represents the executor that executes the actual process to start or start. The concrete
+ * implementation of this interface is expected to be a call back to the system component that can
+ * start or stop partition. This is typically the PartitionManager in the Broker.
+ */
+public interface PartitionTopologyChangeExecutor {
+
+  // The implementation should be able to build new PartitionMetadata from the given partitionId and
+  // priorities.
+  ActorFuture<Void> join(int partitionId, Map<MemberId, Integer> membersWithPriority);
+
+  ActorFuture<Void> leave(int partitionId);
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
@@ -32,7 +32,8 @@ public interface TopologyChangeAppliers {
      * @return an either which contains an exception if the operation is not valid, or a function to
      *     update the cluster topology
      */
-    Either<Exception, UnaryOperator<MemberState>> init();
+    Either<Exception, UnaryOperator<MemberState>> init(
+        final ClusterTopology currentClusterTopology);
 
     /**
      * Applies the operation. This can be run asynchronously and should complete the future when the

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
@@ -5,9 +5,10 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.topology;
+package io.camunda.zeebe.topology.changes;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.util.Either;
@@ -29,7 +30,7 @@ public interface TopologyChangeAppliers {
      * operation. For example, an operation for joining a partition can mark the state as JOINING.
      *
      * @return an either which contains an exception if the operation is not valid, or a function to
-     *     update the cluster toplogy
+     *     update the cluster topology
      */
     Either<Exception, UnaryOperator<MemberState>> init();
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.changes.NoopTopologyChangeAppliers.NoopApplier;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionOperation;
+
+public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
+
+  private final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor;
+  private final MemberId localMemberId;
+
+  public TopologyChangeAppliersImpl(
+      final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor,
+      final MemberId localMemberId) {
+    this.partitionTopologyChangeExecutor = partitionTopologyChangeExecutor;
+    this.localMemberId = localMemberId;
+  }
+
+  @Override
+  public OperationApplier getApplier(final TopologyChangeOperation operation) {
+    if (operation.operation().isPartitionOperation()) {
+      return getPartitionApplier((PartitionOperation) operation.operation());
+    }
+    return new NoopApplier();
+  }
+
+  private OperationApplier getPartitionApplier(final PartitionOperation operation) {
+    return switch (operation.operationType()) {
+      case JOIN -> new PartitionJoinApplier(
+          operation.partitionId(),
+          operation.priority().orElse(-1),
+          localMemberId,
+          partitionTopologyChangeExecutor);
+      default -> new NoopApplier();
+    };
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
@@ -39,6 +39,8 @@ public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
           operation.priority().orElse(-1),
           localMemberId,
           partitionTopologyChangeExecutor);
+      case LEAVE -> new PartitionLeaveApplier(
+          operation.partitionId(), localMemberId, partitionTopologyChangeExecutor);
       default -> new NoopApplier();
     };
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
@@ -20,13 +20,12 @@ import java.util.function.UnaryOperator;
 
 public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
 
-  private final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor;
+  private final PartitionChangeExecutor partitionChangeExecutor;
   private final MemberId localMemberId;
 
   public TopologyChangeAppliersImpl(
-      final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor,
-      final MemberId localMemberId) {
-    this.partitionTopologyChangeExecutor = partitionTopologyChangeExecutor;
+      final PartitionChangeExecutor partitionChangeExecutor, final MemberId localMemberId) {
+    this.partitionChangeExecutor = partitionChangeExecutor;
     this.localMemberId = localMemberId;
   }
 
@@ -37,10 +36,10 @@ public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
           joinOperation.partitionId(),
           joinOperation.priority(),
           localMemberId,
-          partitionTopologyChangeExecutor);
+          partitionChangeExecutor);
     } else if (operation instanceof final PartitionLeaveOperation leaveOperation) {
       return new PartitionLeaveApplier(
-          leaveOperation.partitionId(), localMemberId, partitionTopologyChangeExecutor);
+          leaveOperation.partitionId(), localMemberId, partitionChangeExecutor);
     } else return new FailingApplier(operation);
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
@@ -40,7 +40,9 @@ public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
     } else if (operation instanceof final PartitionLeaveOperation leaveOperation) {
       return new PartitionLeaveApplier(
           leaveOperation.partitionId(), localMemberId, partitionChangeExecutor);
-    } else return new FailingApplier(operation);
+    } else {
+      return new FailingApplier(operation);
+    }
   }
 
   static class FailingApplier implements OperationApplier {

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -65,7 +65,12 @@ public record ClusterTopology(
       throw new IllegalStateException(
           String.format("Expected to update member %s, but member does not exist", memberId.id()));
     }
-    final var updateMemberState = memberStateUpdater.apply(members.get(memberId));
+    final MemberState currentState = members.get(memberId);
+    final var updateMemberState = memberStateUpdater.apply(currentState);
+    if (currentState.equals(updateMemberState)) {
+      return this;
+    }
+
     final var newMembers =
         ImmutableMap.<MemberId, MemberState>builder()
             .putAll(members)

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -153,4 +153,12 @@ public record ClusterTopology(
   private ClusterTopology advance() {
     return new ClusterTopology(version, members, changes.advance());
   }
+
+  public boolean hasMember(final MemberId memberId) {
+    return members().containsKey(memberId);
+  }
+
+  public MemberState getMember(final MemberId memberId) {
+    return members().get(memberId);
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
@@ -133,6 +133,14 @@ public record MemberState(long version, State state, Map<Integer, PartitionState
     return new MemberState(version + 1, state, partitions);
   }
 
+  public boolean hasPartition(final int partitionId) {
+    return partitions().containsKey(partitionId);
+  }
+
+  public PartitionState getPartition(final int partitionId) {
+    return partitions.get(partitionId);
+  }
+
   public enum State {
     UNINITIALIZED,
     JOINING,

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
@@ -61,7 +61,7 @@ public record MemberState(long version, State state, Map<Integer, PartitionState
     return update(State.LEFT, partitions);
   }
 
-  MemberState addPartition(final int partitionId, final PartitionState partitionState) {
+  public MemberState addPartition(final int partitionId, final PartitionState partitionState) {
     if (partitions.containsKey(partitionId)) {
       throw new IllegalStateException(
           String.format(
@@ -72,7 +72,7 @@ public record MemberState(long version, State state, Map<Integer, PartitionState
     return internalUpdatePartition(partitionId, partitionState);
   }
 
-  MemberState updatePartition(
+  public MemberState updatePartition(
       final int partitionId, final UnaryOperator<PartitionState> partitionStateUpdater) {
     if (!partitions.containsKey(partitionId)) {
       throw new IllegalStateException(
@@ -84,7 +84,7 @@ public record MemberState(long version, State state, Map<Integer, PartitionState
     return internalUpdatePartition(partitionId, updatedPartitionState);
   }
 
-  MemberState removePartition(final int partitionId) {
+  public MemberState removePartition(final int partitionId) {
     final var mutableMap = new HashMap<>(partitions);
     mutableMap.remove(partitionId);
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/PartitionState.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/PartitionState.java
@@ -16,7 +16,7 @@ public record PartitionState(State state, int priority) {
     return new PartitionState(State.JOINING, priority);
   }
 
-  PartitionState toActive() {
+  public PartitionState toActive() {
     if (state == State.LEAVING) {
       throw new IllegalStateException(
           String.format("Cannot transition to ACTIVE when current state is %s", state));

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
@@ -14,15 +14,9 @@ import java.util.Optional;
  * An operation that changes the topology. The operation could be a member join or leave a cluster,
  * or a member join or leave partition.
  */
-public interface TopologyChangeOperation {
+public record TopologyChangeOperation(MemberId memberId, Operation operation) {
 
-  MemberId memberId();
-
-  default Operation getOperation() {
-    return Operation.NONE;
-  }
-
-  record PartitionOperation(
+  public record PartitionOperation(
       int partitionId, PartitionOperationType operationType, Optional<Integer> priority)
       implements Operation {
     @Override
@@ -31,7 +25,7 @@ public interface TopologyChangeOperation {
     }
   }
 
-  interface Operation {
+  public interface Operation {
     Operation NONE = new Operation() {};
 
     default boolean isPartitionOperation() {
@@ -39,7 +33,7 @@ public interface TopologyChangeOperation {
     }
   }
 
-  enum PartitionOperationType {
+  public enum PartitionOperationType {
     UNKNOWN,
     JOIN,
     LEAVE

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.topology.state;
 
 import io.atomix.cluster.MemberId;
+import java.util.Optional;
 
 /**
  * An operation that changes the topology. The operation could be a member join or leave a cluster,
@@ -16,4 +17,32 @@ import io.atomix.cluster.MemberId;
 public interface TopologyChangeOperation {
 
   MemberId memberId();
+
+  default Operation getOperation() {
+    return Operation.NONE;
+  }
+
+  record PartitionOperation(
+      int partitionId, PartitionOperationType operationType, Optional<Integer> priority)
+      implements Operation {
+    @Override
+    public boolean isPartitionOperation() {
+      return true;
+    }
+  }
+
+  interface Operation {
+    Operation NONE = new Operation() {};
+
+    default boolean isPartitionOperation() {
+      return false;
+    }
+  }
+
+  enum PartitionOperationType {
+    UNKNOWN,
+    JOIN,
+    LEAVE
+    // Add PROMOTE and DEMOTE when we want to support them
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
@@ -8,35 +8,22 @@
 package io.camunda.zeebe.topology.state;
 
 import io.atomix.cluster.MemberId;
-import java.util.Optional;
 
 /**
  * An operation that changes the topology. The operation could be a member join or leave a cluster,
  * or a member join or leave partition.
  */
-public record TopologyChangeOperation(MemberId memberId, Operation operation) {
+public sealed interface TopologyChangeOperation {
 
-  public record PartitionOperation(
-      int partitionId, PartitionOperationType operationType, Optional<Integer> priority)
-      implements Operation {
-    @Override
-    public boolean isPartitionOperation() {
-      return true;
-    }
-  }
+  MemberId memberId();
 
-  public interface Operation {
-    Operation NONE = new Operation() {};
+  sealed interface PartitionChangeOperation extends TopologyChangeOperation {
+    int partitionId();
 
-    default boolean isPartitionOperation() {
-      return false;
-    }
-  }
+    record PartitionJoinOperation(MemberId memberId, int partitionId, int priority)
+        implements PartitionChangeOperation {}
 
-  public enum PartitionOperationType {
-    UNKNOWN,
-    JOIN,
-    LEAVE
-    // Add PROMOTE and DEMOTE when we want to support them
+    record PartitionLeaveOperation(MemberId memberId, int partitionId)
+        implements PartitionChangeOperation {}
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -38,12 +38,17 @@ public final class ClusterTopologyAssert
     return this;
   }
 
-  ClusterTopologyAssert hasMemberWithPartitions(
+  public ClusterTopologyAssert hasMemberWithPartitions(
       final int member, final Collection<Integer> partitionIds) {
     final var memberId = MemberId.from(Integer.toString(member));
     assertThat(actual.members()).containsKey(memberId);
     assertThat(actual.members().get(memberId).partitions()).containsOnlyKeys(partitionIds);
     return this;
+  }
+
+  public MemberStateAssert member(final MemberId memberId) {
+    assertThat(actual.members()).containsKey(memberId);
+    return MemberStateAssert.assertThat(actual.members().get(memberId));
   }
 
   public ClusterTopologyAssert hasMemberWithState(final int member, final MemberState.State state) {

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -15,6 +15,8 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.topology.changes.NoopTopologyChangeAppliers;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers;
 import io.camunda.zeebe.topology.serializer.ClusterTopologySerializer;
 import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.topology.state.ClusterTopology;

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.topology;
 
 import static io.camunda.zeebe.topology.ClusterTopologyAssert.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.Operation;
 import io.camunda.zeebe.util.Either;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -172,7 +174,8 @@ final class ClusterTopologyManagerTest {
 
     // when
     final ClusterTopology topologyFromOtherMember =
-        initialTopology.startTopologyChange(List.of(() -> localMemberId));
+        initialTopology.startTopologyChange(
+            List.of(new TopologyChangeOperation(localMemberId, mock(Operation.class))));
     clusterTopologyManager.onGossipReceived(topologyFromOtherMember).join();
 
     // then

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.topology;
 
 import static io.camunda.zeebe.topology.ClusterTopologyAssert.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -23,7 +22,7 @@ import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
-import io.camunda.zeebe.topology.state.TopologyChangeOperation.Operation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.util.Either;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -174,8 +173,7 @@ final class ClusterTopologyManagerTest {
 
     // when
     final ClusterTopology topologyFromOtherMember =
-        initialTopology.startTopologyChange(
-            List.of(new TopologyChangeOperation(localMemberId, mock(Operation.class))));
+        initialTopology.startTopologyChange(List.of(new PartitionLeaveOperation(localMemberId, 1)));
     clusterTopologyManager.onGossipReceived(topologyFromOtherMember).join();
 
     // then

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -195,7 +195,8 @@ final class ClusterTopologyManagerTest {
       // ignore type of operation and always apply member leave operation
       return new OperationApplier() {
         @Override
-        public Either<Exception, UnaryOperator<MemberState>> init() {
+        public Either<Exception, UnaryOperator<MemberState>> init(
+            final ClusterTopology currentClusterTopology) {
           return Either.right(MemberState::toLeaving);
         }
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/MemberStateAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/MemberStateAssert.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import java.util.Map;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+public final class MemberStateAssert extends AbstractAssert<MemberStateAssert, MemberState> {
+
+  private MemberStateAssert(final MemberState memberState, final Class<?> selfType) {
+    super(memberState, selfType);
+  }
+
+  public static MemberStateAssert assertThat(final MemberState actual) {
+    return new MemberStateAssert(actual, MemberStateAssert.class);
+  }
+
+  public MemberStateAssert hasPartitionWithState(
+      final int partitionId, final PartitionState state) {
+    final Map<Integer, PartitionState> partitions = actual.partitions();
+    Assertions.assertThat(partitions).containsEntry(partitionId, state);
+    return this;
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/MemberStateAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/MemberStateAssert.java
@@ -29,4 +29,10 @@ public final class MemberStateAssert extends AbstractAssert<MemberStateAssert, M
     Assertions.assertThat(partitions).containsEntry(partitionId, state);
     return this;
   }
+
+  public MemberStateAssert doesNotContainPartition(final int partitionId) {
+    final Map<Integer, PartitionState> partitions = actual.partitions();
+    Assertions.assertThat(partitions).doesNotContainKey(partitionId);
+    return this;
+  }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionJoinApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionJoinApplierTest.java
@@ -27,13 +27,13 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 final class PartitionJoinApplierTest {
-  private final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor =
-      mock(PartitionTopologyChangeExecutor.class);
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
   private final MemberId localMemberId = MemberId.from("1");
   final ClusterTopology initialClusterTopology =
       ClusterTopology.init().addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
   final PartitionJoinApplier partitionJoinApplier =
-      new PartitionJoinApplier(1, 1, localMemberId, partitionTopologyChangeExecutor);
+      new PartitionJoinApplier(1, 1, localMemberId, partitionChangeExecutor);
 
   @Test
   void shouldRejectJoinIfPartitionIsAlreadyJoined() {
@@ -86,7 +86,7 @@ final class PartitionJoinApplierTest {
   void shouldRejectJoinIfPriorityIsNoSet() {
     // given
     final PartitionJoinApplier partitionJoinApplier =
-        new PartitionJoinApplier(1, -1, localMemberId, partitionTopologyChangeExecutor);
+        new PartitionJoinApplier(1, -1, localMemberId, partitionChangeExecutor);
 
     // when - then
     assertThat(partitionJoinApplier.init(initialClusterTopology))
@@ -114,7 +114,7 @@ final class PartitionJoinApplierTest {
     final var updatedTopology =
         initialClusterTopology.updateMember(
             localMemberId, partitionJoinApplier.init(initialClusterTopology).get());
-    when(partitionTopologyChangeExecutor.join(anyInt(), any()))
+    when(partitionChangeExecutor.join(anyInt(), any()))
         .thenReturn(CompletableActorFuture.completed(null));
 
     // when
@@ -122,7 +122,7 @@ final class PartitionJoinApplierTest {
     final var resultingTopology = updatedTopology.updateMember(localMemberId, updater);
 
     // then
-    verify(partitionTopologyChangeExecutor, times(1)).join(anyInt(), any());
+    verify(partitionChangeExecutor, times(1)).join(anyInt(), any());
     ClusterTopologyAssert.assertThatClusterTopology(resultingTopology)
         .hasMemberWithPartitions(1, Set.of(1))
         .member(localMemberId)

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionJoinApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionJoinApplierTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.ClusterTopologyAssert;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import io.camunda.zeebe.topology.state.PartitionState.State;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class PartitionJoinApplierTest {
+  private final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor =
+      mock(PartitionTopologyChangeExecutor.class);
+  private final MemberId localMemberId = MemberId.from("1");
+  final ClusterTopology initialClusterTopology =
+      ClusterTopology.init().addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
+  final PartitionJoinApplier partitionJoinApplier =
+      new PartitionJoinApplier(1, 1, localMemberId, partitionTopologyChangeExecutor);
+
+  @Test
+  void shouldRejectJoinIfPartitionIsAlreadyJoined() {
+    // given
+    final ClusterTopology topologyWithPartitionJoined =
+        initialClusterTopology.updateMember(
+            localMemberId, m -> m.addPartition(1, PartitionState.active(1)));
+
+    // when - then
+    assertThat(partitionJoinApplier.init(topologyWithPartitionJoined))
+        .isLeft()
+        .left()
+        .isInstanceOf(IllegalStateException.class);
+
+    // then
+  }
+
+  @Test
+  void shouldRejectJoinIfPartitionIsAlreadyLeaving() {
+    // given
+    final ClusterTopology topologyWithPartitionLeaving =
+        initialClusterTopology.updateMember(
+            localMemberId, m -> m.addPartition(1, PartitionState.active(1).toLeaving()));
+
+    // when - then
+    assertThat(partitionJoinApplier.init(topologyWithPartitionLeaving))
+        .isLeft()
+        .left()
+        .isInstanceOf(IllegalStateException.class);
+
+    // then
+  }
+
+  @Test
+  void shouldRejectJoinIfMemberIsNotActive() {
+    // given
+    final ClusterTopology topologyWithMemberNotActive =
+        initialClusterTopology.updateMember(localMemberId, MemberState::toLeaving);
+
+    // when - then
+    assertThat(partitionJoinApplier.init(topologyWithMemberNotActive))
+        .isLeft()
+        .left()
+        .isInstanceOf(IllegalStateException.class);
+
+    // then
+  }
+
+  @Test
+  void shouldRejectJoinIfPriorityIsNoSet() {
+    // given
+    final PartitionJoinApplier partitionJoinApplier =
+        new PartitionJoinApplier(1, -1, localMemberId, partitionTopologyChangeExecutor);
+
+    // when - then
+    assertThat(partitionJoinApplier.init(initialClusterTopology))
+        .isLeft()
+        .left()
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldInitializeStateToJoining() {
+    // when
+    final var updater = partitionJoinApplier.init(initialClusterTopology).get();
+    final var resultingTopology = initialClusterTopology.updateMember(localMemberId, updater);
+
+    // then
+    ClusterTopologyAssert.assertThatClusterTopology(resultingTopology)
+        .hasMemberWithPartitions(1, Set.of(1))
+        .member(localMemberId)
+        .hasPartitionWithState(1, new PartitionState(State.JOINING, 1));
+  }
+
+  @Test
+  void shouldExecuteJoinCallBack() {
+    // given
+    final var updatedTopology =
+        initialClusterTopology.updateMember(
+            localMemberId, partitionJoinApplier.init(initialClusterTopology).get());
+    when(partitionTopologyChangeExecutor.join(anyInt(), any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var updater = partitionJoinApplier.apply().join();
+    final var resultingTopology = updatedTopology.updateMember(localMemberId, updater);
+
+    // then
+    verify(partitionTopologyChangeExecutor, times(1)).join(anyInt(), any());
+    ClusterTopologyAssert.assertThatClusterTopology(resultingTopology)
+        .hasMemberWithPartitions(1, Set.of(1))
+        .member(localMemberId)
+        .hasPartitionWithState(1, new PartitionState(State.ACTIVE, 1));
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
@@ -24,14 +24,14 @@ import org.junit.jupiter.api.Test;
 
 final class PartitionLeaveApplierTest {
 
-  private final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor =
-      mock(PartitionTopologyChangeExecutor.class);
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
   private final MemberId localMemberId = MemberId.from("1");
   final ClusterTopology initialClusterTopology =
       ClusterTopology.init().addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
 
   final PartitionLeaveApplier partitionLeaveApplier =
-      new PartitionLeaveApplier(1, localMemberId, partitionTopologyChangeExecutor);
+      new PartitionLeaveApplier(1, localMemberId, partitionChangeExecutor);
 
   @Test
   void shouldRejectLeaveWhenPartitionDoesNotExist() {
@@ -70,15 +70,14 @@ final class PartitionLeaveApplierTest {
         topologyWithPartition.updateMember(
             localMemberId, partitionLeaveApplier.init(topologyWithPartition).get());
 
-    when(partitionTopologyChangeExecutor.leave(1))
-        .thenReturn(CompletableActorFuture.completed(null));
+    when(partitionChangeExecutor.leave(1)).thenReturn(CompletableActorFuture.completed(null));
 
     // when
     final var stateUpdater = partitionLeaveApplier.apply().join();
     final var resultingTopology = topologyAfterInit.updateMember(localMemberId, stateUpdater);
 
     // then
-    verify(partitionTopologyChangeExecutor).leave(1);
+    verify(partitionChangeExecutor).leave(1);
     ClusterTopologyAssert.assertThatClusterTopology(resultingTopology)
         .member(localMemberId)
         .doesNotContainPartition(1);

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.topology.ClusterTopologyAssert;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import io.camunda.zeebe.topology.state.PartitionState.State;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class PartitionLeaveApplierTest {
+
+  private final PartitionTopologyChangeExecutor partitionTopologyChangeExecutor =
+      mock(PartitionTopologyChangeExecutor.class);
+  private final MemberId localMemberId = MemberId.from("1");
+  final ClusterTopology initialClusterTopology =
+      ClusterTopology.init().addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
+
+  final PartitionLeaveApplier partitionLeaveApplier =
+      new PartitionLeaveApplier(1, localMemberId, partitionTopologyChangeExecutor);
+
+  @Test
+  void shouldRejectLeaveWhenPartitionDoesNotExist() {
+    // when - then
+    EitherAssert.assertThat(partitionLeaveApplier.init(initialClusterTopology))
+        .isLeft()
+        .left()
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldUpdateStateToLeavingOnInit() {
+    // given
+    final ClusterTopology topologyWithPartition =
+        initialClusterTopology.updateMember(
+            localMemberId, m -> m.addPartition(1, PartitionState.active(1)));
+
+    // when
+    final var resultingTopology =
+        topologyWithPartition.updateMember(
+            localMemberId, partitionLeaveApplier.init(topologyWithPartition).get());
+
+    // then
+    ClusterTopologyAssert.assertThatClusterTopology(resultingTopology)
+        .member(localMemberId)
+        .hasPartitionWithState(1, new PartitionState(State.LEAVING, 1));
+  }
+
+  @Test
+  void shouldExecuteLeaveOnApply() {
+    // given
+    final var topologyWithPartition =
+        initialClusterTopology.updateMember(
+            localMemberId, m -> m.addPartition(1, PartitionState.active(1)));
+    final var topologyAfterInit =
+        topologyWithPartition.updateMember(
+            localMemberId, partitionLeaveApplier.init(topologyWithPartition).get());
+
+    when(partitionTopologyChangeExecutor.leave(1))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var stateUpdater = partitionLeaveApplier.apply().join();
+    final var resultingTopology = topologyAfterInit.updateMember(localMemberId, stateUpdater);
+
+    // then
+    verify(partitionTopologyChangeExecutor).leave(1);
+    ClusterTopologyAssert.assertThatClusterTopology(resultingTopology)
+        .member(localMemberId)
+        .doesNotContainPartition(1);
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
@@ -7,19 +7,22 @@
  */
 package io.camunda.zeebe.topology.changes;
 
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.topology.ClusterTopologyAssert;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.PartitionState.State;
+import io.camunda.zeebe.util.Either;
 import java.util.Map;
+import java.util.function.UnaryOperator;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class PartitionLeaveApplierTest {
@@ -35,11 +38,16 @@ final class PartitionLeaveApplierTest {
 
   @Test
   void shouldRejectLeaveWhenPartitionDoesNotExist() {
-    // when - then
-    EitherAssert.assertThat(partitionLeaveApplier.init(initialClusterTopology))
-        .isLeft()
-        .left()
-        .isInstanceOf(IllegalStateException.class);
+    // when
+    final Either<Exception, UnaryOperator<MemberState>> result =
+        partitionLeaveApplier.init(initialClusterTopology);
+
+    // then
+    assertThat(result).isLeft();
+
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the partition");
   }
 
   @Test

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
@@ -34,4 +34,21 @@ final class TopologyChangeAppliersImplTest {
     // then
     assertThat(applier).isInstanceOf(PartitionJoinApplier.class);
   }
+
+  @Test
+  void shouldReturnPartitionLeaveApplier() {
+    // given
+    final var topologyChangeAppliers = new TopologyChangeAppliersImpl(null, localMemberId);
+    final var partitionOperation =
+        new TopologyChangeOperation.PartitionOperation(
+            1, TopologyChangeOperation.PartitionOperationType.LEAVE, Optional.of(1));
+
+    // when
+    final var applier =
+        topologyChangeAppliers.getApplier(
+            new TopologyChangeOperation(localMemberId, partitionOperation));
+
+    // then
+    assertThat(applier).isInstanceOf(PartitionLeaveApplier.class);
+  }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
@@ -10,8 +10,8 @@ package io.camunda.zeebe.topology.changes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.topology.state.TopologyChangeOperation;
-import java.util.Optional;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import org.junit.jupiter.api.Test;
 
 final class TopologyChangeAppliersImplTest {
@@ -22,14 +22,10 @@ final class TopologyChangeAppliersImplTest {
   void shouldReturnPartitionJoinApplier() {
     // given
     final var topologyChangeAppliers = new TopologyChangeAppliersImpl(null, localMemberId);
-    final var partitionOperation =
-        new TopologyChangeOperation.PartitionOperation(
-            1, TopologyChangeOperation.PartitionOperationType.JOIN, Optional.of(1));
+    final var partitionOperation = new PartitionJoinOperation(localMemberId, 1, 1);
 
     // when
-    final var applier =
-        topologyChangeAppliers.getApplier(
-            new TopologyChangeOperation(localMemberId, partitionOperation));
+    final var applier = topologyChangeAppliers.getApplier(partitionOperation);
 
     // then
     assertThat(applier).isInstanceOf(PartitionJoinApplier.class);
@@ -39,14 +35,10 @@ final class TopologyChangeAppliersImplTest {
   void shouldReturnPartitionLeaveApplier() {
     // given
     final var topologyChangeAppliers = new TopologyChangeAppliersImpl(null, localMemberId);
-    final var partitionOperation =
-        new TopologyChangeOperation.PartitionOperation(
-            1, TopologyChangeOperation.PartitionOperationType.LEAVE, Optional.of(1));
+    final var partitionOperation = new PartitionLeaveOperation(localMemberId, 1);
 
     // when
-    final var applier =
-        topologyChangeAppliers.getApplier(
-            new TopologyChangeOperation(localMemberId, partitionOperation));
+    final var applier = topologyChangeAppliers.getApplier(partitionOperation);
 
     // then
     assertThat(applier).isInstanceOf(PartitionLeaveApplier.class);

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class TopologyChangeAppliersImplTest {
+
+  private final MemberId localMemberId = MemberId.from("1");
+
+  @Test
+  void shouldReturnPartitionJoinApplier() {
+    // given
+    final var topologyChangeAppliers = new TopologyChangeAppliersImpl(null, localMemberId);
+    final var partitionOperation =
+        new TopologyChangeOperation.PartitionOperation(
+            1, TopologyChangeOperation.PartitionOperationType.JOIN, Optional.of(1));
+
+    // when
+    final var applier =
+        topologyChangeAppliers.getApplier(
+            new TopologyChangeOperation(localMemberId, partitionOperation));
+
+    // then
+    assertThat(applier).isInstanceOf(PartitionJoinApplier.class);
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
@@ -8,11 +8,11 @@
 package io.camunda.zeebe.topology.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.ClusterTopologyAssert;
 import io.camunda.zeebe.topology.state.MemberState.State;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -122,7 +122,9 @@ class ClusterTopologyTest {
         ClusterTopology.init()
             .addMember(member(1), MemberState.uninitialized())
             .startTopologyChange(
-                List.of(mock(TopologyChangeOperation.class), mock(TopologyChangeOperation.class)));
+                List.of(
+                    new PartitionLeaveOperation(member(1), 1),
+                    new PartitionLeaveOperation(member(2), 2)));
 
     // when
     final var updatedTopology =
@@ -140,7 +142,9 @@ class ClusterTopologyTest {
         ClusterTopology.init()
             .addMember(member(1), MemberState.uninitialized())
             .startTopologyChange(
-                List.of(mock(TopologyChangeOperation.class), mock(TopologyChangeOperation.class)));
+                List.of(
+                    new PartitionLeaveOperation(member(1), 1),
+                    new PartitionLeaveOperation(member(2), 2)));
 
     // when
     final var updatedTopology =


### PR DESCRIPTION
## Description

This PR adds implementations of `OperationApplier` for partition join and leave operation. The operation executes a call back to start or stop partition. The callback is expected to be provided by the Broker, which could probably redirect to `PartitionManager`.

The validation of the operation can fail if the preconditions are not met. For example, we can join only if the partition is not already active, or the member is active. If the validation fails, right now there is no way to recover. The topology change operation will be stuck forever. In future, we could provide some way to cancel an ongoing topology change to recover from such scenarios.

## Related issues

- [x] ClusterTopologyManager can react to a Partition join operation by invoking a callback to start partition.
- [x] ClusterTopologyManager can react to a Partition leave operation by invoking a callback to stop the partition

related #14159 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
