### PR TITLE
Allow exporting forms to elastic-search and opensearch

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -285,6 +285,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.commandDistribution) {
         createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION);
       }
+      if (index.form) {
+        createValueIndexTemplate(ValueType.FORM);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -118,6 +118,8 @@ public class ElasticsearchExporterConfiguration {
         return index.resourceDeletion;
       case COMMAND_DISTRIBUTION:
         return index.commandDistribution;
+      case FORM:
+        return index.form;
       default:
         return false;
     }
@@ -179,6 +181,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean signalSubscription = true;
     public boolean resourceDeletion = true;
     public boolean commandDistribution = true;
+    public boolean form = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -272,6 +275,8 @@ public class ElasticsearchExporterConfiguration {
           + resourceDeletion
           + ", commandDistribution="
           + commandDistribution
+          + ", form="
+          + form
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-form-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-form-template.json
@@ -1,0 +1,53 @@
+{
+  "index_patterns": [
+    "zeebe-record_form_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-form": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "formId": {
+              "type": "keyword"
+            },
+            "version": {
+              "type": "long"
+            },
+            "formKey": {
+              "type": "long"
+            },
+            "resourceName": {
+              "type": "keyword"
+            },
+            "resource": {
+              "enabled": false
+            },
+            "checksum": {
+              "enabled": false
+            },
+            "duplicate": {
+              "type": "boolean"
+            },
+            "tenantId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -78,6 +78,7 @@ final class TestSupport {
       case SIGNAL_SUBSCRIPTION -> config.signalSubscription = value;
       case RESOURCE_DELETION -> config.resourceDeletion = value;
       case COMMAND_DISTRIBUTION -> config.commandDistribution = value;
+      case FORM -> config.form = value;
       default -> throw new IllegalArgumentException(
           "No known indexing configuration option for value type " + valueType);
     }

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -279,6 +279,9 @@ public class OpensearchExporter implements Exporter {
       if (index.commandDistribution) {
         createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION);
       }
+      if (index.form) {
+        createValueIndexTemplate(ValueType.FORM);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -114,6 +114,8 @@ public class OpensearchExporterConfiguration {
         return index.resourceDeletion;
       case COMMAND_DISTRIBUTION:
         return index.commandDistribution;
+      case FORM:
+        return index.form;
       default:
         return false;
     }
@@ -175,6 +177,8 @@ public class OpensearchExporterConfiguration {
     public boolean signalSubscription = true;
     public boolean resourceDeletion = true;
     public boolean commandDistribution = true;
+
+    public boolean form = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -266,6 +270,8 @@ public class OpensearchExporterConfiguration {
           + resourceDeletion
           + ", recordDistribution="
           + commandDistribution
+          + ", form="
+          + form
           + '}';
     }
   }

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-form-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-form-template.json
@@ -1,0 +1,53 @@
+{
+  "index_patterns": [
+    "zeebe-record_form_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-form": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "formId": {
+              "type": "keyword"
+            },
+            "version": {
+              "type": "long"
+            },
+            "formKey": {
+              "type": "long"
+            },
+            "resourceName": {
+              "type": "keyword"
+            },
+            "resource": {
+              "enabled": false
+            },
+            "checksum": {
+              "enabled": false
+            },
+            "duplicate": {
+              "type": "boolean"
+            },
+            "tenantId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -77,6 +77,7 @@ final class TestSupport {
       case SIGNAL_SUBSCRIPTION -> config.signalSubscription = value;
       case RESOURCE_DELETION -> config.resourceDeletion = value;
       case COMMAND_DISTRIBUTION -> config.commandDistribution = value;
+      case FORM -> config.form = value;
       default -> throw new IllegalArgumentException(
           "No known indexing configuration option for value type " + valueType);
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
@@ -74,6 +75,7 @@ import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import java.util.Collections;
@@ -204,6 +206,7 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.PROCESS_INSTANCE_BATCH,
         new Mapping<>(ProcessInstanceBatchRecordValue.class, ProcessInstanceBatchIntent.class));
+    mapping.put(ValueType.FORM, new Mapping<>(Form.class, FormIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/FormIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/FormIntent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum FormIntent implements Intent {
+  CREATED((short) 0);
+
+  private final short value;
+
+  FormIntent(final short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -52,7 +52,8 @@ public interface Intent {
           SignalSubscriptionIntent.class,
           ResourceDeletionIntent.class,
           CommandDistributionIntent.class,
-          ProcessInstanceBatchIntent.class);
+          ProcessInstanceBatchIntent.class,
+          FormIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -123,6 +124,8 @@ public interface Intent {
         return CommandDistributionIntent.from(intent);
       case PROCESS_INSTANCE_BATCH:
         return ProcessInstanceBatchIntent.from(intent);
+      case FORM:
+        return FormIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -190,6 +193,8 @@ public interface Intent {
         return SignalSubscriptionIntent.valueOf(intent);
       case RESOURCE_DELETION:
         return ResourceDeletionIntent.valueOf(intent);
+      case FORM:
+        return FormIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -50,6 +50,7 @@
       <validValue name="COMMAND_DISTRIBUTION">33</validValue>
       <validValue name="PROCESS_INSTANCE_BATCH">34</validValue>
       <validValue name="MESSAGE_BATCH">35</validValue>
+      <validValue name="FORM">36</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR allow exporting forms into elastic-search and opensearch. A new index `zeebe-record_form_*` will be created, that stores all the deployed forms

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14136 
closes #14222 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
