### PR TITLE
Add and set tenant on message related records

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -62,8 +62,6 @@ public final class CatchEventBehavior {
   private final TimerRecord timerRecord = new TimerRecord();
   private final DueDateTimerChecker timerChecker;
   private final KeyGenerator keyGenerator;
-  private final int currentPartitionId;
-
   private final SignalSubscriptionRecord signalSubscription = new SignalSubscriptionRecord();
 
   public CatchEventBehavior(
@@ -88,8 +86,6 @@ public final class CatchEventBehavior {
 
     this.keyGenerator = keyGenerator;
     this.timerChecker = timerChecker;
-
-    currentPartitionId = processingState.getPartitionId();
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -281,7 +281,8 @@ public final class CatchEventBehavior {
         bpmnProcessId,
         messageName,
         correlationKey,
-        event.isInterrupting());
+        event.isInterrupting(),
+        context.getTenantId());
   }
 
   private void subscribeToTimerEvents(
@@ -412,16 +413,21 @@ public final class CatchEventBehavior {
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, subscription.getRecord());
     sendCloseMessageSubscriptionCommand(
-        subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName);
+        subscriptionPartitionId,
+        processInstanceKey,
+        elementInstanceKey,
+        messageName,
+        subscription.getRecord().getTenantId());
   }
 
   private boolean sendCloseMessageSubscriptionCommand(
       final int subscriptionPartitionId,
       final long processInstanceKey,
       final long elementInstanceKey,
-      final DirectBuffer messageName) {
+      final DirectBuffer messageName,
+      final String tenantId) {
     return subscriptionCommandSender.closeMessageSubscription(
-        subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName);
+        subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName, tenantId);
   }
 
   private boolean sendOpenMessageSubscription(
@@ -431,7 +437,8 @@ public final class CatchEventBehavior {
       final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
-      final boolean closeOnCorrelate) {
+      final boolean closeOnCorrelate,
+      final String tenantId) {
     return subscriptionCommandSender.openMessageSubscription(
         subscriptionPartitionId,
         processInstanceKey,
@@ -439,7 +446,8 @@ public final class CatchEventBehavior {
         bpmnProcessId,
         messageName,
         correlationKey,
-        closeOnCorrelate);
+        closeOnCorrelate,
+        tenantId);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -265,6 +265,7 @@ public final class CatchEventBehavior {
     subscription.setCorrelationKey(correlationKey);
     subscription.setElementId(event.getId());
     subscription.setInterrupting(event.isInterrupting());
+    subscription.setTenantId(context.getTenantId());
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -188,7 +188,8 @@ public final class EventHandle {
         .setCorrelationKey(message.getCorrelationKeyBuffer())
         .setMessageKey(messageKey)
         .setMessageName(message.getNameBuffer())
-        .setVariables(message.getVariablesBuffer());
+        .setVariables(message.getVariablesBuffer())
+        .setTenantId(subscription.getTenantId());
 
     stateWriter.appendFollowUpEvent(
         subscriptionKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/StartEventSubscriptionManager.java
@@ -183,7 +183,8 @@ public class StartEventSubscriptionManager {
                   .setMessageName(messageNameBuffer)
                   .setProcessDefinitionKey(processDefinition.getKey())
                   .setBpmnProcessId(processDefinition.getBpmnProcessId())
-                  .setStartEventId(startEvent.getId());
+                  .setStartEventId(startEvent.getId())
+                  .setTenantId(processDefinition.getTenantId());
 
               final var subscriptionKey = keyGenerator.nextKey();
               stateWriter.appendFollowUpEvent(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -89,6 +89,7 @@ public final class MessageCorrelator {
         subscriptionRecord.getMessageNameBuffer(),
         subscriptionRecord.getMessageKey(),
         subscriptionRecord.getVariablesBuffer(),
-        subscriptionRecord.getCorrelationKeyBuffer());
+        subscriptionRecord.getCorrelationKeyBuffer(),
+        subscriptionRecord.getTenantId());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -53,7 +53,6 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE,
             MessageIntent.PUBLISH,
             new MessagePublishProcessor(
-                processingState.getPartitionId(),
                 messageState,
                 subscriptionState,
                 startEventSubscriptionState,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -125,6 +125,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
 
   private void correlateToSubscriptions(final long messageKey, final MessageRecord message) {
     subscriptionState.visitSubscriptions(
+        message.getTenantId(),
         message.getNameBuffer(),
         message.getCorrelationKeyBuffer(),
         subscription -> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -168,7 +168,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
           if (!correlatingSubscriptions.contains(bpmnProcessIdBuffer)
               && (correlationKeyBuffer.capacity() == 0
                   || !messageState.existActiveProcessInstance(
-                      bpmnProcessIdBuffer, correlationKeyBuffer))) {
+                      messageRecord.getTenantId(), bpmnProcessIdBuffer, correlationKeyBuffer))) {
 
             correlatingSubscriptions.add(subscriptionRecord);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -188,6 +188,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
                 messageRecord.getNameBuffer(),
                 messageKey,
                 messageRecord.getVariablesBuffer(),
-                messageRecord.getCorrelationKeyBuffer()));
+                messageRecord.getCorrelationKeyBuffer(),
+                messageRecord.getTenantId()));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -156,6 +156,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
   private void correlateToMessageStartEvents(final MessageRecord messageRecord) {
 
     startEventSubscriptionState.visitSubscriptionsByMessageName(
+        messageRecord.getTenantId(),
         messageRecord.getNameBuffer(),
         subscription -> {
           final var subscriptionRecord = subscription.getRecord();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -50,11 +49,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
   private long messageKey;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
-  private final SideEffectWriter sideEffectWriter;
-  private final int currentPartitionId;
 
   public MessagePublishProcessor(
-      final int partitionId,
       final MessageState messageState,
       final MessageSubscriptionState subscriptionState,
       final MessageStartEventSubscriptionState startEventSubscriptionState,
@@ -68,13 +64,11 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     this.messageState = messageState;
     this.subscriptionState = subscriptionState;
     this.startEventSubscriptionState = startEventSubscriptionState;
-    currentPartitionId = partitionId;
     this.commandSender = commandSender;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
-    sideEffectWriter = writers.sideEffect();
     eventHandle =
         new EventHandle(
             keyGenerator,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -99,6 +99,7 @@ public final class MessageSubscriptionCreateProcessor
         subscriptionRecord.getProcessInstanceKey(),
         subscriptionRecord.getElementInstanceKey(),
         subscriptionRecord.getMessageNameBuffer(),
-        subscriptionRecord.isInterrupting());
+        subscriptionRecord.isInterrupting(),
+        subscriptionRecord.getTenantId());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -82,6 +82,7 @@ public final class MessageSubscriptionDeleteProcessor
     return commandSender.closeProcessMessageSubscription(
         subscriptionRecord.getProcessInstanceKey(),
         subscriptionRecord.getElementInstanceKey(),
-        subscriptionRecord.getMessageNameBuffer());
+        subscriptionRecord.getMessageNameBuffer(),
+        subscriptionRecord.getTenantId());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -73,6 +73,7 @@ public final class MessageSubscriptionRejectProcessor
     }
 
     subscriptionState.visitSubscriptions(
+        subscriptionRecord.getTenantId(),
         subscriptionRecord.getMessageNameBuffer(),
         subscriptionRecord.getCorrelationKeyBuffer(),
         subscription -> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -108,7 +108,8 @@ public final class MessageSubscriptionRejectProcessor
         subscription.getMessageNameBuffer(),
         subscription.getMessageKey(),
         subscription.getVariablesBuffer(),
-        subscription.getCorrelationKeyBuffer());
+        subscription.getCorrelationKeyBuffer(),
+        subscription.getTenantId());
   }
 
   private void rejectCommand(final TypedRecord<MessageSubscriptionRecord> record) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
@@ -42,7 +42,8 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
         record.getMessageNameBuffer(),
         record.getMessageKey(),
         record.getVariablesBuffer(),
-        record.getCorrelationKeyBuffer());
+        record.getCorrelationKeyBuffer(),
+        record.getTenantId());
 
     // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)
     final var sentTime = ActorClock.currentTimeMillis();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -103,7 +103,8 @@ public final class PendingProcessMessageSubscriptionChecker
         subscription.getRecord().getBpmnProcessIdBuffer(),
         subscription.getRecord().getMessageNameBuffer(),
         subscription.getRecord().getCorrelationKeyBuffer(),
-        subscription.getRecord().isInterrupting());
+        subscription.getRecord().isInterrupting(),
+        subscription.getRecord().getTenantId());
   }
 
   private void sendCloseCommand(final ProcessMessageSubscription subscription) {
@@ -111,6 +112,7 @@ public final class PendingProcessMessageSubscriptionChecker
         subscription.getRecord().getSubscriptionPartitionId(),
         subscription.getRecord().getProcessInstanceKey(),
         subscription.getRecord().getElementInstanceKey(),
-        subscription.getRecord().getMessageNameBuffer());
+        subscription.getRecord().getMessageNameBuffer(),
+        subscription.getRecord().getTenantId());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -153,7 +153,8 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         subscription.getProcessInstanceKey(),
         subscription.getElementInstanceKey(),
         subscription.getBpmnProcessIdBuffer(),
