### PR TITLE
Allow a broker to be removed from the ClusterTopology

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberLeaveApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberLeaveApplier.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+public class MemberLeaveApplier implements OperationApplier {
+
+  private final MemberId memberId;
+  private final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor;
+
+  public MemberLeaveApplier(
+      final MemberId memberId,
+      final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor) {
+    this.memberId = memberId;
+    this.topologyMembershipChangeExecutor = topologyMembershipChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> init(
+      final ClusterTopology currentClusterTopology) {
+    if (!currentClusterTopology.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to remove member %s, but the member is not part of the topology",
+                  memberId)));
+    }
+
+    final boolean hasPartitions =
+        !currentClusterTopology.getMember(memberId).partitions().isEmpty();
+    if (hasPartitions) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to remove member %s, but the member still has partitions assigned. Partitions: [%s]",
+                  memberId, currentClusterTopology.getMember(memberId).partitions())));
+    }
+
+    return Either.right(MemberState::toLeaving);
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<MemberState>> apply() {
+    final var future = new CompletableActorFuture<UnaryOperator<MemberState>>();
+    topologyMembershipChangeExecutor
+        .removeBroker(memberId)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                future.complete(MemberState::toLeft);
+              } else {
+                future.completeExceptionally(error);
+              }
+            });
+
+    return future;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopTopologyMembershipChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopTopologyMembershipChangeExecutor.java
@@ -17,4 +17,9 @@ public class NoopTopologyMembershipChangeExecutor implements TopologyMembershipC
   public ActorFuture<Void> addBroker(final MemberId memberId) {
     return CompletableActorFuture.completed(null);
   }
+
+  @Override
+  public ActorFuture<Void> removeBroker(final MemberId memberId) {
+    return CompletableActorFuture.completed(null);
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.util.Either;
@@ -44,7 +45,9 @@ public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
     } else if (operation instanceof final MemberJoinOperation memberJoinOperation) {
       return new MemberJoinApplier(
           memberJoinOperation.memberId(), topologyMembershipChangeExecutor);
-
+    } else if (operation instanceof final MemberLeaveOperation memberLeaveOperation) {
+      return new MemberLeaveApplier(
+          memberLeaveOperation.memberId(), topologyMembershipChangeExecutor);
     } else {
       return new FailingApplier(operation);
     }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyMembershipChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyMembershipChangeExecutor.java
