### PR TITLE
Further reduce scope of AppendListener

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -645,7 +645,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                 appendListener.onCommit(indexed.index());
                 raft.notifyCommittedEntryListeners(indexed);
               } else {
-                appendListener.onCommitError(indexed, commitError);
+                appendListener.onCommitError(indexed.index(), commitError);
                 // replicating the entry will be retried on the next append request
                 log.error("Failed to replicate entry: {}", indexed, commitError);
               }

--- a/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
@@ -95,9 +95,9 @@ public interface ZeebeLogAppender {
      * Called when an error occurred while replicating or committing an entry, typically when if an
      * append operation was pending when shutting down the server or stepping down as leader.
      *
-     * @param indexed the entry that should have been committed
+     * @param index the index of the entry that should have been committed
      * @param error the error that occurred
      */
-    default void onCommitError(final IndexedRaftLogEntry indexed, final Throwable error) {}
+    default void onCommitError(final long index, final Throwable error) {}
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -673,8 +673,8 @@ public final class ControllableRaftContexts {
     }
 
     @Override
-    public void onCommitError(final IndexedRaftLogEntry indexed, final Throwable error) {
-      delegate.onCommitError(indexed, error);
+    public void onCommitError(final long index, final Throwable error) {
+      delegate.onCommitError(index, error);
     }
 
     public String getFailMessage() {

--- a/atomix/cluster/src/test/java/io/atomix/raft/MemberJoinTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/MemberJoinTest.java
@@ -328,7 +328,7 @@ final class MemberJoinTest {
     }
 
     @Override
-    public void onCommitError(final IndexedRaftLogEntry indexed, final Throwable error) {
+    public void onCommitError(final long index, final Throwable error) {
       commit.completeExceptionally(error);
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -694,7 +694,7 @@ public final class RaftRule extends ExternalResource {
     }
 
     @Override
-    public void onCommitError(final IndexedRaftLogEntry indexed, final Throwable error) {
+    public void onCommitError(final long index, final Throwable error) {
       commitFuture.completeExceptionally(error);
     }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -572,7 +572,7 @@ public class RaftTest extends ConcurrentTestCase {
     }
 
     @Override
-    public void onCommitError(final IndexedRaftLogEntry indexed, final Throwable error) {
+    public void onCommitError(final long index, final Throwable error) {
       fail("Unexpected write error: " + error.getMessage());
     }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/TestAppender.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/TestAppender.java
@@ -51,7 +51,7 @@ public class TestAppender implements AppendListener {
   }
 
   @Override
-  public void onCommitError(final IndexedRaftLogEntry indexed, final Throwable error) {
+  public void onCommitError(final long index, final Throwable error) {
     errors.offer(error);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixAppendListenerAdapter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixAppendListenerAdapter.java
@@ -55,7 +55,7 @@ public final class AtomixAppendListenerAdapter implements AppendListener {
   }
 
   @Override
-  public void onCommitError(final IndexedRaftLogEntry indexed, final Throwable error) {
-    delegate.onCommitError(indexed.index(), error);
+  public void onCommitError(final long index, final Throwable error) {
+    delegate.onCommitError(index, error);
   }
 }


### PR DESCRIPTION
## Description

Remove the indexed record from the onError call, and only consume the index.

Based on #14311 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #14275 