-        subscription.getMessageNameBuffer());
+        subscription.getMessageNameBuffer(),
+        subscription.getTenantId());
   }
 
   private void sendRejectionCommand(final ProcessMessageSubscriptionRecord subscription) {
@@ -162,6 +163,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         subscription.getBpmnProcessIdBuffer(),
         subscription.getMessageKey(),
         subscription.getMessageNameBuffer(),
-        subscription.getCorrelationKeyBuffer());
+        subscription.getCorrelationKeyBuffer(),
+        subscription.getTenantId());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -133,7 +133,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer messageName,
       final long messageKey,
       final DirectBuffer variables,
-      final DirectBuffer correlationKey) {
+      final DirectBuffer correlationKey,
+      final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -146,7 +147,8 @@ public class SubscriptionCommandSender {
             .setMessageKey(messageKey)
             .setMessageName(messageName)
             .setVariables(variables)
-            .setCorrelationKey(correlationKey));
+            .setCorrelationKey(correlationKey)
+            .setTenantId(tenantId));
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -58,7 +58,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
-      final boolean closeOnCorrelate) {
+      final boolean closeOnCorrelate,
+      final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -70,7 +71,8 @@ public class SubscriptionCommandSender {
             .setMessageKey(-1)
             .setMessageName(messageName)
             .setCorrelationKey(correlationKey)
-            .setInterrupting(closeOnCorrelate));
+            .setInterrupting(closeOnCorrelate)
+            .setTenantId(tenantId));
   }
 
   /**
@@ -85,6 +87,7 @@ public class SubscriptionCommandSender {
    * @param messageName the name of the message for which the subscription should be correlated
    * @param correlationKey the correlation key for which the message should be correlated
    * @param closeOnCorrelate indicates whether the subscription should be closed after correlation
+   * @param tenantId the tenant id the message subscription is created for
    */
   public void sendDirectOpenMessageSubscription(
       final int subscriptionPartitionId,
@@ -93,7 +96,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
-      final boolean closeOnCorrelate) {
+      final boolean closeOnCorrelate,
+      final String tenantId) {
     interPartitionCommandSender.sendCommand(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -105,7 +109,8 @@ public class SubscriptionCommandSender {
             .setMessageKey(-1)
             .setMessageName(messageName)
             .setCorrelationKey(correlationKey)
-            .setInterrupting(closeOnCorrelate));
+            .setInterrupting(closeOnCorrelate)
+            .setTenantId(tenantId));
   }
 
   public boolean openProcessMessageSubscription(
@@ -192,7 +197,8 @@ public class SubscriptionCommandSender {
       final long processInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer bpmnProcessId,
-      final DirectBuffer messageName) {
+      final DirectBuffer messageName,
+      final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -202,14 +208,16 @@ public class SubscriptionCommandSender {
             .setElementInstanceKey(elementInstanceKey)
             .setBpmnProcessId(bpmnProcessId)
             .setMessageKey(-1)
-            .setMessageName(messageName));
+            .setMessageName(messageName)
+            .setTenantId(tenantId));
   }
 
   public boolean closeMessageSubscription(
       final int subscriptionPartitionId,
       final long processInstanceKey,
       final long elementInstanceKey,
-      final DirectBuffer messageName) {
+      final DirectBuffer messageName,
+      final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -218,7 +226,8 @@ public class SubscriptionCommandSender {
             .setProcessInstanceKey(processInstanceKey)
             .setElementInstanceKey(elementInstanceKey)
             .setMessageKey(-1L)
-            .setMessageName(messageName));
+            .setMessageName(messageName)
+            .setTenantId(tenantId));
   }
 
   /**
@@ -230,12 +239,14 @@ public class SubscriptionCommandSender {
    * @param processInstanceKey the related process instance key
    * @param elementInstanceKey the related element instance key
    * @param messageName the name of the message for which the subscription should be closed
+   * @param tenantId the tenant for which the subscription should be closed
    */
   public void sendDirectCloseMessageSubscription(
       final int subscriptionPartitionId,
       final long processInstanceKey,
       final long elementInstanceKey,
-      final DirectBuffer messageName) {
+      final DirectBuffer messageName,
+      final String tenantId) {
     interPartitionCommandSender.sendCommand(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -244,7 +255,8 @@ public class SubscriptionCommandSender {
             .setProcessInstanceKey(processInstanceKey)
             .setElementInstanceKey(elementInstanceKey)
             .setMessageKey(-1L)
-            .setMessageName(messageName));
+            .setMessageName(messageName)
+            .setTenantId(tenantId));
   }
 
   public boolean closeProcessMessageSubscription(
@@ -268,7 +280,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer bpmnProcessId,
       final long messageKey,
       final DirectBuffer messageName,
-      final DirectBuffer correlationKey) {
+      final DirectBuffer correlationKey,
+      final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -280,7 +293,8 @@ public class SubscriptionCommandSender {
             .setMessageName(messageName)
             .setCorrelationKey(correlationKey)
             .setMessageKey(messageKey)
-            .setInterrupting(false));
+            .setInterrupting(false)
+            .setTenantId(tenantId));
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -117,7 +117,8 @@ public class SubscriptionCommandSender {
       final long processInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer messageName,
-      final boolean closeOnCorrelate) {
+      final boolean closeOnCorrelate,
+      final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -128,7 +129,8 @@ public class SubscriptionCommandSender {
             .setElementInstanceKey(elementInstanceKey)
             .setMessageKey(-1)
             .setMessageName(messageName)
-            .setInterrupting(closeOnCorrelate));
+            .setInterrupting(closeOnCorrelate)
+            .setTenantId(tenantId));
   }
 
   public boolean correlateProcessMessageSubscription(
@@ -168,6 +170,7 @@ public class SubscriptionCommandSender {
    * @param messageKey the key of the message for which the subscription should be correlated
    * @param variables the variables of the message
    * @param correlationKey the correlation key for which the message should be correlated
+   * @param tenantId the tenant the message subscription is correlated for
    */
   public void sendDirectCorrelateProcessMessageSubscription(
       final long processInstanceKey,
@@ -176,7 +179,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer messageName,
       final long messageKey,
       final DirectBuffer variables,
-      final DirectBuffer correlationKey) {
+      final DirectBuffer correlationKey,
+      final String tenantId) {
     interPartitionCommandSender.sendCommand(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -189,7 +193,8 @@ public class SubscriptionCommandSender {
             .setMessageKey(messageKey)
             .setMessageName(messageName)
             .setVariables(variables)
-            .setCorrelationKey(correlationKey));
+            .setCorrelationKey(correlationKey)
+            .setTenantId(tenantId));
   }
 
   public boolean correlateMessageSubscription(
@@ -262,7 +267,8 @@ public class SubscriptionCommandSender {
   public boolean closeProcessMessageSubscription(
       final long processInstanceKey,
       final long elementInstanceKey,
-      final DirectBuffer messageName) {
+      final DirectBuffer messageName,
+      final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -272,7 +278,8 @@ public class SubscriptionCommandSender {
             .setProcessInstanceKey(processInstanceKey)
             .setElementInstanceKey(elementInstanceKey)
             .setMessageKey(-1)
-            .setMessageName(messageName));
+            .setMessageName(messageName)
+            .setTenantId(tenantId));
   }
 
   public boolean rejectCorrelateMessageSubscription(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageStartEventSubscriptionState.java
@@ -16,7 +16,9 @@ public interface MessageStartEventSubscriptionState {
   boolean exists(MessageStartEventSubscriptionRecord subscription);
 
   void visitSubscriptionsByMessageName(
-      DirectBuffer messageName, MessageStartEventSubscriptionVisitor visitor);
+      final String tenantId,
+      DirectBuffer messageName,
+      MessageStartEventSubscriptionVisitor visitor);
 
   /**
    * Visit all subscriptions with the given process definition key.

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageState.java
@@ -14,7 +14,8 @@ public interface MessageState {
 
   boolean existMessageCorrelation(long messageKey, DirectBuffer bpmnProcessId);
 
-  boolean existActiveProcessInstance(DirectBuffer bpmnProcessId, DirectBuffer correlationKey);
+  boolean existActiveProcessInstance(
+      final String tenantId, DirectBuffer bpmnProcessId, DirectBuffer correlationKey);
 
   DirectBuffer getProcessInstanceCorrelationKey(long processInstanceKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MessageSubscriptionState.java
@@ -14,8 +14,14 @@ public interface MessageSubscriptionState {
 
   MessageSubscription get(long elementInstanceKey, DirectBuffer messageName);
 
+  /**
+   * Visits the message subscriptions that match a given tenant, message name, and correlation key.
+   */
   void visitSubscriptions(
-      DirectBuffer messageName, DirectBuffer correlationKey, MessageSubscriptionVisitor visitor);
+      final String tenantId,
+      DirectBuffer messageName,
+      DirectBuffer correlationKey,
+      MessageSubscriptionVisitor visitor);
 
   boolean existSubscriptionForElementInstance(long elementInstanceKey, DirectBuffer messageName);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
@@ -90,7 +90,9 @@ public final class DbMessageStartEventSubscriptionState
 
   @Override
   public void visitSubscriptionsByMessageName(
-      final DirectBuffer messageName, final MessageStartEventSubscriptionVisitor visitor) {
+      final String tenantId,
+      final DirectBuffer messageName,
+      final MessageStartEventSubscriptionVisitor visitor) {
 
     this.messageName.wrapBuffer(messageName);
     subscriptionsColumnFamily.whileEqualPrefix(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -347,7 +347,7 @@ public final class DbMessageState implements MutableMessageState {
 
   @Override
   public boolean existActiveProcessInstance(
-      final DirectBuffer bpmnProcessId, final DirectBuffer correlationKey) {
+      final String tenantId, final DirectBuffer bpmnProcessId, final DirectBuffer correlationKey) {
     ensureNotNullOrEmpty("BPMN process id", bpmnProcessId);
     ensureNotNullOrEmpty("correlation key", correlationKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -98,6 +98,7 @@ public final class DbMessageSubscriptionState
 
   @Override
   public void visitSubscriptions(
+      final String tenantId,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
       final MessageSubscriptionVisitor visitor) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -102,7 +102,8 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getProcessInstanceKey()),
             eq(subscription.getElementInstanceKey()),
             any(),
-            anyBoolean());
+            anyBoolean(),
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Test
@@ -229,7 +230,8 @@ public final class MessageStreamProcessorTest {
         .closeProcessMessageSubscription(
             eq(subscription.getProcessInstanceKey()),
             eq(subscription.getElementInstanceKey()),
-            any(DirectBuffer.class));
+            any(DirectBuffer.class),
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.util.FeatureFlags;
@@ -46,6 +47,7 @@ import org.junit.Test;
 public final class MessageStreamProcessorTest {
 
   private static final EngineConfiguration DEFAULT_ENGINE_CONFIGURATION = new EngineConfiguration();
+  private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
 
   @Rule public final StreamProcessorRule rule = new StreamProcessorRule();
 
@@ -255,7 +257,8 @@ public final class MessageStreamProcessorTest {
             any(),
             eq(messageKey),
             any(),
-            any());
+            any(),
+            eq(DEFAULT_TENANT));
   }
 
   @Test
@@ -294,7 +297,8 @@ public final class MessageStreamProcessorTest {
             any(),
             eq(firstMessageKey),
             any(),
-            any());
+            any(),
+            eq(DEFAULT_TENANT));
 
     verify(spySubscriptionCommandSender, timeout(5_000))
         .correlateProcessMessageSubscription(
@@ -304,7 +308,8 @@ public final class MessageStreamProcessorTest {
             any(),
             eq(lastMessageKey),
             any(),
-            any());
+            any(),
+            eq(DEFAULT_TENANT));
   }
 
   @Test
@@ -394,7 +399,8 @@ public final class MessageStreamProcessorTest {
             any(DirectBuffer.class),
             eq(messageKey),
             any(DirectBuffer.class),
-            eq(firstSubscription.getCorrelationKeyBuffer()));
+            eq(firstSubscription.getCorrelationKeyBuffer()),
+            eq(DEFAULT_TENANT));
 
     verify(spySubscriptionCommandSender, timeout(5_000))
         .correlateProcessMessageSubscription(
@@ -404,7 +410,8 @@ public final class MessageStreamProcessorTest {
             any(DirectBuffer.class),
             eq(messageKey),
             any(DirectBuffer.class),
-            eq(secondSubscription.getCorrelationKeyBuffer()));
+            eq(secondSubscription.getCorrelationKeyBuffer()),
+            eq(DEFAULT_TENANT));
   }
 
   private void assertAllMessagesReceived(final MessageSubscriptionRecord subscription) {
@@ -430,7 +437,8 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getMessageNameBuffer()),
             eq(firstMessageKey),
             any(),
-            eq(subscription.getCorrelationKeyBuffer()));
+            eq(subscription.getCorrelationKeyBuffer()),
+            eq(DEFAULT_TENANT));
 
     verify(spySubscriptionCommandSender, timeout(5_000))
         .correlateProcessMessageSubscription(
@@ -440,7 +448,8 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getMessageNameBuffer()),
             eq(lastMessageKey),
             any(),
