### PR TITLE
fix(clients/go): client does not retry on permanent errors

### DIFF
--- a/clients/go/pkg/commands/activate_jobs.go
+++ b/clients/go/pkg/commands/activate_jobs.go
@@ -16,11 +16,13 @@ package commands
 
 import (
 	"context"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+	"errors"
 	"io"
 	"log"
 	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 )
 
 const (
@@ -96,7 +98,7 @@ func (cmd *ActivateJobsCommand) Send(ctx context.Context) ([]entities.Job, error
 	var activatedJobs []entities.Job
 	for {
 		response, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if cmd.shouldRetry(ctx, err) {

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -105,52 +105,56 @@ func withStopOnPermanentError(shouldRetryRequest func(ctx context.Context, err e
 	}
 }
 
+func (c *ClientImpl) shouldRetryRequest(ctx context.Context, err error) bool {
+	return withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest)(ctx, err)
+}
+
 func (c *ClientImpl) NewTopologyCommand() *commands.TopologyCommand {
-	return commands.NewTopologyCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewTopologyCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewDeployProcessCommand() *commands.DeployCommand {
-	return commands.NewDeployCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest)) // nolint
+	return commands.NewDeployCommand(c.gateway, c.shouldRetryRequest) // nolint
 }
 
 func (c *ClientImpl) NewDeployResourceCommand() *commands.DeployResourceCommand {
-	return commands.NewDeployResourceCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewDeployResourceCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewEvaluateDecisionCommand() commands.EvaluateDecisionCommandStep1 {
-	return commands.NewEvaluateDecisionCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewEvaluateDecisionCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewPublishMessageCommand() commands.PublishMessageCommandStep1 {
-	return commands.NewPublishMessageCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewPublishMessageCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewBroadcastSignalCommand() commands.BroadcastSignalCommandStep1 {
-	return commands.NewBroadcastSignalCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewBroadcastSignalCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewResolveIncidentCommand() commands.ResolveIncidentCommandStep1 {
-	return commands.NewResolveIncidentCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewResolveIncidentCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewCreateInstanceCommand() commands.CreateInstanceCommandStep1 {
-	return commands.NewCreateInstanceCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewCreateInstanceCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewCancelInstanceCommand() commands.CancelInstanceStep1 {
-	return commands.NewCancelInstanceCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewCancelInstanceCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewCompleteJobCommand() commands.CompleteJobCommandStep1 {
-	return commands.NewCompleteJobCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewCompleteJobCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewFailJobCommand() commands.FailJobCommandStep1 {
-	return commands.NewFailJobCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewFailJobCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewUpdateJobRetriesCommand() commands.UpdateJobRetriesCommandStep1 {
-	return commands.NewUpdateJobRetriesCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewUpdateJobRetriesCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewUpdateJobTimeoutCommand() commands.UpdateJobTimeoutCommandStep1 {
@@ -158,19 +162,19 @@ func (c *ClientImpl) NewUpdateJobTimeoutCommand() commands.UpdateJobTimeoutComma
 }
 
 func (c *ClientImpl) NewSetVariablesCommand() commands.SetVariablesCommandStep1 {
-	return commands.NewSetVariablesCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewSetVariablesCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewActivateJobsCommand() commands.ActivateJobsCommandStep1 {
-	return commands.NewActivateJobsCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewActivateJobsCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewThrowErrorCommand() commands.ThrowErrorCommandStep1 {
-	return commands.NewThrowErrorCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewThrowErrorCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewDeleteResourceCommand() commands.DeleteResourceCommandStep1 {
-	return commands.NewDeleteResourceCommand(c.gateway, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return commands.NewDeleteResourceCommand(c.gateway, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) NewStreamJobsCommand() commands.StreamJobsCommandStep1 {
@@ -178,7 +182,7 @@ func (c *ClientImpl) NewStreamJobsCommand() commands.StreamJobsCommandStep1 {
 }
 
 func (c *ClientImpl) NewJobWorker() worker.JobWorkerBuilderStep1 {
-	return worker.NewJobWorkerBuilder(c.gateway, c, withStopOnPermanentError(c.credentialsProvider.ShouldRetryRequest))
+	return worker.NewJobWorkerBuilder(c.gateway, c, c.shouldRetryRequest)
 }
 
 func (c *ClientImpl) Close() error {

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -25,16 +25,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/camunda/zeebe/clients/go/v8/internal/embedded"
-	"google.golang.org/grpc/credentials/insecure"
-
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/camunda/zeebe/clients/go/v8/internal/embedded"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/worker"


### PR DESCRIPTION
## Description

Ensure commands stop on permanent errors, whatever the behavior of the credential provider.
- permanent errors are considered non-retry-able
- otherwise default to the retry predicate

## Related issues

camunda/issue-migration-go-client#14 

closes camunda/issue-migration-go-client#14 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
