### PR TITLE
Multi-tenancy over Identity E2E tests for process deployment and process instance creation

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -107,10 +107,12 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     }
 
     commandRequestDecoder.skipValue();
-    final int authOffset =
-        commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
-    authInfo.wrap(buffer, authOffset, commandRequestDecoder.authorizationLength());
-    metadata.authorization(authInfo);
+    if (commandRequestDecoder.limit() != buffer.capacity()) {
+      final int authOffset =
+          commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
+      authInfo.wrap(buffer, authOffset, commandRequestDecoder.authorizationLength());
+      metadata.authorization(authInfo);
+    }
   }
 
   public UnifiedRecordValue value() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder.TEMP
 
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
 import io.camunda.zeebe.broker.transport.RequestReaderException;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -61,6 +62,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
 
   private UnifiedRecordValue value;
   private final RecordMetadata metadata = new RecordMetadata();
+  private final AuthInfo authInfo = new AuthInfo();
   private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
   private final ExecuteCommandRequestDecoder commandRequestDecoder =
       new ExecuteCommandRequestDecoder();
@@ -103,6 +105,12 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
       value = recordSupplier.get();
       value.wrap(buffer, valueOffset, valueLength);
     }
+
+    commandRequestDecoder.skipValue();
+    final int authOffset =
+        commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
+    authInfo.wrap(buffer, authOffset, commandRequestDecoder.authorizationLength());
+    metadata.authorization(authInfo);
   }
 
   public UnifiedRecordValue value() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -107,7 +107,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     }
 
     commandRequestDecoder.skipValue();
