### PR TITLE
Add test standalone restore application and basic scaffolding

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsRestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsRestoreAcceptanceIT.java
@@ -8,16 +8,22 @@
 package io.camunda.zeebe.it.backup;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import com.google.cloud.storage.BucketInfo;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.testcontainers.GcsContainer;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.restore.BackupNotFoundException;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.StateCode;
 import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
@@ -29,11 +35,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.ContainerLaunchException;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -73,10 +76,10 @@ final class GcsRestoreAcceptanceIT {
 
   @Test
   void shouldFailForNonExistingBackup() {
-    // then -- restore container exits with an error code
-    // we can't check the exit code directly, but we can observe that testcontainers was unable
-    // to start the container.
-    assertThatExceptionOfType(ContainerLaunchException.class).isThrownBy(() -> restoreBackup(1234));
+    // then -- restore application exits with an error code
+    assertThatCode(() -> restoreBackup(1234))
+        .isInstanceOf(IllegalStateException.class)
+        .hasRootCauseExactlyInstanceOf(BackupNotFoundException.class);
   }
 
   private void takeBackup(final long backupId) {
@@ -117,21 +120,22 @@ final class GcsRestoreAcceptanceIT {
   }
 
   private void restoreBackup(final long backupId) {
-    try (final var restore =
-        new GenericContainer<>(ZeebeTestContainerDefaults.defaultTestImage())
-            .withLogConsumer(new Slf4jLogConsumer(LOG))
-            .withNetwork(NETWORK)
-            .dependsOn(GCS)
-            .withStartupAttempts(1)
-            .withStartupCheckStrategy(
-                new OneShotStartupCheckStrategy().withTimeout(Duration.ofMinutes(1)))
-            .withEnv("ZEEBE_RESTORE", "true")
-            .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "GCS")
-            .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_BUCKETNAME", BUCKET_NAME)
-            .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_AUTH", "none")
-            .withEnv("ZEEBE_BROKER_DATA_BACKUP_GCS_HOST", GCS.internalEndpoint())
-            .withEnv("ZEEBE_RESTORE_FROM_BACKUP_ID", String.valueOf(backupId))) {
-      restore.start();
-    }
+    final var restore =
+        new TestRestoreApp()
+            .withBrokerConfig(this::configureBackupStore)
+            .withBackupId(backupId)
+            .start();
+    restore.close();
+  }
+
+  private void configureBackupStore(final BrokerCfg cfg) {
+    final var backup = cfg.getData().getBackup();
+    backup.setStore(BackupStoreType.GCS);
+
+    final var config = new GcsBackupStoreConfig();
+    config.setAuth(GcsBackupStoreAuth.NONE);
+    config.setBucketName(BUCKET_NAME);
+    config.setHost(GCS.externalEndpoint());
+    backup.setGcs(config);
   }
 }

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -126,5 +126,30 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -122,5 +122,9 @@
       <artifactId>zeebe-scheduler</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+public interface TestApplication<T extends TestApplication<T>> extends AutoCloseable {
+
+  /** Starts the node in a blocking fashion. */
+  T start();
+
+  /** Attempts to stop the container gracefully in a blocking fashion. */
+  T stop();
+
+  /** Returns whether the underlying application is started yet; does not include any probes */
+  boolean isStarted();
+
+  @Override
+  default void close() {
+    //noinspection resource
+    stop();
+  }
+
+  /** Convenience method to return the appropriate concrete type */
+  T self();
+
+  /**
+   * When the underlying application is started, all beans of the given type will resolve to the
+   * given value. The qualifier is useful for cases where more than one beans of the same type are
+   * defined with different qualifiers.
+   *
+   * @param qualifier the bean name/qualifier
+   * @param bean the object to inject as the bean value
+   * @param type the type to be resolved/autowired
+   * @return itself for chaining
+   * @param <V> the bean type
+   */
+  <V> T withBean(final String qualifier, final V bean, final Class<V> type);
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.restore.RestoreApp;
+import io.camunda.zeebe.shared.Profile;
+import java.util.function.Consumer;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+/** Represents an instance of the {@link RestoreApp} Spring application. */
+public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> {
+  private final BrokerCfg config;
+  private long backupId;
+
+  public TestRestoreApp() {
+    this(new BrokerCfg());
+  }
+
+  public TestRestoreApp(final BrokerCfg config) {
+    super(RestoreApp.class);
+    this.config = config;
+
+    //noinspection resource
+    withBean("config", config, BrokerCfg.class);
+  }
+
+  @Override
+  public TestRestoreApp self() {
+    return this;
+  }
+
+  @Override
+  protected String[] commandLineArgs() {
+    return new String[] {"--backupId=" + backupId};
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringBuilder() {
+    return super.createSpringBuilder().profiles(Profile.RESTORE.getId());
+  }
+
+  public TestRestoreApp withBrokerConfig(final Consumer<BrokerCfg> modifier) {
+    modifier.accept(config);
+    return this;
+  }
+
+  public TestRestoreApp withBackupId(final long backupId) {
+    this.backupId = backupId;
+    return this;
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -11,12 +11,13 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.restore.RestoreApp;
 import io.camunda.zeebe.shared.Profile;
 import java.util.function.Consumer;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
 /** Represents an instance of the {@link RestoreApp} Spring application. */
 public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> {
   private final BrokerCfg config;
-  private long backupId;
+  private Long backupId;
 
   public TestRestoreApp() {
     this(new BrokerCfg());
@@ -37,12 +38,14 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
 
   @Override
   protected String[] commandLineArgs() {
-    return new String[] {"--backupId=" + backupId};
+    return backupId == null ? super.commandLineArgs() : new String[] {"--backupId=" + backupId};
   }
 
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
-    return super.createSpringBuilder().profiles(Profile.RESTORE.getId());
+    return super.createSpringBuilder()
+        .web(WebApplicationType.NONE)
+        .profiles(Profile.RESTORE.getId());
   }
 
   public TestRestoreApp withBrokerConfig(final Consumer<BrokerCfg> modifier) {

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -43,6 +43,11 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     if (!propertyOverrides.containsKey("server.port")) {
       propertyOverrides.put("server.port", SocketUtil.getNextAddress().getPort());
     }
+
+    if (!beans.containsKey("collectorRegistry")) {
+      beans.put(
+          "collectorRegistry", new Bean<>(new RelaxedCollectorRegistry(), CollectorRegistry.class));
+    }
   }
 
   @Override
@@ -85,11 +90,6 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
    * can override this to customize the behavior of the test application.
    */
   protected SpringApplicationBuilder createSpringBuilder() {
-    if (!beans.containsKey("collectorRegistry")) {
-      beans.put(
-          "collectorRegistry", new Bean<>(new RelaxedCollectorRegistry(), CollectorRegistry.class));
-    }
-
     return MainSupport.createDefaultApplicationBuilder()
         .bannerMode(Mode.OFF)
         .lazyInitialization(true)

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer;
+import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer.Bean;
+import io.camunda.zeebe.qa.util.cluster.util.RelaxedCollectorRegistry;
+import io.camunda.zeebe.shared.MainSupport;
+import io.camunda.zeebe.shared.Profile;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.prometheus.client.CollectorRegistry;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.Banner.Mode;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+abstract class TestSpringApplication<T extends TestSpringApplication<T>>
+    implements TestApplication<T> {
+  private final Class<?> springApplication;
+  private final Map<String, Bean<?>> beans;
+  private final Map<String, Object> propertyOverrides;
+
+  private ConfigurableApplicationContext springContext;
+
+  public TestSpringApplication(final Class<?> springApplication) {
+    this(springApplication, new HashMap<>(), new HashMap<>());
+  }
+
+  private TestSpringApplication(
+      final Class<?> springApplication,
+      final Map<String, Bean<?>> beans,
+      final Map<String, Object> propertyOverrides) {
+    this.springApplication = springApplication;
+    this.beans = beans;
+    this.propertyOverrides = propertyOverrides;
+
+    if (!propertyOverrides.containsKey("server.port")) {
+      propertyOverrides.put("server.port", SocketUtil.getNextAddress().getPort());
+    }
+  }
+
+  @Override
+  public T start() {
+    if (!isStarted()) {
+      springContext = createSpringBuilder().run(commandLineArgs());
+    }
+
+    return self();
+  }
+
+  @Override
+  public T stop() {
+    if (springContext != null) {
+      springContext.close();
+      springContext = null;
+    }
+
+    return self();
+  }
+
+  @Override
+  public boolean isStarted() {
+    return springContext != null && springContext.isActive();
+  }
+
+  @Override
+  public <V> T withBean(final String qualifier, final V bean, final Class<V> type) {
+    beans.put(qualifier, new Bean<>(bean, type));
+    return self();
+  }
+
+  /** Returns the command line arguments that will be passed when the application is started. */
+  protected String[] commandLineArgs() {
+    return new String[0];
+  }
+
+  /**
+   * Returns a builder which can be modified to enable more profiles, inject beans, etc. Sub-classes
+   * can override this to customize the behavior of the test application.
+   */
+  protected SpringApplicationBuilder createSpringBuilder() {
+    if (!beans.containsKey("collectorRegistry")) {
+      beans.put(
+          "collectorRegistry", new Bean<>(new RelaxedCollectorRegistry(), CollectorRegistry.class));
+    }
+
+    return MainSupport.createDefaultApplicationBuilder()
+        .bannerMode(Mode.OFF)
+        .lazyInitialization(true)
+        .registerShutdownHook(false)
+        .initializers(new ContextOverrideInitializer(beans, propertyOverrides))
+        .profiles(Profile.TEST.getId())
+        .sources(springApplication);
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/util/ContextOverrideInitializer.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/util/ContextOverrideInitializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster.util;
+
+import java.util.Map;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * Context initializers are called before beans are resolved/autowired, and allows us to prepare the
+ * context, so to speak. That way, we can pre-register some beans so they will be autowired first,
+ * e.g. programmatic configuration.
+ */
+public final class ContextOverrideInitializer
+    implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+  private final Map<String, Bean<?>> beans;
+  private final Map<String, Object> properties;
+
+  public ContextOverrideInitializer(
+      final Map<String, Bean<?>> beans, final Map<String, Object> properties) {
+    this.beans = beans;
+    this.properties = properties;
+  }
+
+  @Override
+  public void initialize(final ConfigurableApplicationContext applicationContext) {
+    final var environment = applicationContext.getEnvironment();
+    final var sources = environment.getPropertySources();
+    final var beanFactory = applicationContext.getBeanFactory();
+
+    beans.forEach((qualifier, bean) -> overrideBean(beanFactory, qualifier, bean.value, bean.type));
+
+    sources.addFirst(new MapPropertySource("test properties", properties));
+  }
+
+  private void overrideBean(
+      final ConfigurableListableBeanFactory beanFactory,
+      final String qualifier,
+      final Object object,
+      final Class<?> type) {
+    if (object == null) {
+      return;
+    }
+
+    beanFactory.registerResolvableDependency(type, object);
+    beanFactory.registerSingleton(qualifier, object);
+  }
+
+  public record Bean<T>(T value, Class<T> type) {}
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/util/RelaxedCollectorRegistry.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/util/RelaxedCollectorRegistry.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster.util;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+
+/** A {@link CollectorRegistry} which silently ignores duplicate metric registration. */
+public final class RelaxedCollectorRegistry extends CollectorRegistry {
+
+  @Override
+  public void register(final Collector m) {
+    try {
+      super.register(m);
+    } catch (final IllegalArgumentException ignored) {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a way to start/stop a standalone `RestoreApp`, along with basic scaffolding to expand this to other standalone applications (broker, gateway, etc.).

There are three layers:

1. `TestApplication`, which will be a common interface type for all standalone applications.
1. `TestSpringApplication`, an abstract application which encapsulates some common Spring logic, such as setting a random monitoring port, injecting configuration beans, allow registering multiple times the same metric, etc.
1. `TestRestoreApp`, the actual wrapper around the `RestoreApp` standalone application.

The scaffolding will be expanded in future issues with more functionality pertaining to gateways and brokers (e.g. await complete topology, await asynchronous start, probe specific health indicators, etc.)

In lieu of tests, I refactored the `GcsRestoreAcceptanceIT` and `S3RestoreAcceptanceIT` test classes to use the new application. You'll notice we can now properly assert the exception on failure :slightly_smiling_face: 

One additional thing: the original issue #13966 mentioned already all the functionality the base Spring class should do. I opted against adding this here. This cuts down on the PR size, and also on extraneous functionality that isn't obviously useful until it's in use. Instead, I propose we expand the base class as we go along.

## Related issues

closes #13967
closes #13966

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