-            eq(subscription.getCorrelationKeyBuffer()));
+            eq(subscription.getCorrelationKeyBuffer()),
+            eq(DEFAULT_TENANT));
   }
 
   private MessageSubscriptionRecord messageSubscription() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -103,7 +103,7 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getElementInstanceKey()),
             any(),
             anyBoolean(),
-            TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+            eq(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
   }
 
   @Test
@@ -231,7 +231,7 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getProcessInstanceKey()),
             eq(subscription.getElementInstanceKey()),
             any(DirectBuffer.class),
-            TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+            eq(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -66,7 +66,10 @@ public class SubscriptionCommandSenderTest {
 
     // when
     subscriptionCommandSender.closeProcessMessageSubscription(
-        DIFFERENT_RECEIVER_PARTITION_KEY, DEFAULT_ELEMENT_INSTANCE_KEY, DEFAULT_MESSAGE_NAME);
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_MESSAGE_NAME,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -79,7 +82,10 @@ public class SubscriptionCommandSenderTest {
 
     // when
     subscriptionCommandSender.closeProcessMessageSubscription(
-        SAME_RECEIVER_PARTITION_KEY, DEFAULT_ELEMENT_INSTANCE_KEY, DEFAULT_MESSAGE_NAME);
+        SAME_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
+        DEFAULT_MESSAGE_NAME,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -138,7 +144,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_NAME,
         DEFAULT_MESSAGE_KEY,
         DEFAULT_VARIABLES,
-        DEFAULT_CORRELATION_KEY);
+        DEFAULT_CORRELATION_KEY,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockInterPartitionCommandSender)
@@ -280,7 +287,11 @@ public class SubscriptionCommandSenderTest {
 
     // when
     subscriptionCommandSender.openProcessMessageSubscription(
-        DIFFERENT_PARTITION, DIFFERENT_RECEIVER_PARTITION_KEY, DEFAULT_MESSAGE_NAME, true);
+        DIFFERENT_PARTITION,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_MESSAGE_NAME,
+        true,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -293,7 +304,11 @@ public class SubscriptionCommandSenderTest {
 
     // when
     subscriptionCommandSender.openProcessMessageSubscription(
-        SAME_RECEIVER_PARTITION_KEY, DIFFERENT_RECEIVER_PARTITION_KEY, DEFAULT_MESSAGE_NAME, true);
+        SAME_RECEIVER_PARTITION_KEY,
+        DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_MESSAGE_NAME,
+        true,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -160,7 +160,8 @@ public class SubscriptionCommandSenderTest {
         DIFFERENT_PARTITION,
         DIFFERENT_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,
-        DEFAULT_MESSAGE_NAME);
+        DEFAULT_MESSAGE_NAME,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -176,7 +177,8 @@ public class SubscriptionCommandSenderTest {
         SAME_PARTITION,
         DIFFERENT_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,
-        DEFAULT_MESSAGE_NAME);
+        DEFAULT_MESSAGE_NAME,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -192,7 +194,8 @@ public class SubscriptionCommandSenderTest {
         DIFFERENT_PARTITION,
         DIFFERENT_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,
-        DEFAULT_MESSAGE_NAME);
+        DEFAULT_MESSAGE_NAME,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockInterPartitionCommandSender)
@@ -217,7 +220,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_NAME,
         DEFAULT_CORRELATION_KEY,
-        true);
+        true,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -236,7 +240,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_NAME,
         DEFAULT_CORRELATION_KEY,
-        true);
+        true,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -255,7 +260,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_NAME,
         DEFAULT_CORRELATION_KEY,
