### PR TITLE
Fix startup failure due to old install requests

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -263,11 +263,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   private void onNewPersistedSnapshot(final PersistedSnapshot persistedSnapshot) {
-    threadContext.execute(
-        () -> {
-          currentSnapshot = persistedSnapshot;
-          logCompactor.compactFromSnapshots(persistedSnapshotStore);
-        });
+    threadContext.execute(() -> setCurrentSnapshot(persistedSnapshot));
   }
 
   private void onUncaughtException(final Throwable error) {
@@ -1242,6 +1238,12 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   public PersistedSnapshot getCurrentSnapshot() {
     return currentSnapshot;
+  }
+
+  public void setCurrentSnapshot(final PersistedSnapshot snapshot) {
+    checkThread();
+    currentSnapshot = snapshot;
+    logCompactor.compactFromSnapshots(persistedSnapshotStore);
   }
 
   public long getCurrentSnapshotIndex() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -369,6 +369,7 @@ final class LeaderAppender {
         log.warn(
             "Expected to send Snapshot {} to {}. But could not open SnapshotChunkReader. Will retry.",
             persistedSnapshot.getId(),
+            member,
             e);
         return Optional.empty();
       }
@@ -593,7 +594,7 @@ final class LeaderAppender {
     // when attempting to send entries to down followers.
     final int failures = member.incrementFailureCount();
     if (failures <= 3 || failures % 100 == 0) {
-      log.warn("{} to {} failed: {}", request, member.getMember().memberId(), error);
+      log.warn("{} to {} failed", request, member.getMember().memberId(), error);
     }
 
     // Fail heartbeat futures.

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverIT.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverIT.java
@@ -380,34 +380,6 @@ public class RaftFailOverIT {
   }
 
   @Test
-  public void shouldTruncateLogOnNewerSnapshotEvenAfterRestart() throws Throwable {
-    // given
-    raftRule.appendEntries(50);
-    final var followerB = raftRule.shutdownFollower();
-    raftRule.appendEntries(250);
-    raftRule.takeCompactingSnapshot(200); // take into account the replication threshold
-    // Leader and Follower A Log [200-300].
-    // Follower B Log [1-51]
-
-    // Follower B has old log AND snapshot
-    final var nodes = raftRule.getNodes();
-    final var followerA = nodes.stream().findFirst().orElseThrow();
-    raftRule.copySnapshotOffline(followerA, followerB);
-
-    // when Follower B is started again it should truncate its log to join the cluster
-    raftRule.joinCluster(followerB);
-    raftRule.appendEntries(50);
-
-    // then
-    assertThat(raftRule.allNodesHaveSnapshotWithIndex(200)).isTrue();
-    final var memberLogs = raftRule.getMemberLogs();
-    final var entries = memberLogs.get(followerB);
-    // Follower B should have truncated his log to not have any gaps in his log
-    // entries after snapshot should be replicated
-    assertThat(entries.get(0).index()).isEqualTo(201);
-  }
-
-  @Test
   public void shouldNotReplicateSnapshotWhenIndexIsZero() throws Exception {
     // given
     final var follower = raftRule.shutdownFollower();

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
@@ -15,6 +15,9 @@
  */
 package io.atomix.raft;
 
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftRule.Configurator;
+import io.atomix.raft.RaftServer.Builder;
 import io.atomix.raft.partition.RaftElectionConfig;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,24 +37,35 @@ public class RaftPriorityElectionTest {
       new Object[] {
         RaftRule.withBootstrappedNodes(
             3,
-            (member, builder) ->
-                // Assign node priority as the same value as nodeId
+            new Configurator() {
+              @Override
+              public void configure(final MemberId id, final Builder builder) {
                 builder.withElectionConfig(
-                    RaftElectionConfig.ofPriorityElection(3, Integer.parseInt(member.id()) + 1)))
+                    RaftElectionConfig.ofPriorityElection(3, Integer.parseInt(id.id()) + 1));
+              }
+            })
       },
       new Object[] {
         RaftRule.withBootstrappedNodes(
             4,
-            (member, builder) ->
+            new Configurator() {
+              @Override
+              public void configure(final MemberId id, final Builder builder) {
                 builder.withElectionConfig(
-                    RaftElectionConfig.ofPriorityElection(4, Integer.parseInt(member.id()) + 1)))
+                    RaftElectionConfig.ofPriorityElection(4, Integer.parseInt(id.id()) + 1));
+              }
+            })
       },
       new Object[] {
         RaftRule.withBootstrappedNodes(
             5,
-            (member, builder) ->
+            new Configurator() {
+              @Override
+              public void configure(final MemberId id, final Builder builder) {
                 builder.withElectionConfig(
-                    RaftElectionConfig.ofPriorityElection(5, Integer.parseInt(member.id()) + 1)))
+                    RaftElectionConfig.ofPriorityElection(5, Integer.parseInt(id.id()) + 1));
+              }
+            })
       }
     };
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -521,7 +521,7 @@ public final class RaftRule extends ExternalResource {
     final var memberDirectory = getMemberDirectory(directory, memberId.toString());
     final var snapshotStore = new TestSnapshotStore(getOrCreatePersistedSnapshot(memberId.id()));
     snapshotStores.put(memberId.id(), snapshotStore);
-    configurator.configure(memberId, snapshotStore);
+    configurator.configure(snapshotStore);
 
     final var builder =
         RaftStorage.builder()
@@ -530,7 +530,6 @@ public final class RaftRule extends ExternalResource {
             .withFreeDiskSpace(100)
             .withSnapshotStore(snapshotStore);
 
-    configurator.configure(memberId, builder);
     return builder.build();
   }
 
@@ -722,8 +721,6 @@ public final class RaftRule extends ExternalResource {
   public interface Configurator {
     default void configure(final MemberId id, final RaftServer.Builder builder) {}
 
-    default void configure(final MemberId id, final RaftStorage.Builder builder) {}
-
-    default void configure(final MemberId id, final TestSnapshotStore snapshotStore) {}
+    default void configure(final TestSnapshotStore snapshotStore) {}
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -520,16 +520,6 @@ public final class RaftRule extends ExternalResource {
     return server;
   }
 
-  public void copySnapshotOffline(final String sourceNode, final String targetNode) {
-    final var snapshotOnNode = getSnapshotOnNode(sourceNode);
-    final var targetSnapshotStore = new TestSnapshotStore(getOrCreatePersistedSnapshot(sourceNode));
-    final var receivedSnapshot = targetSnapshotStore.newReceivedSnapshot(snapshotOnNode.getId());
-    for (final var reader = snapshotOnNode.newChunkReader(); reader.hasNext(); ) {
-      receivedSnapshot.apply(reader.next());
-    }
-    receivedSnapshot.persist();
-  }
-
   private RaftStorage createStorage(final MemberId memberId, final Configurator configurator) {
     final var memberDirectory = getMemberDirectory(directory, memberId.toString());
     final var snapshotStore = new TestSnapshotStore(getOrCreatePersistedSnapshot(memberId.id()));

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftStartupConsistencyCheckTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftStartupConsistencyCheckTest.java
@@ -10,7 +10,8 @@ package io.atomix.raft;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-import io.atomix.raft.RaftRule.SnapshotStoreConfigurator;
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftRule.Configurator;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.LangUtil;
@@ -101,7 +102,12 @@ public class RaftStartupConsistencyCheckTest {
         };
     raftRule.bootstrapNode(
         follower.name(),
-        (SnapshotStoreConfigurator) (m, b) -> b.interceptOnNewSnapshot(interceptor));
+        new Configurator() {
+          @Override
+          public void configure(final MemberId id, final TestSnapshotStore snapshotStore) {
+            snapshotStore.interceptOnNewSnapshot(interceptor);
+          }
+        });
 
     // then -- rejoined follower should catch up
     raftRule.allNodesHaveSnapshotWithIndex(snapshotIndex);

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftStartupConsistencyCheckTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftStartupConsistencyCheckTest.java
@@ -12,8 +12,13 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftRule.Configurator;
+import io.atomix.raft.RaftServer.Builder;
+import io.atomix.raft.protocol.InstallRequest;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.agrona.LangUtil;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
@@ -80,6 +85,8 @@ public class RaftStartupConsistencyCheckTest {
   @Test // regression test for https://github.com/camunda/zeebe/issues/14367
   public void shouldHandleRetriedRequestsAfterSnapshotPersist() throws Exception {
     // given -- force a follower to receive a snapshot on restart
+    final var snapshotPersistCalled = new AtomicBoolean();
+    final var retryBarrier = new CountDownLatch(1);
     final var leader = raftRule.getLeader().orElseThrow();
     final var follower = raftRule.getFollower().orElseThrow();
     raftRule.shutdownServer(follower);
@@ -94,8 +101,8 @@ public class RaftStartupConsistencyCheckTest {
     final Runnable interceptor =
         () -> {
           try {
-            // TODO: better way to force a timeout?
-            Thread.sleep(2_000);
+            snapshotPersistCalled.set(true);
+            retryBarrier.await();
           } catch (final InterruptedException e) {
             LangUtil.rethrowUnchecked(e);
           }
@@ -104,7 +111,21 @@ public class RaftStartupConsistencyCheckTest {
         follower.name(),
         new Configurator() {
           @Override
-          public void configure(final MemberId id, final TestSnapshotStore snapshotStore) {
+          public void configure(final MemberId id, final Builder builder) {
+            final var protocol = (TestRaftServerProtocol) builder.protocol;
+            protocol.interceptRequest(
+                InstallRequest.class,
+                r -> {
+                  // only allow the persist method to complete if we know this request was received
+                  // AFTER we already tried persisting (i.e. when persist is currently blocking)
+                  if (snapshotPersistCalled.get()) {
+                    retryBarrier.countDown();
+                  }
+                });
+          }
+
+          @Override
+          public void configure(final TestSnapshotStore snapshotStore) {
             snapshotStore.interceptOnNewSnapshot(interceptor);
           }
         });

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
 import io.camunda.zeebe.snapshots.SnapshotId;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -114,6 +115,13 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
 
   @Override
   public ReceivedSnapshot newReceivedSnapshot(final String snapshotId) {
+    if (Optional.ofNullable(currentPersistedSnapshot.get())
+        .map(PersistedSnapshot::getId)
+        .orElse("")
+        .equals(snapshotId)) {
+      throw new SnapshotAlreadyExistsException("Snapshot with this ID is already persisted");
+    }
+
     final var newSnapshot = new InMemorySnapshot(this, snapshotId);
     receivedSnapshots.add(newSnapshot);
     return newSnapshot;


### PR DESCRIPTION
## Description

This PR fixes an edge case where install requests were retried/queued after the snapshot had been persisted (e.g. an I/O stall causes the persist to slow down, causing the leader to retry the last chunk). This would prevent startup. This was due to the snapshot listeners being called asynchronously. Since this is what updates the Raft context's local current snapshot reference, it created a small window where the follower would reply with an outdated snapshot reference, and accept out of order install requests.

The fix is to immediately update local snapshot reference on update. Additionally, the `SnapshotAlreadyExistsException` is tolerated on the follower, and a warning issues when it happens.

Test infrastructure was updated to support multiple ways to configure a server. Previously, you could only configure the `RaftServer.Builder`, but since we have multiple builders, it wasn't very useful. By introducing a generic interface, and checking multiple types in different places, you can now pass a single object which can configure various builders.

The last commit also removes an outdated test which was incorrectly testing behavior that
does not exist anymore. We used to persist snapshots before resetting the log, and this is what the test was covering. However, it never worked because it was in fact restarting the node with no snapshot (which is also why it didn't fail when we removed the old behavior).

As we now always persist snapshots after resetting the log, this case simply cannot happen.

## Related issues

closes #14367 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
