### PR TITLE
feat(raft): members can leave a cluster

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -288,12 +288,23 @@ public interface RaftServer {
 
   /**
    * Starts this raft server by joining an existing replication group. A {@link
-   * io.atomix.raft.protocol.JoinRequest} is sent to an arbitrary member of the cluster, as provided
-   * by the {@link ClusterMembershipService}.
+   * io.atomix.raft.protocol.JoinRequest} is sent to an arbitrary member of the cluster.
    *
+   * @param cluster a list of member ids that are part of the cluster and assist in joining.
    * @return A completable future to be completed once the server has joined the cluster.
    */
-  CompletableFuture<RaftServer> join();
+  CompletableFuture<RaftServer> join(Collection<MemberId> cluster);
+
+  /**
+   * Starts this raft server by joining an existing replication group. A {@link
+   * io.atomix.raft.protocol.JoinRequest} is sent to an arbitrary member of the cluster.
+   *
+   * @param cluster a list of member ids that are part of the cluster and assist in joining.
+   * @return A completable future to be completed once the server has joined the cluster.
+   */
+  default CompletableFuture<RaftServer> join(final MemberId... cluster) {
+    return join(Arrays.asList(cluster));
+  }
 
   /**
    * Requests to leave the replication group by sending a {@link

--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -296,6 +296,15 @@ public interface RaftServer {
   CompletableFuture<RaftServer> join();
 
   /**
+   * Requests to leave the replication group by sending a {@link
+   * io.atomix.raft.protocol.LeaveRequest} to an arbitrary member of the cluster, as provided by the
+   * {@link ClusterMembershipService}.
+   *
+   * @return A future to be completed successfully once the server has left the cluster.
+   */
+  CompletableFuture<RaftServer> leave();
+
+  /**
    * Promotes the server to leader if possible.
    *
    * @return a future to be completed once the server has been promoted

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftCluster.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftCluster.java
@@ -135,7 +135,7 @@ public interface RaftCluster {
    */
   CompletableFuture<Void> bootstrap(Collection<MemberId> cluster);
 
-  CompletableFuture<Void> join();
+  CompletableFuture<Void> join(Collection<MemberId> cluster);
 
   /**
    * Returns a member by ID.

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -341,6 +341,11 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
 
     final var membersInNewConfiguration = configuration.allMembers();
 
+    // Update the local member's type if it has changed
+    if (!membersInNewConfiguration.contains(localMember)) {
+      localMember.update(Type.INACTIVE, time);
+    }
+
     // Close and remove contexts which are not needed anymore
     final var membersToRemove =
         remoteMemberContexts.values().stream()

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -362,8 +362,7 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     final var memberId = member.memberId();
     final var context = remoteMemberContexts.get(memberId);
     if (context != null) {
-      context.closeReplicationContext();
-      context.getMember().close();
+      context.close();
       remoteMemberContexts.remove(memberId);
       remoteActiveMembers.remove(context);
       replicationTargets.remove(context);
@@ -417,8 +416,7 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
 
   @Override
   public void close() {
-    remoteMemberContexts.values().forEach(context -> context.getMember().close());
-    remoteMemberContexts.values().forEach(RaftMemberContext::closeReplicationContext);
+    remoteMemberContexts.values().forEach(RaftMemberContext::close);
     localMember.close();
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -92,8 +92,8 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
   }
 
   @Override
-  public CompletableFuture<Void> join() {
-    return raft.join();
+  public CompletableFuture<Void> join(final Collection<MemberId> cluster) {
+    return raft.join(cluster);
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -99,11 +99,6 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
-  public CompletableFuture<RaftServer> join() {
-    return start(() -> cluster().join());
-  }
-
-  @Override
   public CompletableFuture<RaftServer> leave() {
     return context.leave().thenApply(v -> this);
   }
@@ -172,6 +167,11 @@ public class DefaultRaftServer implements RaftServer {
   public CompletableFuture<Void> stepDown() {
     return CompletableFuture.runAsync(
         () -> context.transition(Role.FOLLOWER), context.getThreadContext());
+  }
+
+  @Override
+  public CompletableFuture<RaftServer> join(final Collection<MemberId> cluster) {
+    return start(() -> cluster().join(cluster));
   }
 
   /** Starts the server. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -104,6 +104,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public CompletableFuture<RaftServer> leave() {
+    return context.leave().thenApply(v -> this);
+  }
+
+  @Override
   public CompletableFuture<RaftServer> promote() {
     return context.anoint().thenApply(v -> this);
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -301,6 +301,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     protocol.registerInstallHandler(request -> runOnContext(() -> role.onInstall(request)));
     protocol.registerReconfigureHandler(request -> runOnContext(() -> role.onReconfigure(request)));
     protocol.registerJoinHandler(request -> runOnContext(() -> role.onJoin(request)));
+    protocol.registerLeaveHandler(request -> runOnContext(() -> role.onLeave(request)));
     protocol.registerTransferHandler(request -> runOnContext(() -> role.onTransfer(request)));
     protocol.registerAppendV1Handler(
         request -> runOnContext(() -> role.onAppend(ProtocolVersionHandler.transform(request))));
@@ -912,6 +913,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     protocol.unregisterInstallHandler();
     protocol.unregisterReconfigureHandler();
     protocol.unregisterJoinHandler();
+    protocol.unregisterLeaveHandler();
     protocol.unregisterTransferHandler();
     protocol.unregisterAppendHandler();
     protocol.unregisterPollHandler();

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -29,6 +29,7 @@ class RaftMessageContext {
   final String configureSubject;
   final String reconfigureSubject;
   final String joinSubject;
+  final String leaveSubject;
   final String installSubject;
   final String transferSubject;
   final String pollSubject;
@@ -48,6 +49,7 @@ class RaftMessageContext {
     configureSubject = getSubject(prefix, "configure");
     reconfigureSubject = getSubject(prefix, "reconfigure");
     joinSubject = getSubject(prefix, "join");
+    leaveSubject = getSubject(prefix, "leave");
     installSubject = getSubject(prefix, "install");
     transferSubject = getSubject(prefix, "transfer");
     pollSubject = getSubject(prefix, "poll");

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -29,6 +29,8 @@ import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeaveRequest;
+import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
@@ -90,6 +92,8 @@ public final class RaftNamespaces {
           .register(ReplicatableJournalRecord.class)
           .register(JoinRequest.class)
           .register(JoinResponse.class)
+          .register(LeaveRequest.class)
+          .register(LeaveResponse.class)
           .name("RaftProtocol")
           .build();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -118,7 +118,7 @@ public class RaftPartitionServer implements HealthMonitorable {
     final long joinStartTime = System.currentTimeMillis();
     log.info("Server joining partition {}", partition.id());
     return server
-        .join()
+        .join(partitionMetadata.members())
         .whenComplete(
             (r, e) -> {
               if (e == null) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -202,7 +202,7 @@ public class RaftServerCommunicator implements RaftServerProtocol {
 
   @Override
   public void unregisterLeaveHandler() {
-    clusterCommunicator.unsubscribe(context.joinSubject);
+    clusterCommunicator.unsubscribe(context.leaveSubject);
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeaveRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeaveRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+import static java.util.Objects.requireNonNull;
+
+import io.atomix.raft.cluster.RaftMember;
+import java.util.Objects;
+
+public final class LeaveRequest extends AbstractRaftRequest {
+  private final RaftMember leaving;
+
+  public LeaveRequest(final RaftMember leaving) {
+    this.leaving = requireNonNull(leaving);
+  }
+
+  public RaftMember leavingMember() {
+    return leaving;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(leaving);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LeaveRequest that = (LeaveRequest) o;
+    return Objects.equals(leaving, that.leaving);
+  }
+
+  public static final class Builder
+      extends AbstractRaftRequest.Builder<LeaveRequest.Builder, LeaveRequest> {
+    private RaftMember leaving;
+
+    private Builder() {}
+
+    public Builder withLeavingMember(final RaftMember leaving) {
+      this.leaving = leaving;
+      return this;
+    }
+
+    @Override
+    public LeaveRequest build() {
+      validate();
+      return new LeaveRequest(leaving);
+    }
+
+    @Override
+    protected void validate() {
+      requireNonNull(leaving, "leaving member cannot be null");
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeaveResponse.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeaveResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.protocol;
+
+import io.atomix.raft.RaftError;
+
+public final class LeaveResponse extends AbstractRaftResponse {
+  private LeaveResponse(final Status status, final RaftError error) {
+    super(status, error);
+  }
+
+  public static LeaveResponse.Builder builder() {
+    return new LeaveResponse.Builder();
+  }
+
+  public static final class Builder
+      extends AbstractRaftResponse.Builder<LeaveResponse.Builder, LeaveResponse> {
+    private Builder() {}
+
+    @Override
+    public LeaveResponse build() {
+      validate();
+      return new LeaveResponse(status, error);
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -51,6 +51,15 @@ public interface RaftServerProtocol {
   CompletableFuture<JoinResponse> join(MemberId memberId, JoinRequest request);
 
   /**
+   * Sends a leave request to the given node.
+   *
+   * @param memberId the node to which to send the request
+   * @param request the request to send
+   * @return a future to be completed with the response
+   */
+  CompletableFuture<LeaveResponse> leave(MemberId memberId, LeaveRequest request);
+
+  /**
    * Sends an install request to the given node.
    *
    * @param memberId the node to which to send the request
@@ -133,6 +142,10 @@ public interface RaftServerProtocol {
   void registerJoinHandler(Function<JoinRequest, CompletableFuture<JoinResponse>> handler);
 
   void unregisterJoinHandler();
+
+  void registerLeaveHandler(Function<LeaveRequest, CompletableFuture<LeaveResponse>> handler);
+
+  void unregisterLeaveHandler();
 
   /**
    * Registers a install request callback.

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -28,6 +28,8 @@ import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeaveRequest;
+import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftResponse;
@@ -113,6 +115,15 @@ public class InactiveRole extends AbstractRole {
     final var result =
         logResponse(
             JoinResponse.builder().withStatus(Status.ERROR).withError(Type.UNAVAILABLE).build());
+    return CompletableFuture.completedFuture(result);
+  }
+
+  @Override
+  public CompletableFuture<LeaveResponse> onLeave(final LeaveRequest request) {
+    logRequest(request);
+    final var result =
+        logResponse(
+            LeaveResponse.builder().withStatus(Status.ERROR).withError(Type.UNAVAILABLE).build());
     return CompletableFuture.completedFuture(result);
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -742,7 +742,7 @@ final class LeaderAppender {
 
   private boolean hasMoreEntries(final RaftMemberContext member) {
     // If the member's nextIndex is an entry in the local log then more entries can be sent.
-    return member.hasNextEntry();
+    return !member.hasReplicationContext() || member.hasNextEntry();
   }
 
   private void handleAppendResponseError(

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -689,8 +689,15 @@ final class LeaderAppender {
    * @param member The member to which to send the append request.
    */
   private void appendEntries(final RaftMemberContext member) {
-    // Prevent recursive, asynchronous appends from being executed if the appender has been closed.
     if (!open) {
+      // Prevent recursive, asynchronous appends from being executed if the appender has been
+      // closed.
+      return;
+    }
+
+    if (!member.isOpen()) {
+      // Prevent recursive, asynchronous appends from being executed if the member is no longer
+      // open.
       return;
     }
 
@@ -735,7 +742,7 @@ final class LeaderAppender {
 
   private boolean hasMoreEntries(final RaftMemberContext member) {
     // If the member's nextIndex is an entry in the local log then more entries can be sent.
-    return !member.hasReplicationContext() || member.hasNextEntry();
+    return member.hasNextEntry();
   }
 
   private void handleAppendResponseError(

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -216,7 +216,14 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                     .withError(Type.PROTOCOL_ERROR, throwable.getMessage())
                     .build();
               }
-              return JoinResponse.builder().withStatus(Status.OK).build();
+              if (reconfigureResponse.status() == Status.OK) {
+                return JoinResponse.builder().withStatus(Status.OK).build();
+              } else {
+                return JoinResponse.builder()
+                    .withStatus(Status.ERROR)
+                    .withError(reconfigureResponse.error())
+                    .build();
+              }
             });
   }
 
