### PR TITLE
Enhance requests with authorized tenants

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -60,6 +60,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-auth</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.msgpack</groupId>
       <artifactId>msgpack-core</artifactId>
       <scope>test</scope>

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -300,7 +300,9 @@ public final class Gateway implements CloseableSilently {
     interceptors.add(MONITORING_SERVER_INTERCEPTOR);
     if (AuthMode.IDENTITY == gatewayCfg.getSecurity().getAuthentication().getMode()) {
       interceptors.add(
-          new IdentityInterceptor(gatewayCfg.getSecurity().getAuthentication().getIdentity()));
+          new IdentityInterceptor(
+              gatewayCfg.getSecurity().getAuthentication().getIdentity(),
+              gatewayCfg.getMultiTenancy()));
     }
 
     return ServerInterceptors.intercept(service, interceptors);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExecuteCommand.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExecuteCommand.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.gateway.impl.broker.response.BrokerRejection;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerRejectionResponse;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo.AuthDataFormat;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandRequest;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandResponse;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder;
@@ -56,6 +57,12 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
   @Override
   public void setPartitionId(final int partitionId) {
     request.setPartitionId(partitionId);
+  }
+
+  @Override
+  public void setAuthorization(final String authorizationToken) {
+    request.setAuthorization(
+        new AuthInfo().setFormatProp(AuthDataFormat.JWT).setAuthData(authorizationToken));
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExecuteCommand.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExecuteCommand.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.gateway.cmd.UnsupportedBrokerResponseException;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerRejection;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerRejectionResponse;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandRequest;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandResponse;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder;
@@ -104,6 +105,10 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
   @Override
   public RequestType getRequestType() {
     return RequestType.COMMAND;
+  }
+
+  public AuthInfo getAuthorization() {
+    return request.getAuthorization();
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerRequest.java
@@ -43,6 +43,10 @@ public abstract class BrokerRequest<T> implements ClientRequest {
 
   public abstract void setPartitionId(int partitionId);
 
+  public void setAuthorization(final String authorizationToken) {
+    // Unsupported by default
+  }
+
   public abstract boolean addressesSpecificPartition();
 
   public abstract boolean requiresPartitionId();

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -11,6 +11,7 @@ import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.identity.sdk.authentication.exception.TokenVerificationException;
 import io.camunda.zeebe.gateway.impl.configuration.IdentityCfg;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -25,13 +26,15 @@ public final class IdentityInterceptor implements ServerInterceptor {
       Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
 
   private final Identity identity;
+  private final MultiTenancyCfg multiTenancy;
 
-  public IdentityInterceptor(final IdentityCfg config) {
-    this(createIdentity(config));
+  public IdentityInterceptor(final IdentityCfg config, final MultiTenancyCfg multiTenancy) {
+    this(createIdentity(config), multiTenancy);
   }
 
-  public IdentityInterceptor(final Identity identity) {
+  public IdentityInterceptor(final Identity identity, final MultiTenancyCfg multiTenancy) {
     this.identity = identity;
+    this.multiTenancy = multiTenancy;
   }
 
   private static Identity createIdentity(final IdentityCfg config) {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/AuthorizedTenantsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/AuthorizedTenantsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import io.camunda.identity.sdk.tenants.dto.Tenant;
+import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AuthorizedTenantsTest extends GatewayTest {
+
+  public AuthorizedTenantsTest() {
+    super(cfg -> cfg.getMultiTenancy().setEnabled(true));
+  }
+
+  @Before
+  public void setup() {
+    final FakeRequestStub stub = new FakeRequestStub();
+    stub.registerWith(brokerClient);
+  }
+
+  @Test
+  public void brokerRequestsShouldContainAuthorizedTenants() {
+    // given
+    when(gateway.getIdentityMock().tenants().forToken(anyString()))
+        .thenReturn(List.of(new Tenant("tenant-a", "A"), new Tenant("tenant-b", "B")));
+
+    // when
+    final DeployResourceResponse response =
+        client.deployResource(DeployResourceRequest.newBuilder().setTenantId("tenant-b").build());
+    assertThat(response).isNotNull();
+
+    // then
+    final BrokerDeployResourceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getAuthorization().toDecodedMap())
+        .hasEntrySatisfying(
+            Authorization.AUTHORIZED_TENANTS,
+            v -> assertThat(v).asList().contains("tenant-a", "tenant-b"));
+  }
+
+  public static final class FakeRequestStub
+      implements RequestStub<BrokerDeployResourceRequest, BrokerResponse<DeploymentRecord>> {
+
+    @Override
+    public void registerWith(final StubbedBrokerClient gateway) {
+      gateway.registerHandler(BrokerDeployResourceRequest.class, this);
+    }
+
+    @Override
+    public BrokerResponse<DeploymentRecord> handle(final BrokerDeployResourceRequest request)
+        throws Exception {
+      final DeploymentRecord deploymentRecord = request.getRequestWriter();
+      return new BrokerResponse<>(deploymentRecord, 0, 123);
+    }
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
@@ -48,6 +49,18 @@ public class MultiTenancyDisabledTest extends GatewayTest {
         .hasEntrySatisfying(
             Authorization.AUTHORIZED_TENANTS,
             v -> assertThat(v).asList().contains(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+  }
+
+  @Test
+  public void deployResourceRequestRejectsTenantId() {
+    // given
+    final var request = DeployResourceRequest.newBuilder().setTenantId("tenant-a").build();
+
+    // when/then
+    assertThatThrownBy(() -> client.deployResource(request))
+        .hasMessageContaining(
+            "Expected to handle gRPC request DeployResource with tenant identifier")
+        .hasMessageContaining("but multi-tenancy is disabled");
   }
 
   public static final class FakeRequestStub

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MultiTenancyDisabledTest extends GatewayTest {
+
+  public MultiTenancyDisabledTest() {
+    super(cfg -> cfg.getMultiTenancy().setEnabled(false));
+  }
+
+  @Before
+  public void setup() {
+    final FakeRequestStub stub = new FakeRequestStub();
+    stub.registerWith(brokerClient);
+  }
+
+  @Test
+  public void deployResourceRequestShouldContainDefaultTenantAsAuthorizedTenants() {
+    // given
+    final var request = DeployResourceRequest.newBuilder().build();
+
+    // when
+    final var response = client.deployResource(request);
+    assertThat(response).isNotNull();
+
+    // then
+    final BrokerDeployResourceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getAuthorization().toDecodedMap())
+        .hasEntrySatisfying(
+            Authorization.AUTHORIZED_TENANTS,
+            v -> assertThat(v).asList().contains(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+  }
+
+  public static final class FakeRequestStub
+      implements RequestStub<BrokerDeployResourceRequest, BrokerResponse<DeploymentRecord>> {
+
+    @Override
+    public void registerWith(final StubbedBrokerClient gateway) {
+      gateway.registerHandler(BrokerDeployResourceRequest.class, this);
+    }
+
+    @Override
+    public BrokerResponse<DeploymentRecord> handle(final BrokerDeployResourceRequest request)
+        throws Exception {
+      final DeploymentRecord deploymentRecord = request.getRequestWriter();
+      return new BrokerResponse<>(deploymentRecord, 0, 123);
+    }
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -54,6 +55,19 @@ public class MultiTenancyEnabledTest extends GatewayTest {
         .hasEntrySatisfying(
             Authorization.AUTHORIZED_TENANTS,
             v -> assertThat(v).asList().contains("tenant-a", "tenant-b"));
+  }
+
+  @Test
+  public void deployResourceRequestRequiresTenantId() {
+    // given
+    when(gateway.getIdentityMock().tenants().forToken(anyString()))
+        .thenReturn(List.of(new Tenant("tenant-a", "A"), new Tenant("tenant-b", "B")));
+
+    // when/then
+    assertThatThrownBy(() -> client.deployResource(DeployResourceRequest.newBuilder().build()))
+        .hasMessageContaining(
+            "Expected to handle gRPC request DeployResource with tenant identifier ``")
+        .hasMessageContaining("but no tenant identifier was provided");
   }
 
   public static final class FakeRequestStub

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -25,9 +25,9 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-public class AuthorizedTenantsTest extends GatewayTest {
+public class MultiTenancyEnabledTest extends GatewayTest {
 
-  public AuthorizedTenantsTest() {
+  public MultiTenancyEnabledTest() {
     super(cfg -> cfg.getMultiTenancy().setEnabled(true));
   }
 
@@ -38,7 +38,7 @@ public class AuthorizedTenantsTest extends GatewayTest {
   }
 
   @Test
-  public void brokerRequestsShouldContainAuthorizedTenants() {
+  public void deployResourceRequestShouldContainAuthorizedTenants() {
     // given
     when(gateway.getIdentityMock().tenants().forToken(anyString()))
         .thenReturn(List.of(new Tenant("tenant-a", "A"), new Tenant("tenant-b", "B")));

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.authentication.exception.TokenVerificationException;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.MethodDescriptor;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 public class IdentityInterceptorTest {
 
+  private final MultiTenancyCfg multiTenancy = new MultiTenancyCfg();
+
   @Test
   public void missingTokenIsRejected() {
     // given
@@ -35,7 +38,7 @@ public class IdentityInterceptorTest {
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
-    new IdentityInterceptor(identityMock)
+    new IdentityInterceptor(identityMock, multiTenancy)
         .interceptCall(closeStatusCapturingServerCall, new Metadata(), failingNextHandler());
 
     // then
@@ -59,7 +62,7 @@ public class IdentityInterceptorTest {
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
-    new IdentityInterceptor(identityMock)
+    new IdentityInterceptor(identityMock, multiTenancy)
         .interceptCall(closeStatusCapturingServerCall, createAuthHeader(), failingNextHandler());
 
     // then
@@ -82,7 +85,7 @@ public class IdentityInterceptorTest {
     // when
     assertThatThrownBy(
             () ->
-                new IdentityInterceptor(identityMock)
+                new IdentityInterceptor(identityMock, multiTenancy)
                     .interceptCall(
                         new NoopServerCall<>(), createAuthHeader(), failingNextHandler()))
         // then
@@ -98,7 +101,7 @@ public class IdentityInterceptorTest {
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
-    new IdentityInterceptor(identityMock)
+    new IdentityInterceptor(identityMock, multiTenancy)
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -59,7 +59,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpcomponents>4.4.16</version.httpcomponents>
-    <version.identity>8.2.13</version.identity>
+    <version.identity>8.3.0-alpha6</version.identity>
     <version.jackson>2.15.2</version.jackson>
     <version.java-grpc-prometheus>0.6.0</version.java-grpc-prometheus>
     <version.jna>5.13.0</version.jna>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -58,14 +58,14 @@ public class GatewayAuthenticationIdentityIT {
 
   @Container
   private static final GenericContainer<?> KEYCLOAK =
-      new GenericContainer<>("quay.io/keycloak/keycloak:19.0.3")
+      new GenericContainer<>("bitnami/keycloak:22.0.1")
           .withEnv("KC_HEALTH_ENABLED", "true")
-          .withEnv("KEYCLOAK_ADMIN", KEYCLOAK_USER)
+          .withEnv("KEYCLOAK_ADMIN_USER", KEYCLOAK_USER)
           .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)
+          .withEnv("KEYCLOAK_DATABASE_VENDOR", "dev-mem")
           .withNetwork(NETWORK)
           .withNetworkAliases("keycloak")
           .withExposedPorts(8080)
-          .withCommand("start-dev")
           .waitingFor(
               new HttpWaitStrategy()
                   .forPort(8080)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When `zeebe.gateway.multiTenancy.enabled` (or `zeebe.broker.gateway.multiTenancy.enabled`), then this does the following:
- retrieve the authorized tenants from Identity using the request's Authorization header token
- encode the authorized tenants in a JWT
- store this JWT as AuthInfo on the authorization of the BrokerRequest

This also updates the used Identity version to `8.3.0-alpha6` to access the `.tenant()` API. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13237

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
