### PR TITLE
feat(qa): add test standalone gateway

### DIFF
--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.qa.util.cluster;
 
+import io.atomix.cluster.MemberId;
+
 public interface TestApplication<T extends TestApplication<T>> extends AutoCloseable {
 
   /** Starts the node in a blocking fashion. */
@@ -38,5 +40,54 @@ public interface TestApplication<T extends TestApplication<T>> extends AutoClose
    * @return itself for chaining
    * @param <V> the bean type
    */
+  @SuppressWarnings("UnusedReturnValue")
   <V> T withBean(final String qualifier, final V bean, final Class<V> type);
+
+  /** Returns this node's unique cluster ID */
+  MemberId nodeId();
+
+  /**
+   * Returns the hostname of this node, such that it is visible to hosts from the outside of the
+   * Docker network.
+   *
+   * @return the hostname of this node
+   */
+  default String host() {
+    return "localhost";
+  }
+
+  /** Returns the actual port for the given logical port. */
+  default int mappedPort(final TestZeebePort port) {
+    return port.port();
+  }
+
+  /**
+   * Returns the address of this node for the given port.
+   *
+   * @param port the target port
+   * @return externally accessible address for {@code port}
+   */
+  default String address(final int port) {
+    return host() + ":" + port;
+  }
+
+  /**
+   * Returns the address of this node for the given port.
+   *
+   * @param port the target port
+   * @return externally accessible address for {@code port}
+   */
+  default String address(final TestZeebePort port) {
+    return address(mappedPort(port));
+  }
+
+  /**
+   * Returns the address to access the monitoring API of this node from outside the container
+   * network of this node.
+   *
+   * @return the external monitoring address
+   */
+  default String monitoringAddress() {
+    return address(TestZeebePort.MONITORING);
+  }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.qa.util.cluster;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.restore.RestoreApp;
 import io.camunda.zeebe.shared.Profile;
@@ -34,6 +35,11 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
   @Override
   public TestRestoreApp self() {
     return this;
+  }
+
+  @Override
+  public MemberId nodeId() {
+    return MemberId.from(String.valueOf(config.getCluster().getNodeId()));
   }
 
   @Override

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.gateway.StandaloneGateway;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.shared.Profile;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+/** Encapsulates an instance of the {@link StandaloneGateway} Spring application. */
+public final class TestStandaloneGateway extends TestSpringApplication<TestStandaloneGateway> {
+  private final GatewayCfg config;
+
+  public TestStandaloneGateway() {
+    super(StandaloneGateway.class);
+    config = new GatewayCfg();
+
+    config.getNetwork().setHost("0.0.0.0");
+    config.getNetwork().setPort(SocketUtil.getNextAddress().getPort());
+    config.getCluster().setPort(SocketUtil.getNextAddress().getPort());
+
+    //noinspection resource
+    withBean("config", config, GatewayCfg.class);
+  }
+
+  @Override
+  public TestStandaloneGateway self() {
+    return this;
+  }
+
+  @Override
+  public MemberId nodeId() {
+    return MemberId.from(config.getCluster().getMemberId());
+  }
+
+  @Override
+  public String host() {
+    return config.getNetwork().getHost();
+  }
+
+  @Override
+  public int mappedPort(final TestZeebePort port) {
+    return switch (port) {
+      case GATEWAY -> config.getNetwork().getPort();
+      case CLUSTER -> config.getCluster().getPort();
+      default -> super.mappedPort(port);
+    };
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringBuilder() {
+    return super.createSpringBuilder().profiles(Profile.GATEWAY.getId());
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestZeebePort.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestZeebePort.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+/** Represents the known ports in Zeebe and their default values. */
+public enum TestZeebePort {
+  /** Port of the command API, i.e. the port used by the gateway to communicate with the broker */
+  COMMAND(26501),
+  /** Port of the gateway API, i.e. the port used by the client to communicate with any gateway */
+  GATEWAY(26500),
+  /** Port for internal communication, i.e. what all nodes use to communicate for clustering */
+  CLUSTER(26502),
+  /** Port for the management server, i.e. actuators, metrics, etc. */
+  MONITORING(9600);
+
+  private final int port;
+
+  TestZeebePort(final int port) {
+    this.port = port;
+  }
+
+  /** Returns the default port number for this port */
+  public int port() {
+    return port;
+  }
+}


### PR DESCRIPTION
## Description

Adds a test launcher for `StandaloneGateway`, with minimal features allowing you to launch multiple instances of said gateway. It's still lacking many features which will be added once we start building clusters, or when we add the test broker launcher.

In lieu of tests, two of the existing gateway specific tests (without broker dependency) are refactored.

Like the previous PR, instead of building all features as listed in the original issue, I decided to keep it minimal. Some of them (e.g. the health probes/await stuff) will be added when we build up the cluster API, and some (like a common gateway interface for both this and the embedded gateway) will be added with the broker. This is all done to keep PRs to a manageable size. Hope it makes sense!

## Related issues

closes #13969 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