-    if (commandRequestDecoder.limit() != buffer.capacity()) {
+    if (commandRequestDecoder.limit() < buffer.capacity()) {
       final int authOffset =
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
       authInfo.wrap(buffer, authOffset, commandRequestDecoder.authorizationLength());

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -95,6 +95,11 @@
             # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE.
             # type: keycloak
 
+            # The URL to the Identity instance. Must be defined when multi-tenancy is enabled and authentication mode is set to 'identity'.
+            # This is used to retrieve the authorized tenants for requests based on the token.
+            # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL.
+            # baseUrl:
+
       # longPolling:
         # Enables long polling for available jobs
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_LONGPOLLING_ENABLED.

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -177,6 +177,11 @@
             # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE.
             # type: keycloak
 
+            # The URL to the Identity instance. Must be defined when multi-tenancy is enabled and authentication mode is set to 'identity'.
+            # This is used to retrieve the authorized tenants for requests based on the token.
+            # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL.
+            # baseUrl:
+
       # Configure compression algorithm for all messages sent between the gateway and
       # the brokers. Available options are NONE, GZIP and SNAPPY.
       # This feature is useful when the network latency between the nodes is very high (for example when nodes are deployed in different data centers).

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/IdentityCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/IdentityCfg.java
@@ -13,6 +13,7 @@ public final class IdentityCfg {
   private String issuerBackendUrl;
   private String audience = "zeebe-api";
   private OAuthType type = OAuthType.KEYCLOAK;
+  private String baseUrl;
 
   public String getIssuerBackendUrl() {
     return issuerBackendUrl;
@@ -38,9 +39,17 @@ public final class IdentityCfg {
     this.type = type;
   }
 
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public void setBaseUrl(final String baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(issuerBackendUrl, audience, type);
+    return Objects.hash(issuerBackendUrl, audience, type, baseUrl);
   }
 
   @Override
@@ -51,10 +60,11 @@ public final class IdentityCfg {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final IdentityCfg identityCfg = (IdentityCfg) o;
-    return Objects.equals(issuerBackendUrl, identityCfg.issuerBackendUrl)
-        && Objects.equals(audience, identityCfg.audience)
-        && type == identityCfg.type;
+    final IdentityCfg that = (IdentityCfg) o;
+    return Objects.equals(issuerBackendUrl, that.issuerBackendUrl)
+        && Objects.equals(audience, that.audience)
+        && type == that.type
+        && Objects.equals(baseUrl, that.baseUrl);
   }
 
   @Override
@@ -68,6 +78,9 @@ public final class IdentityCfg {
         + '\''
         + ", type="
         + type
+        + ", baseUrl='"
+        + baseUrl
+        + '\''
         + '}';
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -49,6 +49,7 @@ public final class IdentityInterceptor implements ServerInterceptor {
             .withIssuerBackendUrl(config.getIssuerBackendUrl())
             .withAudience(config.getAudience())
             .withType(config.getType().name())
+            .withBaseUrl(config.getBaseUrl())
             .build());
   }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1678,6 +1678,7 @@
                   <dep>org.junit.vintage:junit-vintage-engine</dep>
                   <dep>com.tngtech.archunit:archunit-junit5-engine</dep>
                   <dep>org.openjdk.jmh:jmh-generator-annprocess</dep>
+                  <dep>org.postgresql:postgresql</dep>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -128,6 +128,7 @@
     <version.swagger-annotations>2.2.16</version.swagger-annotations>
     <version.checker-qual>3.38.0</version.checker-qual>
     <version.java-jwt>4.4.0</version.java-jwt>
+    <version.reactive-streams>1.0.4</version.reactive-streams>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.1.0</plugin.version.antrun>
@@ -193,7 +194,6 @@
     <sort.skip>${skipChecks}</sort.skip>
     <spotless.apply.skip>${skipChecks}</spotless.apply.skip>
     <spotless.checks.skip>${skipChecks}</spotless.checks.skip>
-    <version.reactive-streams>1.0.4</version.reactive-streams>
   </properties>
 
   <dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -129,6 +129,7 @@
     <version.checker-qual>3.38.0</version.checker-qual>
     <version.java-jwt>4.4.0</version.java-jwt>
     <version.reactive-streams>1.0.4</version.reactive-streams>
+    <version.postgresql>42.6.0</version.postgresql>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.1.0</plugin.version.antrun>
@@ -906,6 +907,12 @@
             <artifactId>jmock-testjar</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${version.postgresql}</version>
       </dependency>
 
       <dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -240,6 +240,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
@@ -148,7 +148,7 @@ public final class CreateDeploymentTest {
     final var modelThatFitsJustWithinMaxMessageSize =
         Bpmn.createExecutableProcess("PROCESS")
             .startEvent()
-            .documentation("x".repeat((1046900)))
+            .documentation("x".repeat((1046700)))
             .done();
     final var command =
         CLIENT_RULE

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -393,6 +393,36 @@ public class MultiTenancyOverIdentityIT {
             });
   }
 
+  private static void awaitServiceAccountExistsForClient(final String clientId) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(120))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              try (final PostgresHelper postgres = new PostgresHelper()) {
+                // Retrieve service account associated to Zeebe Client registered in Identity
+                try (final var resultSet =
+                    postgres.executeQuery(
+                        """
+                        SELECT id \
+                        FROM user_entity \
+                        WHERE service_account_client_link IN (\
+                          SELECT id \
+                          FROM client \
+                          WHERE client_id = '%s'\
+                        )"""
+                            .formatted(clientId))) {
+                  assertThat(resultSet.next())
+                      .describedAs(
+                          "Expected to find service account associated to Zeebe Client registered in Identity. "
+                              + "This can happen when Identity has not yet completed its initialization.")
+                      .isTrue();
+                }
+              }
+            });
+  }
+
   /**
    * Creates a new Zeebe Client with the given client ID such that Identity can provide the
    * associated tenant IDs. The credentials are cached separately for each test case.
@@ -427,6 +457,9 @@ public class MultiTenancyOverIdentityIT {
    */
   private static void associateTenantsWithClient(
       final List<String> tenantIds, final String clientId) throws Exception {
+
+    awaitServiceAccountExistsForClient(clientId);
+
     try (final PostgresHelper postgres = new PostgresHelper()) {
       final String serviceAccountId;
       // Retrieve service account associated to Zeebe Client registered in Identity
@@ -445,7 +478,7 @@ public class MultiTenancyOverIdentityIT {
           throw new IllegalStateException(
               """
               Expected to find service account associated to Zeebe Client registered in Identity.
-              This can happen when Identity has not yet completed its initialization.""");
+              This was supposed to have been checked before querying the database.""");
         }
         serviceAccountId = resultSet.getString(1);
       }
@@ -463,9 +496,7 @@ public class MultiTenancyOverIdentityIT {
                   .formatted(serviceAccountId))) {
         if (!resultSet.next()) {
           throw new IllegalStateException(
-              """
-              Expected to find service account associated to Zeebe Client registered in Identity.
-              This can happen when Identity has not yet completed its initialization.""");
+              "Expected to find access rule associated to service account.");
         }
         accessRuleId = resultSet.getString(1);
       }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -432,8 +432,8 @@ public class MultiTenancyOverIdentityIT {
               INSERT INTO access_rules \
                 (member_id, member_type, global) \
               VALUES ('%s', 'APPLICATION', false) \
-              RETURNING id \
-              ON CONFLICT DO NOTHING"""
+              ON CONFLICT DO NOTHING \
+              RETURNING id"""
                   .formatted(serviceAccountId))) {
         if (!resultSet.next()) {
           throw new IllegalStateException(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.multitenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.client.api.response.Process;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.zeebe.containers.ZeebeContainer;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/** Verifies that data can be isolated per tenant using Identity as the tenant provider. */
+@Testcontainers
+public class MultiTenancyOverIdentityIT {
+
+  @TempDir private static Path credentialsCacheDir;
+
+  private static final String DATABASE_HOST = "postgres";
+  private static final int DATABASE_PORT = 5432;
+  private static final String DATABASE_USER = "postgres";
+  private static final String DATABASE_PASSWORD = "zecret";
+  private static final String DATABASE_NAME = "postgres";
+
+  private static final String KEYCLOAK_USER = "admin";
+  private static final String KEYCLOAK_PASSWORD = "admin";
+  private static final String KEYCLOAK_PATH_CAMUNDA_REALM = "/realms/camunda-platform";
+
+  private static final String ZEEBE_CLIENT_ID_TENANT_A = "zeebe-tenant-a";
+  private static final String ZEEBE_CLIENT_ID_TENANT_B = "zeebe-tenant-b";
+  private static final String ZEEBE_CLIENT_ID_TENANT_A_AND_B = "zeebe-tenant-a-and-b";
+  private static final String ZEEBE_CLIENT_AUDIENCE = "zeebe-api";
+  private static final String ZEEBE_CLIENT_SECRET = "zecret";
+
+  private static final Network NETWORK = Network.newNetwork();
+
+  @Container
+  @SuppressWarnings("resource")
+  private static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:15.0-alpine")
+          .withExposedPorts(DATABASE_PORT)
+          .withDatabaseName(DATABASE_NAME)
+          .withUsername(DATABASE_USER)
+          .withPassword(DATABASE_PASSWORD)
+          .withNetwork(NETWORK)
+          .withNetworkAliases(DATABASE_HOST);
+
+  @Container
+  @SuppressWarnings("resource")
+  private static final GenericContainer<?> KEYCLOAK =
+      new GenericContainer<>("bitnami/keycloak:22.0.1")
+          .dependsOn(POSTGRES)
+          .withEnv("KC_HEALTH_ENABLED", "true")
+          .withEnv("KEYCLOAK_ADMIN_USER", KEYCLOAK_USER)
+          .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)
+          .withEnv("KEYCLOAK_DATABASE_HOST", DATABASE_HOST)
+          .withEnv("KEYCLOAK_DATABASE_PORT", String.valueOf(DATABASE_PORT))
+          .withEnv("KEYCLOAK_DATABASE_USER", DATABASE_USER)
+          .withEnv("KEYCLOAK_DATABASE_PASSWORD", DATABASE_PASSWORD)
+          .withEnv("KEYCLOAK_DATABASE_NAME", DATABASE_NAME)
+          .withNetwork(NETWORK)
+          .withNetworkAliases("keycloak")
+          .withExposedPorts(8080)
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(8080)
+                  .forPath("/health/ready")
+                  .allowInsecure()
+                  .forStatusCode(200));
+
+  @Container
+  @SuppressWarnings("resource")
+  private static final GenericContainer<?> IDENTITY =
+      new GenericContainer<>(
+              DockerImageName.parse("camunda/identity")
+                  .withTag(System.getProperty("identity.docker.image.version", "SNAPSHOT")))
+          .withImagePullPolicy(
+              System.getProperty("identity.docker.image.version", "SNAPSHOT").equals("SNAPSHOT")
+                  ? PullPolicy.alwaysPull()
+                  : PullPolicy.defaultPolicy())
+          .dependsOn(POSTGRES, KEYCLOAK)
+          .withEnv("MULTI_TENANCY_ENABLED", "true")
+          .withEnv("RESOURCE_AUTHORIZATIONS_ENABLED", "true")
+          .withEnv("IDENTITY_LOG_LEVEL", "TRACE")
+          .withEnv("logging_level_org_springframework_security", "DEBUG")
+          .withEnv("LOGGING_LEVEL_org.springframework", "DEBUG")
+          .withEnv("KEYCLOAK_URL", "http://keycloak:8080")
+          .withEnv(
+              "IDENTITY_AUTH_PROVIDER_BACKEND_URL",
+              "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
+          .withEnv("KEYCLOAK_SETUP_USER", KEYCLOAK_USER)
+          .withEnv("KEYCLOAK_SETUP_PASSWORD", KEYCLOAK_PASSWORD)
+          .withEnv("KEYCLOAK_INIT_ZEEBE_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_0_NAME", ZEEBE_CLIENT_ID_TENANT_A)
+          .withEnv("KEYCLOAK_CLIENTS_0_ID", ZEEBE_CLIENT_ID_TENANT_A)
+          .withEnv("KEYCLOAK_CLIENTS_0_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_0_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("KEYCLOAK_CLIENTS_1_NAME", ZEEBE_CLIENT_ID_TENANT_B)
+          .withEnv("KEYCLOAK_CLIENTS_1_ID", ZEEBE_CLIENT_ID_TENANT_B)
+          .withEnv("KEYCLOAK_CLIENTS_1_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_1_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_1_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_1_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("KEYCLOAK_CLIENTS_2_NAME", ZEEBE_CLIENT_ID_TENANT_A_AND_B)
+          .withEnv("KEYCLOAK_CLIENTS_2_ID", ZEEBE_CLIENT_ID_TENANT_A_AND_B)
+          .withEnv("KEYCLOAK_CLIENTS_2_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_2_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("IDENTITY_RETRY_ATTEMPTS", "90")
+          .withEnv("IDENTITY_RETRY_DELAY_SECONDS", "1")
+          .withEnv("IDENTITY_DATABASE_HOST", DATABASE_HOST)
+          .withEnv("IDENTITY_DATABASE_PORT", String.valueOf(DATABASE_PORT))
+          .withEnv("IDENTITY_DATABASE_NAME", DATABASE_NAME)
+          .withEnv("IDENTITY_DATABASE_USERNAME", DATABASE_USER)
+          .withEnv("IDENTITY_DATABASE_PASSWORD", DATABASE_PASSWORD)
+          .withNetwork(NETWORK)
+          .withExposedPorts(8080, 8082)
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(8082)
+                  .forPath("/actuator/health")
+                  .allowInsecure()
+                  .forStatusCode(200))
+          .withNetworkAliases("identity");
+
+  @Container
+  private static final ZeebeContainer ZEEBE =
+      new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+          .dependsOn(KEYCLOAK, IDENTITY)
+          .withoutTopologyCheck()
+          .withEnv("ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED", "true")
+          .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
+          .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE", "identity")
+          .withEnv(
+              "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL",
+              "http://identity:8080")
+          .withEnv(
+              "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL",
+              "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
+          .withEnv(
+              "ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE",
+              ZEEBE_CLIENT_AUDIENCE)
+          .withNetwork(NETWORK);
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(
+          () ->
+              Map.of(
+                  "postgres",
+                  POSTGRES,
+                  "keycloak",
+                  KEYCLOAK,
+                  "identity",
+                  IDENTITY,
+                  "zeebe",
+                  ZEEBE));
+
+  private BpmnModelInstance process;
+
+  @BeforeAll
+  static void init() throws Exception {
+    associateTenantsWithClient(List.of("tenant-a"), ZEEBE_CLIENT_ID_TENANT_A);
+    associateTenantsWithClient(List.of("tenant-b"), ZEEBE_CLIENT_ID_TENANT_B);
+    associateTenantsWithClient(List.of("tenant-a", "tenant-b"), ZEEBE_CLIENT_ID_TENANT_A_AND_B);
+  }
+
+  @BeforeEach
+  void setup() {
+    process =
+        Bpmn.createExecutableProcess(Strings.newRandomValidBpmnId())
+            .startEvent()
+            .serviceTask("task", b -> b.zeebeJobType("type"))
+            .endEvent()
+            .done();
+  }
+
+  @Test
+  void shouldDenyDeployProcessWhenUnauthorized() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // when
+      final Future<DeploymentEvent> result =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId("tenant-b")
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request DeployResource with tenant identifier `tenant-b`")
+          .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @Test
+  void shouldAuthorizeCreateProcessInstance() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId("tenant-a")
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
+
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId("tenant-a")
+              .send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that process instance can be created as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldNotFindOtherTenantsProcess() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId("tenant-a")
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId("tenant-b")
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("Expected to find process definition with key")
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+          .withMessageContaining("and tenant ID 'tenant-b', but none found");
+    }
+  }
+
+  /**
+   * This test case may become obsolete when we allow shared processes definitions across tenants.
+   */
+  @Test
+  void shouldNotFindOtherTenantsProcessEvenWhenClientIsAuthorizedForTenant() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId("tenant-a")
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId("tenant-b")
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("Expected to find process definition with key")
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+          .withMessageContaining("and tenant ID 'tenant-b', but none found");
+    }
+  }
+
+  /**
+   * Creates a new Zeebe Client with the given client ID such that Identity can provide the
+   * associated tenant IDs. The credentials are cached separately for each test case.
+   *
+   * @param clientId The client ID to use for the new Zeebe Client
+   * @return A new Zeebe Client to use in these tests
+   */
+  private static ZeebeClient createZeebeClient(final String clientId) {
+    return ZeebeClient.newClientBuilder()
+        .gatewayAddress(ZEEBE.getExternalGatewayAddress())
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(clientId)
+                .clientSecret(ZEEBE_CLIENT_SECRET)
+                .audience(ZEEBE_CLIENT_AUDIENCE)
+                .authorizationServerUrl(
+                    "http://localhost:%d%s/protocol/openid-connect/token"
+                        .formatted(KEYCLOAK.getFirstMappedPort(), KEYCLOAK_PATH_CAMUNDA_REALM))
+                .credentialsCachePath(credentialsCacheDir.resolve(clientId).toString())
+                .build())
+        .defaultRequestTimeout(Duration.ofSeconds(10))
+        .usePlaintext()
+        .build();
+  }
+
+  /**
+   * Sets up the association between the given tenant IDs and the given client ID in Keycloak and
+   * Identity.
+   *
+   * @param tenantIds The tenant ids to associate with the client
+   * @param clientId The client id to associate the tenants with
+   * @throws Exception If an error occurs while performing the database operations
+   */
+  private static void associateTenantsWithClient(
+      final List<String> tenantIds, final String clientId) throws Exception {
+    try (final PostgresHelper postgres = new PostgresHelper()) {
+      final String serviceAccountId;
+      // Retrieve service account associated to Zeebe Client registered in Identity
+      try (final var resultSet =
+          postgres.executeQuery(
+              """
+              SELECT id \
+              FROM user_entity \
+              WHERE service_account_client_link IN (\
+                SELECT id \
+                FROM client \
+                WHERE client_id = '%s'\
+              )"""
+                  .formatted(clientId))) {
+        resultSet.next();
+        serviceAccountId = resultSet.getString(1);
+      }
+
+      final String accessRuleId;
+      // Create access rule for service account
+      try (final var resultSet =
+          postgres.executeQuery(
+              """
+              INSERT INTO access_rules \
+                (member_id, member_type, global) \
+              VALUES ('%s', 'APPLICATION', false) \
+              RETURNING id"""
+                  .formatted(serviceAccountId))) {
+        resultSet.next();
+        accessRuleId = resultSet.getString(1);
+      }
+
+      // Create tenant(s) if not already existing,
+      // using tenantId for both id and name
+      tenantIds.forEach(
+          (tenantId) ->
+              postgres.execute(
+                  """
+                  INSERT INTO tenants \
+                    (name, tenant_id) \
+                  VALUES ('%s', '%s') \
+                  ON CONFLICT DO NOTHING"""
+                      .formatted(tenantId, tenantId)));
+
+      // Connect tenants to access rule
+      tenantIds.forEach(
+          tenantId ->
+              postgres.execute(
+                  """
+                      INSERT INTO access_rules_tenants \
+                        (tenant_id, access_rule_id) \
+                      VALUES ('%s', '%s')"""
+                      .formatted(tenantId, accessRuleId)));
+    }
+  }
+
+  /**
+   * Helper class to perform queries against the Postgres database. It will automatically create and
+   * close the connection. To be used within a try-with-resources block.
+   */
+  private static class PostgresHelper implements AutoCloseable {
+    private final Supplier<Connection> connector;
+    private Connection connection;
+
+    private PostgresHelper() {
+      final String jdbcUrl = POSTGRES.getJdbcUrl();
+      final String username = POSTGRES.getUsername();
+      final String password = POSTGRES.getPassword();
+      connector =
+          () -> {
+            try {
+              return DriverManager.getConnection(jdbcUrl, username, password);
+            } catch (final SQLException e) {
+              throw new RuntimeException(e);
+            }
+          };
+    }
+
+    private ResultSet executeQuery(final String query) {
+      if (connection == null) {
+        connection = connector.get();
+      }
+      try {
+        final var statement = connection.createStatement();
+        return statement.executeQuery(query);
+      } catch (final SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    private void execute(final String query) {
+      if (connection == null) {
+        connection = connector.get();
+      }
+      try (final var statement = connection.createStatement()) {
+        statement.execute(query);
+      } catch (final SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (connection != null) {
+        connection.close();
+      }
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -337,10 +337,10 @@ public class MultiTenancyOverIdentityIT {
       assertThat(result)
           .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
           .withMessageContaining("NOT_FOUND")
           .withMessageContaining("Expected to find process definition with key")
-          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-          .withMessageContaining("and tenant ID 'tenant-b', but none found");
+          .withMessageContaining("but none found");
     }
   }
 
@@ -379,10 +379,10 @@ public class MultiTenancyOverIdentityIT {
       assertThat(result)
           .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
           .withMessageContaining("NOT_FOUND")
           .withMessageContaining("Expected to find process definition with key")
-          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-          .withMessageContaining("and tenant ID 'tenant-b', but none found");
+          .withMessageContaining("but none found");
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -432,7 +432,8 @@ public class MultiTenancyOverIdentityIT {
               INSERT INTO access_rules \
                 (member_id, member_type, global) \
               VALUES ('%s', 'APPLICATION', false) \
-              RETURNING id"""
+              RETURNING id \
+              ON CONFLICT DO NOTHING"""
                   .formatted(serviceAccountId))) {
         if (!resultSet.next()) {
           throw new IllegalStateException(
@@ -462,7 +463,8 @@ public class MultiTenancyOverIdentityIT {
                   """
                       INSERT INTO access_rules_tenants \
                         (tenant_id, access_rule_id) \
-                      VALUES ('%s', '%s')"""
+                      VALUES ('%s', '%s') \
+                      ON CONFLICT DO NOTHING"""
                       .formatted(tenantId, accessRuleId)));
     }
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -230,6 +230,25 @@ public class MultiTenancyOverIdentityIT {
   }
 
   @Test