-        true);
+        true,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockInterPartitionCommandSender)
@@ -304,7 +310,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_KEY,
         DEFAULT_MESSAGE_NAME,
-        DEFAULT_CORRELATION_KEY);
+        DEFAULT_CORRELATION_KEY,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -321,7 +328,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_KEY,
         DEFAULT_MESSAGE_NAME,
-        DEFAULT_CORRELATION_KEY);
+        DEFAULT_CORRELATION_KEY,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -338,7 +346,8 @@ public class SubscriptionCommandSenderTest {
         DIFFERENT_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_ID,
-        DEFAULT_MESSAGE_NAME);
+        DEFAULT_MESSAGE_NAME,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -355,7 +364,8 @@ public class SubscriptionCommandSenderTest {
         DIFFERENT_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_ID,
-        DEFAULT_MESSAGE_NAME);
+        DEFAULT_MESSAGE_NAME,
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -43,6 +44,7 @@ public class SubscriptionCommandSenderTest {
       Protocol.encodePartitionId(SAME_PARTITION, 1);
   private static final long DEFAULT_ELEMENT_INSTANCE_KEY = 111;
   private static final DirectBuffer DEFAULT_MESSAGE_NAME = BufferUtil.wrapString("msg");
+  private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   private InterPartitionCommandSender mockInterPartitionCommandSender;
   private SubscriptionCommandSender subscriptionCommandSender;
   private ProcessingResultBuilder mockProcessingResultBuilder;
@@ -96,7 +98,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_NAME,
         DEFAULT_MESSAGE_KEY,
         DEFAULT_VARIABLES,
-        DEFAULT_CORRELATION_KEY);
+        DEFAULT_CORRELATION_KEY,
+        DEFAULT_TENANT);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -115,7 +118,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_NAME,
         DEFAULT_MESSAGE_KEY,
         DEFAULT_VARIABLES,
