### PR TITLE
A new member can be added to the topology

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -19,10 +19,12 @@ import io.camunda.zeebe.topology.TopologyInitializer.GossipInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.StaticInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.SyncInitializer;
 import io.camunda.zeebe.topology.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.topology.changes.NoopTopologyMembershipChangeExecutor;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.topology.changes.TopologyChangeAppliersImpl;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinatorImpl;
+import io.camunda.zeebe.topology.changes.TopologyMembershipChangeExecutor;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiper;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
 import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
@@ -55,7 +57,8 @@ public final class ClusterTopologyManagerService extends Actor {
         communicationService,
         memberShipService,
         config,
-        new NoopPartitionChangeExecutor());
+        new NoopPartitionChangeExecutor(),
+        new NoopTopologyMembershipChangeExecutor());
   }
 
   public ClusterTopologyManagerService(
@@ -63,7 +66,8 @@ public final class ClusterTopologyManagerService extends Actor {
       final ClusterCommunicationService communicationService,
       final ClusterMembershipService memberShipService,
       final ClusterTopologyGossiperConfig config,
-      final PartitionChangeExecutor partitionChangeExecutor) {
+      final PartitionChangeExecutor partitionChangeExecutor,
+      final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor) {
     try {
       FileUtil.ensureDirectoryExists(dataRootDirectory);
     } catch (final IOException e) {
@@ -78,7 +82,8 @@ public final class ClusterTopologyManagerService extends Actor {
             this,
             localMemberId,
             persistedClusterTopology,
-            new TopologyChangeAppliersImpl(partitionChangeExecutor));
+            new TopologyChangeAppliersImpl(
+                partitionChangeExecutor, topologyMembershipChangeExecutor));
     clusterTopologyGossiper =
         new ClusterTopologyGossiper(
             this,

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberJoinApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberJoinApplier.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/** A Member join operation is applied when the member is not already part of the topology. */
+final class MemberJoinApplier implements OperationApplier {
+
+  private final MemberId memberId;
+  private final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor;
+
+  MemberJoinApplier(
+      final MemberId memberId,
+      final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor) {
+    this.memberId = memberId;
+    this.topologyMembershipChangeExecutor = topologyMembershipChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> init(
+      final ClusterTopology currentClusterTopology) {
+    if (currentClusterTopology.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to join member %s, but the member is already part of the topology",
+                  memberId)));
+    }
+
+    return Either.right(
+        ignore ->
+            // Member doesn't exist, so create a new state
+            MemberState.uninitialized().toJoining());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<MemberState>> apply() {
+    final var future = new CompletableActorFuture<UnaryOperator<MemberState>>();
+    topologyMembershipChangeExecutor
+        .addBroker(memberId)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                future.complete(MemberState::toActive);
+              } else {
+                future.completeExceptionally(error);
+              }
+            });
+    return future;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopTopologyMembershipChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopTopologyMembershipChangeExecutor.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+
+public class NoopTopologyMembershipChangeExecutor implements TopologyMembershipChangeExecutor {
+
+  @Override
+  public ActorFuture<Void> addBroker(final MemberId memberId) {
+    return CompletableActorFuture.completed(null);
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.util.Either;
@@ -20,9 +21,13 @@ import java.util.function.UnaryOperator;
 public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
 
   private final PartitionChangeExecutor partitionChangeExecutor;
+  private final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor;
 
-  public TopologyChangeAppliersImpl(final PartitionChangeExecutor partitionChangeExecutor) {
+  public TopologyChangeAppliersImpl(
+      final PartitionChangeExecutor partitionChangeExecutor,
+      final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor) {
     this.partitionChangeExecutor = partitionChangeExecutor;
+    this.topologyMembershipChangeExecutor = topologyMembershipChangeExecutor;
   }
 
   @Override
@@ -36,6 +41,10 @@ public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
     } else if (operation instanceof final PartitionLeaveOperation leaveOperation) {
       return new PartitionLeaveApplier(
           leaveOperation.partitionId(), leaveOperation.memberId(), partitionChangeExecutor);
+    } else if (operation instanceof final MemberJoinOperation memberJoinOperation) {
+      return new MemberJoinApplier(
+          memberJoinOperation.memberId(), topologyMembershipChangeExecutor);
+
     } else {
       return new FailingApplier(operation);
     }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -108,7 +108,8 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
     } else {
       // simulate applying changes to validate the operations
       final var topologyChangeSimulator =
-          new TopologyChangeAppliersImpl(new NoopPartitionChangeExecutor());
+          new TopologyChangeAppliersImpl(
+              new NoopPartitionChangeExecutor(), new NoopTopologyMembershipChangeExecutor());
       final var topologyWithPendingOperations =
           currentClusterTopology.startTopologyChange(operations);
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyMembershipChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyMembershipChangeExecutor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
+public interface TopologyMembershipChangeExecutor {
+
+  /**
+   * The implementation of this method can react to a new node joining the cluster. For example,
+   * this can update BrokerInfo so that the gateway can see the new clusterSize.
+   *
+   * @param memberId id of the broker that is newly added to the cluster
+   * @return future when the operation is completed.
+   */
+  ActorFuture<Void> addBroker(MemberId memberId);
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.topology.state.ClusterChangePlan;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import java.util.Map;
@@ -198,6 +199,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer {
       builder.setPartitionLeave(
           Topology.PartitionLeaveOperation.newBuilder()
               .setPartitionId(leaveOperation.partitionId()));
+    } else if (operation instanceof MemberJoinOperation) {
+      builder.setMemberJoin(Topology.MemberJoinOperation.newBuilder().build());
     } else {
       throw new IllegalArgumentException(
           "Unknown operation type: " + operation.getClass().getSimpleName());
@@ -225,6 +228,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer {
       return new PartitionLeaveOperation(
           MemberId.from(topologyChangeOperation.getMemberId()),
           topologyChangeOperation.getPartitionLeave().getPartitionId());
+    } else if (topologyChangeOperation.hasMemberJoin()) {
+      return new MemberJoinOperation(MemberId.from(topologyChangeOperation.getMemberId()));
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableMap;
 import io.atomix.cluster.MemberId;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -76,7 +77,7 @@ public record ClusterTopology(
     final MemberState currentState = members.get(memberId);
     final var updateMemberState = memberStateUpdater.apply(currentState);
 
-    if (currentState != null && currentState.equals(updateMemberState)) {
+    if (Objects.equals(currentState, updateMemberState)) {
       return this;
     }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -59,23 +59,41 @@ public record ClusterTopology(
     return new ClusterTopology(version, newMembers, changes);
   }
 
+  /**
+   * Adds or updates a member in the topology.
+   *
+   * <p>memberStateUpdater is invoked with the current state of the member. If the member does not
+   * exist, and memberStateUpdater returns a non-null value, then the member is added to the
+   * topology. If the member exists, and the memberStateUpdater returns a null value, then the
+   * member is removed.
+   *
+   * @param memberId id of the member to be updated
+   * @param memberStateUpdater transforms the current state of the member to the new state
+   * @return the updated ClusterTopology
+   */
   public ClusterTopology updateMember(
       final MemberId memberId, final UnaryOperator<MemberState> memberStateUpdater) {
-    if (!members.containsKey(memberId)) {
-      throw new IllegalStateException(
-          String.format("Expected to update member %s, but member does not exist", memberId.id()));
-    }
     final MemberState currentState = members.get(memberId);
     final var updateMemberState = memberStateUpdater.apply(currentState);
-    if (currentState.equals(updateMemberState)) {
+
+    if (currentState != null && currentState.equals(updateMemberState)) {
       return this;
     }
 
-    final var newMembers =
-        ImmutableMap.<MemberId, MemberState>builder()
-            .putAll(members)
-            .put(memberId, updateMemberState)
-            .buildKeepingLast();
+    final var mapBuilder = ImmutableMap.<MemberId, MemberState>builder();
+
+    if (updateMemberState != null) {
+      // Add/Update the member
+      mapBuilder.putAll(members).put(memberId, updateMemberState);
+    } else {
+      // remove memberId from the map
+      mapBuilder.putAll(
+          members.entrySet().stream()
+              .filter(entry -> !entry.getKey().equals(memberId))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    final var newMembers = mapBuilder.buildKeepingLast();
     return new ClusterTopology(version, newMembers, changes);
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
@@ -29,11 +29,11 @@ public record MemberState(long version, State state, Map<Integer, PartitionState
     return new MemberState(0, State.ACTIVE, Map.copyOf(initialPartitions));
   }
 
-  static MemberState uninitialized() {
+  public static MemberState uninitialized() {
     return new MemberState(0, State.UNINITIALIZED, Map.of());
   }
 
-  MemberState toJoining() {
+  public MemberState toJoining() {
     if (state == State.LEAVING) {
       throw new IllegalStateException(
           String.format("Cannot transition to JOINING when current state is %s", state));

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
@@ -17,6 +17,8 @@ public sealed interface TopologyChangeOperation {
 
   MemberId memberId();
 
+  record MemberJoinOperation(MemberId memberId) implements TopologyChangeOperation {}
+
   sealed interface PartitionChangeOperation extends TopologyChangeOperation {
     int partitionId();
 

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -34,6 +34,7 @@ message TopologyChangeOperation {
   oneof operation {
     PartitionJoinOperation partitionJoin = 2;
     PartitionLeaveOperation partitionLeave = 3;
+    MemberJoinOperation memberJoin = 4;
   }
 }
 
@@ -45,6 +46,8 @@ message PartitionJoinOperation {
 message PartitionLeaveOperation {
   int32 partitionId = 1;
 }
+
+message MemberJoinOperation {}
 
 enum State {
   UNKNOWN = 0;

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagementIntegrationTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagementIntegrationTest.java
@@ -21,8 +21,10 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.topology.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.topology.changes.NoopTopologyMembershipChangeExecutor;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator;
+import io.camunda.zeebe.topology.changes.TopologyMembershipChangeExecutor;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -48,6 +50,8 @@ class ClusterTopologyManagementIntegrationTest {
 
   private final ActorScheduler actorScheduler = ActorScheduler.newActorScheduler().build();
   private final PartitionChangeExecutor partitionChangeExecutor = new NoopPartitionChangeExecutor();
+  private final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor =
+      new NoopTopologyMembershipChangeExecutor();
 
   private final List<Node> clusterNodes =
       List.of(createNode("0"), createNode("1"), createNode("2"));
@@ -216,7 +220,8 @@ class ClusterTopologyManagementIntegrationTest {
             cluster.getCommunicationService(),
             cluster.getMembershipService(),
             new ClusterTopologyGossiperConfig(Duration.ofSeconds(1), Duration.ofMillis(100), 2),
-            partitionChangeExecutor);
+            partitionChangeExecutor,
+            topologyMembershipChangeExecutor);
     return new TestNode(cluster, service);
   }
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import static io.camunda.zeebe.topology.state.MemberState.State.ACTIVE;
+import static io.camunda.zeebe.topology.state.MemberState.State.JOINING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class MemberJoinApplierTest {
+
+  @Test
+  void shouldFailMemberJoinOnInitIfMemberExistsAndActive() {
+    // given
+    final MemberId memberId = MemberId.from("1");
+    final var memberJoinApplier = new MemberJoinApplier(memberId, null);
+
+    final ClusterTopology clusterTopologyWithMember =
+        ClusterTopology.init().addMember(memberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = memberJoinApplier.init(clusterTopologyWithMember);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("but the member is already part of the topology");
+  }
+
+  @Test
+  void shouldFailMemberJoinOnInitIfMemberExistsInJoiningState() {
+    final MemberId memberId = MemberId.from("1");
+    final var memberJoinApplier = new MemberJoinApplier(memberId, null);
+
+    final ClusterTopology clusterTopologyWithMember =
+        ClusterTopology.init().addMember(memberId, MemberState.uninitialized().toJoining());
+
+    // when
+    final var result = memberJoinApplier.init(clusterTopologyWithMember);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("but the member is already part of the topology");
+  }
+
+  @Test
+  void shouldSetTheStateToJoiningOnInit() {
+    // given
+    final MemberId memberId = MemberId.from("1");
+    final var memberJoinApplier = new MemberJoinApplier(memberId, null);
+
+    final ClusterTopology clusterTopologyWithMember = ClusterTopology.init();
+
+    // when
+    final var result = memberJoinApplier.init(clusterTopologyWithMember);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get()).isNotNull();
+    assertThat(result.get().apply(null).state()).isEqualTo(JOINING);
+  }
+
+  @Test
+  void shouldSetTheStateToActiveOnApply() {
+    // given
+    final MemberId memberId = MemberId.from("1");
+    final var memberJoinApplier =
+        new MemberJoinApplier(memberId, new NoopTopologyMembershipChangeExecutor());
+
+    final ClusterTopology clusterTopologyWithMember = ClusterTopology.init();
+    final var updater = memberJoinApplier.init(clusterTopologyWithMember).get();
+    final var topologyWithJoining = clusterTopologyWithMember.updateMember(memberId, updater);
+
+    // when
+    final var result = memberJoinApplier.apply();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofMillis(100));
+    final var finalTopology = topologyWithJoining.updateMember(memberId, result.join());
+    assertThat(finalTopology.getMember(memberId).state()).isEqualTo(ACTIVE);
+  }
+
+  @Test
+  void shouldFailFutureIfJoinFails() {
+    // given
+    final MemberId memberId = MemberId.from("1");
+    final var memberJoinApplier =
+        new MemberJoinApplier(memberId, new FailingTopologyMembershipChangeExecutor());
+
+    final ClusterTopology clusterTopologyWithMember = ClusterTopology.init();
+    memberJoinApplier.init(clusterTopologyWithMember);
+
+    // when
+    final var result = memberJoinApplier.apply();
+
+    // then
+    assertThat(result).failsWithin(Duration.ofMillis(100));
+  }
+
+  private static final class FailingTopologyMembershipChangeExecutor
+      implements TopologyMembershipChangeExecutor {
+
+    @Override
+    public ActorFuture<Void> addBroker(final MemberId memberId) {
+      return CompletableActorFuture.completedExceptionally(new RuntimeException("Expected"));
+    }
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
@@ -21,7 +21,7 @@ final class TopologyChangeAppliersImplTest {
   @Test
   void shouldReturnPartitionJoinApplier() {
     // given
-    final var topologyChangeAppliers = new TopologyChangeAppliersImpl(null);
+    final var topologyChangeAppliers = new TopologyChangeAppliersImpl(null, null);
     final var partitionOperation = new PartitionJoinOperation(localMemberId, 1, 1);
 
     // when
@@ -34,7 +34,7 @@ final class TopologyChangeAppliersImplTest {
   @Test
   void shouldReturnPartitionLeaveApplier() {
     // given
-    final var topologyChangeAppliers = new TopologyChangeAppliersImpl(null);
+    final var topologyChangeAppliers = new TopologyChangeAppliersImpl(null, null);
     final var partitionOperation = new PartitionLeaveOperation(localMemberId, 1);
 
     // when

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.MemberState.State;
 import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import java.util.List;
@@ -71,7 +72,8 @@ final class ProtoBufSerializerTest {
         topologyWithOneMemberOneJoiningPartition(),
         topologyWithOneMemberTwoPartitions(),
         topologyWithTwoMembers(),
-        topologyWithClusterChangePlan());
+        topologyWithClusterChangePlan(),
+        topologyWithClusterChangePlanWithMemberOperations());
   }
 
   private static ClusterTopology topologyWithOneMemberNoPartitions() {
@@ -137,6 +139,14 @@ final class ProtoBufSerializerTest {
         List.of(
             new PartitionLeaveOperation(MemberId.from("1"), 1),
             new PartitionJoinOperation(MemberId.from("2"), 2, 5));
+    return ClusterTopology.init()
+        .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
+        .startTopologyChange(changes);
+  }
+
+  private static ClusterTopology topologyWithClusterChangePlanWithMemberOperations() {
+    final List<TopologyChangeOperation> changes =
+        List.of(new MemberJoinOperation(MemberId.from("2")));
     return ClusterTopology.init()
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
         .startTopologyChange(changes);


### PR DESCRIPTION
## Description

Added a member join operation to the list of allowed ToologyChangeOperations. This operation add a new broker to the topology. The new member won't replicate any partitions until partition join operation is applied.

Note that this operation results in change in clusterSize. But this is not reflected in the status returned by the gateway because `BrokerInfo` contains the initial static clusterSize. This should be fixed in a later PR.

## Related issues

related #14298 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
