### PR TITLE
Fix flaky retry test

### DIFF
--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -156,8 +156,8 @@ final class RetryStrategyTest {
     final var barrier = new LinkedTransferQueue<Boolean>();
     final var future = new CompletableFuture<Void>();
     final var secondActor = new ControllableActor();
-    schedulerRule.submitActor(test.actor);
-    schedulerRule.submitActor(secondActor);
+    schedulerRule.submitActor(test.actor).join();
+    schedulerRule.submitActor(secondActor).join();
 
     // when
     test.strategy.runWithRetry(

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -156,8 +156,8 @@ final class RetryStrategyTest {
     final var barrier = new LinkedTransferQueue<Boolean>();
     final var future = new CompletableFuture<Void>();
     final var secondActor = new ControllableActor();
-    schedulerRule.submitActor(test.actor).join();
-    schedulerRule.submitActor(secondActor).join();
+    schedulerRule.submitActor(test.actor);
+    schedulerRule.submitActor(secondActor);
 
     // when
     test.strategy.runWithRetry(

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -163,9 +163,9 @@ final class RetryStrategyTest {
     test.strategy.runWithRetry(
         () -> {
           // capture the result before to ensure we're looping
-          final boolean shouldRetry = !future.isDone();
+          final boolean isDone = future.isDone();
           barrier.offer(true);
-          return shouldRetry;
+          return isDone; // false - will cause to retry; true will complete the retry strategy
         });
     // toggle the retry strategy to stop retrying, letting workUntilDone finish
     secondActor.run(


### PR DESCRIPTION
## Description

This PR adds some better observability when the test fails and actually fixes a race condition that we run into.

TL;DR; If we want to guarantee an ordering of jobs executed on different actors, we need to await for the actors to be submitted completely (which means they are started).

### Details:


Await the actor lifecycle to be completely started before we submit
jobs on different actors, otherwise the ordering is not guaranteed.

When running more than one actor, even with one thread, it might
happen that jobs (even submitted after each other) might run in a
different ordering.

Submitting an actor to the scheduler will actually submit in the
background the [ActorTask to the WorkStealingGroup and notify the
ActorThread.](https://github.com/camunda/zeebe/blob/main/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java#L62-L64)

The Actors have a specific lifecycle that they run [before they
actually execute any jobs that are submitted from outside.](https://github.com/camunda/zeebe/blob/main/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java#L428-L429)
[If they complete that lifecycle they will end in the STARTED state
and put themself to waiting (if they have no jobs submitted)](https://github.com/camunda/zeebe/blob/main/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java#L184). 

[If this is the case and a new job is
submitted, this means the corresponding ActorTask is resubmitted to
the WorkStealingGroup and the ActorThread is notified.](https://github.com/camunda/zeebe/blob/main/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java#L107)

If the Actor is still running like running the last job in the
lifecycle to start the Actor and the new job was already submitted
[It will directly consume it via polling the submitted queue.](https://github.com/camunda/zeebe/blob/main/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java#L118)

### Example 
Imagine the following ordering:

Task 1 - Actor submit -> submit starting job
Task 2 - Actor submit -> submit starting job

T1 - onActorStarting -> submit STARTED job
T2 - onActorStarting -> submit STARTED job

T1 - STARTED <- Try Wait
   | When now a job is submitted here the task is resubmitted to
   | the queue to run the job
T2 - STARTED
   | When a job for T2 was submitted before it went to the
   | waiting state it will immediately be consumed before T1 can run

T1 - job 


In consequence what does this mean? If we want to guarantee an ordering we need to await that the actors are submitted completed (which means they are started).

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/12976