### PR TITLE
Add test application launcher for the StandaloneBroker

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
@@ -9,147 +9,127 @@ package io.camunda.zeebe.it.gateway;
 
 import static io.restassured.RestAssured.given;
 
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
-import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.zeebe.containers.ZeebeBrokerContainer;
-import io.zeebe.containers.ZeebeGatewayContainer;
-import io.zeebe.containers.ZeebePort;
 import java.time.Duration;
-import java.util.stream.Stream;
-import org.agrona.CloseHelper;
+import java.util.List;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.lifecycle.Startable;
 
 public class GatewayHealthProbeIntegrationTest {
 
   private static final String PATH_LIVENESS_PROBE = "/actuator/health/liveness";
   private static final String PATH_READINESS_PROBE = "/actuator/health/readiness";
 
-  @Test
-  void shouldReportLivenessUpIfConnectedToBroker() {
-    // --- given ---------------------------------------
+  @Nested
+  final class WithBrokerTest {
+    @Test
+    void shouldReportLivenessUpIfConnectedToBroker() {
+      // given
+      try (final var broker = new TestStandaloneBroker().start().awaitCompleteTopology();
+          final var gateway =
+              new TestStandaloneGateway()
+                  .withGatewayConfig(config -> configureGateway(config, broker))
+                  .start()
+                  .awaitCompleteTopology()) {
+        final var gatewayServerSpec =
+            new RequestSpecBuilder()
+                .setContentType(ContentType.JSON)
+                .setBaseUri("http://" + gateway.monitoringAddress())
+                .addFilter(new ResponseLoggingFilter())
+                .addFilter(new RequestLoggingFilter())
+                .build();
 
-    // create a broker and a standalone gateway
-    final ZeebeBrokerContainer broker =
-        new ZeebeBrokerContainer(ZeebeTestContainerDefaults.defaultTestImage());
-    final ZeebeGatewayContainer gateway =
-        new ZeebeGatewayContainer(ZeebeTestContainerDefaults.defaultTestImage())
-            .withNetwork(broker.getNetwork())
-            .withEnv("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getInternalClusterAddress());
-    gateway.addExposedPorts(ZeebePort.MONITORING.getPort());
-
-    // start both containers
-    Stream.of(gateway, broker).parallel().forEach(Startable::start);
-
-    final Integer actuatorPort = gateway.getMappedPort(ZeebePort.MONITORING.getPort());
-    final String containerIPAddress = gateway.getExternalHost();
-
-    final RequestSpecification gatewayServerSpec =
-        new RequestSpecBuilder()
-            .setContentType(ContentType.JSON)
-            .setBaseUri("http://" + containerIPAddress)
-            .setPort(actuatorPort)
-            .addFilter(new ResponseLoggingFilter())
-            .addFilter(new RequestLoggingFilter())
-            .build();
-
-    // --- when + then ---------------------------------------
-    // most of the liveness probes use a delayed health indicator which is scheduled at a fixed
-    // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
-    // gateway finds the broker
-    try {
-      Awaitility.await("wait until status turns UP")
-          .atMost(Duration.ofSeconds(10))
-          .pollInterval(Duration.ofMillis(100))
-          .untilAsserted(
-              () ->
-                  given()
-                      .spec(gatewayServerSpec)
-                      .when()
-                      .get(PATH_LIVENESS_PROBE)
-                      .then()
-                      .statusCode(200));
-    } catch (final ConditionTimeoutException e) {
-      // it can happen that a single request takes too long and causes awaitility to timeout,
-      // in which case we want to try a second time to run the request without timeout
-      given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(200);
+        // when - then
+        // most of the liveness probes use a delayed health indicator which is scheduled at a fixed
+        // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
+        // gateway finds the broker
+        try {
+          Awaitility.await("wait until status turns UP")
+              .atMost(Duration.ofSeconds(10))
+              .pollInterval(Duration.ofMillis(100))
+              .untilAsserted(
+                  () ->
+                      given()
+                          .spec(gatewayServerSpec)
+                          .when()
+                          .get(PATH_LIVENESS_PROBE)
+                          .then()
+                          .statusCode(200));
+        } catch (final ConditionTimeoutException e) {
+          // it can happen that a single request takes too long and causes awaitility to timeout,
+          // in which case we want to try a second time to run the request without timeout
+          given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(200);
+        }
+      }
     }
 
-    // --- shutdown ------------------------------------------
-    Stream.of(gateway, broker).parallel().forEach(Startable::stop);
+    private void configureGateway(final GatewayCfg config, final TestApplication<?> broker) {
+      config.getCluster().setInitialContactPoints(List.of(broker.address(TestZeebePort.CLUSTER)));
+    }
   }
 
   @Nested
   final class WithoutBrokerTest {
-    private final TestStandaloneGateway gateway = new TestStandaloneGateway();
-
-    @BeforeEach
-    void beforeEach() {
-      gateway.start();
-    }
-
-    @AfterEach
-    void afterEach() {
-      CloseHelper.quietClose(gateway);
-    }
-
     @Test
     void shouldReportLivenessDownIfNotConnectedToBroker() {
-      // --- given ---------------------------------------
-      final RequestSpecification gatewayServerSpec =
-          new RequestSpecBuilder()
-              .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringAddress())
-              .addFilter(new ResponseLoggingFilter())
-              .addFilter(new RequestLoggingFilter())
-              .build();
+      // given
+      try (final var gateway = new TestStandaloneGateway().start()) {
+        final var gatewayServerSpec =
+            new RequestSpecBuilder()
+                .setContentType(ContentType.JSON)
+                .setBaseUri("http://" + gateway.monitoringAddress())
+                .addFilter(new ResponseLoggingFilter())
+                .addFilter(new RequestLoggingFilter())
+                .build();
 
-      // --- when + then ---------------------------------------
-      given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(503);
+        // when - then
+        given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(503);
+      }
     }
 
     @Test
     void shouldReportReadinessUpIfApplicationIsUp() {
       // given
-      final var gatewayServerSpec =
-          new RequestSpecBuilder()
-              .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringAddress())
-              .addFilter(new ResponseLoggingFilter())
-              .addFilter(new RequestLoggingFilter())
-              .build();
+      try (final var gateway = new TestStandaloneGateway().start()) {
+        final var gatewayServerSpec =
+            new RequestSpecBuilder()
+                .setContentType(ContentType.JSON)
+                .setBaseUri("http://" + gateway.monitoringAddress())
+                .addFilter(new ResponseLoggingFilter())
+                .addFilter(new RequestLoggingFilter())
+                .build();
 
-      // when
-      // then
-      // most of the readiness probes use a delayed health indicator which is scheduled at a fixed
-      // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
-      // gateway finds the broker
-      try {
-        Awaitility.await("wait until status turns UP")
-            .atMost(Duration.ofSeconds(10))
-            .pollInterval(Duration.ofMillis(100))
-            .untilAsserted(
-                () ->
-                    given()
-                        .spec(gatewayServerSpec)
-                        .when()
-                        .get(PATH_READINESS_PROBE)
-                        .then()
-                        .statusCode(200));
-      } catch (final ConditionTimeoutException e) {
-        // it can happen that a single request takes too long and causes awaitility to timeout,
-        // in which case we want to try a second time to run the request without timeout
-        given().spec(gatewayServerSpec).when().get(PATH_READINESS_PROBE).then().statusCode(200);
+        // when - then
+        // most of the readiness probes use a delayed health indicator which is scheduled at a fixed
+        // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
+        // gateway finds the broker
+        try {
+          Awaitility.await("wait until status turns UP")
+              .atMost(Duration.ofSeconds(10))
+              .pollInterval(Duration.ofMillis(100))
+              .untilAsserted(
+                  () ->
+                      given()
+                          .spec(gatewayServerSpec)
+                          .when()
+                          .get(PATH_READINESS_PROBE)
+                          .then()
+                          .statusCode(200));
+        } catch (final ConditionTimeoutException e) {
+          // it can happen that a single request takes too long and causes awaitility to timeout,
+          // in which case we want to try a second time to run the request without timeout
+          given().spec(gatewayServerSpec).when().get(PATH_READINESS_PROBE).then().statusCode(200);
+        }
       }
     }
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayIntegrationTest.java
@@ -9,70 +9,50 @@ package io.camunda.zeebe.it.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.broker.clustering.ClusterServices;
-import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.gateway.cmd.BrokerRejectionException;
-import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerRejection;
-import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.scheduler.ActorScheduler;
-import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
-import java.time.Duration;
-import java.util.Collections;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public final class GatewayIntegrationTest {
-  @Rule
-  public EmbeddedBrokerRule broker =
-      new EmbeddedBrokerRule(brokerCfg -> brokerCfg.getGateway().setEnable(false));
+@AutoCloseResources
+final class GatewayIntegrationTest {
+  @AutoCloseResource
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker().withBrokerConfig(config -> config.getGateway().setEnable(false));
 
-  private final ActorScheduler actorScheduler = new ActorSchedulerBuilder().build();
-  private BrokerClientImpl client;
+  @AutoCloseResource
+  private final TestStandaloneGateway gateway =
+      new TestStandaloneGateway()
+          .withGatewayConfig(
+              config ->
+                  config
+                      .getCluster()
+                      .setInitialContactPoints(List.of(broker.address(TestZeebePort.CLUSTER))));
 
-  @Before
-  public void setup() {
-    final GatewayCfg configuration = new GatewayCfg();
-    final var brokerCfg = broker.getBrokerCfg();
-    final var internalApi = brokerCfg.getNetwork().getInternalApi();
-    configuration
-        .getCluster()
-        .setHost("0.0.0.0")
-        .setPort(SocketUtil.getNextAddress().getPort())
-        .setInitialContactPoints(Collections.singletonList(internalApi.toString()))
-        .setRequestTimeout(Duration.ofSeconds(10));
-    configuration.init();
-
-    final ClusterServices clusterServices = broker.getClusterServices();
-    actorScheduler.start();
-    client =
-        new BrokerClientImpl(
-            configuration.getCluster().getRequestTimeout(),
-            clusterServices.getMessagingService(),
-            clusterServices.getMembershipService(),
-            clusterServices.getEventService(),
-            actorScheduler);
-    client.start();
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    client.close();
-    actorScheduler.close();
+  @BeforeEach
+  void beforeEach() {
+    broker.start().await(TestHealthProbe.READY);
+    gateway.start().awaitCompleteTopology();
   }
 
   @Test
-  public void shouldReturnRejectionWithCorrectTypeAndReason() throws InterruptedException {
+  void shouldReturnRejectionWithCorrectTypeAndReason() throws InterruptedException {
     // given
-    final CountDownLatch latch = new CountDownLatch(1);
+    final var latch = new CountDownLatch(1);
     final AtomicReference<Throwable> errorResponse = new AtomicReference<>();
+    final var client = gateway.bean(BrokerClient.class);
 
     // when
     client.sendRequestWithRetry(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/queryapi/QueryApiIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/queryapi/QueryApiIT.java
@@ -15,73 +15,67 @@ import io.camunda.zeebe.client.api.response.CancelProcessInstanceResponse;
 import io.camunda.zeebe.client.api.response.CompleteJobResponse;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
 import io.camunda.zeebe.it.queryapi.util.TestAuthorizationClientInterceptor;
 import io.camunda.zeebe.it.queryapi.util.TestAuthorizationListener;
 import io.camunda.zeebe.it.queryapi.util.TestAuthorizationServerInterceptor;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.grpc.CloseAwareListener;
-import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
 import io.grpc.StatusRuntimeException;
-import io.zeebe.containers.ZeebeContainer;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import net.bytebuddy.ByteBuddy;
+import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.MountableFile;
 
-@Testcontainers
 final class QueryApiIT {
-  private static final Logger LOGGER = LoggerFactory.getLogger(QueryApiIT.class);
   private static final BpmnModelInstance PROCESS =
       Bpmn.createExecutableProcess("tenantA.process")
           .startEvent()
           .serviceTask("task", b -> b.zeebeJobType("type"))
           .endEvent()
           .done();
+
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBrokerConfig(cfg -> cfg.getExperimental().getQueryApi().setEnabled(true))
+          .withBrokerConfig(
+              cfg -> {
+                final var config = new InterceptorCfg();
+                config.setId("auth");
+                config.setClassName(TestAuthorizationServerInterceptor.class.getName());
+                config.setJarPath(createInterceptorJar().getAbsolutePath());
+                cfg.getGateway().getInterceptors().add(config);
+              });
+
   private static long processDefinitionKey;
-
-  @Container
-  private static final ZeebeContainer BROKER =
-      new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
-          .withEnv("ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED", "true")
-          .withEnv("ZEEBE_BROKER_GATEWAY_INTERCEPTORS_0_ID", "auth")
-          .withEnv(
-              "ZEEBE_BROKER_GATEWAY_INTERCEPTORS_0_CLASSNAME",
-              TestAuthorizationServerInterceptor.class.getName())
-          .withEnv("ZEEBE_BROKER_GATEWAY_INTERCEPTORS_0_JARPATH", "/tmp/interceptor.jar")
-          .withCopyFileToContainer(
-              MountableFile.forHostPath(createInterceptorJar().getAbsolutePath()),
-              "/tmp/interceptor.jar");
-
-  @SuppressWarnings("unused")
-  @RegisterExtension
-  private static final ContainerLogsDumper CONTAINER_LOGS_DUMPER =
-      new ContainerLogsDumper(() -> Map.of("broker", BROKER), LOGGER);
 
   @BeforeAll
   static void beforeAll() {
+    BROKER.start().awaitCompleteTopology();
+
     try (final var client = createZeebeClient("beforeAll")) {
       final var deployment =
           client.newDeployResourceCommand().addProcessModel(PROCESS, "process.bpmn").send().join();
       processDefinitionKey = deployment.getProcesses().get(0).getProcessDefinitionKey();
     }
+  }
+
+  @AfterAll
+  static void afterAll() {
+    CloseHelper.quietClose(BROKER);
   }
 
   @Test
@@ -200,7 +194,7 @@ final class QueryApiIT {
     final List<ActivatedJob> jobs = new CopyOnWriteArrayList<>();
     final JobHandler handler = (client, job) -> jobs.add(job);
     try (final var client = createZeebeClient("tenantA");
-        final var worker = client.newWorker().jobType("type").handler(handler).open()) {
+        final var ignored = client.newWorker().jobType("type").handler(handler).open()) {
       client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
       Awaitility.await("until one job is activated")
           .untilAsserted(() -> assertThat(jobs).isNotEmpty());
@@ -210,11 +204,10 @@ final class QueryApiIT {
   }
 
   private static ZeebeClient createZeebeClient(final String tenant) {
-    return ZeebeClient.newClientBuilder()
-        .gatewayAddress(BROKER.getExternalGatewayAddress())
+    return BROKER
+        .newClientBuilder()
         .withInterceptors(new TestAuthorizationClientInterceptor(tenant))
         .defaultRequestTimeout(Duration.ofMinutes(1))
-        .usePlaintext()
         .build();
   }
 

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -151,5 +151,16 @@
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import java.util.function.Consumer;
+import org.awaitility.Awaitility;
+
+/**
+ * Represents a Zeebe gateway, either standalone or embedded.
+ *
+ * @param <T> the concrete type of the implementation
+ */
+public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T> {
+
+  /**
+   * Returns the address used by clients to interact with the gateway.
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .gatewayAddress(gateway.gatewayAddress())
+   *     .usePlaintext()
+   *     .build();
+   * }</pre>
+   *
+   * @return the gateway address
+   */
+  default String gatewayAddress() {
+    return address(TestZeebePort.GATEWAY);
+  }
+
+  /**
+   * Returns the health actuator for this gateway. You can use this to check for liveness,
+   * readiness, and startup.
+   */
+  default GatewayHealthActuator gatewayHealth() {
+    return GatewayHealthActuator.ofAddress(monitoringAddress());
+  }
+
+  @Override
+  default HealthActuator healthActuator() {
+    return gatewayHealth();
+  }
+
+  @Override
+  default boolean isGateway() {
+    return true;
+  }
+
+  /**
+   * Allows modifying the gateway configuration. Changes will not take effect until the node is
+   * restarted.
+   */
+  T withGatewayConfig(final Consumer<GatewayCfg> modifier);
+
+  /** Returns the gateway configuration for this node. */
+  GatewayCfg gatewayConfig();
+
+  /** Returns a new pre-configured client builder for this gateway */
+  default ZeebeClientBuilder newClientBuilder() {
+    final var builder = ZeebeClient.newClientBuilder().gatewayAddress(gatewayAddress());
+    final var security = gatewayConfig().getSecurity();
+    if (security.isEnabled()) {
+      builder.caCertificatePath(security.getCertificateChainPath().getAbsolutePath());
+    } else {
+      builder.usePlaintext();
+    }
+
+    return builder;
+  }
+
+  /**
+   * Blocks until the topology is complete. See {@link TopologyAssert#isComplete(int, int, int)} for
+   * semantics.
+   *
+   * @return itself for chaining
+   * @see TopologyAssert#isComplete(int, int, int)
+   */
+  default T awaitCompleteTopology(
+      final int clusterSize,
+      final int partitionCount,
+      final int replicationFactor,
+      final Duration timeout) {
+    try (final var client = newClientBuilder().build()) {
+      Awaitility.await("until cluster topology is complete")
+          .atMost(timeout)
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                      .isComplete(clusterSize, partitionCount, replicationFactor));
+    }
+
+    return self();
+  }
+
+  /**
+   * Convenience method to await complete topology of single node clusters.
+   *
+   * @return itself for chaining
+   */
+  default T awaitCompleteTopology() {
+    return awaitCompleteTopology(1, 1, 1, Duration.ofSeconds(30));
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestHealthProbe.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestHealthProbe.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+/** Logical representation of the various health probes in Zeebe */
+public enum TestHealthProbe {
+  LIVE,
+  READY,
+  STARTED;
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.restore.RestoreApp;
 import io.camunda.zeebe.shared.Profile;
 import java.util.function.Consumer;
@@ -40,6 +41,16 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
   @Override
   public MemberId nodeId() {
     return MemberId.from(String.valueOf(config.getCluster().getNodeId()));
+  }
+
+  @Override
+  public HealthActuator healthActuator() {
+    return new HealthActuator.NoopHealthActuator();
+  }
+
+  @Override
+  public boolean isGateway() {
+    return false;
   }
 
   @Override

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -90,6 +90,11 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     return monitoringPort();
   }
 
+  @Override
+  public <V> V bean(final Class<V> type) {
+    return springContext.getBean(type);
+  }
+
   /** Returns the command line arguments that will be passed when the application is started. */
   protected String[] commandLineArgs() {
     return new String[0];

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.StandaloneBroker;
+import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration.WorkingDirectory;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.qa.util.actuator.BrokerHealthActuator;
+import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator;
+import io.camunda.zeebe.shared.Profile;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+/** Represents an instance of the {@link StandaloneBroker} Spring application. */
+@SuppressWarnings("UnusedReturnValue")
+public final class TestStandaloneBroker extends TestSpringApplication<TestStandaloneBroker>
+    implements TestGateway<TestStandaloneBroker> {
+
+  private static final String RECORDING_EXPORTER_ID = "recordingExporter";
+  private final BrokerCfg config;
+
+  public TestStandaloneBroker() {
+    super(StandaloneBroker.class);
+
+    config = new BrokerCfg();
+
+    config.getNetwork().getCommandApi().setPort(SocketUtil.getNextAddress().getPort());
+    config.getNetwork().getInternalApi().setPort(SocketUtil.getNextAddress().getPort());
+    config.getGateway().getNetwork().setPort(SocketUtil.getNextAddress().getPort());
+
+    //noinspection resource
+    withBean("uninitializedBrokerCfg", config, BrokerCfg.class);
+  }
+
+  @Override
+  public TestStandaloneBroker self() {
+    return this;
+  }
+
+  @Override
+  public MemberId nodeId() {
+    return MemberId.from(String.valueOf(config.getCluster().getNodeId()));
+  }
+
+  @Override
+  public String host() {
+    return config.getNetwork().getHost();
+  }
+
+  @Override
+  public HealthActuator healthActuator() {
+    return brokerHealth();
+  }
+
+  @Override
+  public boolean isGateway() {
+    return config.getGateway().isEnable();
+  }
+
+  @Override
+  public int mappedPort(final TestZeebePort port) {
+    return switch (port) {
+      case COMMAND -> config.getNetwork().getCommandApi().getPort();
+      case GATEWAY -> config.getGateway().getNetwork().getPort();
+      case CLUSTER -> config.getNetwork().getInternalApi().getPort();
+      default -> super.mappedPort(port);
+    };
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringBuilder() {
+    return super.createSpringBuilder().profiles(Profile.BROKER.getId());
+  }
+
+  @Override
+  public String gatewayAddress() {
+    if (!isGateway()) {
+      throw new IllegalStateException(
+          "Expected to get the gateway address for this broker, but the embedded gateway is not enabled");
+    }
+
+    return TestGateway.super.gatewayAddress();
+  }
+
+  @Override
+  public GatewayHealthActuator gatewayHealth() {
+    throw new UnsupportedOperationException("Brokers do not support the gateway health indicators");
+  }
+
+  @Override
+  public TestStandaloneBroker withGatewayConfig(final Consumer<GatewayCfg> modifier) {
+    modifier.accept(config.getGateway());
+    return this;
+  }
+
+  @Override
+  public GatewayCfg gatewayConfig() {
+    return config.getGateway();
+  }
+
+  @Override
+  public ZeebeClientBuilder newClientBuilder() {
+    if (!isGateway()) {
+      throw new IllegalStateException(
+          "Cannot create a new client for this broker, as it does not have an embedded gateway");
+    }
+
+    return TestGateway.super.newClientBuilder();
+  }
+
+  /** Returns the broker configuration */
+  public BrokerCfg brokerConfig() {
+    return config;
+  }
+
+  /**
+   * Modifies the broker configuration. Will still mutate the configuration if the broker is
+   * started, but likely has no effect until it's restarted.
+   */
+  public TestStandaloneBroker withBrokerConfig(final Consumer<BrokerCfg> modifier) {
+    modifier.accept(config);
+    return this;
+  }
+
+  /**
+   * Returns the health actuator for this broker. You can use this to check for liveness, readiness,
+   * and startup.
+   */
+  public BrokerHealthActuator brokerHealth() {
+    return BrokerHealthActuator.ofAddress(monitoringAddress());
+  }
+
+  /**
+   * Enables/disables usage of the recording exporter using {@link #RECORDING_EXPORTER_ID} as its
+   * unique ID.
+   *
+   * @param useRecordingExporter if true, will enable the exporter; if false, will remove it from
+   *     the config
+   * @return itself for chaining
+   */
+  public TestStandaloneBroker withRecordingExporter(final boolean useRecordingExporter) {
+    if (!useRecordingExporter) {
+      config.getExporters().remove(RECORDING_EXPORTER_ID);
+      return this;
+    }
+
+    return withExporter(
+        RECORDING_EXPORTER_ID, cfg -> cfg.setClassName(RecordingExporter.class.getName()));
+  }
+
+  /**
+   * Adds or replaces a new exporter with the given ID. If it was already existing, the existing
+   * configuration is passed to the modifier. If it's new, a blank configuration is passed.
+   *
+   * @param id the ID of the exporter
+   * @param modifier a configuration function
+   * @return itself for chaining
+   */
+  public TestStandaloneBroker withExporter(final String id, final Consumer<ExporterCfg> modifier) {
+    final var exporterConfig =
+        config.getExporters().computeIfAbsent(id, ignored -> new ExporterCfg());
+    modifier.accept(exporterConfig);
+
+    return this;
+  }
+
+  /**
+   * Sets the broker's working directory, aka its data directory. If a path is given, the broker
+   * will not delete it on shutdown.
+   *
+   * @param directory path to the broker's root data directory
+   * @return itself for chaining
+   */
+  public TestStandaloneBroker withWorkingDirectory(final Path directory) {
+    return withBean(
+        "workingDirectory", new WorkingDirectory(directory, false), WorkingDirectory.class);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a test application launcher for the `StandaloneBroker`, which allows configuring the `BrokerCfg` bean programmatically, probing the health actuator, and awaiting it's various states (e.g. topology complete, broker ready, etc.), as well as common helpers to add exporters, the recording exporter, etc.

Additionally, a new interface is added to identify apps that can act as gateways (i.e. the broker and standalone gateway). This will become particularly useful when we start with the cluster API.

As usual, in lieu of tests, some existing test classes have been refactored. This PR also doesn't cover all the points raised in the original issue to keep it small (even though it's not small :sweat_smile:), and most will be added with the cluster extension.

## Related issues

closes #13968 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
