### PR TITLE
Reduce scope for AppendListener

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -642,7 +642,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
               // up to date with the latest entries, so it can handle configuration and initial
               // entries properly on fail over
               if (commitError == null) {
-                appendListener.onCommit(indexed);
+                appendListener.onCommit(indexed.index());
                 raft.notifyCommittedEntryListeners(indexed);
               } else {
                 appendListener.onCommitError(indexed, commitError);

--- a/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 /**
  * A log appender provides a central entry point to append to the local Raft log such that it is
  * automatically replicated and eventually committed, and the ability for callers to be notified of
- * various events, e.g. {@link AppendListener#onCommit(IndexedRaftLogEntry)}.
+ * various events, e.g. {@link AppendListener#onCommit(long)}.
  */
 @FunctionalInterface
 public interface ZeebeLogAppender {
@@ -87,9 +87,9 @@ public interface ZeebeLogAppender {
     /**
      * Called when the entry has been committed.
      *
-     * @param indexed the entry that was committed
+     * @param index the entry that was committed
      */
-    default void onCommit(final IndexedRaftLogEntry indexed) {}
+    default void onCommit(final long index) {}
 
     /**
      * Called when an error occurred while replicating or committing an entry, typically when if an

--- a/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
@@ -87,7 +87,7 @@ public interface ZeebeLogAppender {
     /**
      * Called when the entry has been committed.
      *
-     * @param index the entry that was committed
+     * @param index the index of the entry that was committed
      */
     default void onCommit(final long index) {}
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
@@ -635,7 +636,7 @@ public final class ControllableRaftContexts {
     final AppendListener delegate;
 
     // Keep track of committed entries and its checksum.
-    final Map<Long, Long> indexToChecksumMap = new HashMap<>();
+    final Map<Long, List<Long>> indexToChecksumMap = new HashMap<>();
 
     private String failMessage = "";
     private boolean dataloss = false;
@@ -646,6 +647,10 @@ public final class ControllableRaftContexts {
 
     @Override
     public void onWrite(final IndexedRaftLogEntry indexed) {
+      final long index = indexed.index();
+      final var entryChecksum = indexed.getPersistedRaftRecord().checksum();
+      indexToChecksumMap.computeIfAbsent(index, (i) -> new ArrayList<>());
+      indexToChecksumMap.get(index).add(entryChecksum);
       delegate.onWrite(indexed);
     }
 
@@ -655,18 +660,16 @@ public final class ControllableRaftContexts {
     }
 
     @Override
-    public void onCommit(final IndexedRaftLogEntry indexed) {
-      final var entryChecksum = indexed.getPersistedRaftRecord().checksum();
-      final long index = indexed.index();
-      if (indexToChecksumMap.containsKey(index) && indexToChecksumMap.get(index) != entryChecksum) {
+    public void onCommit(final long index) {
+      if (indexToChecksumMap.containsKey(index) && indexToChecksumMap.get(index).size() > 1) {
+        final List<Long> checksums = indexToChecksumMap.get(index);
         failMessage =
             "Committed entry at index %d checksum %d is being overwritten by entry with checksum %d"
-                .formatted(index, indexToChecksumMap.get(index), entryChecksum);
+                .formatted(index, checksums.get(0), checksums.get(1));
         LOG.info(failMessage);
         dataloss = true;
       }
-      indexToChecksumMap.put(index, entryChecksum);
-      delegate.onCommit(indexed);
+      delegate.onCommit(index);
     }
 
     @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -51,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
@@ -636,7 +635,9 @@ public final class ControllableRaftContexts {
     final AppendListener delegate;
 
     // Keep track of committed entries and its checksum.
-    final Map<Long, List<Long>> indexToChecksumMap = new HashMap<>();
+    final Map<Long, Long> committedIndexToChecksumMap = new HashMap<>();
+
+    final Map<Long, Long> pendingWriteToBeCommitted = new HashMap<>();
 
     private String failMessage = "";
     private boolean dataloss = false;
@@ -649,8 +650,7 @@ public final class ControllableRaftContexts {
     public void onWrite(final IndexedRaftLogEntry indexed) {
       final long index = indexed.index();
       final var entryChecksum = indexed.getPersistedRaftRecord().checksum();
-      indexToChecksumMap.computeIfAbsent(index, (i) -> new ArrayList<>());
-      indexToChecksumMap.get(index).add(entryChecksum);
+      pendingWriteToBeCommitted.put(index, entryChecksum);
       delegate.onWrite(indexed);
     }
 
@@ -661,14 +661,19 @@ public final class ControllableRaftContexts {
 
     @Override
     public void onCommit(final long index) {
-      if (indexToChecksumMap.containsKey(index) && indexToChecksumMap.get(index).size() > 1) {
-        final List<Long> checksums = indexToChecksumMap.get(index);
+      if (committedIndexToChecksumMap.containsKey(index)
+          && pendingWriteToBeCommitted.containsKey(index)
+          && pendingWriteToBeCommitted.get(index).equals(committedIndexToChecksumMap.get(index))) {
         failMessage =
             "Committed entry at index %d checksum %d is being overwritten by entry with checksum %d"
-                .formatted(index, checksums.get(0), checksums.get(1));
+                .formatted(
+                    index,
+                    committedIndexToChecksumMap.get(index),
+                    pendingWriteToBeCommitted.get(index));
         LOG.info(failMessage);
         dataloss = true;
       }
+      committedIndexToChecksumMap.put(index, pendingWriteToBeCommitted.remove(index));
       delegate.onCommit(index);
     }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -663,7 +663,7 @@ public final class ControllableRaftContexts {
     public void onCommit(final long index) {
       if (committedIndexToChecksumMap.containsKey(index)
           && pendingWriteToBeCommitted.containsKey(index)
-          && pendingWriteToBeCommitted.get(index).equals(committedIndexToChecksumMap.get(index))) {
+          && !pendingWriteToBeCommitted.get(index).equals(committedIndexToChecksumMap.get(index))) {
         failMessage =
             "Committed entry at index %d checksum %d is being overwritten by entry with checksum %d"
                 .formatted(

--- a/atomix/cluster/src/test/java/io/atomix/raft/MemberJoinTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/MemberJoinTest.java
@@ -323,8 +323,8 @@ final class MemberJoinTest {
     }
 
     @Override
-    public void onCommit(final IndexedRaftLogEntry indexed) {
-      commit.complete(indexed.index());
+    public void onCommit(final long index) {
+      commit.complete(index);
     }
 
     @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -689,8 +689,8 @@ public final class RaftRule extends ExternalResource {
     }
 
     @Override
-    public void onCommit(final IndexedRaftLogEntry indexed) {
-      commitFuture.complete(indexed.index());
+    public void onCommit(final long index) {
+      commitFuture.complete(index);
     }
 
     @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -567,8 +567,8 @@ public class RaftTest extends ConcurrentTestCase {
     }
 
     @Override
-    public void onCommit(final IndexedRaftLogEntry indexed) {
-      commitFuture.complete(indexed.index());
+    public void onCommit(final long index) {
+      commitFuture.complete(index);
     }
 
     @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeLogAppenderTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeLogAppenderTest.java
@@ -83,8 +83,8 @@ public class ZeebeLogAppenderTest {
     append();
 
     // then
-    final IndexedRaftLogEntry appended = appenderListener.pollCommitted();
-    assertNotNull(appended);
+    final var committed = appenderListener.pollCommitted();
+    assertNotNull(committed);
     assertEquals(0, appenderListener.getErrors().size());
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/TestAppender.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/TestAppender.java
@@ -26,7 +26,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 public class TestAppender implements AppendListener {
   private final BlockingQueue<IndexedRaftLogEntry> written;
-  private final BlockingQueue<IndexedRaftLogEntry> committed;
+  private final BlockingQueue<Long> committed;
   private final BlockingQueue<Throwable> errors;
 
   public TestAppender() {
@@ -46,8 +46,8 @@ public class TestAppender implements AppendListener {
   }
 
   @Override
-  public void onCommit(final IndexedRaftLogEntry indexed) {
-    committed.offer(indexed);
+  public void onCommit(final long index) {
+    committed.offer(index);
   }
 
   @Override
@@ -68,7 +68,7 @@ public class TestAppender implements AppendListener {
     return takeUnchecked(written);
   }
 
-  public IndexedRaftLogEntry pollCommitted() {
+  public Long pollCommitted() {
     return takeUnchecked(committed);
   }
 
@@ -80,7 +80,7 @@ public class TestAppender implements AppendListener {
     return new ArrayList<>(written);
   }
 
-  public List<IndexedRaftLogEntry> getCommitted() {
+  public List<Long> getCommitted() {
     return new ArrayList<>(committed);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixAppendListenerAdapter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixAppendListenerAdapter.java
@@ -50,8 +50,8 @@ public final class AtomixAppendListenerAdapter implements AppendListener {
   }
 
   @Override
-  public void onCommit(final IndexedRaftLogEntry indexed) {
-    delegate.onCommit(indexed.index());
+  public void onCommit(final long index) {
+    delegate.onCommit(index);
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
@@ -175,7 +175,7 @@ final class AtomixLogStorageReaderTest {
       final var indexed = log.append(new RaftLogEntry(1, entry));
       appendListener.onWrite(indexed);
       log.setCommitIndex(indexed.index());
-      appendListener.onCommit(indexed);
+      appendListener.onCommit(indexed.index());
     }
   }
 }


### PR DESCRIPTION


## Description

In order to remove a memory leak we need to reduce the references to the indexed record.

This is the first iteration to keep the scope of the PR's and changes small. Here we adjust the AppendListener#onCommit to only pass in the index instead of the whole object.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/zeebe/issues/14275
