### PR TITLE
feat(topology): include cluster change plan in the gossiped topology

### DIFF
--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -10,6 +10,7 @@ message GossipState {
 message ClusterTopology {
   int64 version = 1;
   map<string, MemberState> members = 2;
+  ClusterChangePlan changes = 3;
 }
 
 message MemberState {
@@ -23,10 +24,29 @@ message PartitionState {
   int32 priority = 2;
 }
 
+message ClusterChangePlan {
+  int32 version = 1;
+  repeated TopologyChangeOperation operation = 2;
+}
+
+message TopologyChangeOperation {
+  string memberId = 1;
+  OperationType type = 2;
+  optional int32 partitionId = 3;
+  optional int32 priority = 4;
+}
 enum State {
   UNKNOWN = 0;
   JOINING = 1;
   ACTIVE = 2;
   LEAVING = 3;
   LEFT = 4;
+}
+
+enum OperationType{
+  UNKNOWN_OPERATION = 0;
+  MEMBER_JOIN = 1;
+  MEMBER_LEAVE = 2;
+  PARTITION_JOIN_= 3;
+  PARTITION_LEAVE = 4;
 }

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -31,10 +31,21 @@ message ClusterChangePlan {
 
 message TopologyChangeOperation {
   string memberId = 1;
-  OperationType type = 2;
-  optional int32 partitionId = 3;
-  optional int32 priority = 4;
+  oneof operation {
+    PartitionJoinOperation partitionJoin = 2;
+    PartitionLeaveOperation partitionLeave = 3;
+  }
 }
+
+message PartitionJoinOperation {
+  int32 partitionId = 1;
+  int32 priority = 2;
+}
+
+message PartitionLeaveOperation {
+  int32 partitionId = 1;
+}
+
 enum State {
   UNKNOWN = 0;
   JOINING = 1;
@@ -43,10 +54,4 @@ enum State {
   LEFT = 4;
 }
 
-enum OperationType{
-  UNKNOWN_OPERATION = 0;
-  MEMBER_JOIN = 1;
-  MEMBER_LEAVE = 2;
-  PARTITION_JOIN_= 3;
-  PARTITION_LEAVE = 4;
-}
+

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -15,6 +15,10 @@ import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.MemberState.State;
 import io.camunda.zeebe.topology.state.PartitionState;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -66,7 +70,8 @@ final class ProtoBufSerializerTest {
         topologyWithOneMemberOneLeavingPartition(),
         topologyWithOneMemberOneJoiningPartition(),
         topologyWithOneMemberTwoPartitions(),
-        topologyWithTwoMembers());
+        topologyWithTwoMembers(),
+        topologyWithClusterChangePlan());
   }
 
   private static ClusterTopology topologyWithOneMemberNoPartitions() {
@@ -125,5 +130,15 @@ final class ProtoBufSerializerTest {
             MemberState.initializeAsActive(
                 Map.of(1, PartitionState.joining(1), 2, PartitionState.active(2))))
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()).toLeaving());
+  }
+
+  private static ClusterTopology topologyWithClusterChangePlan() {
+    final List<TopologyChangeOperation> changes =
+        List.of(
+            new PartitionLeaveOperation(MemberId.from("1"), 1),
+            new PartitionJoinOperation(MemberId.from("2"), 2, 5));
+    return ClusterTopology.init()
+        .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
+        .startTopologyChange(changes);
   }
 }


### PR DESCRIPTION
## Description

This PR adds protobuf definitions for `ClusterChangePlan`. This is then serialized and deserialized with the `ClusterTopology` during gossip.

For defining `TopologyChangeOperation`, partitionId and prioirity are added as optional fields. Alternative is to define a type for each of the operation type and use `OneOf`. But I think it is better to keep it simple, as it is just two optional fields. Besides it is unclear to me how [backward compatibility works with OneOf](https://protobuf.dev/programming-guides/proto3/#backward).

## Related issues

- [x] Pending topology change are disseminated it via gossip

related to #14159
