### PR TITLE
Mark broker ready after all partitions joined raft

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/PartitionRaftListener.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/PartitionRaftListener.java
@@ -9,9 +9,7 @@ package io.camunda.zeebe.broker;
 
 /**
  * Can be implemented and used to react on partition role changes, like on Leader on Actor should be
- * started and on Follower one should be removed. If this listener performs actions that are
- * critical to the progress of a partition, it is expected to complete the future exceptionally on a
- * failure. Otherwise the future should complete normally.
+ * started and on Follower one should be removed.
  */
 public interface PartitionRaftListener {
   /**

--- a/broker/src/main/java/io/camunda/zeebe/broker/PartitionRaftListener.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/PartitionRaftListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker;
+
+/**
+ * Can be implemented and used to react on partition role changes, like on Leader on Actor should be
+ * started and on Follower one should be removed. If this listener performs actions that are
+ * critical to the progress of a partition, it is expected to complete the future exceptionally on a
+ * failure. Otherwise the future should complete normally.
+ */
+public interface PartitionRaftListener {
+  /**
+   * Is called by the {@link io.camunda.zeebe.broker.system.partitions.ZeebePartition} on starting
+   * to become partition follower. This is called before the installation starts, but after the node
+   * became already follower on raft level.
+   *
+   * @param partitionId the corresponding partition id
+   * @param term the current term
+   */
+  void onBecameRaftFollower(final int partitionId, final long term);
+
+  /**
+   * Is called by the {@link io.camunda.zeebe.broker.system.partitions.ZeebePartition} on starting
+   * to become partition leader. This is called before the installation starts, but after the node
+   * became already leader on raft level.
+   *
+   * @param partitionId the corresponding partition id
+   * @param term the current term
+   */
+  void onBecameRaftLeader(final int partitionId, final long term);
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
@@ -51,7 +52,13 @@ public interface BrokerStartupContext {
 
   void removePartitionListener(PartitionListener partitionListener);
 
+  void addPartitionRaftListener(PartitionRaftListener partitionListener);
+
+  void removePartitionRaftListener(PartitionRaftListener partitionListener);
+
   List<PartitionListener> getPartitionListeners();
+
+  List<PartitionRaftListener> getPartitionRaftListeners();
 
   ClusterServicesImpl getClusterServices();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -12,6 +12,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
@@ -43,6 +44,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final ExporterRepository exporterRepository;
   private final ClusterServicesImpl clusterServices;
   private final List<PartitionListener> partitionListeners = new ArrayList<>();
+  private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
 
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
@@ -126,8 +128,23 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
+  public void addPartitionRaftListener(final PartitionRaftListener listener) {
+    partitionRaftListeners.add(requireNonNull(listener));
+  }
+
+  @Override
+  public void removePartitionRaftListener(final PartitionRaftListener listener) {
+    partitionRaftListeners.remove(requireNonNull(listener));
+  }
+
+  @Override
   public List<PartitionListener> getPartitionListeners() {
     return unmodifiableList(partitionListeners);
+  }
+
+  @Override
+  public List<PartitionRaftListener> getPartitionRaftListeners() {
+    return unmodifiableList(partitionRaftListeners);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
@@ -42,7 +42,7 @@ final class MonitoringServerStep extends AbstractBrokerStartupStep {
 
     final var springBrokerBridge = brokerShutdownContext.getSpringBrokerBridge();
     springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> null);
-    brokerShutdownContext.removePartitionListener(healthCheckService);
+    brokerShutdownContext.removePartitionRaftListener(healthCheckService);
     concurrencyControl.runOnCompletion(
         healthCheckService.closeAsync(),
         (ok, error) -> {
@@ -64,7 +64,7 @@ final class MonitoringServerStep extends AbstractBrokerStartupStep {
     } else {
       final var springBrokerBridge = brokerStartupContext.getSpringBrokerBridge();
       springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
-      brokerStartupContext.addPartitionListener(healthCheckService);
+      brokerStartupContext.addPartitionRaftListener(healthCheckService);
       startupFuture.complete(brokerStartupContext);
     }
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -32,6 +32,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getHealthCheckService(),
             brokerStartupContext.getDiskSpaceUsageMonitor(),
             brokerStartupContext.getPartitionListeners(),
+            brokerStartupContext.getPartitionRaftListeners(),
             brokerStartupContext.getCommandApiService(),
             brokerStartupContext.getExporterRepository(),
             brokerStartupContext.getGatewayBrokerTransport(),

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -11,6 +11,7 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.primitive.partition.impl.DefaultPartitionManagementService;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
@@ -74,6 +75,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
       final BrokerHealthCheckService healthCheckService,
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final List<PartitionListener> partitionListeners,
+      final List<PartitionRaftListener> partitionRaftListeners,
       final CommandApiService commandApiService,
       final ExporterRepository exporterRepository,
       final AtomixServerTransport gatewayBrokerTransport,
@@ -105,6 +107,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
             gatewayBrokerTransport,
             jobStreamer,
             listeners,
+            partitionRaftListeners,
             topologyManager,
             featureFlags);
     managementService =

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.partitioning.startup;
 
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
@@ -95,6 +96,7 @@ public final class ZeebePartitionFactory {
   private final List<PartitionListener> partitionListeners;
   private final TopologyManagerImpl topologyManager;
   private final FeatureFlags featureFlags;
+  private final List<PartitionRaftListener> partitionRaftListeners;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -108,6 +110,7 @@ public final class ZeebePartitionFactory {
       final AtomixServerTransport gatewayBrokerTransport,
       final JobStreamer jobStreamer,
       final List<PartitionListener> partitionListeners,
+      final List<PartitionRaftListener> partitionRaftListeners,
       final TopologyManagerImpl topologyManager,
       final FeatureFlags featureFlags) {
     this.actorSchedulingService = actorSchedulingService;
@@ -121,6 +124,7 @@ public final class ZeebePartitionFactory {
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.jobStreamer = jobStreamer;
     this.partitionListeners = partitionListeners;
+    this.partitionRaftListeners = partitionRaftListeners;
     this.topologyManager = topologyManager;
     this.featureFlags = featureFlags;
   }
@@ -142,6 +146,7 @@ public final class ZeebePartitionFactory {
             communicationService,
             raftPartition,
             partitionListeners,
+            partitionRaftListeners,
             new AtomixPartitionMessagingService(
                 communicationService, membershipService, raftPartition.members()),
             actorSchedulingService,

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -10,13 +10,10 @@ package io.camunda.zeebe.broker.system.monitoring;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.PartitionListener;
-import io.camunda.zeebe.engine.state.QueryService;
-import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.health.CriticalComponentsHealthMonitor;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.health.HealthMonitorable;
@@ -89,7 +86,7 @@ import org.slf4j.Logger;
  *
  * https://textik.com/#cb084adedb02d970
  */
-public final class BrokerHealthCheckService extends Actor implements PartitionListener {
+public final class BrokerHealthCheckService extends Actor implements PartitionRaftListener {
 
   private static final String PARTITION_COMPONENT_NAME_FORMAT = "Partition-%d";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
@@ -120,25 +117,15 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   }
 
   @Override
-  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
+  public void onBecameRaftFollower(final int partitionId, final long term) {
     checkState();
-    return updateBrokerReadyStatus(partitionId);
+    updateBrokerReadyStatus(partitionId);
   }
 
   @Override
-  public ActorFuture<Void> onBecomingLeader(
-      final int partitionId,
-      final long term,
-      final LogStream logStream,
-      final QueryService queryService) {
+  public void onBecameRaftLeader(final int partitionId, final long term) {
     checkState();
-    return updateBrokerReadyStatus(partitionId);
-  }
-
-  @Override
-  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
-    checkState();
-    return CompletableActorFuture.completed(null);
+    updateBrokerReadyStatus(partitionId);
   }
 
   private void checkState() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -28,6 +28,10 @@ public interface PartitionContext {
 
   RaftPartition getRaftPartition();
 
+  void notifyListenersOfBecameRaftLeader(final long newTerm);
+
+  void notifyListenersOfBecameRaftFollower(final long newTerm);
+
   @Deprecated // will be moved to transition logic and happen automatically
   List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.processing.CheckpointRecordsProcessor;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
@@ -60,6 +61,7 @@ public class PartitionStartupAndTransitionContextImpl
 
   private final int nodeId;
   private final List<PartitionListener> partitionListeners;
+  private final List<PartitionRaftListener> partitionRaftListeners;
   private final ClusterCommunicationService clusterCommunicationService;
   private final PartitionMessagingService messagingService;
   private final ActorSchedulingService actorSchedulingService;
@@ -104,6 +106,7 @@ public class PartitionStartupAndTransitionContextImpl
       final ClusterCommunicationService clusterCommunicationService,
       final RaftPartition raftPartition,
       final List<PartitionListener> partitionListeners,
+      final List<PartitionRaftListener> partitionRaftListeners,
       final PartitionMessagingService partitionCommunicationService,
       final ActorSchedulingService actorSchedulingService,
       final BrokerCfg brokerCfg,
@@ -128,6 +131,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.commandResponseWriterSupplier = commandResponseWriterSupplier;
     this.persistedSnapshotStore = persistedSnapshotStore;
     this.partitionListeners = Collections.unmodifiableList(partitionListeners);
+    this.partitionRaftListeners = Collections.unmodifiableList(partitionRaftListeners);
     partitionId = raftPartition.id().id();
     this.actorSchedulingService = actorSchedulingService;
     maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
@@ -136,18 +140,6 @@ public class PartitionStartupAndTransitionContextImpl
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.topologyManager = topologyManager;
-  }
-
-  @Override
-  public String toString() {
-    return "PartitionStartupAndTransitionContextImpl{"
-        + "partition="
-        + partitionId
-        + ", term="
-        + currentTerm
-        + ", role="
-        + currentRole
-        + '}';
   }
 
   public PartitionAdminControl getPartitionAdminControl() {
@@ -168,6 +160,16 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public RaftPartition getRaftPartition() {
     return raftPartition;
+  }
+
+  @Override
+  public void notifyListenersOfBecameRaftLeader(final long newTerm) {
+    partitionRaftListeners.forEach(l -> l.onBecameRaftLeader(getPartitionId(), newTerm));
+  }
+
+  @Override
+  public void notifyListenersOfBecameRaftFollower(final long newTerm) {
+    partitionRaftListeners.forEach(l -> l.onBecameRaftFollower(getPartitionId(), newTerm));
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -508,4 +508,16 @@ public class PartitionStartupAndTransitionContextImpl
   public ExporterRepository getExporterRepository() {
     return exporterRepository;
   }
+
+  @Override
+  public String toString() {
+    return "PartitionStartupAndTransitionContextImpl{"
+        + "partitionId="
+        + partitionId
+        + ", currentTerm="
+        + currentTerm
+        + ", currentRole="
+        + currentRole
+        + '}';
+  }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -235,6 +235,7 @@ public final class ZeebePartition extends Actor
 
   private ActorFuture<Void> leaderTransition(final long newTerm) {
     final var latencyTimer = roleMetrics.startLeaderTransitionLatencyTimer();
+    context.notifyListenersOfBecameRaftLeader(newTerm);
     final var leaderTransitionFuture = transition.toLeader(newTerm);
     leaderTransitionFuture.onComplete(
         (success, error) -> {
@@ -259,6 +260,7 @@ public final class ZeebePartition extends Actor
   }
 
   private ActorFuture<Void> followerTransition(final long newTerm) {
+    context.notifyListenersOfBecameRaftFollower(newTerm);
     final var followerTransitionFuture = transition.toFollower(newTerm);
     followerTransitionFuture.onComplete(
         (success, error) -> {

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStepTest.java
@@ -86,7 +86,7 @@ class MonitoringServerStepTest {
     await().until(future::isDone);
 
     // then
-    verify(mockBrokerStartupContext).addPartitionListener(mockHealthCheckService);
+    verify(mockBrokerStartupContext).addPartitionRaftListener(mockHealthCheckService);
   }
 
   @Test
@@ -130,7 +130,7 @@ class MonitoringServerStepTest {
     await().until(future::isDone);
 
     // then
-    verify(mockBrokerStartupContext).removePartitionListener(mockHealthCheckService);
+    verify(mockBrokerStartupContext).removePartitionRaftListener(mockHealthCheckService);
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -45,11 +45,9 @@ public class BrokerHealthCheckServiceTest {
 
     // when + then
 
-    assertThatThrownBy(() -> healthCheckService.onBecomingInactive(0, 0))
+    assertThatThrownBy(() -> healthCheckService.onBecameRaftFollower(0, 0))
         .isInstanceOf(IllegalStateException.class);
-    assertThatThrownBy(() -> healthCheckService.onBecomingFollower(0, 0))
-        .isInstanceOf(IllegalStateException.class);
-    assertThatThrownBy(() -> healthCheckService.onBecomingLeader(0, 0, null, null))
+    assertThatThrownBy(() -> healthCheckService.onBecameRaftLeader(0, 0))
         .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -84,6 +84,12 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
+  public void notifyListenersOfBecameRaftLeader(final long newTerm) {}
+
+  @Override
+  public void notifyListenersOfBecameRaftFollower(final long newTerm) {}
+
+  @Override
   public List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm) {
     return List.of(TestActorFuture.completedFuture(null));
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -91,6 +92,32 @@ public class ZeebePartitionTest {
 
     // then
     verify(transition).toLeader(1);
+  }
+
+  @Test
+  public void shouldNotifyPartitionRaftListenersOnBecomingLeader() {
+    // given
+    schedulerRule.submitActor(partition);
+
+    // when
+    partition.onNewRole(Role.LEADER, 1);
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(ctx, timeout(1000)).notifyListenersOfBecameRaftLeader(1);
+  }
+
+  @Test
+  public void shouldNotifyPartitionRaftListenersOnBecomingFollower() {
+    // given
+    schedulerRule.submitActor(partition);
+
+    // when
+    partition.onNewRole(Role.FOLLOWER, 1);
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(ctx, timeout(1000)).notifyListenersOfBecameRaftFollower(1);
   }
 
   @Test


### PR DESCRIPTION
## Description

Introduce new PartitionRaftListener, which notifies when the partition successfully changed a role in raft. This can be follower or leader. This means the listener is notified earlier as the existing PartitionListeners, which are notified AFTER the zeebe partition is completely installed.

The BrokerHealtCheckService will be registered as PartitionRaftListener in order to mark the broker earlier ready. This is useful in order to do rolling updates faster and without issues, like running into time outs with the readiness probe. It is especially useful when partition installation might take long, due to longer replay or migration of state (due to an version upgrade for example).

See related discussion https://github.com/camunda/zeebe/issues/14252#issuecomment-1717064788

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates #14252 
