### PR TITLE
fix(gateway): serialize access to StreamObserver

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/ClientStreamAdapter.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/ClientStreamAdapter.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.transport.stream.api.ClientStreamer;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.internal.SerializingExecutor;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CompletableFuture;
@@ -83,12 +84,12 @@ public class ClientStreamAdapter {
   @VisibleForTesting("Allow unit testing behavior job handling behavior")
   static final class ClientStreamConsumerImpl implements ClientStreamConsumer {
     private final StreamObserver<ActivatedJob> responseObserver;
-    private final Executor executor;
+    private final SerializingExecutor executor;
 
     public ClientStreamConsumerImpl(
         final StreamObserver<ActivatedJob> responseObserver, final Executor executor) {
       this.responseObserver = responseObserver;
-      this.executor = executor;
+      this.executor = new SerializingExecutor(executor);
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR fixes concurrent access to the same stream observer which results in broken streams. However, it uses an internal gRPC API which is likely to be made inaccessible in the future.

## Related issues

related to #14236 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
