### PR TITLE
Reject request for unauthorized tenant

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -287,7 +287,13 @@ public final class RequestMapper {
   public static String ensureTenantIdSet(final String commandName, final String tenantId) {
 
     final boolean hasTenantId = !StringUtils.isBlank(tenantId);
-    if (isMultiTenancyEnabled) {
+    if (!isMultiTenancyEnabled) {
+      if (hasTenantId && !TenantOwned.DEFAULT_TENANT_IDENTIFIER.equals(tenantId)) {
+        throw new InvalidTenantRequestException(commandName, tenantId, "multi-tenancy is disabled");
+      }
+
+      return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    } else {
 
       if (!hasTenantId) {
         throw new InvalidTenantRequestException(
@@ -318,12 +324,7 @@ public final class RequestMapper {
       }
 
       return tenantId;
-    } else {
-      if (hasTenantId && !TenantOwned.DEFAULT_TENANT_IDENTIFIER.equals(tenantId)) {
-        throw new InvalidTenantRequestException(commandName, tenantId, "multi-tenancy is disabled");
-      }
-
-      return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     }
+
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.agrona.LangUtil.rethrowUnchecked;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import io.camunda.zeebe.gateway.cmd.IllegalTenantRequestException;
 import io.camunda.zeebe.gateway.cmd.InvalidTenantRequestException;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerBroadcastSignalRequest;
@@ -319,7 +320,7 @@ public final class RequestMapper {
           commandName, tenantId, "tenant could not be retrieved from the request context", e);
     }
     if (!authorizedTenants.contains(tenantId)) {
-      throw new InvalidTenantRequestException(
+      throw new IllegalTenantRequestException(
           commandName, tenantId, "tenant is not authorized to perform this request");
     }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -293,38 +293,36 @@ public final class RequestMapper {
       }
 
       return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
-    } else {
-
-      if (!hasTenantId) {
-        throw new InvalidTenantRequestException(
-            commandName, tenantId, "no tenant identifier was provided.");
-      }
-
-      if (tenantId.length() > 31) {
-        throw new InvalidTenantRequestException(
-            commandName, tenantId, "tenant identifier is longer than 31 characters");
-      }
-
-      if (!TenantOwned.DEFAULT_TENANT_IDENTIFIER.equals(tenantId)
-          && !TENANT_ID_MASK.matcher(tenantId).matches()) {
-        throw new InvalidTenantRequestException(
-            commandName, tenantId, "tenant identifier contains illegal characters");
-      }
-
-      final List<String> authorizedTenants;
-      try {
-        authorizedTenants = Context.current().call(IdentityInterceptor.AUTHORIZED_TENANTS_KEY::get);
-      } catch (final Exception e) {
-        throw new InvalidTenantRequestException(
-            commandName, tenantId, "tenant could not be retrieved from the request context", e);
-      }
-      if (!authorizedTenants.contains(tenantId)) {
-        throw new InvalidTenantRequestException(
-            commandName, tenantId, "tenant is not authorized to perform this request");
-      }
-
-      return tenantId;
     }
 
+    if (!hasTenantId) {
+      throw new InvalidTenantRequestException(
+          commandName, tenantId, "no tenant identifier was provided.");
+    }
+
+    if (tenantId.length() > 31) {
+      throw new InvalidTenantRequestException(
+          commandName, tenantId, "tenant identifier is longer than 31 characters");
+    }
+
+    if (!TenantOwned.DEFAULT_TENANT_IDENTIFIER.equals(tenantId)
+        && !TENANT_ID_MASK.matcher(tenantId).matches()) {
+      throw new InvalidTenantRequestException(
+          commandName, tenantId, "tenant identifier contains illegal characters");
+    }
+
+    final List<String> authorizedTenants;
+    try {
+      authorizedTenants = Context.current().call(IdentityInterceptor.AUTHORIZED_TENANTS_KEY::get);
+    } catch (final Exception e) {
+      throw new InvalidTenantRequestException(
+          commandName, tenantId, "tenant could not be retrieved from the request context", e);
+    }
+    if (!authorizedTenants.contains(tenantId)) {
+      throw new InvalidTenantRequestException(
+          commandName, tenantId, "tenant is not authorized to perform this request");
+    }
+
+    return tenantId;
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/cmd/IllegalTenantRequestException.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/cmd/IllegalTenantRequestException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.cmd;
+
+public class IllegalTenantRequestException extends ClientException {
+
+  private static final String MESSAGE_FORMAT =
+      "Expected to handle gRPC request %s with tenant identifier `%s`, but %s";
+
+  private final String commandName;
+  private final String tenantId;
+  private final String reason;
+
+  public IllegalTenantRequestException(
+      final String commandName, final String tenantId, final String reason) {
+    super(String.format(MESSAGE_FORMAT, commandName, tenantId, reason));
+
+    this.commandName = commandName;
+    this.tenantId = tenantId;
+    this.reason = reason;
+  }
+
+  public IllegalTenantRequestException(
+      final String commandName, final String tenantId, final String reason, final Exception e) {
+    super(String.format(MESSAGE_FORMAT, commandName, tenantId, reason), e);
+
+    this.commandName = commandName;
+    this.tenantId = tenantId;
+    this.reason = reason;
+  }
+
+  public String getCommandName() {
+    return commandName;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/cmd/InvalidTenantRequestException.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/cmd/InvalidTenantRequestException.java
@@ -25,6 +25,15 @@ public class InvalidTenantRequestException extends ClientException {
     this.reason = reason;
   }
 
+  public InvalidTenantRequestException(
+      final String commandName, final String tenantId, final String reason, final Exception e) {
+    super(String.format(MESSAGE_FORMAT, commandName, tenantId, reason), e);
+
+    this.commandName = commandName;
+    this.tenantId = tenantId;
+    this.reason = reason;
+  }
+
   public String getCommandName() {
     return commandName;
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -15,6 +15,7 @@ import com.google.rpc.Status.Builder;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.cmd.BrokerErrorException;
 import io.camunda.zeebe.gateway.cmd.BrokerRejectionException;
+import io.camunda.zeebe.gateway.cmd.IllegalTenantRequestException;
 import io.camunda.zeebe.gateway.cmd.InvalidBrokerRequestArgumentException;
 import io.camunda.zeebe.gateway.cmd.InvalidTenantRequestException;
 import io.camunda.zeebe.gateway.cmd.NoTopologyAvailableException;
@@ -79,6 +80,9 @@ public final class GrpcErrorMapper {
       logger.debug("Expected to handle gRPC request, but JSON property was invalid", rootError);
     } else if (error instanceof InvalidTenantRequestException) {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
+      logger.debug(error.getMessage(), rootError);
+    } else if (error instanceof IllegalTenantRequestException) {
+      builder.setCode(Code.PERMISSION_DENIED_VALUE).setMessage(error.getMessage());
       logger.debug(error.getMessage(), rootError);
     } else if (error instanceof IllegalArgumentException) {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Deployment;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public final class DeployResourceTest extends GatewayTest {
@@ -87,40 +86,5 @@ public final class DeployResourceTest extends GatewayTest {
     final BrokerDeployResourceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(DeploymentIntent.CREATE);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.DEPLOYMENT);
-  }
-
-  @Test
-  @Ignore("https://github.com/camunda/zeebe/issues/14041")
-  public void shouldMapRequestAndResponseWithCustomTenantId() {
-    // given
-    final var stub = new DeployResourceStub();
-    stub.registerWith(brokerClient);
-
-    final String bpmnName = "testProcess.bpmn";
-    final String dmnName = "testDecision.dmn";
-    final String tenantId = "test-tenant";
-
-    final var builder = DeployResourceRequest.newBuilder();
-    builder.addResourcesBuilder().setName(bpmnName).setContent(ByteString.copyFromUtf8("<xml/>"));
-    builder.addResourcesBuilder().setName(dmnName).setContent(ByteString.copyFromUtf8("test"));
-    builder.setTenantId(tenantId);
-
-    final var request = builder.build();
-
-    // when
-    final var response = client.deployResource(request);
-
-    // then
-    assertThat(response.getTenantId()).isEqualTo(tenantId);
-
-    assertThat(response.getDeploymentsCount()).isEqualTo(3);
-    final ProcessMetadata process = response.getDeployments(0).getProcess();
-    assertThat(process.getTenantId()).isEqualTo(tenantId);
-
-    final DecisionMetadata decision = response.getDeployments(1).getDecision();
-    assertThat(decision.getTenantId()).isEqualTo(tenantId);
-
-    final DecisionRequirementsMetadata drg = response.getDeployments(2).getDecisionRequirements();
-    assertThat(drg.getTenantId()).isEqualTo(tenantId);
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
@@ -17,13 +17,12 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public final class CreateProcessInstanceTest extends GatewayTest {
 
   @Test
-  public void shouldMapRequestAndResponseWithDefaultTenantId() {
+  public void shouldMapRequestAndResponse() {
     // given
     final CreateProcessInstanceStub stub = new CreateProcessInstanceStub();
     stub.registerWith(brokerClient);
@@ -51,32 +50,5 @@ public final class CreateProcessInstanceTest extends GatewayTest {
     assertThat(brokerRequestValue.getProcessDefinitionKey())
         .isEqualTo(stub.getProcessDefinitionKey());
     assertThat(brokerRequestValue.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  }
-
-  @Test
-  @Ignore("https://github.com/camunda/zeebe/issues/14041")
-  public void shouldMapRequestAndResponseWithCustomTenantId() {
-    // given
-    final String tenantId = "test-tenant";
-    final CreateProcessInstanceStub stub = new CreateProcessInstanceStub();
-    stub.registerWith(brokerClient);
-
-    final CreateProcessInstanceRequest request =
-        CreateProcessInstanceRequest.newBuilder()
-            .setProcessDefinitionKey(stub.getProcessDefinitionKey())
-            .setTenantId(tenantId)
-            .build();
-
-    // when
-    final CreateProcessInstanceResponse response = client.createProcessInstance(request);
-
-    // then
-    assertThat(response.getTenantId()).isEqualTo(tenantId);
-
-    final ProcessInstanceCreationRecord brokerRequestValue =
-        (ProcessInstanceCreationRecord) brokerClient.getSingleBrokerRequest().getRequestWriter();
-    assertThat(brokerRequestValue.getProcessDefinitionKey())
-        .isEqualTo(stub.getProcessDefinitionKey());
-    assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantId);
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayAssertions.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayAssertions.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.api.util;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.assertj.core.api.Condition;
+
+public final class GatewayAssertions {
+
+  public static <T extends Throwable> Condition<T> statusRuntimeExceptionWithStatusCode(
+      final Status.Code expected) {
+    return new Condition<>(
+        throwable -> {
+          if (!(throwable instanceof final StatusRuntimeException statusRuntimeException)) {
+            return false;
+          }
+          final Status actualStatus = statusRuntimeException.getStatus();
+          return actualStatus.getCode().equals(expected);
+        },
+        "StatusRuntimeException with status code '%s'",
+        expected);
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -91,4 +91,17 @@ public class MultiTenancyDisabledTest extends GatewayTest {
     // then
     assertDefaultTenantIdSet();
   }
+
+  @Test
+  public void createProcessInstanceRequestRejectsTenantId() {
+    // given
+    final var request = CreateProcessInstanceRequest.newBuilder().setTenantId("tenant-a").build();
+
+    // when/then
+    assertThatThrownBy(() -> client.createProcessInstance(request))
+        .is(statusRuntimeExceptionWithStatusCode(Status.INVALID_ARGUMENT.getCode()))
+        .hasMessageContaining(
+            "Expected to handle gRPC request CreateProcessInstance with tenant identifier")
+        .hasMessageContaining("but multi-tenancy is disabled");
+  }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.gateway.api.process.CreateProcessInstanceStub;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerExecuteCommand;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsMetadata;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
@@ -148,5 +149,20 @@ public class MultiTenancyDisabledTest extends GatewayTest {
 
     // when/then
     assertThatRejectsRequest(() -> client.createProcessInstance(request), "CreateProcessInstance");
+  }
+
+  @Test
+  public void createProcessInstanceResponseHasTenantId() {
+    // given
+    when(gateway.getIdentityMock().tenants().forToken(anyString()))
+        .thenReturn(List.of(new Tenant("tenant-a", "A"), new Tenant("tenant-b", "B")));
+
+    // when
+    final CreateProcessInstanceResponse response =
+        client.createProcessInstance(CreateProcessInstanceRequest.newBuilder().build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl;
 
+import static io.camunda.zeebe.gateway.api.util.GatewayAssertions.statusRuntimeExceptionWithStatusCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -19,6 +20,7 @@ import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.grpc.Status;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,6 +60,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
 
     // when/then
     assertThatThrownBy(() -> client.deployResource(request))
+        .is(statusRuntimeExceptionWithStatusCode(Status.INVALID_ARGUMENT.getCode()))
         .hasMessageContaining(
             "Expected to handle gRPC request DeployResource with tenant identifier")
         .hasMessageContaining("but multi-tenancy is disabled");

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -37,7 +37,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
     new CreateProcessInstanceStub().registerWith(brokerClient);
   }
 
-  private void assertDefaultTenantIdSet() {
+  private void assertThatDefaultTenantIdSet() {
     final var brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(((BrokerExecuteCommand<?>) brokerRequest).getAuthorization().toDecodedMap())
         .describedAs("The broker request should contain the default tenant as authorized tenant")
@@ -71,7 +71,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
     assertThat(response).isNotNull();
 
     // then
-    assertDefaultTenantIdSet();
+    assertThatDefaultTenantIdSet();
   }
 
   @Test
@@ -93,7 +93,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
     assertThat(response).isNotNull();
 
     // then
-    assertDefaultTenantIdSet();
+    assertThatDefaultTenantIdSet();
   }
 
   @Test

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -12,13 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.gateway.api.deployment.DeployResourceStub;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
-import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
-import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
-import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.grpc.Status;
 import org.junit.Before;
@@ -32,8 +29,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
 
   @Before
   public void setup() {
-    final FakeRequestStub stub = new FakeRequestStub();
-    stub.registerWith(brokerClient);
+    new DeployResourceStub().registerWith(brokerClient);
   }
 
   @Test
@@ -64,21 +60,5 @@ public class MultiTenancyDisabledTest extends GatewayTest {
         .hasMessageContaining(
             "Expected to handle gRPC request DeployResource with tenant identifier")
         .hasMessageContaining("but multi-tenancy is disabled");
-  }
-
-  public static final class FakeRequestStub
-      implements RequestStub<BrokerDeployResourceRequest, BrokerResponse<DeploymentRecord>> {
-
-    @Override
-    public void registerWith(final StubbedBrokerClient gateway) {
-      gateway.registerHandler(BrokerDeployResourceRequest.class, this);
-    }
-
-    @Override
-    public BrokerResponse<DeploymentRecord> handle(final BrokerDeployResourceRequest request)
-        throws Exception {
-      final DeploymentRecord deploymentRecord = request.getRequestWriter();
-      return new BrokerResponse<>(deploymentRecord, 0, 123);
-    }
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import com.google.protobuf.ByteString;
 import io.camunda.identity.sdk.tenants.dto.Tenant;
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.gateway.api.deployment.DeployResourceStub;
@@ -22,8 +23,12 @@ import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerExecuteCommand;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsMetadata;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.grpc.Status;
 import java.util.List;
@@ -115,6 +120,42 @@ public class MultiTenancyEnabledTest extends GatewayTest {
 
     // when/then
     assertThatRejectsUnauthorizedRequest(() -> client.deployResource(request), "DeployResource");
+  }
+
+  @Test
+  public void deployResourceResponseHasTenantId() {
+    // given
+    when(gateway.getIdentityMock().tenants().forToken(anyString()))
+        .thenReturn(List.of(new Tenant("tenant-a", "A"), new Tenant("tenant-b", "B")));
+
+    // when
+    final Builder requestBuilder = DeployResourceRequest.newBuilder();
+    requestBuilder
+        .addResourcesBuilder()
+        .setName("testProcess.bpmn")
+        .setContent(ByteString.copyFromUtf8("<xml/>"));
+    requestBuilder
+        .addResourcesBuilder()
+        .setName("testDecision.dmn")
+        .setContent(ByteString.copyFromUtf8("test"));
+    final DeployResourceResponse response =
+        client.deployResource(requestBuilder.setTenantId("tenant-b").build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertThat(response.getTenantId()).isEqualTo("tenant-b");
+
+    assumeThat(response.getDeploymentsCount())
+        .describedAs("Any metadata of the deployed resources should also contain the tenant id")
+        .isEqualTo(3);
+    final ProcessMetadata process = response.getDeployments(0).getProcess();
+    assertThat(process.getTenantId()).isEqualTo("tenant-b");
+
+    final DecisionMetadata decision = response.getDeployments(1).getDecision();
+    assertThat(decision.getTenantId()).isEqualTo("tenant-b");
+
+    final DecisionRequirementsMetadata drg = response.getDeployments(2).getDecisionRequirements();
+    assertThat(drg.getTenantId()).isEqualTo("tenant-b");
   }
 
   @Test

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl;
 
+import static io.camunda.zeebe.gateway.api.util.GatewayAssertions.statusRuntimeExceptionWithStatusCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.grpc.Status;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,6 +67,7 @@ public class MultiTenancyEnabledTest extends GatewayTest {
 
     // when/then
     assertThatThrownBy(() -> client.deployResource(DeployResourceRequest.newBuilder().build()))
+        .is(statusRuntimeExceptionWithStatusCode(Status.INVALID_ARGUMENT.getCode()))
         .hasMessageContaining(
             "Expected to handle gRPC request DeployResource with tenant identifier ``")
         .hasMessageContaining("but no tenant identifier was provided");
@@ -81,6 +84,7 @@ public class MultiTenancyEnabledTest extends GatewayTest {
             () ->
                 client.deployResource(
                     DeployResourceRequest.newBuilder().setTenantId("tenant-c").build()))
+        .is(statusRuntimeExceptionWithStatusCode(Status.PERMISSION_DENIED.getCode()))
         .hasMessageContaining(
             "Expected to handle gRPC request DeployResource with tenant identifier `tenant-c`")
         .hasMessageContaining("but tenant is not authorized to perform this request");

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -15,14 +15,11 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.identity.sdk.tenants.dto.Tenant;
 import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.gateway.api.deployment.DeployResourceStub;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
-import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
-import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
-import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.grpc.Status;
 import java.util.List;
 import org.junit.Before;
@@ -36,8 +33,7 @@ public class MultiTenancyEnabledTest extends GatewayTest {
 
   @Before
   public void setup() {
-    final FakeRequestStub stub = new FakeRequestStub();
-    stub.registerWith(brokerClient);
+    new DeployResourceStub().registerWith(brokerClient);
   }
 
   @Test
@@ -88,21 +84,5 @@ public class MultiTenancyEnabledTest extends GatewayTest {
         .hasMessageContaining(
             "Expected to handle gRPC request DeployResource with tenant identifier `tenant-c`")
         .hasMessageContaining("but tenant is not authorized to perform this request");
-  }
-
-  public static final class FakeRequestStub
-      implements RequestStub<BrokerDeployResourceRequest, BrokerResponse<DeploymentRecord>> {
-
-    @Override
-    public void registerWith(final StubbedBrokerClient gateway) {
-      gateway.registerHandler(BrokerDeployResourceRequest.class, this);
-    }
-
-    @Override
-    public BrokerResponse<DeploymentRecord> handle(final BrokerDeployResourceRequest request)
-        throws Exception {
-      final DeploymentRecord deploymentRecord = request.getRequestWriter();
-      return new BrokerResponse<>(deploymentRecord, 0, 123);
-    }
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -70,6 +70,22 @@ public class MultiTenancyEnabledTest extends GatewayTest {
         .hasMessageContaining("but no tenant identifier was provided");
   }
 
+  @Test
+  public void deployResourceRequestRequiresValidTenantId() {
+    // given
+    when(gateway.getIdentityMock().tenants().forToken(anyString()))
+        .thenReturn(List.of(new Tenant("tenant-a", "A"), new Tenant("tenant-b", "B")));
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                client.deployResource(
+                    DeployResourceRequest.newBuilder().setTenantId("tenant-c").build()))
+        .hasMessageContaining(
+            "Expected to handle gRPC request DeployResource with tenant identifier `tenant-c`")
+        .hasMessageContaining("but tenant is not authorized to perform this request");
+  }
+
   public static final class FakeRequestStub
       implements RequestStub<BrokerDeployResourceRequest, BrokerResponse<DeploymentRecord>> {
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -197,4 +197,20 @@ public class MultiTenancyEnabledTest extends GatewayTest {
     assertThatRejectsUnauthorizedRequest(
         () -> client.createProcessInstance(request), "CreateProcessInstance");
   }
+
+  @Test
+  public void createProcessInstanceResponseHasTenantId() {
+    // given
+    when(gateway.getIdentityMock().tenants().forToken(anyString()))
+        .thenReturn(List.of(new Tenant("tenant-a", "A"), new Tenant("tenant-b", "B")));
+
+    // when
+    final CreateProcessInstanceResponse response =
+        client.createProcessInstance(
+            CreateProcessInstanceRequest.newBuilder().setTenantId("tenant-b").build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertThat(response.getTenantId()).isEqualTo("tenant-b");
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When a client makes a request that is specific to a tenant, then the gateway can reject/accept it based on the requester's authorized tenants.

If [multi-tenancy is enabled in the gateway](https://github.com/camunda/zeebe/issues/14041), then the gateway may reject requests that are not authorized for the specified tenant as `PERMISSION_DENIED`.

If it is disabled, the gateway will simply accept such requests.

This pull request also makes sure that this happens for all requests that support-specifying a tenant-id. At this time:
- DeployResource
- CreateProcessInstance

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14284
closes #13237

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