@@ -242,7 +249,14 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                     .withError(Type.PROTOCOL_ERROR, throwable.getMessage())
                     .build();
               }
-              return LeaveResponse.builder().withStatus(Status.OK).build();
+              if (reconfigureResponse.status() == Status.OK) {
+                return LeaveResponse.builder().withStatus(Status.OK).build();
+              } else {
+                return LeaveResponse.builder()
+                    .withStatus(Status.ERROR)
+                    .withError(reconfigureResponse.error())
+                    .build();
+              }
             });
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -25,6 +25,8 @@ import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
+import io.atomix.raft.protocol.LeaveRequest;
+import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.ReconfigureRequest;
@@ -72,6 +74,9 @@ public interface RaftRole extends Managed<RaftRole> {
 
   /** Handles a request to join the cluster. */
   CompletableFuture<JoinResponse> onJoin(JoinRequest request);
+
+  /** Handles a request to leave the cluster. */
+  CompletableFuture<LeaveResponse> onLeave(LeaveRequest request);
 
   /**
    * Handles a transfer request.

--- a/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -441,16 +441,17 @@ final class ReconfigurationTest {
               m5.bootstrap(id1, id2, id3, id4, id5))
           .join();
 
-      // when -- two members leave
+      // when -- two members leave and one shuts down without leaving
       awaitLeader(m1, m2, m3, m4, m5); // await leader so that join doesn't fail with NO_LEADER
       m4.leave().join();
       awaitLeader(m1, m2, m3, m5); // await leader so that join doesn't fail with NO_LEADER
       m5.leave().join();
       m4.shutdown().join();
       m5.shutdown().join();
+      m3.shutdown().join();
 
       // then -- remaining three can elect a leader and commit entries
-      final var leader = awaitLeader(m1, m2, m3);
+      final var leader = awaitLeader(m1, m2);
       assertThat(appendEntry(leader).commit()).succeedsWithin(Duration.ofSeconds(1));
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -202,7 +202,7 @@ final class ReconfigurationTest {
       // when - a new member joins
       final var id4 = MemberId.from("4");
       final var m4 = createServer(tmp, createMembershipService(id4, id1, id2, id3));
-      m4.join().join();
+      m4.join(id1, id2, id3).join();
 
       // then - all members show a configuration with 4 active members
       final var expected =
@@ -234,7 +234,7 @@ final class ReconfigurationTest {
       CompletableFuture.allOf(
               m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
           .join();
-      m4.join().join();
+      m4.join(id1, id2, id3).join();
 
       // when - appending a new entry
       final var leader = awaitLeader(m1, m2, m3, m4);
@@ -269,8 +269,8 @@ final class ReconfigurationTest {
               m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
           .join();
 
-      m4.join().join();
-      m5.join().join();
+      m4.join(id1, id2, id3).join();
+      m5.join(id1, id2, id3).join();
 
       // when - no quorum possible because three out of five members are down
       m1.shutdown().join();
@@ -302,8 +302,8 @@ final class ReconfigurationTest {
               m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
           .join();
 
-      m4.join().join();
-      m5.join().join();
+      m4.join(id1, id2, id3).join();
+      m5.join(id1, id2, id3).join();
 
       // when - original members fail so that quorum depends on new members
       m1.shutdown().join();

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -31,6 +31,7 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   private Function<ConfigureRequest, CompletableFuture<ConfigureResponse>> configureHandler;
   private Function<ReconfigureRequest, CompletableFuture<ReconfigureResponse>> reconfigureHandler;
   private Function<JoinRequest, CompletableFuture<JoinResponse>> joinHandler;
+  private Function<LeaveRequest, CompletableFuture<LeaveResponse>> leaveHandler;
   private Function<InstallRequest, CompletableFuture<InstallResponse>> installHandler;
   private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
   private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
@@ -79,6 +80,12 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public CompletableFuture<JoinResponse> join(final MemberId memberId, final JoinRequest request) {
     return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.join(request)));
+  }
+
+  @Override
+  public CompletableFuture<LeaveResponse> leave(
+      final MemberId memberId, final LeaveRequest request) {
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.leave(request)));
   }
 
   @Override
@@ -157,6 +164,17 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public void unregisterJoinHandler() {
     joinHandler = null;
+  }
+
+  @Override
+  public void registerLeaveHandler(
+      final Function<LeaveRequest, CompletableFuture<LeaveResponse>> handler) {
+    leaveHandler = handler;
+  }
+
+  @Override
+  public void unregisterLeaveHandler() {
+    leaveHandler = null;
   }
 
   @Override
@@ -269,6 +287,14 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   CompletableFuture<JoinResponse> join(final JoinRequest request) {
     if (joinHandler != null) {
       return joinHandler.apply(request);
+    } else {
+      return CompletableFuture.failedFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<LeaveResponse> leave(final LeaveRequest request) {
+    if (leaveHandler != null) {
+      return leaveHandler.apply(request);
     } else {
       return CompletableFuture.failedFuture(new ConnectException());
     }


### PR DESCRIPTION
Implements support for _leaving_.
Just like _joining_, the _leaving_ member sends a `LeaveRequest` to any other member where it is forwarded until it reaches the leader.

The leader goes through a joint consensus phase to remove the leaving member from the configuration.
When the request to leave was handled successfully, the member does not shut down and remains as follower. Until it is shut down externally, it will observe no heartbeats and thus poll others in an attempt to eventually become leader.


Closes #13906