### PR TITLE
Gateway topology includes dynamic clusterSize from the Cluster Topology

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
@@ -106,6 +106,7 @@ public class DynamicClusterTopologyService implements ClusterTopologyService {
   }
 
   private ClusterTopologyGossiperConfig getDefaultClusterTopologyGossipConfig() {
-    return new ClusterTopologyGossiperConfig(Duration.ofSeconds(10), Duration.ofSeconds(2), 2);
+    return new ClusterTopologyGossiperConfig(
+        true, Duration.ofSeconds(10), Duration.ofSeconds(2), 2);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -39,6 +39,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
             clusterServices.getMessagingService(),
             clusterServices.getMembershipService(),
             clusterServices.getEventService(),
+            clusterServices.getCommunicationService(),
             actorScheduler);
     this.jobStreamClient = jobStreamClient;
     gateway =

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerClientConfiguration.java
@@ -37,6 +37,7 @@ final class BrokerClientConfiguration {
         cluster.getMessagingService(),
         cluster.getMembershipService(),
         cluster.getEventService(),
+        cluster.getCommunicationService(),
         scheduler);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
@@ -41,6 +41,7 @@ public final class BrokerClientComponent {
         atomixCluster.getMessagingService(),
         atomixCluster.getMembershipService(),
         atomixCluster.getEventService(),
+        atomixCluster.getCommunicationService(),
         actorScheduler);
   }
 }

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -142,6 +142,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-topology</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>me.dinowernli</groupId>
       <artifactId>java-grpc-prometheus</artifactId>
     </dependency>
@@ -305,6 +310,7 @@
       <artifactId>bcprov-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <repositories>

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
@@ -18,6 +18,7 @@ import org.agrona.collections.IntArrayList;
 
 public final class BrokerClusterStateImpl implements BrokerClusterState {
 
+  public static final int UNINITIALIZED_CLUSTER_SIZE = -1;
   private static final Long TERM_NONE = -1L;
   private final Int2IntHashMap partitionLeaders;
   private final Int2ObjectHashMap<Long> partitionLeaderTerms;
@@ -30,7 +31,7 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
   private final IntArrayList brokers;
   private final IntArrayList partitions;
   private final Random randomBroker;
-  private int clusterSize;
+  private int clusterSize = UNINITIALIZED_CLUSTER_SIZE;
   private int partitionsCount;
   private int replicationFactor;
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.topology.GatewayClusterTopologyService;
 import io.camunda.zeebe.topology.state.ClusterTopology;
-import io.camunda.zeebe.topology.state.MemberState.State;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -222,16 +221,12 @@ public final class BrokerTopologyManagerImpl extends Actor
           }
 
           final BrokerClusterStateImpl newTopology = new BrokerClusterStateImpl(topology.get());
-          final var clusterSize =
-              (int)
-                  clusterTopology.members().entrySet().stream()
-                      .filter(entry -> entry.getValue().state() != State.LEFT)
-                      .count();
 
           // Overwrite clusterSize. ClusterTopology is the source of truth.
-          newTopology.setClusterSize(clusterSize);
+          newTopology.setClusterSize(clusterTopology.clusterSize());
 
