### PR TITLE
Revert "test(broker): bump reference score for CI"

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -43,7 +43,7 @@ public class LargeStateControllerPerformanceTest {
   private static final double SIZE_GB =
       Double.parseDouble(
           System.getenv().getOrDefault("LARGE_STATE_CONTROLLER_PERFORMANCE_TEST_SIZE_GB", "0.5"));
-  private static final Map<Double, Double> KNOWN_REFERENCE_SCORES = Map.of(0.5, 10.0, 4.0, 12.0);
+  private static final Map<Double, Double> KNOWN_REFERENCE_SCORES = Map.of(0.5, 10.0, 4.0, 10.0);
 
   private TestState.TestContext context;
 


### PR DESCRIPTION
## Description

This reverts the reference score bump introduced with #14239.
We encountered failures due to fluctuating throughput scores, thus it doesn't appear to perform better consistently and we are falling back to the previous baseline.

## Related issues

relates #14239