### PR TITLE
Use IdentityInterceptor in Gateway tests

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -53,14 +53,14 @@ import org.slf4j.LoggerFactory;
  */
 @ThreadSafe
 public final class OAuthCredentialsProvider implements CredentialsProvider {
+  public static final Key<String> HEADER_AUTH_KEY =
+      Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
   private static final ObjectMapper JSON_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   private static final ObjectReader CREDENTIALS_READER =
       JSON_MAPPER.readerFor(ZeebeClientCredentials.class);
   private static final Logger LOG = LoggerFactory.getLogger(OAuthCredentialsProvider.class);
-  private static final Key<String> HEADER_AUTH_KEY =
-      Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
-
   private final URL authorizationServerUrl;
   private final String payload;
   private final String endpoint;

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -30,7 +30,7 @@ public final class IdentityInterceptor implements ServerInterceptor {
     this(createIdentity(config));
   }
 
-  IdentityInterceptor(final Identity identity) {
+  public IdentityInterceptor(final Identity identity) {
     this.identity = identity;
   }
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayTest.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,15 +32,28 @@ public abstract class GatewayTest {
   protected StubbedBrokerClient brokerClient;
   protected StubbedJobStreamer jobStreamer;
 
-  public GatewayTest() {
-    this(new GatewayCfg());
-  }
-
   public GatewayTest(final GatewayCfg config) {
     actorClock = new ControlledActorClock();
     actorSchedulerRule = new ActorSchedulerRule(actorClock);
     gatewayRule = new StubbedGatewayRule(actorSchedulerRule, config);
     ruleChain = RuleChain.outerRule(actorSchedulerRule).around(gatewayRule);
+  }
+
+  public GatewayTest() {
+    this(new GatewayCfg());
+  }
+
+  private GatewayTest(final Supplier<GatewayCfg> configSupplier) {
+    this(configSupplier.get());
+  }
+
+  public GatewayTest(final Consumer<GatewayCfg> modifier) {
+    this(
+        () -> {
+          final GatewayCfg config = new GatewayCfg();
+          modifier.accept(config);
+          return config;
+        });
   }
 
   @Before

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.gateway.EndpointManager;
 import io.camunda.zeebe.gateway.GatewayGrpcService;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
-import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
@@ -70,7 +69,11 @@ public final class StubbedGateway {
 
     final EndpointManager endpointManager =
         new EndpointManager(
-            brokerClient, activateJobsHandler, jobStreamer, Runnable::run, new MultiTenancyCfg());
+            brokerClient,
+            activateJobsHandler,
+            jobStreamer,
+            Runnable::run,
+            config.getMultiTenancy());
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
 
     final InProcessServerBuilder serverBuilder =

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -217,7 +217,7 @@ public final class StubbedGateway {
 
   private record StubbedClientStreamId(UUID serverStreamId) implements ClientStreamId {}
 
-  private static class FakeOAuthCallCredentials extends CallCredentials {
+  private static final class FakeOAuthCallCredentials extends CallCredentials {
 
     /** Can be adjusted to test different token values. */
     private String token = "token";


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This pull request attempts to improve the testability of the gateway. We need this in our future efforts to add multi-tenancy support to the gateway.

It focuses on running the IdentityInterceptor in GatewayTests. The IdentityInterceptor will play a large role for multi-tenancy in the gateway. No additional test cases are added, but many tests now use this interceptor where they did not previously.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #13237

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
