### PR TITLE
[Backport stable/8.2] fix: push snapshot image by passing RW token

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: If true, logs into Docker Hub using our CI account; helpful to prevent rate limiting
     required: false
     default: "true"
+  docker-token:
+    description: The token to use when logging into Docker Hub
+    required: false
+    default: "REGISTRY_HUB_DOCKER_COM_PSW_READ_ONLY"
 
 outputs: {}
 
@@ -68,7 +72,7 @@ runs:
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
           secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
           secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR;
-          secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW_READ_ONLY;
+          secret/data/products/zeebe/ci/zeebe ${{ inputs.docker-token }};
     - uses: actions/setup-java@v3
       if: inputs.java == 'true'
       with:
@@ -84,7 +88,7 @@ runs:
         && inputs.secret_vault_secretId != ''
       with:
         username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
-        password: ${{ steps.secrets.outputs. REGISTRY_HUB_DOCKER_COM_PSW_READ_ONLY }}
+        password: ${{ steps.secrets.outputs[inputs.docker-token] }}
     # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: 'Create settings.xml'
       uses: s4u/maven-settings-action@v2.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,28 +503,13 @@ jobs:
       group: deploy-docker-snapshot
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v3
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v2.5.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR;
-            secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW;
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
-          password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
         with:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          docker-token: REGISTRY_HUB_DOCKER_COM_PSW
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-docker


### PR DESCRIPTION
## Description

Backports #14227 to stable/8.2. This time I did set the param on the right action ;)

(cherry picked from commit 8714217ead3fe7a05a71d5bebafcc504d3eb5b12)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