-        DEFAULT_CORRELATION_KEY);
+        DEFAULT_CORRELATION_KEY,
+        DEFAULT_TENANT);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscriptionStateTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.junit.Test;
 
 public final class MessageStartEventSubscriptionStateTest {
 
+  private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageStartEventSubscriptionState state;
@@ -66,7 +68,7 @@ public final class MessageStartEventSubscriptionStateTest {
     // when
     final var storedSubscription = new MutableReference<MessageStartEventSubscription>();
     state.visitSubscriptionsByMessageName(
-        subscription.getMessageNameBuffer(), storedSubscription::set);
+        DEFAULT_TENANT, subscription.getMessageNameBuffer(), storedSubscription::set);
 
     assertThat(storedSubscription).isNotNull();
     assertThat(storedSubscription.get().getKey()).isEqualTo(1L);
@@ -96,6 +98,7 @@ public final class MessageStartEventSubscriptionStateTest {
     final List<String> visitedStartEvents = new ArrayList<>();
 
     state.visitSubscriptionsByMessageName(
+        DEFAULT_TENANT,
         wrapString("message"),
         subscription -> {
           visitedStartEvents.add(bufferAsString(subscription.getRecord().getStartEventIdBuffer()));
@@ -187,6 +190,7 @@ public final class MessageStartEventSubscriptionStateTest {
 
     // then
     state.visitSubscriptionsByMessageName(
+        DEFAULT_TENANT,
         BufferUtil.wrapString("msg"),
         readRecord -> {
           assertThat(readRecord.getRecord().getMessageNameBuffer())

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import org.junit.Test;
 
 public final class MessageStateTest {
 
+  private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageState messageState;
@@ -497,12 +499,18 @@ public final class MessageStateTest {
     messageState.putActiveProcessInstance(wrapString("wf-1"), wrapString("key-1"));
 
     // then
-    assertThat(messageState.existActiveProcessInstance(wrapString("wf-1"), wrapString("key-1")))
+    assertThat(
+            messageState.existActiveProcessInstance(
+                DEFAULT_TENANT, wrapString("wf-1"), wrapString("key-1")))
         .isTrue();
 
-    assertThat(messageState.existActiveProcessInstance(wrapString("wf-2"), wrapString("key-1")))
+    assertThat(
+            messageState.existActiveProcessInstance(
+                DEFAULT_TENANT, wrapString("wf-2"), wrapString("key-1")))
         .isFalse();
-    assertThat(messageState.existActiveProcessInstance(wrapString("wf-1"), wrapString("key-2")))
+    assertThat(
+            messageState.existActiveProcessInstance(
+                DEFAULT_TENANT, wrapString("wf-1"), wrapString("key-2")))
         .isFalse();
   }
 
@@ -517,11 +525,17 @@ public final class MessageStateTest {
     messageState.removeActiveProcessInstance(wrapString("wf-1"), wrapString("key-1"));
 
     // then
-    assertThat(messageState.existActiveProcessInstance(wrapString("wf-1"), wrapString("key-1")))
+    assertThat(
+            messageState.existActiveProcessInstance(
+                DEFAULT_TENANT, wrapString("wf-1"), wrapString("key-1")))
         .isFalse();
-    assertThat(messageState.existActiveProcessInstance(wrapString("wf-2"), wrapString("key-1")))
+    assertThat(
+            messageState.existActiveProcessInstance(
+                DEFAULT_TENANT, wrapString("wf-2"), wrapString("key-1")))
         .isTrue();
-    assertThat(messageState.existActiveProcessInstance(wrapString("wf-1"), wrapString("key-2")))
+    assertThat(
+            messageState.existActiveProcessInstance(
+                DEFAULT_TENANT, wrapString("wf-1"), wrapString("key-2")))
         .isTrue();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageSubscriptionStateTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -22,6 +23,7 @@ import org.junit.Test;
 
 public final class MessageSubscriptionStateTest {
 
+  private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageSubscriptionState state;
@@ -86,7 +88,10 @@ public final class MessageSubscriptionStateTest {
     // when
     final List<MessageSubscription> subscriptions = new ArrayList<>();
     state.visitSubscriptions(
-        wrapString("messageName"), wrapString("correlationKey"), subscriptions::add);
+        DEFAULT_TENANT,
+        wrapString("messageName"),
+        wrapString("correlationKey"),
+        subscriptions::add);
 
     // then
     assertThat(subscriptions).hasSize(1);
@@ -114,6 +119,7 @@ public final class MessageSubscriptionStateTest {
     // when
     final List<Long> keys = new ArrayList<>();
     state.visitSubscriptions(
+        DEFAULT_TENANT,
         wrapString("messageName"),
         wrapString("correlationKey"),
         s -> keys.add(s.getRecord().getElementInstanceKey()));
@@ -131,6 +137,7 @@ public final class MessageSubscriptionStateTest {
     // when
     final List<Long> keys = new ArrayList<>();
     state.visitSubscriptions(
+        DEFAULT_TENANT,
         wrapString("messageName"),
         wrapString("correlationKey"),
         s -> {
@@ -169,6 +176,7 @@ public final class MessageSubscriptionStateTest {
     // then
     final List<Long> keys = new ArrayList<>();
     state.visitSubscriptions(
+        DEFAULT_TENANT,
         wrapString("messageName"),
         wrapString("correlationKey"),
         s -> keys.add(s.getRecord().getElementInstanceKey()));

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingMessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingMessageSubscriptionStateTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.junit.Test;
 
 public final class PendingMessageSubscriptionStateTest {
 
+  private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableMessageSubscriptionState persistentState;
@@ -171,6 +173,7 @@ public final class PendingMessageSubscriptionStateTest {
     // and
     final List<MessageSubscription> subscriptions = new ArrayList<>();
     persistentState.visitSubscriptions(
+        DEFAULT_TENANT,
         subscription.getMessageNameBuffer(),
         subscription.getCorrelationKeyBuffer(),
         subscriptions::add);
@@ -202,6 +205,7 @@ public final class PendingMessageSubscriptionStateTest {
     // then
     final List<Long> keys = new ArrayList<>();
     persistentState.visitSubscriptions(
+        DEFAULT_TENANT,
         subscription.getMessageNameBuffer(),
         subscription.getCorrelationKeyBuffer(),
         s -> keys.add(s.getRecord().getElementInstanceKey()));

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.message;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -15,7 +17,6 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
@@ -29,6 +30,8 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
 
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
   private final StringProperty messageIdProp = new StringProperty("messageId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageRecord() {
     declareProperty(nameProp)
@@ -36,7 +39,8 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
         .declareProperty(timeToLiveProp)
         .declareProperty(variablesProp)
         .declareProperty(messageIdProp)
-        .declareProperty(deadlineProp);
+        .declareProperty(deadlineProp)
+        .declareProperty(tenantIdProp);
   }
 
   public void wrap(final MessageRecord record) {
@@ -46,6 +50,7 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
     setDeadline(record.getDeadline());
     setVariables(record.getVariablesBuffer());
     setMessageId(record.getMessageIdBuffer());
+    setTenantId(record.getTenantId());
   }
 
   public boolean hasMessageId() {
@@ -64,17 +69,17 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
 
   @Override
   public String getName() {
-    return BufferUtil.bufferAsString(nameProp.getValue());
+    return bufferAsString(nameProp.getValue());
   }
 
   @Override
   public String getCorrelationKey() {
-    return BufferUtil.bufferAsString(correlationKeyProp.getValue());
+    return bufferAsString(correlationKeyProp.getValue());
   }
 
   @Override
   public String getMessageId() {
-    return BufferUtil.bufferAsString(messageIdProp.getValue());
+    return bufferAsString(messageIdProp.getValue());
   }
 
   @Override
@@ -149,7 +154,11 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
 
   @Override
   public String getTenantId() {
-    // todo(#13289): replace dummy implementation
-    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public MessageRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -33,6 +33,8 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
   private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageStartEventSubscriptionRecord() {
     declareProperty(processDefinitionKeyProp)
@@ -42,7 +44,8 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
         .declareProperty(processInstanceKeyProp)
         .declareProperty(messageKeyProp)
         .declareProperty(correlationKeyProp)
-        .declareProperty(variablesProp);
+        .declareProperty(variablesProp)
+        .declareProperty(tenantIdProp);
   }
 
   public void wrap(final MessageStartEventSubscriptionRecord record) {
@@ -50,6 +53,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
     bpmnProcessIdProp.setValue(record.getBpmnProcessIdBuffer());
     messageNameProp.setValue(record.getMessageNameBuffer());
     startEventIdProp.setValue(record.getStartEventIdBuffer());
+    tenantIdProp.setValue(record.getTenantId());
   }
 
   @JsonIgnore
@@ -159,7 +163,11 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
 
   @Override
   public String getTenantId() {
-    // todo(#13289): replace dummy implementation
-    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public MessageStartEventSubscriptionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -33,6 +33,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final BooleanProperty interruptingProp = new BooleanProperty("interrupting", true);
 
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageSubscriptionRecord() {
     declareProperty(processInstanceKeyProp)
@@ -42,7 +44,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(correlationKeyProp)
         .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
-        .declareProperty(variablesProp);
+        .declareProperty(variablesProp)
+        .declareProperty(tenantIdProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -54,6 +57,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setInterrupting(record.isInterrupting());
     setBpmnProcessId(record.getBpmnProcessIdBuffer());
     setVariables(record.getVariablesBuffer());
+    setTenantId(record.getTenantId());
   }
 
   @JsonIgnore
@@ -158,7 +162,11 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   @Override
   public String getTenantId() {
-    // todo(#13289): replace dummy implementation
-    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public MessageSubscriptionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -37,6 +37,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final BooleanProperty interruptingProp = new BooleanProperty("interrupting", true);
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ProcessMessageSubscriptionRecord() {
     declareProperty(subscriptionPartitionIdProp)
@@ -48,7 +50,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(correlationKeyProp)
-        .declareProperty(elementIdProp);
+        .declareProperty(elementIdProp)
+        .declareProperty(tenantIdProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -62,6 +65,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setBpmnProcessId(record.getBpmnProcessIdBuffer());
     setCorrelationKey(record.getCorrelationKeyBuffer());
     setElementId(record.getElementIdBuffer());
+    setTenantId(record.getTenantId());
   }
 
   @JsonIgnore
@@ -191,7 +195,11 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   @Override
   public String getTenantId() {
-    // todo(#13289): replace dummy implementation
-    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public ProcessMessageSubscriptionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds the tenant id property to the records related to messages and makes sure they are set in the relevant places.

One record that's special is the `MessageBatchRecord`. This record is used to expire messages by their key in batches. I believe that message keys are only used internally, and we don't need to change anything here to make expiration tenant aware.

I'll take care of testing as part of https://github.com/camunda/zeebe/issues/14357

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14342 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
