### PR TITLE
test(engine): verify start event with forms

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/StartEventFormTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/StartEventFormTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class StartEventFormTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String TEST_FORM = "/form/test-form-1.form";
+  private static final String FORM_ID = "Form_0w7r08e";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDeployProcessWithFormIdWhenFormIsNotYetDeployed() {
+    // when
+    deployProcess("form-id");
+
+    // then
+    assertProcessDeployed();
+  }
+
+  @Test
+  public void shouldDeployProcessWithFormIdWithFormDeployed() {
+    // when
+    deployForm();
+    deployProcess(FORM_ID);
+
+    // then
+    assertProcessDeployed();
+  }
+
+  @Test
+  public void shouldStartAncCompleteProcessWithForm() {
+    // given
+    deployForm();
+    deployProcess(FORM_ID);
+    assertProcessDeployed();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertProcessInstanceCompleted(processInstanceKey);
+  }
+
+  private void deployProcess(final String formId) {
+    final BpmnModelInstance processWithFormId =
+        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().zeebeFormId(formId).endEvent().done();
+
+    ENGINE.deployment().withXmlResource(processWithFormId).deploy();
+  }
+
+  private void deployForm() {
+    final var deploymentEvent = ENGINE.deployment().withJsonClasspathResource(TEST_FORM).deploy();
+
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATED)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasRecordType(RecordType.EVENT);
+  }
+
+  private void assertProcessDeployed() {
+    assertThat(RecordingExporter.deploymentRecords())
+        .extracting(Record::getRecordType, Record::getIntent)
+        .containsSequence(
+            tuple(RecordType.COMMAND, DeploymentIntent.CREATE),
+            tuple(RecordType.EVENT, DeploymentIntent.CREATED));
+  }
+
+  private void assertProcessInstanceCompleted(final long processInstanceKey) {
+    assertThat(
+            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
+        .extracting(Record::getRecordType, Record::getIntent)
+        .containsSequence(
+            tuple(RecordType.EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(RecordType.EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR add tests to verify the correct behaviour of start event element with a form

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14343 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
