### PR TITLE
Add test standalone cluster builder and launcher

### DIFF
--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -162,5 +162,11 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -49,8 +49,17 @@ public interface BackupActuator {
    * @return a new instance of {@link BackupActuator}
    */
   static BackupActuator of(final ZeebeNode<?> node) {
-    final var endpoint =
-        String.format("http://%s/actuator/backups", node.getExternalMonitoringAddress());
+    return ofAddress(node.getExternalMonitoringAddress());
+  }
+
+  /**
+   * Returns a {@link BackupActuator} instance using the given node as upstream.
+   *
+   * @param address the monitoring address
+   * @return a new instance of {@link BackupActuator}
+   */
+  static BackupActuator ofAddress(final String address) {
+    final var endpoint = String.format("http://%s/actuator/backups", address);
     return of(endpoint);
   }
 

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
@@ -140,4 +140,15 @@ public interface TestApplication<T extends TestApplication<T>> extends AutoClose
    * @param <V> the expected bean type
    */
   <V> V bean(final Class<V> type);
+
+  /**
+   * Configures Spring via properties. This does not work with properties that would be applied to
+   * injected beans (e.g. via {@link #withBean(String, Object, Class)}), since there will be
+   * property resolution for these beans.
+   *
+   * @param key the property key
+   * @param value the new value
+   * @return itself for chaining
+   */
+  T withProperty(final String key, final Object value);
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import io.camunda.zeebe.util.CloseableSilently;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A convenience class representing a one or more Spring applications that form a Zeebe cluster.
+ *
+ * <p>It's recommended to use the {@link TestClusterBuilder} to build one.
+ *
+ * <p>As the cluster is not started automatically, the nodes can still be modified/configured
+ * beforehand. Be aware however that the replication factor and the partitions count cannot be
+ * modified: if you configure different values directly on your brokers, then you may run into
+ * issues. Keep in mind as well that the gateways and brokers should be treated as immutable
+ * collections.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * final class MyClusteredTest {
+ *   private SpringCluster cluster;
+ *
+ *   &#64;BeforeEach
+ *   void beforeEach() {
+ *     cluster = TestCluster.builder()
+ *         .withBrokersCount(3)
+ *         .withReplicationFactor(3)
+ *         .withPartitionsCount(1)
+ *         .useEmbeddedGateway(true)
+ *         .build();
+ *   }
+ *
+ *   &#64;AfterEach
+ *   void afterEach() {
+ *     cluster.stop();
+ *   }
+ *
+ *   &#64;Test
+ *   void shouldConnectToCluster() {
+ *     // given
+ *     cluster.start();
+ *     cluster.awaitCompleteTopology();
+ *
+ *     // when
+ *     final Topology topology;
+ *     try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+ *       topology = c.newTopologyRequest().send().join();
+ *     }
+ *
+ *     // then
+ *     assertThat(topology.getClusterSize()).isEqualTo(3);
+ *   }
+ * }
+ * }</pre>
+ */
+@SuppressWarnings({"ClassCanBeRecord", "UnusedReturnValue"})
+public final class TestCluster implements CloseableSilently {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestCluster.class);
+
+  private final String name;
+  private final Map<MemberId, TestStandaloneGateway> gateways;
+  private final Map<MemberId, TestStandaloneBroker> brokers;
+  private final int replicationFactor;
+  private final int partitionsCount;
+
+  /**
+   * Creates a new cluster from the given parameters.
+   *
+   * @param name the name of the cluster (should also be configured on the nodes)
+   * @param replicationFactor the replication factor of the cluster
+   * @param partitionsCount the number of partitions in the cluster
+   * @param brokers the set of broker nodes, identified by their node ID
+   * @param gateways the set of gateway nodes, identified by their member ID
+   */
+  public TestCluster(
+      final String name,
+      final int replicationFactor,
+      final int partitionsCount,
+      final Map<MemberId, TestStandaloneBroker> brokers,
+      final Map<MemberId, TestStandaloneGateway> gateways) {
+    this.name = name;
+    this.replicationFactor = replicationFactor;
+    this.partitionsCount = partitionsCount;
+    this.brokers = Collections.unmodifiableMap(brokers);
+    this.gateways = Collections.unmodifiableMap(gateways);
+  }
+
+  /** Returns a new cluster builder */
+  public static TestClusterBuilder builder() {
+    return new TestClusterBuilder();
+  }
+
+  /**
+   * Starts all applications in the cluster.
+   *
+   * <p>NOTE: This is a blocking method which returns when all applications are started from the
+   * Spring point of view. This means the broker startup has begun, but is not necessarily yet
+   * finished, such that it may not be ready.
+   *
+   * <p>You can use {@link #await(TestHealthProbe, Duration)} to wait until a specific probe (e.g.
+   * {@link TestHealthProbe#READY} succeeds on all nodes, or {@link
+   * #awaitCompleteTopology(Duration)} to wait until the topology is complete for all gateways.
+   */
+  public TestCluster start() {
+    LOGGER.info(
+        "Starting cluster {} with {} brokers, {} gateways, {} partitions, and a replication factor"
+            + " of {}",
+        name,
+        brokers.size(),
+        gateways.size(),
+        partitionsCount,
+        replicationFactor);
+
+    final var started =
+        nodes().values().stream()
+            .map(node -> CompletableFuture.runAsync(node::start))
+            .toArray(CompletableFuture[]::new);
+    CompletableFuture.allOf(started).join();
+    return this;
+  }
+
+  /**
+   * Stops all containers in the cluster.
+   *
+   * <p>NOTE: this method is blocking, and returns when all nodes are completely shut down.
+   */
+  public TestCluster shutdown() {
+    final var stopped =
+        nodes().values().stream()
+            .map(node -> CompletableFuture.runAsync(node::stop))
+            .toArray(CompletableFuture[]::new);
+    CompletableFuture.allOf(stopped).join();
+    return this;
+  }
+
+  /**
+   * Returns the replication factor configured for the brokers; also used to check for a complete
+   * topology.
+   */
+  public int replicationFactor() {
+    return replicationFactor;
+  }
+
+  /**
+   * Returns the partition count configured for the brokers; also used to check for a complete
+   * topology.
+   */
+  public int partitionsCount() {
+    return partitionsCount;
+  }
+
+  /** Returns the cluster name. */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Returns the first gateway which can accept requests from a Zeebe client.
+   *
+   * <p>NOTE: this includes brokers with embedded gateways.
+   *
+   * @return a gateway ready to accept requests
+   * @throws NoSuchElementException if there are no such gateways (e.g. none are started, or they
+   *     are dead, etc.)
+   */
+  public TestGateway<?> availableGateway() {
+    return allGateways()
+        .filter(this::isReady)
+        .findFirst()
+        .orElseThrow(() -> new NoSuchElementException("No available gateway for cluster"));
+  }
+
+  /**
+   * Returns a map of the gateways in the cluster, where the keys are the memberIds, and the values
+   * the gateway containers.
+   *
+   * <p>NOTE: this does not include brokers which are embedded gateways.
+   *
+   * @return the standalone gateways in this cluster
+   */
+  public Map<MemberId, TestStandaloneGateway> gateways() {
+    return gateways;
+  }
+
+  /**
+   * Returns a map of the brokers in the cluster, where the keys are the broker's nodeId, and the
+   * values the broker containers.
+   *
+   * @return the brokers in this cluster
+   */
+  public Map<MemberId, TestStandaloneBroker> brokers() {
+    return brokers;
+  }
+
+  /**
+   * Returns a map of all nodes in the cluster, where the keys are the member IDs (for brokers, the
+   * node ID), and the values are the nodes.
+   *
+   * @return the nodes of this cluster
+   */
+  public Map<MemberId, TestApplication<?>> nodes() {
+    final Map<MemberId, TestApplication<?>> nodes = new HashMap<>(brokers);
+    nodes.putAll(gateways);
+
+    return nodes;
+  }
+
+  /**
+   * Builds a new client builder by picking a random gateway started gateway for it and disabling
+   * transport security.
+   *
+   * <p>NOTE: this will properly automatically configure the security level, but will not configure
+   * authentication.
+   *
+   * @return a new client builder with the gateway and transport security pre-configured
+   * @throws NoSuchElementException if there are no started gateways
+   */
+  @SuppressWarnings("resource")
+  public ZeebeClientBuilder newClientBuilder() {
+    return ZeebeClient.newClientBuilder()
+        .usePlaintext()
+        .gatewayAddress(availableGateway().gatewayAddress());
+  }
+
+  /**
+   * Convenience alias for {@link #awaitCompleteTopology(Duration)} with a default value of 1 minute
+   * per brokers.
+   */
+  @SuppressWarnings("resource")
+  public TestCluster awaitCompleteTopology() {
+    awaitCompleteTopology(Duration.ofMinutes(brokers.size()));
+    return this;
+  }
+
+  /**
+   * Waits until every gateway in the cluster sees a complete and healthy topology, as defined by
+   * the {@link #replicationFactor}, {@link #partitionsCount}, and count of {@link #brokers} in this
+   * cluster.
+   *
+   * @param timeout maximum time to block before failing
+   * @throws org.awaitility.core.ConditionTimeoutException if timeout expires before the topology is
+   *     complete
+   */
+  public TestCluster awaitCompleteTopology(final Duration timeout) {
+    Awaitility.await("until cluster topology is complete")
+        .atMost(timeout)
+        .untilAsserted(() -> assertThat(allGateways()).allSatisfy(this::assertCompleteTopology));
+    return this;
+  }
+
+  /**
+   * Convenience method for {@link #await(TestHealthProbe, Duration)} with a default timeout of 1
+   * minute per node in the cluster.
+   *
+   * @param probe the probe to wait for
+   */
+  @SuppressWarnings("resource")
+  public TestCluster await(final TestHealthProbe probe) {
+    await(probe, Duration.ofMinutes(brokers.size() + gateways.size()));
+    return this;
+  }
+
+  /**
+   * Waits until the given probe succeeds, or until the timeout expires.
+   *
+   * @param probe the probe to check
+   * @param timeout maximum time to block
+   */
+  public TestCluster await(final TestHealthProbe probe, final Duration timeout) {
+    final var nodes = nodes().values();
+    Awaitility.await("until '%s' probe succeeds on all nodes".formatted(probe))
+        .atMost(timeout)
+        .untilAsserted(() -> assertThat(nodes).allSatisfy(node -> assertProbe(node, probe)));
+    return this;
+  }
+
+  @Override
+  public void close() {
+    //noinspection resource
+    shutdown();
+  }
+
+  private boolean isReady(final TestApplication<?> node) {
+    if (!node.isStarted()) {
+      return false;
+    }
+
+    try {
+      node.probe(TestHealthProbe.READY);
+    } catch (final Exception e) {
+      LOGGER.trace("Node {} is not ready", node.nodeId(), e);
+      return false;
+    }
+
+    return true;
+  }
+
+  private void assertCompleteTopology(final TestGateway<?> node) {
+    assertThatCode(() -> node.probe(TestHealthProbe.READY))
+        .as("gateway '%s' is ready", node.nodeId())
+        .doesNotThrowAnyException();
+    try (final var client = node.newClientBuilder().build()) {
+      TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+          .isComplete(brokers.size(), partitionsCount, replicationFactor);
+    }
+  }
+
+  private void assertProbe(final TestApplication<?> node, final TestHealthProbe probe) {
+    assertThatCode(() -> node.probe(probe)).doesNotThrowAnyException();
+  }
+
+  private Stream<TestGateway<?>> allGateways() {
+    return nodes().values().stream()
+        .filter(TestApplication::isGateway)
+        .filter(TestGateway.class::isInstance)
+        .map(node -> (TestGateway<?>) node);
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -41,9 +41,9 @@ import org.slf4j.LoggerFactory;
  *
  * <pre>{@code
  * final class MyClusteredTest {
- *   private SpringCluster cluster;
+ *   private TestCluster cluster;
  *
- *   &#64;BeforeEach
+ *   @BeforeEach
  *   void beforeEach() {
  *     cluster = TestCluster.builder()
  *         .withBrokersCount(3)
@@ -53,12 +53,12 @@ import org.slf4j.LoggerFactory;
  *         .build();
  *   }
  *
- *   &#64;AfterEach
+ *   @AfterEach
  *   void afterEach() {
  *     cluster.stop();
  *   }
  *
- *   &#64;Test
+ *   @Test
  *   void shouldConnectToCluster() {
  *     // given
  *     cluster.start();

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+@SuppressWarnings({"unused", "resource"})
+public final class TestClusterBuilder {
+
+  private static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
+
+  private String name = DEFAULT_CLUSTER_NAME;
+
+  private int gatewaysCount = 0;
+
+  private int brokersCount = 1;
+  private int partitionsCount = 1;
+  private int replicationFactor = 1;
+  private boolean useEmbeddedGateway = true;
+  private boolean useRecordingExporter = true;
+
+  private Consumer<TestApplication<?>> nodeConfig = node -> {};
+  private BiConsumer<MemberId, TestStandaloneBroker> brokerConfig = (id, broker) -> {};
+  private BiConsumer<MemberId, TestGateway<?>> gatewayConfig = (id, gateway) -> {};
+
+  private final Map<MemberId, TestStandaloneGateway> gateways = new HashMap<>();
+  private final Map<MemberId, TestStandaloneBroker> brokers = new HashMap<>();
+
+  /**
+   * If true, the brokers created by this cluster will use embedded gateways. By default this is
+   * true.
+   *
+   * @param useEmbeddedGateway true or false to enable the embedded gateway on the brokers
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withEmbeddedGateway(final boolean useEmbeddedGateway) {
+    this.useEmbeddedGateway = useEmbeddedGateway;
+    return this;
+  }
+
+  /**
+   * The number of standalone gateway to create in this cluster. By default, this is 0, and the
+   * brokers have embedded gateways.
+   *
+   * <p>Note that this parameter has no impact on the use of embedded gateways, and a cluster can
+   * contain both standalone and embedded gateways.
+   *
+   * @param gatewaysCount the number of standalone gateways to create
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withGatewaysCount(final int gatewaysCount) {
+    this.gatewaysCount = gatewaysCount;
+    return this;
+  }
+
+  /**
+   * The number of brokers to create in this cluster. By default, this is 1.
+   *
+   * <p>Note that it's possible to create a cluster with no brokers, as this is could be a valid
+   * setup for testing purposes. If that's the case, the gateways will not wait for the topology to
+   * be complete (as they cannot know the topology), and will not be configured with a contact
+   * point.
+   *
+   * <p>NOTE: setting this to 0 will also set the replication factor and partitions count to 0.
+   *
+   * @param brokersCount the number of brokers to create
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withBrokersCount(final int brokersCount) {
+    if (brokersCount < 0) {
+      throw new IllegalArgumentException(
+          "Expected brokersCount to be at least 0, but was " + brokersCount);
+    }
+
+    this.brokersCount = brokersCount;
+    if (brokersCount > 0) {
+      partitionsCount = Math.max(partitionsCount, 1);
+      replicationFactor = Math.max(replicationFactor, 1);
+    } else {
+      partitionsCount = 0;
+      replicationFactor = 0;
+    }
+
+    return this;
+  }
+
+  /**
+   * Will set the number of partitions to distribute across the cluster. For example, if there are 3
+   * brokers, 3 partitions, but replication factor of 1, then each broker will get exactly one
+   * partition.
+   *
+   * <p>Note that the number of partitions must be greater than or equal to 1! If you do not want to
+   * have any brokers, then set {@link #withBrokersCount(int)} to 0 instead.
+   *
+   * @param partitionsCount the number of partitions to distribute across the cluster
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withPartitionsCount(final int partitionsCount) {
+    if (partitionsCount <= 0) {
+      throw new IllegalArgumentException(
+          "Expected partitionsCount to be at least 1, but was " + partitionsCount);
+    }
+
+    this.partitionsCount = partitionsCount;
+    return this;
+  }
+
+  /**
+   * Sets the replication factor for each partition in the cluster. Note that this cannot be less
+   * than 1, or greater than the broker count (see {@link #withBrokersCount(int)}).
+   *
+   * @param replicationFactor the replication factor for each partition
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withReplicationFactor(final int replicationFactor) {
+    if (replicationFactor <= 0) {
+      throw new IllegalArgumentException(
+          "Expected replicationFactor to be at least 1, but was " + replicationFactor);
+    }
+
+    this.replicationFactor = replicationFactor;
+    return this;
+  }
+
+  /**
+   * Sets the name of the cluster. This can be used to prevent nodes in one cluster from
+   * inadvertently communicating with nodes in another cluster.
+   *
+   * <p>Unless you're deploying multiple clusters in the same network, leave as is.
+   *
+   * @param name the cluster name
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withName(final String name) {
+    if (name == null || name.trim().length() < 3) {
+      throw new IllegalArgumentException(
+          "Expected cluster name to be at least 3 characters, but was " + name);
+    }
+
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Sets the configuration function that will be executed in the {@link #build()} method on both
+   * brokers and gateways (embedded gateways included). NOTE: this configuration has the lowest
+   * priority, e.g. other configurations ({@link #gatewayConfig} or {@link #brokerConfig}) will
+   * override this configuration in case of conflicts.
+   *
+   * @param modifier the function that will be applied on all cluster nodes
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withNodeConfig(final Consumer<TestApplication<?>> modifier) {
+    nodeConfig = modifier;
+    return this;
+  }
+
+  /**
+   * Sets the configuration function that will be executed in the {@link #build()} method on each
+   * gateway (including embedded gateways). The first argument of is the member ID of the gateway,
+   * and the second argument is the gateway itself.
+   *
+   * <p>NOTE: in case of conflicts with {@link #nodeConfig} this configuration will override {@link
+   * #nodeConfig}.
+   *
+   * <p>NOTE: in case of conflicts with this configuration is an embedded gateway configuration and
+   * a broker configuration, broker configuration will override this configuration.
+   *
+   * @param modifier the function that will be applied on all cluster gateways (embedded ones
+   *     included)
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withGatewayConfig(final BiConsumer<MemberId, TestGateway<?>> modifier) {
+    gatewayConfig = modifier;
+    return this;
+  }
+
+  /**
+   * Sets the configuration function that will be executed in the {@link #build()} method on each
+   * gateway (including embedded gateways).
+   *
+   * <p>NOTE: in case of conflicts with {@link #nodeConfig} this configuration will override {@link
+   * #nodeConfig}.
+   *
+   * <p>NOTE: in case of conflicts with this configuration is an embedded gateway configuration and
+   * a broker configuration, broker configuration will override this configuration.
+   *
+   * @param modifier the function that will be applied on all cluster gateways (embedded ones
+   *     included)
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withGatewayConfig(final Consumer<TestGateway<?>> modifier) {
+    gatewayConfig = (memberId, gateway) -> modifier.accept(gateway);
+    return this;
+  }
+
+  /**
+   * Sets the configuration function that will be executed in the {@link #build()} method on each
+   * broker. The first argument is the broker ID, and the second argument is the broker itself.
+   *
+   * <p>NOTE: in case of conflicts with {@link #nodeConfig} or {@link #gatewayConfig} this
+   * configuration will override them.
+   *
+   * @param modifier the function that will be applied on all cluster brokers
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withBrokerConfig(
+      final BiConsumer<MemberId, TestStandaloneBroker> modifier) {
+    brokerConfig = modifier;
+    return this;
+  }
+
+  /**
+   * Sets the configuration function that will be executed in the {@link #build()} method on each
+   * broker.
+   *
+   * <p>NOTE: in case of conflicts with {@link #nodeConfig} or {@link #gatewayConfig} this
+   * configuration will override them.
+   *
+   * @param modifier the function that will be applied on all cluster brokers
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder withBrokerConfig(final Consumer<TestStandaloneBroker> modifier) {
+    brokerConfig = (id, broker) -> modifier.accept(broker);
+    return this;
+  }
+
+  /**
+   * If true, registers the {@link RecordingExporter} for each broker. Defaults to true.
+   *
+   * @param useRecordingExporter whether to enable the recording exporter
+   * @return this builder instance for chaining
+   */
+  public TestClusterBuilder useRecordingExporter(final boolean useRecordingExporter) {
+    this.useRecordingExporter = useRecordingExporter;
+    return this;
+  }
+
+  /**
+   * Builds a new Zeebe cluster. Will create {@link #brokersCount} brokers (accessible later via
+   * {@link TestCluster#brokers()}) and {@link #gatewaysCount} standalone gateways (accessible later
+   * via {@link TestCluster#gateways()}).
+   *
+   * <p>If {@link #useEmbeddedGateway} is true, then all brokers will have the embedded gateway
+   * enabled and the right topology check configured. Additionally, {@link TestCluster#gateways()}
+   * will also include them, along with any other additional standalone gateway.
+   *
+   * <p>For standalone gateways, if {@link #brokersCount} is at least one, then a random broker is
+   * picked as the contact point for all gateways.
+   *
+   * @return a new Zeebe cluster
+   */
+  public TestCluster build() {
+    gateways.clear();
+    brokers.clear();
+
+    validate();
+    createBrokers();
+
+    // gateways are configured after brokers such that we can set the right contact point if there
+    // is one
+    createGateways();
+
+    return new TestCluster(
+        name, replicationFactor, partitionsCount, new HashMap<>(brokers), new HashMap<>(gateways));
+  }
+
+  private void applyConfigFunctions(final MemberId id, final TestApplication<?> zeebe) {
+    nodeConfig.accept(zeebe);
+
+    if (zeebe instanceof final TestGateway<?> gateway) {
+      gatewayConfig.accept(id, gateway);
+    }
+
+    if (zeebe instanceof final TestStandaloneBroker broker) {
+      brokerConfig.accept(id, broker);
+    }
+  }
+
+  private void validate() {
+    if (replicationFactor > brokersCount) {
+      throw new IllegalStateException(
+          "Expected replicationFactor to be less than or equal to brokersCount, but was "
+              + replicationFactor
+              + " > "
+              + brokersCount);
+    }
+
+    if (brokersCount > 0) {
+      if (partitionsCount < 1) {
+        throw new IllegalStateException(
+            "Expected to have at least one partition if there are any brokers, but partitionsCount"
+                + " was "
+                + partitionsCount);
+      }
+
+      if (replicationFactor < 1) {
+        throw new IllegalStateException(
+            "Expected to have replication factor at least 1 if there are any brokers, but"
+                + " replicationFactor was "
+                + replicationFactor);
+      }
+    }
+  }
+
+  private void createBrokers() {
+    for (int i = 0; i < brokersCount; i++) {
+      final var memberId = MemberId.from(String.valueOf(i));
+      final var broker = createBroker(i);
+
+      applyConfigFunctions(memberId, broker);
+      brokers.put(memberId, broker);
+    }
+
+    // since initial contact points has to contain all known brokers, we can only configure it
+    // AFTER the base broker configuration
+    final var contactPoints = getInitialContactPoints();
+    brokers.values().stream()
+        .map(TestStandaloneBroker::brokerConfig)
+        .map(BrokerCfg::getCluster)
+        .forEach(cfg -> cfg.setInitialContactPoints(contactPoints));
+  }
+
+  private TestStandaloneBroker createBroker(final int index) {
+    return new TestStandaloneBroker()
+        .withBrokerConfig(
+            cfg -> {
+              final var cluster = cfg.getCluster();
+              cluster.setNodeId(index);
+              cluster.setPartitionsCount(partitionsCount);
+              cluster.setReplicationFactor(replicationFactor);
+              cluster.setClusterSize(brokersCount);
+              cluster.setClusterName(name);
+            })
+        .withBrokerConfig(cfg -> cfg.getGateway().setEnable(useEmbeddedGateway))
+        .withRecordingExporter(useRecordingExporter);
+  }
+
+  private void createGateways() {
+    for (int i = 0; i < gatewaysCount; i++) {
+      final var id = "gateway-" + i;
+      final var memberId = MemberId.from(id);
+      final var gateway = createGateway(id);
+
+      applyConfigFunctions(memberId, gateway);
+      gateways.put(memberId, gateway);
+    }
+  }
+
+  private TestStandaloneGateway createGateway(final String id) {
+    return new TestStandaloneGateway()
+        .withGatewayConfig(
+            cfg -> {
+              final var cluster = cfg.getCluster();
+              cluster.setMemberId(id);
+              cluster.setClusterName(name);
+              cluster.setInitialContactPoints(getInitialContactPoints());
+            });
+  }
+
+  private List<String> getInitialContactPoints() {
+    return brokers.values().stream()
+        .map(builder -> builder.address(TestZeebePort.CLUSTER))
+        .toList();
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -95,6 +95,12 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     return springContext.getBean(type);
   }
 
+  @Override
+  public T withProperty(final String key, final Object value) {
+    propertyOverrides.put(key, value);
+    return self();
+  }
+
   /** Returns the command line arguments that will be passed when the application is started. */
   protected String[] commandLineArgs() {
     return new String[0];
@@ -132,5 +138,10 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     }
 
     return Integer.parseInt(portProperty.toString());
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "{nodeId = " + nodeId() + "}";
   }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/GcsContainer.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/GcsContainer.java
@@ -7,32 +7,82 @@
  */
 package io.camunda.zeebe.qa.util.testcontainers;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
 import java.util.List;
+import org.awaitility.Awaitility;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
 import org.testcontainers.utility.DockerImageName;
 
 public final class GcsContainer extends GenericContainer<GcsContainer> {
   private static final DockerImageName IMAGE = DockerImageName.parse("fsouza/fake-gcs-server");
   private static final String IMAGE_TAG = "1";
   private static final int PORT = 8000;
-  private final String domain;
 
-  public GcsContainer(final Network network, final String domain) {
+  public GcsContainer() {
     super(IMAGE.withTag(IMAGE_TAG));
-    this.domain = domain;
-    setCommand(
-        "-scheme", "http", "-external-url", internalEndpoint(), "-port", String.valueOf(PORT));
+    setCommand("-scheme", "http", "-port", String.valueOf(PORT));
     setExposedPorts(List.of(PORT));
-    setNetworkAliases(List.of(domain));
-    setNetwork(network);
-  }
 
-  public String internalEndpoint() {
-    return "http://" + domain + ":" + PORT;
+    // for uploads to work, the container has to advertise the right address; since we don't know
+    // in advance what that will be, we need to update it post-start. to be nice, we do that as part
+    // of the wait strategy, so the container is deemed started when it's ready to be used
+    // completely
+    setWaitStrategy(
+        new WaitAllStrategy()
+            .withStartupTimeout(Duration.ofMinutes(1))
+            .withStrategy(new HostPortWaitStrategy())
+            .withStrategy(new URLUpdatingStrategy()));
   }
 
   public String externalEndpoint() {
     return "http://%s:%d".formatted(getHost(), getMappedPort(PORT));
+  }
+
+  private static final class URLUpdatingStrategy implements WaitStrategy {
+
+    private Duration startupTimeout = Duration.ofSeconds(30);
+
+    @Override
+    public void waitUntilReady(final WaitStrategyTarget waitStrategyTarget) {
+      final var endpoint =
+          "http://" + waitStrategyTarget.getHost() + ":" + waitStrategyTarget.getMappedPort(PORT);
+      Awaitility.await("until the external URL has been changed")
+          .atMost(startupTimeout)
+          .untilAsserted(() -> refreshExternalURL(endpoint));
+    }
+
+    @Override
+    public WaitStrategy withStartupTimeout(final Duration startupTimeout) {
+      this.startupTimeout = startupTimeout;
+      return this;
+    }
+
+    private void refreshExternalURL(final String endpoint) throws Exception {
+      final var modifyExternalUrlRequestUri = endpoint + "/_internal/config";
+      final var updateExternalUrlJson = "{\"externalUrl\": \"" + endpoint + "\"}";
+      final var req =
+          HttpRequest.newBuilder()
+              .uri(URI.create(modifyExternalUrlRequestUri))
+              .header("Content-Type", "application/json")
+              .PUT(BodyPublishers.ofString(updateExternalUrlJson))
+              .build();
+      final var response = HttpClient.newBuilder().build().send(req, BodyHandlers.discarding());
+
+      if (response.statusCode() != 200) {
+        throw new RuntimeException(
+            "error updating fake-gcs-server with external url, response status code "
+                + response.statusCode()
+                + " != 200");
+      }
+    }
   }
 }

--- a/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
+++ b/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2019 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import java.util.Collections;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.assertj.core.api.Condition;
+import org.assertj.core.condition.VerboseCondition;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("resource")
+final class TestClusterBuilderTest {
+  @Test
+  void shouldCreateBrokers() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withBrokersCount(2);
+    final var cluster = builder.build();
+
+    // then
+    assertThat(cluster.brokers())
+        .allSatisfy(
+            haveProperty("cluster size", b -> b.brokerConfig().getCluster().getClusterSize(), 2));
+  }
+
+  @Test
+  void shouldSetPartitionsCount() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withPartitionsCount(2);
+    final var cluster = builder.build();
+
+    // then
+    final var brokers = cluster.brokers();
+    assertThat(brokers)
+        .allSatisfy(
+            haveProperty(
+                "partition count", b -> b.brokerConfig().getCluster().getPartitionsCount(), 2));
+  }
+
+  @Test
+  void shouldSetReplicationFactor() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withBrokersCount(2).withReplicationFactor(2);
+    final var cluster = builder.build();
+
+    // then
+    final var brokers = cluster.brokers();
+    assertThat(brokers)
+        .allSatisfy(
+            haveProperty(
+                "replication factor",
+                b -> b.brokerConfig().getCluster().getReplicationFactor(),
+                2));
+  }
+
+  @Test
+  void shouldSetClusterName() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder
+        .withName("test-cluster")
+        .withEmbeddedGateway(false)
+        .withBrokersCount(2)
+        .withGatewaysCount(2);
+    final var cluster = builder.build();
+
+    // then
+    assertThat(cluster.brokers())
+        .allSatisfy(
+            haveProperty(
+                "cluster name",
+                b -> b.brokerConfig().getCluster().getClusterName(),
+                "test-cluster"));
+    assertThat(cluster.gateways())
+        .allSatisfy(
+            haveProperty(
+                "cluster name",
+                g -> g.gatewayConfig().getCluster().getClusterName(),
+                "test-cluster"));
+  }
+
+  @Test
+  void shouldAssignUniqueMemberIdToEachGateway() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withEmbeddedGateway(false).withGatewaysCount(2);
+    final var cluster = builder.build();
+
+    // then
+    final var memberIds = cluster.gateways().keySet();
+    assertThat(memberIds).hasSize(2);
+    for (final var memberId : memberIds) {
+      final var gateway = cluster.gateways().get(memberId);
+      assertThat(gateway.nodeId()).as("every gateway has a unique member").isEqualTo(memberId);
+    }
+  }
+
+  @Test
+  void shouldAssignUniqueNodeIdToEachBroker() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withEmbeddedGateway(false).withBrokersCount(2);
+    final var cluster = builder.build();
+
+    // then
+    final var nodeIds = cluster.brokers().keySet();
+    assertThat(nodeIds).hasSize(2);
+    for (final var nodeId : nodeIds) {
+      final var broker = cluster.brokers().get(nodeId);
+      assertThat(broker.nodeId())
+          .as("every broker has a unique node ID configured")
+          .isEqualTo(nodeId);
+    }
+  }
+
+  @Test
+  void shouldAssignAllBrokersAsInitialContactPoints() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withEmbeddedGateway(false).withBrokersCount(2);
+    final var cluster = builder.build();
+
+    // then
+    final var expectedValue =
+        cluster.brokers().values().stream().map(b -> b.address(TestZeebePort.CLUSTER)).toList();
+    assertThat(cluster.brokers())
+        .allSatisfy(
+            haveProperty(
+                "initial contact points",
+                b -> b.brokerConfig().getCluster().getInitialContactPoints(),
+                expectedValue));
+    assertThat(cluster.gateways())
+        .allSatisfy(
+            haveProperty(
+                "initial contact points",
+                g -> g.gatewayConfig().getCluster().getInitialContactPoints(),
+                expectedValue));
+  }
+
+  @Test
+  void shouldNotAssignContactPointToStandaloneGatewayIfNoBrokersAvailable() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withGatewaysCount(1).withBrokersCount(0);
+    final var cluster = builder.build();
+
+    // then
+    final var gateway = cluster.gateways().values().iterator().next();
+    assertThat(gateway)
+        .has(
+            hasProperty(
+                "initial contact point",
+                g -> g.gatewayConfig().getCluster().getInitialContactPoints(),
+                Collections.emptyList()));
+  }
+
+  @Test
+  void shouldConfigureEmbeddedGateway() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withEmbeddedGateway(true).withBrokersCount(1);
+    final var cluster = builder.build();
+
+    // then
+    final var brokerId = MemberId.from("0");
+    final var broker = cluster.brokers().get(brokerId);
+    assertThat(broker)
+        .has(
+            hasProperty(
+                "embedded gateway enabled", b -> b.brokerConfig().getGateway().isEnable(), true));
+    assertThat(broker.isGateway()).isTrue();
+  }
+
+  @Test
+  void shouldNotConfigureEmbeddedGateway() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder.withEmbeddedGateway(false).withBrokersCount(1);
+    final var cluster = builder.build();
+
+    // then
+    final var brokerId = MemberId.from("0");
+    final var broker = cluster.brokers().get(brokerId);
+    assertThat(broker)
+        .has(
+            hasProperty(
+                "embedded gateway not enabled",
+                b -> b.brokerConfig().getGateway().isEnable(),
+                false));
+    assertThat(broker.isGateway()).isFalse();
+  }
+
+  private <T extends TestApplication<T>, U> Condition<T> hasProperty(
+      final String name, final Function<T, U> extractor, final U expected) {
+    return VerboseCondition.verboseCondition(
+        app -> extractor.apply(app).equals(expected),
+        "has property '%s' == '%s'".formatted(name, expected),
+        app -> " but actual property is '%s'".formatted(extractor.apply(app)));
+  }
+
+  private <T extends TestApplication<T>, U> BiConsumer<MemberId, T> haveProperty(
+      final String name, final Function<T, U> extractor, final U expected) {
+    return (memberId, app) ->
+        assertThat(app)
+            .as("application '%s'", app.nodeId())
+            .satisfies(hasProperty(name, extractor, expected));
+  }
+}

--- a/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
+++ b/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2019 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.camunda.zeebe.qa.util.cluster;
 


### PR DESCRIPTION
## Description

This PR adds an extension to the existing test standalone applications, providing an easy way to build and manage test clusters for testing purposes.

It adds a new utility to build and launch clusters of `TestApplication`, e.g. `TestStandaloneBroker`, `TestStandaloneGateway`, etc. Allows configuring the cluster in coarse ways (e.g. setting the cluster name across the name, the # of brokers, the replication factor), or fine grained via `withBrokerConfig`, `withGatewayConfig`, and `withNodeConfig`.

Minimal tests were added to the builder, as there it's useful to know if the logic of building your clusters is broken since it won't be immediately obvious by using the `TestCluster` that such things broke.

As usual, some existing tests using `ZeebeCluster` were refactored to showcase the new utility.

## Related issues

related to #13962

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
