### PR TITLE
Set default tenant to `TenantOwned.DEFAULT_TENANT_IDENTIFIER` on all records

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.deployment;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
@@ -14,6 +16,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -25,6 +28,8 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
   private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public PersistedForm() {
     declareProperty(formIdProp)
@@ -32,7 +37,8 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
         .declareProperty(formKeyProp)
         .declareProperty(resourceNameProp)
         .declareProperty(resourceProp)
-        .declareProperty(checksumProp);
+        .declareProperty(checksumProp)
+        .declareProperty(tenantIdProp);
   }
 
   public PersistedForm copy() {
@@ -43,6 +49,7 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
     copy.resourceNameProp.setValue(getResourceName());
     copy.resourceProp.setValue(getResource());
     copy.checksumProp.setValue(getChecksum());
+    copy.tenantIdProp.setValue(getTenantId());
     return copy;
   }
 
@@ -70,6 +77,10 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
     return checksumProp.getValue();
   }
 
+  public String getTenantId() {
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
   public void wrap(final FormRecord record) {
     formIdProp.setValue(record.getFormId());
     versionProp.setValue(record.getVersion());
@@ -77,5 +88,6 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
     resourceNameProp.setValue(record.getResourceNameBuffer());
     resourceProp.setValue(BufferUtil.wrapArray(record.getResource()));
     checksumProp.setValue(record.getChecksumBuffer());
+    tenantIdProp.setValue(record.getTenantId());
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -321,6 +322,6 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13777): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import org.agrona.DirectBuffer;
 
@@ -31,7 +32,8 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
       new LongProperty("decisionRequirementsKey");
 
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DecisionRecord() {
     declareProperty(decisionIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import org.agrona.DirectBuffer;
 
@@ -37,7 +38,8 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
 
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DecisionRequirementsMetadataRecord() {
     declareProperty(decisionRequirementsIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import org.agrona.DirectBuffer;
 
@@ -35,7 +36,8 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
   private final BinaryProperty resourceProp = new BinaryProperty("resource");
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DecisionRequirementsRecord() {
     declareProperty(decisionRequirementsIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
@@ -38,7 +39,8 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
   private final ArrayProperty<DecisionRequirementsMetadataRecord> decisionRequirementsMetadataProp =
       new ArrayProperty<>("decisionRequirementsMetadata", new DecisionRequirementsMetadataRecord());
 
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DeploymentRecord() {
     declareProperty(resourcesProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormMetadataRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormMetadataRecord.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
 import org.agrona.DirectBuffer;
 
@@ -28,6 +29,8 @@ public class FormMetadataRecord extends UnifiedRecordValue implements FormMetada
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public FormMetadataRecord() {
     declareProperty(formIdProp)
@@ -35,7 +38,8 @@ public class FormMetadataRecord extends UnifiedRecordValue implements FormMetada
         .declareProperty(formKeyProp)
         .declareProperty(resourceNameProp)
         .declareProperty(checksumProp)
-        .declareProperty(isDuplicateProp);
+        .declareProperty(isDuplicateProp)
+        .declareProperty(tenantIdProp);
   }
 
   @Override
@@ -115,7 +119,11 @@ public class FormMetadataRecord extends UnifiedRecordValue implements FormMetada
 
   @Override
   public String getTenantId() {
-    // todo(#13320): replace dummy implementation
-    return "";
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public FormMetadataRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormRecord.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.deployment;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
@@ -25,6 +28,8 @@ public final class FormRecord extends UnifiedRecordValue implements Form {
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
   private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public FormRecord() {
     declareProperty(formIdProp)
@@ -32,7 +37,8 @@ public final class FormRecord extends UnifiedRecordValue implements Form {
         .declareProperty(formKeyProp)
         .declareProperty(resourceNameProp)
         .declareProperty(checksumProp)
-        .declareProperty(resourceProp);
+        .declareProperty(resourceProp)
+        .declareProperty(tenantIdProp);
   }
 
   public FormRecord wrap(final FormMetadataRecord metadata, final byte[] resource) {
@@ -42,6 +48,7 @@ public final class FormRecord extends UnifiedRecordValue implements Form {
     formKeyProp.setValue(metadata.getFormKey());
     resourceNameProp.setValue(metadata.getResourceNameBuffer());
     resourceProp.setValue(BufferUtil.wrapArray(resource));
+    tenantIdProp.setValue(metadata.getTenantId());
     return this;
   }
 
@@ -163,7 +170,6 @@ public final class FormRecord extends UnifiedRecordValue implements Form {
 
   @Override
   public String getTenantId() {
-    // todo(#13320): replace dummy implementation
-    return "";
+    return bufferAsString(tenantIdProp.getValue());
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
@@ -36,7 +37,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   // should be set to true if the process was already deployed - property should not be exported
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ProcessMetadata() {
     declareProperty(bpmnProcessIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
@@ -29,7 +30,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
   private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ProcessRecord() {
     declareProperty(bpmnProcessIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/escalation/EscalationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/escalation/EscalationRecord.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
@@ -78,6 +79,6 @@ public class EscalationRecord extends UnifiedRecordValue implements EscalationRe
   @Override
   public String getTenantId() {
     // todo(#13774): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
@@ -182,6 +183,6 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   @Override
   public String getTenantId() {
     // todo(#13426): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -352,6 +353,6 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @Override
   public String getTenantId() {
     // todo(#13345): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -149,6 +150,6 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   @Override
   public String getTenantId() {
     // todo(#13289): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
@@ -159,6 +160,6 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
   @Override
   public String getTenantId() {
     // todo(#13289): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
@@ -158,6 +159,6 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13289): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
@@ -191,6 +192,6 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13289): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -110,6 +111,6 @@ public final class ProcessEventRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13774): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 
 public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
     implements ProcessInstanceBatchRecordValue {
@@ -72,6 +73,6 @@ public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13774): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
@@ -162,6 +163,6 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13774): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -148,6 +149,6 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13288): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.agrona.DirectBuffer;
 
 public final class ProcessInstanceRecord extends UnifiedRecordValue
@@ -219,6 +220,6 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13774): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -106,6 +107,6 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13774): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.resource;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 
 public class ResourceDeletionRecord extends UnifiedRecordValue
     implements ResourceDeletionRecordValue {
@@ -37,6 +38,6 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13238): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalRecord.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -70,6 +71,6 @@ public final class SignalRecord extends UnifiedRecordValue implements SignalReco
   @Override
   public String getTenantId() {
     // todo(#13336): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.agrona.DirectBuffer;
 
 public final class SignalSubscriptionRecord extends UnifiedRecordValue
@@ -117,6 +118,6 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13336): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
@@ -102,6 +103,6 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
   @Override
   public String getTenantId() {
     // todo(#13337): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import java.util.Map;
@@ -103,6 +104,6 @@ public final class VariableDocumentRecord extends UnifiedRecordValue
   @Override
   public String getTenantId() {
     // todo(#13388): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
@@ -118,6 +119,6 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   @Override
   public String getTenantId() {
     // todo(#13388): replace dummy implementation
-    return "";
+    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   }
 }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -209,7 +209,7 @@ final class JsonSerializableToJsonTest {
                 "checksum": "Y2hlY2tzdW0=",
                 "processDefinitionKey": 123,
                 "duplicate": false,
-                "tenantId": ""
+                "tenantId": "<default>"
               }
             ],
             "resources": [
@@ -220,7 +220,7 @@ final class JsonSerializableToJsonTest {
             ],
             "decisionsMetadata": [],
             "decisionRequirementsMetadata": [],
-            "tenantId": ""
+            "tenantId": "<default>"
           }
         }
         """
@@ -262,7 +262,7 @@ final class JsonSerializableToJsonTest {
               "decisionRequirementsMetadata": [],
               "processesMetadata": [],
               "decisionsMetadata": [],
-              "tenantId": ""
+              "tenantId": "<default>"
           }
         }
         """
@@ -334,7 +334,7 @@ final class JsonSerializableToJsonTest {
               "processDefinitionKey": 123,
               "resourceName": "resource",
               "duplicate": true,
-              "tenantId": ""
+              "tenantId": "<default>"
             }
           ],
           "decisionsMetadata": [
@@ -346,7 +346,7 @@ final class JsonSerializableToJsonTest {
               "decisionName": "decision-name",
               "decisionKey": 2,
               "duplicate": true,
-              "tenantId": ""
+              "tenantId": "<default>"
             }
           ],
           "decisionRequirementsMetadata": [
@@ -359,10 +359,10 @@ final class JsonSerializableToJsonTest {
               "resourceName": "resource-name",
               "checksum": "Y2hlY2tzdW0=",
               "duplicate": true,
-              "tenantId": ""
+              "tenantId": "<default>"
             }
           ],
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -395,7 +395,7 @@ final class JsonSerializableToJsonTest {
           "processesMetadata": [],
           "decisionsMetadata": [],
           "decisionRequirementsMetadata": [],
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -436,7 +436,7 @@ final class JsonSerializableToJsonTest {
           "processDefinitionKey": 123,
           "resourceName": "resource",
           "duplicate": false,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -505,7 +505,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": 34,
           "jobKey": 123,
           "variableScopeKey": 34,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -526,7 +526,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": -1,
           "jobKey": -1,
           "variableScopeKey": -1,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -609,7 +609,7 @@ final class JsonSerializableToJsonTest {
               "errorCode": "error",
               "customHeaders": {},
               "deadline": 1000,
-              "tenantId": ""
+              "tenantId": "<default>"
             }
           ],
           "timeout": 2,
@@ -705,7 +705,7 @@ final class JsonSerializableToJsonTest {
             "workerVersion": "42"
           },
           "deadline": 13,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -734,7 +734,7 @@ final class JsonSerializableToJsonTest {
           "errorCode": "",
           "customHeaders": {},
           "deadline": -1,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -768,7 +768,7 @@ final class JsonSerializableToJsonTest {
           "errorCode": "",
           "processDefinitionVersion": -1,
           "customHeaders": {},
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -802,7 +802,7 @@ final class JsonSerializableToJsonTest {
           "messageId": "test-id",
           "name": "test-message",
           "deadline": 22,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -830,7 +830,7 @@ final class JsonSerializableToJsonTest {
           "messageId": "",
           "name": "test-message",
           "deadline": -1,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -908,7 +908,7 @@ final class JsonSerializableToJsonTest {
           "variables": {
             "foo": "bar"
           },
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -935,7 +935,7 @@ final class JsonSerializableToJsonTest {
           "messageKey": -1,
           "correlationKey": "",
           "variables": {},
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -975,7 +975,7 @@ final class JsonSerializableToJsonTest {
             "foo": "bar"
           },
           "interrupting": true,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1004,7 +1004,7 @@ final class JsonSerializableToJsonTest {
           "messageKey": -1,
           "variables": {},
           "interrupting": true,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1048,7 +1048,7 @@ final class JsonSerializableToJsonTest {
           "correlationKey": "key",
           "elementId": "A",
           "interrupting": true,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1078,7 +1078,7 @@ final class JsonSerializableToJsonTest {
           "correlationKey": "",
           "elementId": "",
           "interrupting": true,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1113,7 +1113,7 @@ final class JsonSerializableToJsonTest {
           "targetElementId": "node1",
           "repetitions": 3,
           "processDefinitionKey": 13,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1148,7 +1148,7 @@ final class JsonSerializableToJsonTest {
           "bpmnProcessId": "process",
           "name": "x",
           "value": "1",
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1175,7 +1175,7 @@ final class JsonSerializableToJsonTest {
             "foo": 1
           },
           "scopeKey": 3,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1196,7 +1196,7 @@ final class JsonSerializableToJsonTest {
           "updateSemantics": "PROPAGATE",
           "variables": {},
           "scopeKey": 3,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1239,7 +1239,7 @@ final class JsonSerializableToJsonTest {
               "elementId": "element"
             }
           ],
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1258,7 +1258,7 @@ final class JsonSerializableToJsonTest {
           "version": -1,
           "processInstanceKey": -1,
           "startInstructions": [],
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1309,7 +1309,7 @@ final class JsonSerializableToJsonTest {
             "ancestorScopeKeys": [1,3]
           }],
           "ancestorScopeKeys": [1,3],
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1327,7 +1327,7 @@ final class JsonSerializableToJsonTest {
           "terminateInstructions": [],
           "activateInstructions": [],
           "ancestorScopeKeys": [],
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1371,7 +1371,7 @@ final class JsonSerializableToJsonTest {
           "parentProcessInstanceKey": 11,
           "parentElementInstanceKey": 22,
           "bpmnEventType": "UNSPECIFIED",
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1394,7 +1394,7 @@ final class JsonSerializableToJsonTest {
           "parentProcessInstanceKey": -1,
           "parentElementInstanceKey": -1,
           "bpmnEventType": "UNSPECIFIED",
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1422,7 +1422,7 @@ final class JsonSerializableToJsonTest {
           "decisionRequirementsKey": 3,
           "decisionRequirementsId": "decision-requirements-id",
           "duplicate": false,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1454,7 +1454,7 @@ final class JsonSerializableToJsonTest {
           "resource": "cmVzb3VyY2U=",
           "checksum": "Y2hlY2tzdW0=",
           "duplicate": false,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1562,7 +1562,7 @@ final class JsonSerializableToJsonTest {
           ],
           "evaluationFailureMessage":"evaluation-failure-message",
           "failedDecisionId":"failed-decision-id",
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1591,7 +1591,7 @@ final class JsonSerializableToJsonTest {
           "evaluatedDecisions":[],
           "evaluationFailureMessage":"",
           "failedDecisionId":"",
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1627,7 +1627,7 @@ final class JsonSerializableToJsonTest {
           "escalationCode": "escalation",
           "throwElementId": "throw",
           "catchElementId": "catch",
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1644,7 +1644,7 @@ final class JsonSerializableToJsonTest {
           "escalationCode": "",
           "throwElementId": "",
           "catchElementId": "",
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1668,7 +1668,7 @@ final class JsonSerializableToJsonTest {
           "variables": {
             "foo": "bar"
           },
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1688,7 +1688,7 @@ final class JsonSerializableToJsonTest {
         {
           "signalName":"test-signal",
           "variables": {},
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1719,7 +1719,7 @@ final class JsonSerializableToJsonTest {
           "catchEventId": "startEvent",
           "bpmnProcessId": "process",
           "catchEventInstanceKey":3,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1742,7 +1742,7 @@ final class JsonSerializableToJsonTest {
           "catchEventId":"",
           "bpmnProcessId":"",
           "catchEventInstanceKey":-1,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1760,7 +1760,7 @@ final class JsonSerializableToJsonTest {
         """
         {
           "resourceKey":1,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1810,11 +1810,11 @@ final class JsonSerializableToJsonTest {
               "resourceName": "my_first_bpmn.bpmn",
               "checksum": "c2hhMQ==",
               "duplicate": false,
-              "tenantId": ""
+              "tenantId": "<default>"
             }],
             "decisionsMetadata": [],
             "decisionRequirementsMetadata": [],
-            "tenantId": ""
+            "tenantId": "<default>"
           }
         }
         """
@@ -1852,7 +1852,7 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": 123,
           "batchElementInstanceKey": 456,
           "index": 10,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },
@@ -1872,7 +1872,7 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": 123,
           "batchElementInstanceKey": 456,
           "index": -1,
-          "tenantId": ""
+          "tenantId": "<default>"
         }
         """
       },


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
We left the default on all records an empty string so far. It's a lot easier to deliver smaller chunks of MT if we make this the default tenant instead.

I've also added the tenant id properties to the new Form records as discussed during the Form Deployment kickoff.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
