### PR TITLE
Add `zeebe.gateway.multiTenancy.enabled` feature flag

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -104,7 +104,7 @@
         # Enables multi tenancy for the gateway.
         # When enabled, the gateway enhances requests with the authorized tenant ids of the requester.
         # It also rejects requests that specify a tenant id that the requester is not authorized to access.
-        # When disabled, the gateway enhances requests with the default tenant id.
+        # When disabled, the gateway enhances requests with the default tenant id '<default>'.
         #
         # The authorized tenants are retrieved from the configured tenant authorization provider.
         # For now, only Identity is supported as tenant authorization provider.

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -100,6 +100,19 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_LONGPOLLING_ENABLED.
         # enabled: true
 
+      # multiTenancy:
+        # Enables multi tenancy for the gateway.
+        # When enabled, the gateway enhances requests with the authorized tenant ids of the requester.
+        # It also rejects requests that specify a tenant id that the requester is not authorized to access.
+        # When disabled, the gateway enhances requests with the default tenant id.
+        #
+        # The authorized tenants are retrieved from the configured tenant authorization provider.
+        # For now, only Identity is supported as tenant authorization provider.
+        # It is used when ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE is set to 'identity'.
+        #
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED.
+        enabled: false
+
       # interceptors:
         # Configure interceptors below.
         # Please consider reading our documentation on interceptors first.

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -224,6 +224,19 @@
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_LONGPOLLING_ENABLED.
       # enabled: true
 
+    # multiTenancy:
+      # Enables multi tenancy for the gateway.
+      # When enabled, the gateway enhances requests with the authorized tenant ids of the requester.
+      # It also rejects requests that specify a tenant id that the requester is not authorized to access.
+      # When disabled, the gateway enhances requests with the default tenant id.
+      #
+      # The authorized tenants are retrieved from the configured tenant authorization provider.
+      # For now, only Identity is supported as tenant authorization provider.
+      # It is used when ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE is set to 'identity'.
+      #
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MULTITENANCY_ENABLED.
+      enabled: false
+
     # interceptors:
       # Configure interceptors below.
       # Please consider reading our documentation on interceptors first.

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -228,7 +228,7 @@
       # Enables multi tenancy for the gateway.
       # When enabled, the gateway enhances requests with the authorized tenant ids of the requester.
       # It also rejects requests that specify a tenant id that the requester is not authorized to access.