+  void shouldAuthorizeDeployProcess() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // when
+      final Future<DeploymentEvent> response =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId("tenant-a")
+              .send();
+
+      // then
+      assertThat(response)
+          .describedAs("Expect that process can be deployed for tenant a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
   void shouldDenyDeployProcessWhenUnauthorized() {
     // given
     try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -453,7 +453,7 @@ public class MultiTenancyOverIdentityIT {
    * Helper class to perform queries against the Postgres database. It will automatically create and
    * close the connection. To be used within a try-with-resources block.
    */
-  private static class PostgresHelper implements AutoCloseable {
+  private static final class PostgresHelper implements AutoCloseable {
     private final Supplier<Connection> connector;
     private Connection connection;
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Introduces the first E2E test cases that verify multi-tenancy in combination with Identity as the Authorized Tenants Provider for:
- process deployment
- process instance creation

It also fixes two previously unknown multi-tenancy bugs:
- Identity SDK's `baseUrl` cannot be configured
- Authorization property is not read for Execute Broker Request

### How it works

These tests use the TestStandaloneBroker (introduced with #13962) configured to run the embedded gateway connected to Identity. This runs in combination with three containers:
- Identity configured to work with Keycloak and storing data in a Postgres database
- Keycloak configured to store data in a Postgres database
- Postgres database for Keycloak and Identity

Each of the test cases use specific ZeebeClients that use Identity for authentication. They are associated within Identity to specific tenants. This means that the token in the request received by the Zeebe Gateway is one that Identity has provided and understands. I.e. Identity can tell the Gateway which authorized tenants are associated to the token.

In the test cases the specific ZeeebeClient to use can be defined by passing a specific clientId. See `createZeebeClient`. The used names are supposed to clarify which tenants are associated to the specific client.

To set all this up, several environment variables are defined for Identity, in the form of `KEYCLOAK_CLIENTS_*`. These make sure API clients are registered within Keycloak. Before the tests run, each of these clients is associated to specific tenants (see `init()`). This requires some Postgres SQL statements, as the associations cannot be configured through environment variables **YET**.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14273

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
