### PR TITLE
Serialize access to the underlying gRPC stream via actors

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -65,6 +65,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesReque
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.transport.stream.api.ClientStreamer;
 import io.camunda.zeebe.util.VersionUtil;
 import io.grpc.Context;
@@ -89,12 +90,13 @@ public final class EndpointManager {
       final BrokerClient brokerClient,
       final ActivateJobsHandler activateJobsHandler,
       final ClientStreamer<JobActivationProperties> jobStreamer,
+      final ActorSchedulingService scheduler,
       final Executor executor,
       final MultiTenancyCfg multiTenancy) {
     this.brokerClient = brokerClient;
     this.activateJobsHandler = activateJobsHandler;
 
-    clientStreamAdapter = new ClientStreamAdapter(jobStreamer, executor);
+    clientStreamAdapter = new ClientStreamAdapter(jobStreamer, scheduler, executor);
     topologyManager = brokerClient.getTopologyManager();
     requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
     this.multiTenancy = multiTenancy;

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -130,7 +130,12 @@ public final class Gateway implements CloseableSilently {
 
     final var endpointManager =
         new EndpointManager(
-            brokerClient, activateJobsHandler, jobStreamer, actorSchedulingService, grpcExecutor, multiTenancy);
+            brokerClient,
+            activateJobsHandler,
+            jobStreamer,
+            actorSchedulingService,
+            grpcExecutor,
+            multiTenancy);
     final var gatewayGrpcService = new GatewayGrpcService(endpointManager);
     return buildServer(serverBuilder, gatewayGrpcService);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -130,7 +130,7 @@ public final class Gateway implements CloseableSilently {
 
     final var endpointManager =
         new EndpointManager(
-            brokerClient, activateJobsHandler, jobStreamer, grpcExecutor, multiTenancy);
+            brokerClient, activateJobsHandler, jobStreamer, actorSchedulingService, grpcExecutor, multiTenancy);
     final var gatewayGrpcService = new GatewayGrpcService(endpointManager);
     return buildServer(serverBuilder, gatewayGrpcService);
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -83,7 +83,12 @@ public final class StubbedGateway {
     final MultiTenancyCfg multiTenancy = config.getMultiTenancy();
     final EndpointManager endpointManager =
         new EndpointManager(
-            brokerClient, activateJobsHandler, jobStreamer, actorScheduler, Runnable::run, multiTenancy);
+            brokerClient,
+            activateJobsHandler,
+            jobStreamer,
+            actorScheduler,
+            Runnable::run,
+            multiTenancy);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
 
     final InProcessServerBuilder serverBuilder =

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -7,13 +7,14 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
-import java.util.concurrent.CompletableFuture;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import org.agrona.DirectBuffer;
 
 /**
  * Represents a consumer of a stream which can consume data pushed from the server. The data is
  * typically pushed from a broker, and consumed by gateway.
  */
+@FunctionalInterface
 public interface ClientStreamConsumer {
 
   /**
@@ -23,5 +24,5 @@ public interface ClientStreamConsumer {
    *
    * @param payload the data to be consumed by the client
    */
-  CompletableFuture<Void> push(DirectBuffer payload);
+  ActorFuture<Void> push(DirectBuffer payload);
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
@@ -25,14 +24,8 @@ record ClientStreamImpl<M extends BufferWriter>(
     ClientStreamConsumer clientStreamConsumer)
     implements ClientStream<M> {
 
-  ActorFuture<Void> push(final DirectBuffer payload, final ConcurrencyControl executor) {
-    final ActorFuture<Void> result = executor.createFuture();
-    try {
-      clientStreamConsumer.push(payload).whenComplete(result);
-    } catch (final Exception e) {
-      result.completeExceptionally(e);
-    }
-    return result;
+  ActorFuture<Void> push(final DirectBuffer payload) {
+    return clientStreamConsumer.push(payload);
   }
 
   @Override

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -25,7 +26,11 @@ record ClientStreamImpl<M extends BufferWriter>(
     implements ClientStream<M> {
 
   ActorFuture<Void> push(final DirectBuffer payload) {
-    return clientStreamConsumer.push(payload);
+    try {
+      return clientStreamConsumer.push(payload);
+    } catch (final Exception e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
   }
 
   @Override

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
@@ -86,9 +85,7 @@ final class ClientStreamManager<M extends BufferWriter> {
   }
 
   public void onPayloadReceived(
-      final PushStreamRequest pushStreamRequest,
-      final ActorFuture<Void> responseFuture,
-      final ConcurrencyControl executor) {
+      final PushStreamRequest pushStreamRequest, final ActorFuture<Void> responseFuture) {
     final var streamId = pushStreamRequest.streamId();
     final var payload = pushStreamRequest.payload();
 
@@ -105,7 +102,7 @@ final class ClientStreamManager<M extends BufferWriter> {
     clientStream.ifPresentOrElse(
         stream -> {
           try {
-            stream.push(payload, responseFuture, executor);
+            stream.push(payload, responseFuture);
           } catch (final Exception e) {
             responseFuture.completeExceptionally(e);
           }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -66,7 +66,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
               () -> {
                 try {
                   final ActorFuture<Void> payloadPushed = new CompletableActorFuture<>();
-                  clientStreamManager.onPayloadReceived(request, payloadPushed, actor);
+                  clientStreamManager.onPayloadReceived(request, payloadPushed);
                   payloadPushed.onComplete(
                       (ok, error) -> {
                         if (error == null) {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
@@ -36,7 +37,7 @@ import org.junit.jupiter.api.Test;
 class ClientStreamManagerTest {
 
   private static final ClientStreamConsumer NOOP_CONSUMER =
-      p -> CompletableFuture.completedFuture(null);
+      p -> CompletableActorFuture.completed(null);
   private final DirectBuffer streamType = BufferUtil.wrapString("foo");
   private final TestMetadata metadata = new TestMetadata(1);
   private final ClientStreamRegistry<TestMetadata> registry = new ClientStreamRegistry<>();
@@ -47,7 +48,6 @@ class ClientStreamManagerTest {
           registry,
           new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl()),
           metrics);
-  private final TestConcurrencyControl executor = new TestConcurrencyControl();
 
   @BeforeEach
   void setup() {
@@ -216,7 +216,7 @@ class ClientStreamManagerTest {
             metadata,
             directBuffer -> {
               payloadReceived.wrap(directBuffer);
-              return CompletableFuture.completedFuture(null);
+              return CompletableActorFuture.completed(null);
             });
     final var streamId = getServerStreamId(clientStreamId);
 
@@ -224,7 +224,7 @@ class ClientStreamManagerTest {
     final var payloadPushed = BufferUtil.wrapString("data");
     final var request = new PushStreamRequest().streamId(streamId).payload(payloadPushed);
     final var future = new TestActorFuture<Void>();
-    clientStreamManager.onPayloadReceived(request, future, executor);
+    clientStreamManager.onPayloadReceived(request, future);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(100));
@@ -240,7 +240,7 @@ class ClientStreamManagerTest {
     final var payloadPushed = BufferUtil.wrapString("data");
     final var request = new PushStreamRequest().streamId(UUID.randomUUID()).payload(payloadPushed);
     final var future = new TestActorFuture<Void>();
-    clientStreamManager.onPayloadReceived(request, future, executor);
+    clientStreamManager.onPayloadReceived(request, future);
 
     // then
     assertThat(future)
@@ -266,7 +266,7 @@ class ClientStreamManagerTest {
     final var payloadPushed = BufferUtil.wrapString("data");
     final var request = new PushStreamRequest().streamId(streamId).payload(payloadPushed);
     final var future = new TestActorFuture<Void>();
-    clientStreamManager.onPayloadReceived(request, future, executor);
+    clientStreamManager.onPayloadReceived(request, future);
 
     // then
     assertThat(future)

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistryTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistryTest.java
@@ -9,15 +9,15 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.concurrent.CompletableFuture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class ClientStreamRegistryTest {
   private static final ClientStreamConsumer CLIENT_STREAM_CONSUMER =
-      p -> CompletableFuture.completedFuture(null);
+      p -> CompletableActorFuture.completed(null);
 
   private final TestClientStreamMetrics metrics = new TestClientStreamMetrics();
   private final ClientStreamRegistry<TestSerializableData> registry =

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -20,6 +20,7 @@ import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
@@ -40,7 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -108,7 +108,7 @@ final class StreamIntegrationTest {
                   payload.wrap(p, 0, p.capacity());
                   payloads.get().add(payload.data());
                   latch.countDown();
-                  return CompletableFuture.completedFuture(null);
+                  return CompletableActorFuture.completed(null);
                 })
             .join();
     awaitStreamAdded(streamType, streamId, server1, server2);
@@ -131,7 +131,7 @@ final class StreamIntegrationTest {
     final var streamType = BufferUtil.wrapString("foo");
     final var clientStreamId =
         clientStreamer
-            .add(streamType, metadata, p -> CompletableFuture.completedFuture(null))
+            .add(streamType, metadata, p -> CompletableActorFuture.completed(null))
             .join();
     awaitStreamAdded(streamType, clientStreamId, server1, server2);
     final var serverStream = server1.streamer.streamFor(streamType).orElseThrow();
@@ -210,7 +210,7 @@ final class StreamIntegrationTest {
     final var properties = new TestSerializableData();
     final var streamId =
         clientStreamer
-            .add(streamType, properties, p -> CompletableFuture.completedFuture(null))
+            .add(streamType, properties, p -> CompletableActorFuture.completed(null))
             .join();
     awaitStreamAdded(streamType, streamId, server1, server2);
 
@@ -238,7 +238,7 @@ final class StreamIntegrationTest {
       // when
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableFuture.completedFuture(null))
+              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
               .join();
 
       // then
@@ -252,7 +252,7 @@ final class StreamIntegrationTest {
       final var properties = new TestSerializableData();
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableFuture.completedFuture(null))
+              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
               .join();
 
       // must wait until the stream is connected everywhere before removal, as otherwise there is a
@@ -276,7 +276,7 @@ final class StreamIntegrationTest {
       final var properties = new TestSerializableData();
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableFuture.completedFuture(null))
+              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
               .join();
       awaitStreamAdded(streamType, streamId, server1, server2);
 
@@ -300,7 +300,7 @@ final class StreamIntegrationTest {
       client.streamService.onServerRemoved(server1.memberId());
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableFuture.completedFuture(null))
+              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
               .join();
       awaitStreamOnServer(streamType, server2, stream -> assertThat(stream).isPresent());
       awaitStreamOnClient(
@@ -327,7 +327,7 @@ final class StreamIntegrationTest {
               BufferUtil.wrapString("bar"),
               BufferUtil.wrapString("buz"));
       final var properties = new TestSerializableData();
-      final ClientStreamConsumer consumer = p -> CompletableFuture.completedFuture(null);
+      final ClientStreamConsumer consumer = p -> CompletableActorFuture.completed(null);
       streamTypes.forEach(
           streamType -> {
             final var id = clientStreamer.add(streamType, properties, consumer).join();
@@ -353,7 +353,7 @@ final class StreamIntegrationTest {
       final var properties = new TestSerializableData();
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableFuture.completedFuture(null))
+              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
               .join();
       awaitStreamAdded(streamType, streamId, server1, server2);
       server1.close();

--- a/util/src/main/java/io/camunda/zeebe/util/LockUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/LockUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.concurrent.locks.Lock;
+import org.agrona.ErrorHandler;
+
+/** Utility class for common tasks with {@link Lock} instances. */
+public final class LockUtil {
+
+  private static final ErrorHandler IGNORE_ERROR_HANDLER = error -> {};
+
+  private LockUtil() {}
+
+  /**
+   * Runs the given operation only when the lock has been obtained. Locks interruptibly, meaning if
+   * the thread is interrupted while waiting for the lock, the runnable is not executed.
+   *
+   * @param lock the lock to acquire
+   * @param runnable the operation to run
+   */
+  public static void withLock(final Lock lock, final Runnable runnable) {
+    withLock(lock, runnable, IGNORE_ERROR_HANDLER);
+  }
+
+  /**
+   * Runs the given operation only when the lock has been obtained. Locks interruptibly, meaning if
+   * the thread is interrupted while waiting for the lock, the runnable is not executed. If
+   * interrupted, calls the error handler.
+   *
+   * @param lock the lock to acquire
+   * @param runnable the operation to run
+   * @param errorHandler called if an error occurs during interruption
+   */
+  public static void withLock(
+      final Lock lock, final Runnable runnable, final ErrorHandler errorHandler) {
+    try {
+      lock.lockInterruptibly();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      errorHandler.onError(e);
+      return;
+    }
+
+    try {
+      runnable.run();
+    } finally {
+      lock.unlock();
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes concurrent access to the gRPC `StreamObserver` during job push by making each job client stream an actor.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14236 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