-          LOG.debug("Received new cluster topology with clusterSize {}", clusterSize);
+          LOG.debug(
+              "Received new cluster topology with clusterSize {}", newTopology.getClusterSize());
           topology.set(newTopology);
         });
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -20,6 +20,9 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.GatewayClusterTopologyService;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState.State;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -27,7 +30,9 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 public final class BrokerTopologyManagerImpl extends Actor
-    implements BrokerTopologyManager, ClusterMembershipEventListener {
+    implements BrokerTopologyManager,
+        ClusterMembershipEventListener,
+        GatewayClusterTopologyService.Listener {
 
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;
 
@@ -162,7 +167,13 @@ public final class BrokerTopologyManagerImpl extends Actor
   private void processProperties(
       final BrokerInfo distributedBrokerInfo, final BrokerClusterStateImpl newTopology) {
 
-    newTopology.setClusterSize(distributedBrokerInfo.getClusterSize());
+    // Do not overwrite clusterSize received from BrokerInfo. ClusterTopology received via
+    // GatewayClusterTopologyService.Listener. BrokerInfo contains the static clusterSize which is
+    // the initial clusterSize. However, we still have to initialize it because it should have the
+    // correct value even when the dynamic ClusterTopology is disabled.
+    if (newTopology.getClusterSize() == BrokerClusterStateImpl.UNINITIALIZED_CLUSTER_SIZE) {
+      newTopology.setClusterSize(distributedBrokerInfo.getClusterSize());
+    }
     newTopology.setPartitionsCount(distributedBrokerInfo.getPartitionsCount());
     newTopology.setReplicationFactor(distributedBrokerInfo.getReplicationFactor());
 
@@ -199,6 +210,29 @@ public final class BrokerTopologyManagerImpl extends Actor
           if (followers != null) {
             followers.forEach(broker -> topologyMetrics.setFollower(partition, broker));
           }
+        });
+  }
+
+  @Override
+  public void onClusterTopologyChanged(final ClusterTopology clusterTopology) {
+    actor.run(
+        () -> {
+          if (clusterTopology.isUninitialized()) {
+            return;
+          }
+
+          final BrokerClusterStateImpl newTopology = new BrokerClusterStateImpl(topology.get());
+          final var clusterSize =
+              (int)
+                  clusterTopology.members().entrySet().stream()
+                      .filter(entry -> entry.getValue().state() != State.LEFT)
+                      .count();
+
+          // Overwrite clusterSize. ClusterTopology is the source of truth.
+          newTopology.setClusterSize(clusterSize);
+
+          LOG.debug("Received new cluster topology with clusterSize {}", clusterSize);
+          topology.set(newTopology);
         });
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -68,6 +68,7 @@ class UnavailableBrokersTest {
             cluster.getMessagingService(),
             cluster.getMembershipService(),
             cluster.getEventService(),
+            cluster.getCommunicationService(),
             actorScheduler);
     jobStreamClient = new JobStreamClientImpl(actorScheduler, cluster.getCommunicationService());
     jobStreamClient.start().join();

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
@@ -98,6 +98,7 @@ public final class BrokerClientTest {
             atomixCluster.getMessagingService(),
             atomixCluster.getMembershipService(),
             atomixCluster.getEventService(),
+            atomixCluster.getCommunicationService(),
             actorScheduler.get());
 
     client.start().forEach(ActorFuture::join);

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -72,6 +72,7 @@ final class InterceptorIT {
             cluster.getMessagingService(),
             cluster.getMembershipService(),
             cluster.getEventService(),
+            cluster.getCommunicationService(),
             scheduler);
     jobStreamClient = new JobStreamClientImpl(scheduler, cluster.getCommunicationService());
     gateway = new Gateway(config, brokerClient, scheduler, jobStreamClient.streamer());

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -159,6 +159,7 @@ final class SecurityTest {
             atomix.getMessagingService(),
             atomix.getMembershipService(),
             atomix.getEventService(),
+            atomix.getCommunicationService(),
             actorScheduler);
     jobStreamClient = new JobStreamClientImpl(actorScheduler, atomix.getCommunicationService());
     jobStreamClient.start().join();

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -175,4 +175,9 @@ public final class ClusterTopologyManagerService extends Actor {
         ? Optional.of(new TopologyChangeCoordinatorImpl(clusterTopologyManager, this))
         : Optional.empty();
   }
+
+  @Override
+  protected void onActorClosing() {
+    clusterTopologyGossiper.closeAsync();
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/GatewayClusterTopologyService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/GatewayClusterTopologyService.java
@@ -81,7 +81,9 @@ public class GatewayClusterTopologyService extends Actor {
     actor.run(
         () -> {
           topologyChangeListeners.add(listener);
-          listener.onClusterTopologyChanged(clusterTopology);
+          if (!clusterTopology.isUninitialized()) {
+            listener.onClusterTopologyChanged(clusterTopology);
+          }
         });
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/GatewayClusterTopologyService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/GatewayClusterTopologyService.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiper;
+import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
+import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The GatewayClusterTopologyService contains minimal functionality required for the Gateway. The
+ * Gateway only listens to ClusterTopology changes. It cannot make changes to the topology. So the
+ * service does not run ClusterTopologyManager, but only contains the ClusterTopologyGossiper.
+ */
+public class GatewayClusterTopologyService extends Actor {
+
+  private final Set<Listener> topologyChangeListeners = new HashSet<>();
+  private final ClusterTopologyGossiper clusterTopologyGossiper;
+
+  // Keep an in memory copy of the topology. No need to persist it.
+  private ClusterTopology clusterTopology = ClusterTopology.uninitialized();
+
+  public GatewayClusterTopologyService(
+      final ClusterCommunicationService communicationService,
+      final ClusterMembershipService memberShipService,
+      final ClusterTopologyGossiperConfig config) {
+    clusterTopologyGossiper =
+        new ClusterTopologyGossiper(
+            this,
+            communicationService,
+            memberShipService,
+            new ProtoBufSerializer(),
+            config,
+            this::updateClusterTopology);
+  }
+
+  private ActorFuture<ClusterTopology> updateClusterTopology(
+      final ClusterTopology clusterTopology) {
+    final CompletableActorFuture<ClusterTopology> updated = new CompletableActorFuture<>();
+    actor.run(
+        () -> {
+          try {
+            final var updateTopology = this.clusterTopology.merge(clusterTopology);
+            if (!updateTopology.equals(this.clusterTopology)) {
+              this.clusterTopology = updateTopology;
+              topologyChangeListeners.forEach(
+                  listener -> listener.onClusterTopologyChanged(updateTopology));
+            }
+            updated.complete(updateTopology);
+          } catch (final Exception updateFailed) {
+            updated.completeExceptionally(updateFailed);
+          }
+        });
+
+    return updated;
+  }
+
+  @Override
+  protected void onActorStarting() {
+    clusterTopologyGossiper.start();
+  }
+
+  @Override
+  protected void onActorClosing() {
+    clusterTopologyGossiper.closeAsync();
+  }
+
+  public void registerClusterTopologyChangeListener(final Listener listener) {
+    actor.run(
+        () -> {
+          topologyChangeListeners.add(listener);
+          listener.onClusterTopologyChanged(clusterTopology);
+        });
+  }
+
+  public void removeClusterTopologyChangeListener(final Listener listener) {
+    actor.run(() -> topologyChangeListeners.remove(listener));
+  }
+
+  public interface Listener {
+    void onClusterTopologyChanged(ClusterTopology clusterTopology);
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiper.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiper.java
@@ -123,7 +123,9 @@ public final class ClusterTopologyGossiper
   }
 
   private void scheduleSync() {
-    executor.schedule(config.syncDelay(), this::sync);
+    if (config.enableSync()) {
+      executor.schedule(config.syncDelay(), this::sync);
+    }
   }
 
   private void sync() {
@@ -289,7 +291,12 @@ public final class ClusterTopologyGossiper
   public void event(final ClusterMembershipEvent event) {
     // When a new member is added to the cluster, immediately sync with it so that the new member
     // receives the latest topology as fast as possible.
-    executor.run(() -> sync(event.subject().id()));
+    executor.run(
+        () -> {
+          if (config.enableSync()) {
+            sync(event.subject().id());
+          }
+        });
   }
 
   @Override

--- a/topology/src/main/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiperConfig.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiperConfig.java
@@ -10,4 +10,4 @@ package io.camunda.zeebe.topology.gossip;
 import java.time.Duration;
 
 public record ClusterTopologyGossiperConfig(
-    Duration syncDelay, Duration syncRequestTimeout, int gossipFanout) {}
+    boolean enableSync, Duration syncDelay, Duration syncRequestTimeout, int gossipFanout) {}

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.topology.state;
 
 import com.google.common.collect.ImmutableMap;
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.state.MemberState.State;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -183,5 +184,15 @@ public record ClusterTopology(
 
   public boolean hasPendingChanges() {
     return !changes.pendingOperations().isEmpty();
+  }
+
+  public int clusterSize() {
+    return (int)
+        members.entrySet().stream()
+            .filter(
+                entry ->
+                    entry.getValue().state() != State.LEFT
+                        && entry.getValue().state() != State.UNINITIALIZED)
+            .count();
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagementIntegrationTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagementIntegrationTest.java
@@ -219,7 +219,8 @@ class ClusterTopologyManagementIntegrationTest {
             tempDir.resolve(cluster.getMembershipService().getLocalMember().id().id()),
             cluster.getCommunicationService(),
             cluster.getMembershipService(),
-            new ClusterTopologyGossiperConfig(Duration.ofSeconds(1), Duration.ofMillis(100), 2),
+            new ClusterTopologyGossiperConfig(
+                true, Duration.ofSeconds(1), Duration.ofMillis(100), 2),
             partitionChangeExecutor,
             topologyMembershipChangeExecutor);
     return new TestNode(cluster, service);

--- a/topology/src/test/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiperTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiperTest.java
@@ -84,14 +84,14 @@ final class ClusterTopologyGossiperTest {
     return Stream.of(
         Arguments.of(
             Named.of(
-                "by gossip", // Configure high delay for sync
+                "by gossip", // Disable sync
                 new ClusterTopologyGossiperConfig(
-                    Duration.ofMinutes(10), Duration.ofSeconds(1), 2))),
+                    false, Duration.ofMinutes(10), Duration.ofSeconds(1), 2))),
         Arguments.of(
             Named.of(
                 "by sync", // Set gossipFanout to 0
                 new ClusterTopologyGossiperConfig(
-                    Duration.ofMillis(100), Duration.ofSeconds(1), 0))));
+                    true, Duration.ofMillis(100), Duration.ofSeconds(1), 0))));
   }
 
   private Node createNode(final String id) {


### PR DESCRIPTION
## Description

`TopologyResponse` for the grpc request contains the `clusterSize` which was previously calculated from the `BrokerInfo`. `BrokerInfo` contains the static cluster size that is derived from the static configuration. With the dynamic cluster topology, a new broker can be added or removed from the cluster. This is not reflected in the `BrokerInfo`. In this PR, we start a `ClusterTopologyGossiper` in the gateway so that it can listen to the changes in `ClusterTopology`. `BrokerTopologyManager` is adjusted to calculate clusterSize from the ClusterTopology.

Periodic sync is disabled in the gateway gossiper to avoid unnecessary noise in the logs if the feature is disabled in the Broker. Even if sync is disabled, the gateway can still receive gossip and sync request from other Brokers. So it will eventually receive the updated ClusterTopology. When the feature is permanently enabled in the Broker, we can also enabled sync here.

`BrokerInfo` still contains the incorrect `clusterSize`, as it is not updated. This is not ideal. A better solution can be found when working on #14018. 

I have also thought about extracting a common interface for `ClusterTopologyService` that is exposed to both Gateway and Broker so that the concrete implementations `ClusterTopologyManagerService` and `GatewayTopologyService` can be hidden. However, at this moment it is not clear if that is useful or not. 

## Related issues

closes #14298 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
