### PR TITLE
Add Junit5 extension to manage TestCluster and TestApplication instances

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsBackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsBackupAcceptanceIT.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.testcontainers.GcsContainer;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.PartitionBackupInfo;
@@ -53,6 +55,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  */
 @AutoCloseResources
 @Testcontainers
+@ZeebeIntegration
 final class GcsBackupAcceptanceIT {
 
   private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
@@ -61,7 +64,7 @@ final class GcsBackupAcceptanceIT {
 
   private final String basePath = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
-  @AutoCloseResource
+  @TestZeebe
   private final TestCluster cluster =
       TestCluster.builder()
           .withBrokersCount(2)
@@ -91,7 +94,6 @@ final class GcsBackupAcceptanceIT {
 
   @BeforeEach
   void beforeEach() {
-    cluster.start().awaitCompleteTopology();
     client = cluster.newClientBuilder().build();
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
@@ -9,22 +9,21 @@ package io.camunda.zeebe.it.gateway;
 
 import static io.restassured.RestAssured.given;
 
-import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
-import io.camunda.zeebe.qa.util.cluster.TestApplication;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
-import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
 import java.time.Duration;
-import java.util.List;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+@ZeebeIntegration
 public class GatewayHealthProbeIntegrationTest {
 
   private static final String PATH_LIVENESS_PROBE = "/actuator/health/liveness";
@@ -32,104 +31,97 @@ public class GatewayHealthProbeIntegrationTest {
 
   @Nested
   final class WithBrokerTest {
+    @TestZeebe
+    private final TestCluster cluster =
+        TestCluster.builder().withEmbeddedGateway(false).withGatewaysCount(1).build();
+
     @Test
     void shouldReportLivenessUpIfConnectedToBroker() {
       // given
-      try (final var broker = new TestStandaloneBroker().start().awaitCompleteTopology();
-          final var gateway =
-              new TestStandaloneGateway()
-                  .withGatewayConfig(config -> configureGateway(config, broker))
-                  .start()
-                  .awaitCompleteTopology()) {
-        final var gatewayServerSpec =
-            new RequestSpecBuilder()
-                .setContentType(ContentType.JSON)
-                .setBaseUri("http://" + gateway.monitoringAddress())
-                .addFilter(new ResponseLoggingFilter())
-                .addFilter(new RequestLoggingFilter())
-                .build();
+      final var gateway = cluster.availableGateway();
+      final var gatewayServerSpec =
+          new RequestSpecBuilder()
+              .setContentType(ContentType.JSON)
+              .setBaseUri("http://" + gateway.monitoringAddress())
+              .addFilter(new ResponseLoggingFilter())
+              .addFilter(new RequestLoggingFilter())
+              .build();
 
-        // when - then
-        // most of the liveness probes use a delayed health indicator which is scheduled at a fixed
-        // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
-        // gateway finds the broker
-        try {
-          Awaitility.await("wait until status turns UP")
-              .atMost(Duration.ofSeconds(10))
-              .pollInterval(Duration.ofMillis(100))
-              .untilAsserted(
-                  () ->
-                      given()
-                          .spec(gatewayServerSpec)
-                          .when()
-                          .get(PATH_LIVENESS_PROBE)
-                          .then()
-                          .statusCode(200));
-        } catch (final ConditionTimeoutException e) {
-          // it can happen that a single request takes too long and causes awaitility to timeout,
-          // in which case we want to try a second time to run the request without timeout
-          given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(200);
-        }
+      // when - then
+      // most of the liveness probes use a delayed health indicator which is scheduled at a fixed
+      // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
+      // gateway finds the broker
+      try {
+        Awaitility.await("wait until status turns UP")
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(
+                () ->
+                    given()
+                        .spec(gatewayServerSpec)
+                        .when()
+                        .get(PATH_LIVENESS_PROBE)
+                        .then()
+                        .statusCode(200));
+      } catch (final ConditionTimeoutException e) {
+        // it can happen that a single request takes too long and causes awaitility to timeout,
+        // in which case we want to try a second time to run the request without timeout
+        given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(200);
       }
-    }
-
-    private void configureGateway(final GatewayCfg config, final TestApplication<?> broker) {
-      config.getCluster().setInitialContactPoints(List.of(broker.address(TestZeebePort.CLUSTER)));
     }
   }
 
   @Nested
   final class WithoutBrokerTest {
+    @TestZeebe(awaitReady = false, awaitCompleteTopology = false) // since there's no broker
+    private final TestStandaloneGateway gateway = new TestStandaloneGateway();
+
     @Test
     void shouldReportLivenessDownIfNotConnectedToBroker() {
       // given
-      try (final var gateway = new TestStandaloneGateway().start()) {
-        final var gatewayServerSpec =
-            new RequestSpecBuilder()
-                .setContentType(ContentType.JSON)
-                .setBaseUri("http://" + gateway.monitoringAddress())
-                .addFilter(new ResponseLoggingFilter())
-                .addFilter(new RequestLoggingFilter())
-                .build();
+      final var gatewayServerSpec =
+          new RequestSpecBuilder()
+              .setContentType(ContentType.JSON)
+              .setBaseUri("http://" + gateway.monitoringAddress())
+              .addFilter(new ResponseLoggingFilter())
+              .addFilter(new RequestLoggingFilter())
+              .build();
 
-        // when - then
-        given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(503);
-      }
+      // when - then
+      given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(503);
     }
 
     @Test
     void shouldReportReadinessUpIfApplicationIsUp() {
       // given
-      try (final var gateway = new TestStandaloneGateway().start()) {
-        final var gatewayServerSpec =
-            new RequestSpecBuilder()
-                .setContentType(ContentType.JSON)
-                .setBaseUri("http://" + gateway.monitoringAddress())
-                .addFilter(new ResponseLoggingFilter())
-                .addFilter(new RequestLoggingFilter())
-                .build();
+      final var gatewayServerSpec =
+          new RequestSpecBuilder()
+              .setContentType(ContentType.JSON)
+              .setBaseUri("http://" + gateway.monitoringAddress())
+              .addFilter(new ResponseLoggingFilter())
+              .addFilter(new RequestLoggingFilter())
+              .build();
 
-        // when - then
-        // most of the readiness probes use a delayed health indicator which is scheduled at a fixed
-        // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
-        // gateway finds the broker
-        try {
-          Awaitility.await("wait until status turns UP")
-              .atMost(Duration.ofSeconds(10))
-              .pollInterval(Duration.ofMillis(100))
-              .untilAsserted(
-                  () ->
-                      given()
-                          .spec(gatewayServerSpec)
-                          .when()
-                          .get(PATH_READINESS_PROBE)
-                          .then()
-                          .statusCode(200));
-        } catch (final ConditionTimeoutException e) {
-          // it can happen that a single request takes too long and causes awaitility to timeout,
-          // in which case we want to try a second time to run the request without timeout
-          given().spec(gatewayServerSpec).when().get(PATH_READINESS_PROBE).then().statusCode(200);
-        }
+      // when - then
+      // most of the readiness probes use a delayed health indicator which is scheduled at a fixed
+      // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
+      // gateway finds the broker
+      try {
+        Awaitility.await("wait until status turns UP")
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(
+                () ->
+                    given()
+                        .spec(gatewayServerSpec)
+                        .when()
+                        .get(PATH_READINESS_PROBE)
+                        .then()
+                        .statusCode(200));
+      } catch (final ConditionTimeoutException e) {
+        // it can happen that a single request takes too long and causes awaitility to timeout,
+        // in which case we want to try a second time to run the request without timeout
+        given().spec(gatewayServerSpec).when().get(PATH_READINESS_PROBE).then().statusCode(200);
       }
     }
   }

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -166,7 +166,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegration.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegration.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Registers the {@link ZeebeIntegrationExtension} extension, which will manage the lifecycle of {@link io.camunda.zeebe.qa.util.cluster.TestCluster} or {@link io.camunda.zeebe.qa.util.cluster.TestApplication} instances.
+ *
+ * <pre>{@code
+ * @ManageTestZeebe
+ * final class MyClusteredTest {
+ *   @TestZeebe(autoStart = true, awaitCompleteTopology = true)
+ *   private TestCluster cluster = TestCluster.builder()
+ *          .withBrokersCount(3)
+ *          .withReplicationFactor(3)
+ *          .withPartitionsCount(1)
+ *          .useEmbeddedGateway(true)
+ *          .build();
+ *
+ *   @Test
+ *   void shouldConnectToCluster() {
+ *     // given
+ *     final Topology topology;
+ *
+ *     // when
+ *     try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+ *       topology = c.newTopologyRequest().send().join();
+ *     }
+ *
+ *     // then
+ *     assertThat(topology.getClusterSize()).isEqualTo(3);
+ *   }
+ * }</pre>
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ExtendWith(ZeebeIntegrationExtension.class)
+public @interface ZeebeIntegration {
+
+  @Target({ElementType.FIELD})
+  @Retention(RetentionPolicy.RUNTIME)
+  @Documented
+  @Inherited
+  @interface TestZeebe {
+    /** If true (the default), will automatically start the annotated instance before tests. */
+    boolean autoStart() default true;
+
+    /**
+     * If true (the default), will block and wait until all managed applications are ready.
+     *
+     * <p>Does nothing if {@link #autoStart()} is false.
+     */
+    boolean awaitReady() default true;
+
+    /**
+     * If true (the default), will block and wait until all managed applications are started.
+     *
+     * <p>Does nothing if {@link #autoStart()} is false.
+     */
+    boolean awaitStarted() default true;
+
+    /**
+     * If true (the default), will block and wait until the topology is complete, using {@link
+     * #clusterSize()}, {@link #partitionCount()}, and {@link #replicationFactor()} as parameters.
+     *
+     * <p>If a {@link io.camunda.zeebe.qa.util.cluster.TestCluster} instance is annotated with this,
+     * verifies this on all gateways. If the cluster size, partition count, and replication factor
+     * attributes are left to defaults (-1), uses the cluster's information to replace them.
+     * However, if they're set to something, this will override the cluster's settings.
+     *
+     * <p>If a {@link io.camunda.zeebe.qa.util.cluster.TestGateway} instance is annotated with this,
+     * and replaces the default cluster size, partition count, and replication factor by 1.
+     *
+     * <p>Does nothing if a {@link io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker} is
+     * annotated with this that does not have an embedded broker.
+     *
+     * <p>Does nothing if {@link #autoStart()} is false.
+     */
+    boolean awaitCompleteTopology() default true;
+
+    /** The expected number of brokers in the cluster, used for {@link #awaitCompleteTopology()}. */
+    int clusterSize() default 0;
+
+    /** The expected partition count, used for {@link #awaitCompleteTopology()}. */
+    int partitionCount() default 0;
+
+    /** The expected replication factor, used for {@link #awaitCompleteTopology()}. */
+    int replicationFactor() default 0;
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegration.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegration.java
@@ -79,11 +79,13 @@ public @interface ZeebeIntegration {
      *
      * <p>If a {@link io.camunda.zeebe.qa.util.cluster.TestCluster} instance is annotated with this,
      * verifies this on all gateways. If the cluster size, partition count, and replication factor
-     * attributes are left to defaults (0), uses the cluster's information to replace them.
-     * However, if they're set to something, this will override the cluster's settings.
+     * attributes are left to defaults (0), uses the cluster's information to replace them. However,
+     * if they're set to something, this will override the cluster's settings.
      *
      * <p>If a {@link io.camunda.zeebe.qa.util.cluster.TestGateway} instance is annotated with this,
-     * and replaces the default cluster size, partition count, and replication factor by 1.
+     * then only this gateway is used to await the complete topology. In this case, the default for
+     * the annotation params ({@link #clusterSize()}, {@link #partitionCount()}, {@link
+     * #replicationFactor()}) are all 1.
      *
      * <p>Does nothing if a {@link io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker} is
      * annotated with this that does not have an embedded gateway.
@@ -100,5 +102,11 @@ public @interface ZeebeIntegration {
 
     /** The expected replication factor, used for {@link #awaitCompleteTopology()}. */
     int replicationFactor() default 0;
+
+    /**
+     * The expected topology timeout, used for {@link #awaitCompleteTopology()}; if omitted,
+     * defaults to 1 minute per brokers in the cluster.
+     */
+    long topologyTimeoutMs() default 0;
   }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegration.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegration.java
@@ -86,7 +86,7 @@ public @interface ZeebeIntegration {
      * and replaces the default cluster size, partition count, and replication factor by 1.
      *
      * <p>Does nothing if a {@link io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker} is
-     * annotated with this that does not have an embedded broker.
+     * annotated with this that does not have an embedded gateway.
      *
      * <p>Does nothing if {@link #autoStart()} is false.
      */

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegration.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegration.java
@@ -79,7 +79,7 @@ public @interface ZeebeIntegration {
      *
      * <p>If a {@link io.camunda.zeebe.qa.util.cluster.TestCluster} instance is annotated with this,
      * verifies this on all gateways. If the cluster size, partition count, and replication factor
-     * attributes are left to defaults (-1), uses the cluster's information to replace them.
+     * attributes are left to defaults (0), uses the cluster's information to replace them.
      * However, if they're set to something, this will override the cluster's settings.
      *
      * <p>If a {@link io.camunda.zeebe.qa.util.cluster.TestGateway} instance is annotated with this,

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -52,6 +52,10 @@ import org.slf4j.LoggerFactory;
  * <p>For brokers, a temporary folder is created and managed by the extension. This allows you to
  * stop and restart the same broker with the same data without losing it.
  *
+ * <p>Additionally, after every test, will reset the recording exporter. On failure, prints out the
+ * recording exporter using a {@link RecordLogger}. If using a shared cluster, this may output
+ * records from a previous test, since the recording exporter is not isolated to your test.
+ *
  * <p>See {@link TestZeebe} for annotation parameters.
  */
 final class ZeebeIntegrationExtension
@@ -59,6 +63,12 @@ final class ZeebeIntegrationExtension
 
   private static final Logger LOG = LoggerFactory.getLogger(ZeebeIntegrationExtension.class);
 
+  /**
+   * Looks up all static {@link TestCluster} and {@link TestApplication} fields, tying their own
+   * lifecycle to the {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_CLASS} lifecycle.
+   *
+   * <p>{@inheritDoc}
+   */
   @Override
   public void beforeAll(final ExtensionContext extensionContext) {
     final var resources = lookupClusters(extensionContext, null, ModifierSupport::isStatic);
@@ -67,6 +77,12 @@ final class ZeebeIntegrationExtension
     manageApplications(extensionContext, nodes);
   }
 
+  /**
+   * Looks up all non-static {@link TestCluster} and {@link TestApplication} fields, tying their own
+   * lifecycle to the {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_METHOD} lifecycle.
+   *
+   * <p>{@inheritDoc}
+   */
   @Override
   public void beforeEach(final ExtensionContext extensionContext) {
     final var testInstance = extensionContext.getRequiredTestInstance();

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.junit;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordLogger;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.function.Predicate;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ModifierSupport;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An extension which will manage all static and instance level fields of type {@link
+ * TestApplication} and {@link TestCluster}, iff they are annotated by {@link TestZeebe}.
+ *
+ * <p>The lifecycle of these thus depends on the field being static. If it's static, then it's
+ * started once before all tests, and stopped after all tests; if it's instance, then it's started
+ * for every test, and stopped after every test. This includes all adjacent resources created for
+ * that field (e.g. temporary folders, assigned ports, etc.)
+ *
+ * <p>For brokers, a temporary folder is created and managed by the extension. This allows you to
+ * stop and restart the same broker with the same data without losing it.
+ *
+ * <p>See {@link TestZeebe} for annotation parameters.
+ */
+final class ZeebeIntegrationExtension
+    implements BeforeAllCallback, BeforeEachCallback, BeforeTestExecutionCallback, TestWatcher {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZeebeIntegrationExtension.class);
+
+  @Override
+  public void beforeAll(final ExtensionContext extensionContext) {
+    final var resources = lookupClusters(extensionContext, null, ModifierSupport::isStatic);
+    final var nodes = lookupApplications(extensionContext, null, ModifierSupport::isStatic);
+    manageClusters(extensionContext, resources);
+    manageApplications(extensionContext, nodes);
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext extensionContext) {
+    final var testInstance = extensionContext.getRequiredTestInstance();
+    final var clusters =
+        lookupClusters(extensionContext, testInstance, ModifierSupport::isNotStatic);
+    final var nodes =
+        lookupApplications(extensionContext, testInstance, ModifierSupport::isNotStatic);
+    manageClusters(extensionContext, clusters);
+    manageApplications(extensionContext, nodes);
+  }
+
+  @Override
+  public void testFailed(final ExtensionContext context, final Throwable cause) {
+    RecordLogger.logRecords();
+  }
+
+  @Override
+  public void beforeTestExecution(final ExtensionContext extensionContext) {
+    RecordingExporter.reset();
+  }
+
+  private Iterable<ClusterResource> lookupClusters(
+      final ExtensionContext extensionContext,
+      final Object testInstance,
+      final Predicate<Field> fieldType) {
+    return AnnotationSupport.findAnnotatedFields(
+            extensionContext.getRequiredTestClass(),
+            TestZeebe.class,
+            fieldType.and(
+                field -> ReflectionUtils.isAssignableTo(field.getType(), TestCluster.class)),
+            HierarchyTraversalMode.TOP_DOWN)
+        .stream()
+        .map(field -> asClusterResource(testInstance, field))
+        .toList();
+  }
+
+  private Iterable<ApplicationResource> lookupApplications(
+      final ExtensionContext extensionContext,
+      final Object testInstance,
+      final Predicate<Field> fieldType) {
+    return AnnotationSupport.findAnnotatedFields(
+            extensionContext.getRequiredTestClass(),
+            TestZeebe.class,
+            fieldType.and(
+                field -> ReflectionUtils.isAssignableTo(field.getType(), TestApplication.class)),
+            HierarchyTraversalMode.TOP_DOWN)
+        .stream()
+        .map(field -> asNodeResource(testInstance, field))
+        .toList();
+  }
+
+  private void manageClusters(
+      final ExtensionContext extensionContext, final Iterable<ClusterResource> resources) {
+    final var store = store(extensionContext);
+
+    // register all resources first to ensure we close them; this avoids leaking resource if
+    // starting one fails
+    resources.forEach(resource -> store.put(resource, resource));
+    for (final var resource : resources) {
+      final var directory = createManagedDirectory(store, resource.cluster.name());
+      manageCluster(directory, resource);
+    }
+  }
+
+  private void manageCluster(final Path directory, final ClusterResource resource) {
+    final var cluster = resource.cluster;
+    final var annotation = resource.annotation;
+
+    // assign a working directory for each broker that gets deleted with the extension lifecycle,
+    // and not when the broker is shutdown. this allows to introspect or move the data around even
+    // after stopping a broker
+    cluster.brokers().forEach((id, broker) -> setWorkingDirectory(directory, id, broker));
+
+    if (annotation.autoStart()) {
+      cluster.start();
+
+      if (annotation.awaitStarted()) {
+        cluster.await(TestHealthProbe.STARTED);
+      }
+
+      if (annotation.awaitReady()) {
+        cluster.await(TestHealthProbe.READY);
+      }
+
+      if (annotation.awaitCompleteTopology()) {
+        final var clusterSize =
+            annotation.clusterSize() <= 0 ? cluster.brokers().size() : annotation.clusterSize();
+        final var partitionCount =
+            annotation.partitionCount() <= 0
+                ? cluster.partitionsCount()
+                : annotation.partitionCount();
+        final var replicationFactor =
+            annotation.replicationFactor() <= 0
+                ? cluster.replicationFactor()
+                : annotation.replicationFactor();
+
+        cluster.awaitCompleteTopology(
+            clusterSize,
+            partitionCount,
+            replicationFactor,
+            Duration.ofMinutes(cluster.nodes().size()));
+      }
+    }
+  }
+
+  private void manageApplications(
+      final ExtensionContext extensionContext, final Iterable<ApplicationResource> resources) {
+    final var store = store(extensionContext);
+
+    // register all resources first to ensure we close them; this avoids leaking resource if
+    // starting one fails
+    resources.forEach(resource -> store.put(resource, resource));
+    for (final var resource : resources) {
+      manageApplication(store, resource);
+    }
+  }
+
+  private void manageApplication(final Store store, final ApplicationResource resource) {
+    final var node = resource.node;
+    final var annotation = resource.annotation;
+
+    if (node instanceof final TestStandaloneBroker broker) {
+      final var directory = createManagedDirectory(store, "broker-" + broker.nodeId().id());
+      setWorkingDirectory(directory, broker.nodeId(), broker);
+    }
+
+    if (annotation.autoStart()) {
+      node.start();
+
+      if (annotation.awaitStarted()) {
+        node.await(TestHealthProbe.STARTED);
+      }
+
+      if (annotation.awaitReady()) {
+        node.await(TestHealthProbe.READY);
+      }
+
+      if (annotation.awaitCompleteTopology()
+          && node.isGateway()
+          && node instanceof final TestGateway<?> gateway) {
+        gateway.awaitCompleteTopology(
+            Math.max(1, annotation.clusterSize()),
+            Math.max(1, annotation.clusterSize()),
+            Math.max(1, annotation.clusterSize()),
+            Duration.ofSeconds(30));
+      }
+    }
+  }
+
+  private void setWorkingDirectory(
+      final Path directory, final MemberId id, final TestStandaloneBroker broker) {
+    final Path workingDirectory = directory.resolve("broker-" + id.id());
+    try {
+      Files.createDirectory(workingDirectory);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    broker.withWorkingDirectory(workingDirectory);
+  }
+
+  private Path createManagedDirectory(final Store store, final String prefix) {
+    try {
+      final var directory = Files.createTempDirectory(prefix);
+      store.put(directory, new DirectoryResource(directory));
+      return directory;
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private ClusterResource asClusterResource(final Object testInstance, final Field field) {
+    final TestCluster value;
+
+    try {
+      value = (TestCluster) ReflectionUtils.makeAccessible(field).get(testInstance);
+    } catch (final IllegalAccessException e) {
+      throw new UnsupportedOperationException(e);
+    }
+
+    return new ClusterResource(value, field.getAnnotation(TestZeebe.class));
+  }
+
+  private ApplicationResource asNodeResource(final Object testInstance, final Field field) {
+    final TestApplication<?> value;
+
+    try {
+      value = (TestApplication<?>) ReflectionUtils.makeAccessible(field).get(testInstance);
+    } catch (final IllegalAccessException e) {
+      throw new UnsupportedOperationException(e);
+    }
+
+    return new ApplicationResource(value, field.getAnnotation(TestZeebe.class));
+  }
+
+  private Store store(final ExtensionContext extensionContext) {
+    return extensionContext.getStore(Namespace.create(ZeebeIntegrationExtension.class));
+  }
+
+  private record ClusterResource(TestCluster cluster, TestZeebe annotation)
+      implements CloseableResource {
+
+    @Override
+    public void close() {
+      CloseHelper.close(
+          error -> LOG.warn("Failed to close cluster {}, leaking resources", cluster.name(), error),
+          cluster);
+    }
+  }
+
+  private record ApplicationResource(TestApplication<?> node, TestZeebe annotation)
+      implements CloseableResource {
+
+    @Override
+    public void close() {
+      CloseHelper.close(
+          error -> LOG.warn("Failed to close test node {}, leaking resources", node.nodeId()),
+          node);
+    }
+  }
+
+  private record DirectoryResource(Path directory) implements CloseableResource {
+
+    @Override
+    public void close() {
+      try {
+        FileUtil.deleteFolderIfExists(directory);
+      } catch (final IOException e) {
+        LOG.warn("Failed to clean up temporary directory {}, leaking resources...", directory, e);
+      }
+    }
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -283,8 +283,12 @@ final class ZeebeIntegrationExtension
           annotation.replicationFactor() <= 0
               ? cluster.replicationFactor()
               : annotation.replicationFactor();
-      cluster.awaitCompleteTopology(
-          clusterSize, partitionCount, replicationFactor, Duration.ofMinutes(clusterSize));
+      final var timeout =
+          annotation.topologyTimeoutMs() == 0
+              ? Duration.ofMinutes(clusterSize)
+              : Duration.ofMillis(annotation().topologyTimeoutMs());
+
+      cluster.awaitCompleteTopology(clusterSize, partitionCount, replicationFactor, timeout);
     }
   }
 
@@ -313,11 +317,15 @@ final class ZeebeIntegrationExtension
         return;
       }
 
+      final var timeout =
+          annotation.topologyTimeoutMs() == 0
+              ? Duration.ofMinutes(1)
+              : Duration.ofMillis(annotation().topologyTimeoutMs());
       gateway.awaitCompleteTopology(
           Math.max(1, annotation.clusterSize()),
-          Math.max(1, annotation.clusterSize()),
-          Math.max(1, annotation.clusterSize()),
-          Duration.ofSeconds(30));
+          Math.max(1, annotation.partitionCount()),
+          Math.max(1, annotation.replicationFactor()),
+          timeout);
     }
   }
 


### PR DESCRIPTION
## Description

This PR adds a new `ZeebeIntegration` extension which will manage `TestZeebe` annotated static/instance fields, iff they are of type `TestCluster` or `TestApplication`.

It's usage is meant to be something like:

```java
@ZeebeIntegration
final class MyTest {
  // once before all test, will start the cluster and await the complete topology; after all
  // tests, the cluster is shut down
  @TestZeebe
  private static final TestCluster SHARED_CLUSTER = TestCluster.builder().build();

  // for each test, will start the cluster and await until the topology is complete before
  // running the test; after each test, the cluster is shut down
  @TestZeebe(awaitCompleteTopology = true)
  private final TestCluster cluster = TestCluster.builder().build();
}
```

For each broker annotated, a new working directory is created and managed by the extension lifecycle, allowing restarts of the same broker with the same data. The directory is deleted with the extension's store.

The extension also manages some "wait" states, i.e. await readiness, started, or complete topology, with multiple options. 

Awaiting topology has some special behavior. If a broker without an embedded gateway is annotated with `TestZeebe`, this attribute is completely ignored. Otherwise, it will await the complete topology _from the point of view of all gateways managed by the single `TestZeebe` annotation_ (e.g. for a single app that's a gateway, it's just that app - for a cluster, all gateways must see the complete topology).

To await custom topologies, you can specify `TestZeebe(clusterSize = 2, partitionCount = 3, replicationFactor = 1)` for example. This will await specifically that complete topology (e.g. 2 brokers, 3 partitions each with a leader, and only 1 replica per partition). By default, these attributes are 0. Anything less than or equal to 0 is replaced by a default value on start. If it's a standalone app, this becomes 1. If it's a cluster, it just uses the cluster's configuration.

It's a bit hard to test Junit 5 extensions, even if the logic is not the simplest...right now I refactored some tests to show this works, but I'm happy for suggestions on how to test the extension itself. I think I have some idea of how to test the instance fields, but none on how to test the static ones...

## Related issues

related to #13962

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
