### PR TITLE
[Backport stable/8.2] refactor: arch-agnostic Dockerfile

### DIFF
--- a/docker/test/verify.sh
+++ b/docker/test/verify.sh
@@ -56,11 +56,11 @@ if [ "$actualArchitecture" != "\"$arch\"" ]; then
   exit 1
 fi
 
-DIGEST_REGEX="BASE_DIGEST_$(echo "$arch" | tr '[:lower:]' '[:upper:]')=\"(sha256\:[a-f0-9\:]+)\""
+DIGEST_REGEX="BASE_DIGEST=\"(sha256\:[a-f0-9\:]+)\""
 DOCKERFILE=$(<"${BASH_SOURCE%/*}/../../Dockerfile")
 if [[ $DOCKERFILE =~ $DIGEST_REGEX ]]; then
     DIGEST="${BASH_REMATCH[1]}"
-    echo "Digest found for architecture $arch: $DIGEST"
+    echo "Digest found: $DIGEST"
 else
     echo >&2 "Docker image digest can not be found in the Dockerfile"
     exit 1


### PR DESCRIPTION
## Description

Refactors the `Dockerfile` to be architecture/platform agnostic. Since images have a general digests, separate from their platform-specific digests, we can simply target that one. When building that image on the specific platform (or even cross-building) the appropriate image will be selected anyway, so we don't need to keep track of platform specific digests.

One caveat is that it seems the ARM64 JDK image fails to build a custom JRE without specifying a different process launching mechanism. It's a bit unclear to me why, but apparently it's not an uncommon problem, and the simplest option is to change the launch mechanism. Naja, not perfect, but works.

(cherry picked from commit 82d1f59863089d8fc82c4fd9e69a5f2a3d396c48)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