-      # When disabled, the gateway enhances requests with the default tenant id.
+      # When disabled, the gateway enhances requests with the default tenant id '<default>'.
       #
       # The authorized tenants are retrieved from the configured tenant authorization provider.
       # For now, only Identity is supported as tenant authorization provider.

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.gateway.impl.broker.RequestRetryHandler;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.stream.ClientStreamAdapter;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
@@ -76,18 +77,22 @@ public final class EndpointManager {
   private final ActivateJobsHandler activateJobsHandler;
   private final RequestRetryHandler requestRetryHandler;
   private final ClientStreamAdapter clientStreamAdapter;
+  private final MultiTenancyCfg multiTenancy;
 
   public EndpointManager(
       final BrokerClient brokerClient,
       final ActivateJobsHandler activateJobsHandler,
       final ClientStreamer<JobActivationProperties> jobStreamer,
-      final Executor executor) {
+      final Executor executor,
+      final MultiTenancyCfg multiTenancy) {
     this.brokerClient = brokerClient;
     this.activateJobsHandler = activateJobsHandler;
 
     clientStreamAdapter = new ClientStreamAdapter(jobStreamer, executor);
     topologyManager = brokerClient.getTopologyManager();
     requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
+    this.multiTenancy = multiTenancy;
+    RequestMapper.setMultiTenancyEnabled(multiTenancy.isEnabled());
   }
 
   private void addBrokerInfo(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.gateway.health.impl.GatewayHealthManagerImpl;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg.AuthMode;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
@@ -120,13 +121,16 @@ public final class Gateway implements CloseableSilently {
   }
 
   private Server createServer(final ActivateJobsHandler activateJobsHandler) {
+    final NetworkCfg network = gatewayCfg.getNetwork();
+    final MultiTenancyCfg multiTenancy = gatewayCfg.getMultiTenancy();
 
-    final var serverBuilder = applyNetworkConfig(gatewayCfg.getNetwork());
+    final var serverBuilder = applyNetworkConfig(network);
     applyExecutorConfiguration(serverBuilder);
     applySecurityConfiguration(serverBuilder);
 
     final var endpointManager =
-        new EndpointManager(brokerClient, activateJobsHandler, jobStreamer, grpcExecutor);
+        new EndpointManager(
+            brokerClient, activateJobsHandler, jobStreamer, grpcExecutor, multiTenancy);
     final var gatewayGrpcService = new GatewayGrpcService(endpointManager);
     return buildServer(serverBuilder, gatewayGrpcService);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfg.java
@@ -27,6 +27,7 @@ public class GatewayCfg {
   private SecurityCfg security = new SecurityCfg();
   private LongPollingCfg longPolling = new LongPollingCfg();
   private List<InterceptorCfg> interceptors = new ArrayList<>();
+  private MultiTenancyCfg multiTenancy = new MultiTenancyCfg();
 
   public void init() {
     init(ConfigurationDefaults.DEFAULT_HOST);
@@ -89,43 +90,51 @@ public class GatewayCfg {
     this.interceptors = interceptors;
   }
 
+  public MultiTenancyCfg getMultiTenancy() {
+    return multiTenancy;
+  }
+
+  public void setMultiTenancy(final MultiTenancyCfg multiTenancy) {
+    this.multiTenancy = multiTenancy;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(network, cluster, threads, security, longPolling, interceptors);
+    return Objects.hash(
+        network, cluster, threads, security, longPolling, interceptors, multiTenancy);
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
     final GatewayCfg that = (GatewayCfg) o;
     return Objects.equals(network, that.network)
         && Objects.equals(cluster, that.cluster)
         && Objects.equals(threads, that.threads)
         && Objects.equals(security, that.security)
         && Objects.equals(longPolling, that.longPolling)
-        && Objects.equals(interceptors, that.interceptors);
+        && Objects.equals(interceptors, that.interceptors)
+        && Objects.equals(multiTenancy, that.multiTenancy);
   }
 
   @Override
   public String toString() {
     return "GatewayCfg{"
-        + "networkCfg="
+        + "network="
         + network
-        + ", clusterCfg="
+        + ", cluster="
         + cluster
-        + ", threadsCfg="
+        + ", threads="
         + threads
-        + ", securityCfg="
+        + ", security="
         + security
-        + ", longPollingCfg="
+        + ", longPolling="
         + longPolling
         + ", interceptors="
         + interceptors
+        + ", multiTenancy="
+        + multiTenancy
         + '}';
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfg.java
@@ -106,8 +106,12 @@ public class GatewayCfg {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     final GatewayCfg that = (GatewayCfg) o;
     return Objects.equals(network, that.network)
         && Objects.equals(cluster, that.cluster)

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/MultiTenancyCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/MultiTenancyCfg.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.configuration;
+
+import java.util.Objects;
+
+public class MultiTenancyCfg {
+
+  private boolean enabled = false;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public MultiTenancyCfg setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final MultiTenancyCfg that = (MultiTenancyCfg) o;
+    return enabled == that.enabled;
+  }
+
+  @Override
+  public String toString() {
+    return "MultiTenancyCfg{" + "enabled=" + enabled + '}';
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/MultiTenancyCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/MultiTenancyCfg.java
@@ -29,8 +29,12 @@ public class MultiTenancyCfg {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     final MultiTenancyCfg that = (MultiTenancyCfg) o;
     return enabled == that.enabled;
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.gateway.EndpointManager;
 import io.camunda.zeebe.gateway.GatewayGrpcService;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
@@ -68,7 +69,8 @@ public final class StubbedGateway {
     submitActorToActivateJobs(activateJobsHandler);
 
     final EndpointManager endpointManager =
-        new EndpointManager(brokerClient, activateJobsHandler, jobStreamer, Runnable::run);
+        new EndpointManager(
+            brokerClient, activateJobsHandler, jobStreamer, Runnable::run, new MultiTenancyCfg());
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
 
     final InProcessServerBuilder serverBuilder =

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTenantTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTenantTest.java
@@ -59,7 +59,8 @@ public class GrpcErrorMapperTenantTest {
     // given
     final String requestName = "DeployResource";
     try {
-      RequestMapper.ensureTenantIdSet(requestName, invalidTenantId, multiTenancyEnabled);
+      RequestMapper.setMultiTenancyEnabled(multiTenancyEnabled);
+      RequestMapper.ensureTenantIdSet(requestName, invalidTenantId);
       fail("Expected to throw exception");
     } catch (final RuntimeException exception) {
       assertThat(exception).isInstanceOf(InvalidTenantRequestException.class);
@@ -82,12 +83,13 @@ public class GrpcErrorMapperTenantTest {
   @ParameterizedTest
   @MethodSource("validTenantIds")
   void shouldNotLogInvalidTenantRequestException(
-      final String invalidTenantId, final boolean multiTenancyEnabled) {
+      final String validTenantId, final boolean multiTenancyEnabled) {
     // given
     final String requestName = "DeployResource";
 
     // when
-    RequestMapper.ensureTenantIdSet(requestName, invalidTenantId, multiTenancyEnabled);
+    RequestMapper.setMultiTenancyEnabled(multiTenancyEnabled);
+    RequestMapper.ensureTenantIdSet(requestName, validTenantId);
 
     // then
     assertThat(recorder.getAppendedEvents()).hasSize(0);

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -49,6 +49,7 @@ public final class GatewayCfgTest {
         .setPrivateKeyPath(new File("privateKeyPath"));
     CUSTOM_CFG.getThreads().setManagementThreads(100);
     CUSTOM_CFG.getLongPolling().setEnabled(false);
+    CUSTOM_CFG.getMultiTenancy().setEnabled(true);
     CUSTOM_CFG.getInterceptors().add(new InterceptorCfg());
     CUSTOM_CFG.getInterceptors().get(0).setId("example");
     CUSTOM_CFG.getInterceptors().get(0).setClassName("io.camunda.zeebe.example.Interceptor");
@@ -136,6 +137,7 @@ public final class GatewayCfgTest {
             .getPath());
     setEnv("zeebe.gateway.network.minKeepAliveInterval", Duration.ofSeconds(30).toString());
     setEnv("zeebe.gateway.longPolling.enabled", String.valueOf(true));
+    setEnv("zeebe.gateway.multiTenancy.enabled", String.valueOf(false));
     setEnv("zeebe.gateway.interceptors.0.id", "overwritten");
     setEnv("zeebe.gateway.interceptors.0.className", "Overwritten");
     setEnv("zeebe.gateway.interceptors.0.jarPath", "./overwritten.jar");
@@ -165,6 +167,7 @@ public final class GatewayCfgTest {
             new File(
                 getClass().getClassLoader().getResource("security/test-chain.cert.pem").getPath()));
     expected.getLongPolling().setEnabled(true);
+    expected.getMultiTenancy().setEnabled(false);
 
     expected.getInterceptors().add(new InterceptorCfg());
     expected.getInterceptors().get(0).setId("overwritten");

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -135,6 +135,7 @@ public final class GatewayCfgTest {
             .getResource("security/test-chain.cert.pem")
             .getPath());
     setEnv("zeebe.gateway.network.minKeepAliveInterval", Duration.ofSeconds(30).toString());
+    setEnv("zeebe.gateway.longPolling.enabled", String.valueOf(true));
     setEnv("zeebe.gateway.interceptors.0.id", "overwritten");
     setEnv("zeebe.gateway.interceptors.0.className", "Overwritten");
     setEnv("zeebe.gateway.interceptors.0.jarPath", "./overwritten.jar");
@@ -163,7 +164,7 @@ public final class GatewayCfgTest {
         .setCertificateChainPath(
             new File(
                 getClass().getClassLoader().getResource("security/test-chain.cert.pem").getPath()));
-    expected.getLongPolling().setEnabled(false);
+    expected.getLongPolling().setEnabled(true);
 
     expected.getInterceptors().add(new InterceptorCfg());
     expected.getInterceptors().get(0).setId("overwritten");

--- a/gateway/src/test/resources/configuration/gateway.custom.yaml
+++ b/gateway/src/test/resources/configuration/gateway.custom.yaml
@@ -31,6 +31,9 @@ zeebe:
     longPolling:
       enabled: false
 
+    multiTenancy:
+      enabled: true
+
     interceptors:
       - id: example
         className: io.camunda.zeebe.example.Interceptor

--- a/gateway/src/test/resources/configuration/gateway.default.yaml
+++ b/gateway/src/test/resources/configuration/gateway.default.yaml
@@ -118,3 +118,16 @@
 # Enables long polling for available jobs
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_LONGPOLLING_ENABLED.
 # enabled: true
+
+# multiTenancy:
+# Enables multi tenancy for the gateway.
+# When enabled, the gateway enhances requests with the authorized tenant ids of the requester.
+# It also rejects requests that specify a tenant id that the requester is not authorized to access.
+# When disabled, the gateway enhances requests with the default tenant id.
+#
+# The authorized tenants are retrieved from the configured tenant authorization provider.
+# For now, only Identity is supported as tenant authorization provider.
+# It is used when ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE is set to 'identity'.
+#
+# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MULTITENANCY_ENABLED.
+# enabled: false

--- a/gateway/src/test/resources/configuration/gateway.default.yaml
+++ b/gateway/src/test/resources/configuration/gateway.default.yaml
@@ -123,7 +123,7 @@
 # Enables multi tenancy for the gateway.
 # When enabled, the gateway enhances requests with the authorized tenant ids of the requester.
 # It also rejects requests that specify a tenant id that the requester is not authorized to access.
-# When disabled, the gateway enhances requests with the default tenant id.
+# When disabled, the gateway enhances requests with the default tenant id '<default>'.
 #
 # The authorized tenants are retrieved from the configured tenant authorization provider.
 # For now, only Identity is supported as tenant authorization provider.


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds a flag `zeebe.gateway.multiTenancy.enabled` (default: `false`) that can be used to enable or disable multi-tenancy in the gateway.

At the time of writing, this flag has no effect yet. In the future, this flag enables several gateway responsibilities:
- Retrieve the authorized tenants using the request's Authorization header either from Identity or another authorized tenant provider
- Reject the request when it refers to a tenant id that the requester is not authorized for
- Encode the authorized tenants in a JWT stored in the Authorization property of the broker request

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14041 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
