### PR TITLE
feat(protocol-impl): add tenant ids property for job poll and push requests

### DIFF
--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
+import java.util.List;
 import org.agrona.DirectBuffer;
 
 /**
@@ -41,4 +42,15 @@ public interface JobActivationProperties extends BufferReader, BufferWriter {
    * @see JobRecordValue#getDeadline()
    */
   long timeout();
+
+  /**
+   * When jobs are streamed from the engine, it is possible that the jobs belong to different
+   * tenants.
+   *
+   * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
+   * jobs will be owned by the tenant that owns the corresponding process instance.
+   *
+   * @return the identifiers of the tenants for which to stream jobs
+   */
+  List<String> getTenantIds();
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
@@ -44,13 +44,10 @@ public interface JobActivationProperties extends BufferReader, BufferWriter {
   long timeout();
 
   /**
-   * When jobs are streamed from the engine, it is possible that the jobs belong to different
-   * tenants.
+   * Returns the identifiers of the tenants that own the jobs requested to be activated by the
+   * worker.
    *
-   * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
-   * jobs will be owned by the tenant that owns the corresponding process instance.
-   *
-   * @return the identifiers of the tenants for which to stream jobs
+   * @return the identifiers of the tenants for which to activate jobs
    */
   List<String> getTenantIds();
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -12,9 +12,13 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -23,6 +27,8 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   private final LongProperty timeoutProp = new LongProperty("timeout", -1);
   private final ArrayProperty<StringValue> fetchVariablesProp =
       new ArrayProperty<>("variables", new StringValue());
+  private final ArrayProperty<StringValue> tenantIdsProp =
+      new ArrayProperty<>("tenantIds", new StringValue(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
   public JobActivationPropertiesImpl() {
     declareProperty(workerProp).declareProperty(timeoutProp).declareProperty(fetchVariablesProp);
@@ -60,5 +66,17 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   @Override
   public long timeout() {
     return timeoutProp.getValue();
+  }
+
+  @Override
+  public List<String> getTenantIds() {
+    return StreamSupport.stream(tenantIdsProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .collect(Collectors.toList());
+  }
+
+  public ValueArray<StringValue> tenantIds() {
+    return tenantIdsProp;
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Implement the `tenantIds` property for the `JobBatchRecord` and the `JobActivationProperties` classes. The new `tenantIds` property will declare the IDs of the tenants that users want to activate and process jobs for.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13318 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