@@ -20,4 +20,12 @@ public interface TopologyMembershipChangeExecutor {
    * @return future when the operation is completed.
    */
   ActorFuture<Void> addBroker(MemberId memberId);
+
+  /**
+   * The implementation of this method can react to a node leaving the cluster.
+   *
+   * @param memberId id of the member that is leaving the cluster
+   * @return future when the operation is completed
+   */
+  ActorFuture<Void> removeBroker(MemberId memberId);
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import java.util.Map;
@@ -206,6 +207,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer {
               .setPartitionId(leaveOperation.partitionId()));
     } else if (operation instanceof MemberJoinOperation) {
       builder.setMemberJoin(Topology.MemberJoinOperation.newBuilder().build());
+    } else if (operation instanceof MemberLeaveOperation) {
+      builder.setMemberLeave(Topology.MemberLeaveOperation.newBuilder().build());
     } else {
       throw new IllegalArgumentException(
           "Unknown operation type: " + operation.getClass().getSimpleName());
@@ -235,6 +238,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer {
           topologyChangeOperation.getPartitionLeave().getPartitionId());
     } else if (topologyChangeOperation.hasMemberJoin()) {
       return new MemberJoinOperation(MemberId.from(topologyChangeOperation.getMemberId()));
+    } else if (topologyChangeOperation.hasMemberLeave()) {
+      return new MemberLeaveOperation(MemberId.from(topologyChangeOperation.getMemberId()));
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -11,6 +11,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossipState;
 import io.camunda.zeebe.topology.protocol.Topology;
+import io.camunda.zeebe.topology.protocol.Topology.MemberState;
 import io.camunda.zeebe.topology.state.ClusterChangePlan;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.PartitionState;
@@ -107,7 +108,10 @@ public class ProtoBufSerializer implements ClusterTopologySerializer {
             .map(e -> Map.entry(e.getKey(), decodePartitionState(e.getValue())))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     return new io.camunda.zeebe.topology.state.MemberState(
-        memberState.getVersion(), toMemberState(memberState.getState()), partitions);
+        memberState.getVersion(),
+        memberState.getLastUpdatedTimestamp(),
+        toMemberState(memberState.getState()),
+        partitions);
   }
 
   private io.camunda.zeebe.topology.state.PartitionState decodePartitionState(
@@ -122,8 +126,9 @@ public class ProtoBufSerializer implements ClusterTopologySerializer {
         memberState.partitions().entrySet().stream()
             .map(e -> Map.entry(e.getKey(), encodePartitions(e.getValue())))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    return Topology.MemberState.newBuilder()
+    return MemberState.newBuilder()
         .setVersion(memberState.version())
+        .setLastUpdatedTimestamp(memberState.lastUpdatedTimestamp())
         .setState(toSerializedState(memberState.state()))
         .putAllPartitions(partitions)
         .build();

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.topology.state;
 
 import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -24,15 +25,14 @@ import java.util.function.UnaryOperator;
  * @param partitions state of all partitions that the member is replicating
  */
 public record MemberState(
-    long version, long lastUpdatedTimestamp, State state, Map<Integer, PartitionState> partitions) {
+    long version, Instant lastUpdated, State state, Map<Integer, PartitionState> partitions) {
   public static MemberState initializeAsActive(
       final Map<Integer, PartitionState> initialPartitions) {
-    return new MemberState(
-        0, System.currentTimeMillis(), State.ACTIVE, Map.copyOf(initialPartitions));
+    return new MemberState(0, Instant.now(), State.ACTIVE, Map.copyOf(initialPartitions));
   }
 
   public static MemberState uninitialized() {
-    return new MemberState(0, 0, State.UNINITIALIZED, Map.of());
+    return new MemberState(0, Instant.MIN, State.UNINITIALIZED, Map.of());
   }
 
   public MemberState toJoining() {
@@ -144,7 +144,7 @@ public record MemberState(
   }
 
   private MemberState update(final State state, final Map<Integer, PartitionState> partitions) {
-    return new MemberState(version + 1, System.currentTimeMillis(), state, partitions);
+    return new MemberState(version + 1, Instant.now(), state, partitions);
   }
 
   public boolean hasPartition(final int partitionId) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
@@ -19,6 +19,8 @@ public sealed interface TopologyChangeOperation {
 
   record MemberJoinOperation(MemberId memberId) implements TopologyChangeOperation {}
 
+  record MemberLeaveOperation(MemberId memberId) implements TopologyChangeOperation {}
+
   sealed interface PartitionChangeOperation extends TopologyChangeOperation {
     int partitionId();
 

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -15,8 +15,9 @@ message ClusterTopology {
 
 message MemberState {
   int64 version = 1;
-  State state = 2;
-  map<int32, PartitionState> partitions = 3;
+  int64 lastUpdatedTimestamp = 2;
+  State state = 3;
+  map<int32, PartitionState> partitions = 4;
 }
 
 message PartitionState {

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -36,6 +36,7 @@ message TopologyChangeOperation {
     PartitionJoinOperation partitionJoin = 2;
     PartitionLeaveOperation partitionLeave = 3;
     MemberJoinOperation memberJoin = 4;
+    MemberLeaveOperation memberLeave = 5;
   }
 }
 
@@ -49,6 +50,8 @@ message PartitionLeaveOperation {
 }
 
 message MemberJoinOperation {}
+
+message MemberLeaveOperation {}
 
 enum State {
   UNKNOWN = 0;

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -1,6 +1,8 @@
 syntax = 'proto3';
 package topology_protocol;
 
+import "google/protobuf/timestamp.proto";
+
 option java_package = "io.camunda.zeebe.topology.protocol";
 
 message GossipState {
@@ -15,7 +17,7 @@ message ClusterTopology {
 
 message MemberState {
   int64 version = 1;
-  int64 lastUpdatedTimestamp = 2;
+  google.protobuf.Timestamp lastUpdated = 2;
   State state = 3;
   map<int32, PartitionState> partitions = 4;
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -51,6 +51,12 @@ public final class ClusterTopologyAssert
     return MemberStateAssert.assertThat(actual.members().get(memberId));
   }
 
+  public MemberStateAssert member(final int memberId) {
+    final MemberId id = MemberId.from(String.valueOf(memberId));
+    assertThat(actual.members()).containsKey(id);
+    return MemberStateAssert.assertThat(actual.members().get(id));
+  }
+
   public ClusterTopologyAssert hasMemberWithState(final int member, final MemberState.State state) {
     final var memberId = MemberId.from(Integer.toString(member));
     assertThat(actual.members()).containsKey(memberId);
@@ -58,7 +64,7 @@ public final class ClusterTopologyAssert
     return this;
   }
 
-  ClusterTopologyAssert hasOnlyMembers(final Set<Integer> members) {
+  public ClusterTopologyAssert hasOnlyMembers(final Set<Integer> members) {
     final var memberIds =
         members.stream().map(id -> MemberId.from(String.valueOf(id))).collect(Collectors.toSet());
     assertThat(actual.members()).containsOnlyKeys(memberIds);

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/FailingTopologyMembershipChangeExecutor.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/FailingTopologyMembershipChangeExecutor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+
+final class FailingTopologyMembershipChangeExecutor implements TopologyMembershipChangeExecutor {
+
+  @Override
+  public ActorFuture<Void> addBroker(final MemberId memberId) {
+    return CompletableActorFuture.completedExceptionally(new RuntimeException("Force failure"));
+  }
+
+  @Override
+  public ActorFuture<Void> removeBroker(final MemberId memberId) {
+    return CompletableActorFuture.completedExceptionally(new RuntimeException("Force failure"));
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
@@ -12,13 +12,12 @@ import static io.camunda.zeebe.topology.state.MemberState.State.JOINING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
 final class MemberJoinApplierTest {
@@ -111,15 +110,9 @@ final class MemberJoinApplierTest {
     final var result = memberJoinApplier.apply();
 
     // then
-    assertThat(result).failsWithin(Duration.ofMillis(100));
-  }
-
-  private static final class FailingTopologyMembershipChangeExecutor
-      implements TopologyMembershipChangeExecutor {
-
-    @Override
-    public ActorFuture<Void> addBroker(final MemberId memberId) {
-      return CompletableActorFuture.completedExceptionally(new RuntimeException("Expected"));
-    }
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Force failure");
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberLeaveApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberLeaveApplierTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.topology.ClusterTopologyAssert;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+final class MemberLeaveApplierTest {
+
+  @Test
+  void shouldFailInitIfMemberDoesNotExist() {
+    final MemberId memberId = MemberId.from("1");
+    final var memberLeaveApplier = new MemberLeaveApplier(memberId, null);
+
+    final ClusterTopology clusterTopologyWithOutMember = ClusterTopology.init();
+
+    // when
+    final var result = memberLeaveApplier.init(clusterTopologyWithOutMember);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("but the member is not part of the topology");
+  }
+
+  @Test
+  void shouldFailInitIfMemberHasPartitions() {
+    final MemberId memberId = MemberId.from("1");
+    final var memberLeaveApplier = new MemberLeaveApplier(memberId, null);
+
+    final ClusterTopology clusterTopologyWithMember =
+        ClusterTopology.init()
+            .addMember(
+                memberId,
+                MemberState.initializeAsActive(Map.of()).addPartition(1, PartitionState.active(1)));
+
+    // when
+    final var result = memberLeaveApplier.init(clusterTopologyWithMember);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("but the member still has partitions assigned");
+  }
+
+  @Test
+  void shouldSetStateToLeavingOnInit() {
+    final MemberId memberId = MemberId.from("1");
+    final var memberLeaveApplier = new MemberLeaveApplier(memberId, null);
+
+    final ClusterTopology clusterTopologyWithMember =
+        ClusterTopology.init().addMember(memberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = memberLeaveApplier.init(clusterTopologyWithMember);
+    final var updateTopologyAfterInit =
+        clusterTopologyWithMember.updateMember(memberId, result.get());
+
+    // then
+    ClusterTopologyAssert.assertThatClusterTopology(updateTopologyAfterInit)
+        .hasMemberWithState(1, MemberState.State.LEAVING);
+  }
+
+  @Test
+  void shouldSetStateToLeftOnApply() {
+    // given
+    final MemberId memberId = MemberId.from("1");
+    final var memberLeaveApplier =
+        new MemberLeaveApplier(memberId, new NoopTopologyMembershipChangeExecutor());
+
+    final ClusterTopology clusterTopologyWithMember =
+        ClusterTopology.init().addMember(memberId, MemberState.initializeAsActive(Map.of()));
+    final var updater = memberLeaveApplier.init(clusterTopologyWithMember).get();
+    final var topologyWithLeaving = clusterTopologyWithMember.updateMember(memberId, updater);
+
+    // when
+    final var result = memberLeaveApplier.apply().join();
+    final var updateTopologyAfterApply = topologyWithLeaving.updateMember(memberId, result);
+
+    // then
+    ClusterTopologyAssert.assertThatClusterTopology(updateTopologyAfterApply)
+        .hasMemberWithState(1, MemberState.State.LEFT);
+  }
+
+  @Test
+  void shouldFailFutureIfLeaveFails() {
+    // given
+    final MemberId memberId = MemberId.from("1");
+    final var memberLeaveApplier =
+        new MemberLeaveApplier(memberId, new FailingTopologyMembershipChangeExecutor());
+
+    final ClusterTopology clusterTopologyWithMember =
+        ClusterTopology.init().addMember(memberId, MemberState.initializeAsActive(Map.of()));
+    memberLeaveApplier.init(clusterTopologyWithMember);
+
+    // when
+    final var result = memberLeaveApplier.apply();
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Force failure");
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import java.util.List;
@@ -145,7 +146,9 @@ final class ProtoBufSerializerTest {
 
   private static ClusterTopology topologyWithClusterChangePlanWithMemberOperations() {
     final List<TopologyChangeOperation> changes =
-        List.of(new MemberJoinOperation(MemberId.from("2")));
+        List.of(
+            new MemberJoinOperation(MemberId.from("2")),
+            new MemberLeaveOperation(MemberId.from("1")));
     return ClusterTopology.init()
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
         .startTopologyChange(changes);

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -13,7 +13,6 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossipState;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
-import io.camunda.zeebe.topology.state.MemberState.State;
 import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
@@ -83,7 +82,7 @@ final class ProtoBufSerializerTest {
 
   private static ClusterTopology topologyWithOneJoiningMember() {
     return ClusterTopology.init()
-        .addMember(MemberId.from("1"), new MemberState(0, State.JOINING, Map.of()));
+        .addMember(MemberId.from("1"), MemberState.uninitialized().toJoining());
   }
 
   private static ClusterTopology topologyWithOneLeavingMember() {


### PR DESCRIPTION
## Description

This PR adds a TopologyChangeOperation for removing a member from the ClusterTopology. A member can leave only if it doesn't replicate any partitions. When the leave operation is applied, the member state is updated to LEFT, but it is not removed from the topology. 

In addition,it adds a lastUpdated timestamp to `MemberState`. This is useful for two reasons
1. Observability. We can track how long a member has been in a particular state. This is especially useful when the topology change operation is not making progress.
2. Might be useful to garbage collect members that are in state LEFT.

I initially used `int64` to encode lastUpdated timestamp. But protobuf best practices recommends to use pre-define type Timestamp. 


## Related issues

related #14353 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
