### PR TITLE
Directly write snapshots to the correct location

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -294,7 +294,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
                 Long.MAX_VALUE);
       }
       final PersistedSnapshot value =
-          snapshotStore.persistNewSnapshot(snapshotId, directory, checksumCollection, metadata);
+          snapshotStore.persistNewSnapshot(snapshotId, checksumCollection, metadata);
       future.complete(value);
     } catch (final Exception e) {
       future.completeExceptionally(e);

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -194,7 +194,7 @@ public final class FileBasedSnapshotStore extends Actor
               + " (e.g. crash during move), and will be deleted",
           path);
       try {
-        FileUtil.deleteFolder(path);
+        deleteFolder(path);
       } catch (final Exception e) {
         // it's fine to ignore failures to delete here, as it would constitute mostly noise
         LOGGER.debug("Failed to delete partial snapshot {}", path, e);
@@ -333,14 +333,14 @@ public final class FileBasedSnapshotStore extends Actor
 
           try {
             LOGGER.debug("DELETE FOLDER {}", snapshotsDirectory);
-            FileUtil.deleteFolder(snapshotsDirectory);
+            deleteFolder(snapshotsDirectory);
           } catch (final IOException e) {
             throw new UncheckedIOException(e);
           }
 
           try {
             LOGGER.debug("DELETE FOLDER {}", pendingDirectory);
-            FileUtil.deleteFolder(pendingDirectory);
+            deleteFolder(pendingDirectory);
           } catch (final IOException e) {
             throw new UncheckedIOException(e);
           }
@@ -489,7 +489,7 @@ public final class FileBasedSnapshotStore extends Actor
     final var optionalMetadata = FileBasedSnapshotId.ofPath(pendingSnapshot);
     if (optionalMetadata.isPresent() && optionalMetadata.get().compareTo(cutoffIndex) < 0) {
       try {
-        FileUtil.deleteFolder(pendingSnapshot);
+        deleteFolder(pendingSnapshot);
         LOGGER.debug("Deleted orphaned snapshot {}", pendingSnapshot);
       } catch (final IOException e) {
         LOGGER.warn(
@@ -623,7 +623,7 @@ public final class FileBasedSnapshotStore extends Actor
 
   private void purgePendingSnapshot(final Path pendingSnapshot) {
     try {
-      FileUtil.deleteFolder(pendingSnapshot);
+      deleteFolder(pendingSnapshot);
       LOGGER.debug("Deleted not completed (orphaned) snapshot {}", pendingSnapshot);
     } catch (final IOException e) {
       LOGGER.warn("Failed to delete not completed (orphaned) snapshot {}", pendingSnapshot, e);

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -377,7 +377,7 @@ public final class FileBasedSnapshotStore extends Actor
         // this should not happen
         // this means we persisted a snapshot - marked as valid
         // and now received the same snapshot via replication
-        throw new IllegalStateException(
+        throw new SnapshotAlreadyExistsException(
             String.format(
                 "Expected to receive snapshot with id %s, but was already persisted. This shouldn't happen.",
                 snapshotId));

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -149,7 +149,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
               snapshotId.getExportedPosition(),
               lastFollowupEventPosition);
       writeMetadataAndUpdateChecksum(metadata);
-      snapshot = snapshotStore.persistNewSnapshot(snapshotId, directory, checksum, metadata);
+      snapshot = snapshotStore.persistNewSnapshot(snapshotId, checksum, metadata);
       future.complete(snapshot);
     } catch (final Exception e) {
       future.completeExceptionally(e);

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.InvalidSnapshotChecksum;
 import io.camunda.zeebe.snapshots.impl.SnapshotWriteException;
@@ -182,7 +183,7 @@ public class ReceivedSnapshotTest {
 
     // when then throw - receives same snapshot again
     assertThatThrownBy(() -> receiveSnapshot(persistedSnapshot))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(SnapshotAlreadyExistsException.class)
         .hasMessageContaining(
             "Expected to receive snapshot with id 1-0-1-0, but was already persisted");
   }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -216,21 +216,6 @@ public class TransientSnapshotTest {
   }
 
   @Test
-  public void shouldRemoveTransientSnapshotOnPersist() {
-    // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
-    transientSnapshot.take(this::writeSnapshot);
-
-    // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
-    newSnapshot.take(this::writeSnapshot);
-    newSnapshot.persist().join();
-
-    // then
-    assertThat(newSnapshot.getPath()).as("the transient snapshot was removed").doesNotExist();
-  }
-
-  @Test
   public void shouldNotRemoveTransientSnapshotWithGreaterIdOnPersist() {
     final var newerTransientSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
     newerTransientSnapshot.take(this::writeSnapshot);

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -85,8 +85,8 @@ public class FileBasedTransientSnapshotTest {
 
     // then
     assertThat(snapshotsDir)
-        .as("the committed snapshots directory should be empty")
-        .isEmptyDirectory();
+        .isDirectoryNotContaining(
+            p -> p.getFileName().toFile().getName().equals("1-2-3-4.checksum"));
   }
 
   @Test
@@ -100,7 +100,7 @@ public class FileBasedTransientSnapshotTest {
     // then
     assertThat(transientSnapshot.getPath())
         .as("the transient snapshot directory was written in the pending directory")
-        .hasParent(pendingDir)
+        .hasParent(snapshotsDir)
         .isNotEmptyDirectory();
   }
 
@@ -138,21 +138,6 @@ public class FileBasedTransientSnapshotTest {
     assertThat(snapshotStore.getLatestSnapshot())
         .as("the latest snapshot was not changed after purge")
         .hasValue(persistedSnapshot);
-  }
-
-  @Test
-  public void shouldDeleteOlderTransientDirectoryOnPersist() {
-    // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
-    transientSnapshot.take(this::writeSnapshot).join();
-
-    // when
-    transientSnapshot.persist().join();
-
-    // then
-    assertThat(transientSnapshot.getPath())
-        .as("the transient directory is removed after persist")
-        .doesNotExist();
   }
 
   @Test
@@ -249,7 +234,7 @@ public class FileBasedTransientSnapshotTest {
     assertThat(newerTransientSnapshot.getPath())
         .as("the newer transient snapshot still exists since it has a greater ID")
         .isNotEmptyDirectory()
-        .hasParent(pendingDir);
+        .hasParent(snapshotsDir);
   }
 
   @Test


### PR DESCRIPTION
## Description

> Note: 
> This solves the problem of having replicated snapshots multiple times via just deleting the previous one, instead of creating unique snapshot directories. If this is not acceptable this PR should be rejected. See related comment https://github.com/camunda/zeebe/issues/14045#issuecomment-1711710503


Instead of writing to a pending directory we directly write to the snapshot directory. This allows us to remove the move
and we already make sure that a snapshot is only valid because of an existing checksum.

If we receive multiple snapshots with the same ID we delete the previous one, if it is not persisted yet.

See related slack discussion https://camunda.slack.com/archives/C037RS2JHB8/p1694182399011709


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14045 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
