### PR TITLE
Reduce allocation rate of MDC called for every actor task

### DIFF
--- a/dist/src/main/resources/log4j2.component.properties
+++ b/dist/src/main/resources/log4j2.component.properties
@@ -1,0 +1,11 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Zeebe Community License 1.1. You may not use this file
+# except in compliance with the Zeebe Community License 1.1.
+#
+# Set up garbage free logging; see https://logging.apache.org/log4j/2.x/manual/garbagefree.html
+log4j2.enableThreadlocals=true
+log4j2.enableDirectEncoders=true
+log4j2.garbagefreeThreadContextMap=true

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -99,7 +99,6 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
     final var properties = currentTask.getActor().getContext();
     boolean resubmit = false;
 
-    MDC.put("actor-scheduler", actorThreadGroup.getSchedulerName());
     for (final var property : properties.entrySet()) {
       MDC.put(property.getKey(), property.getValue());
     }
@@ -200,6 +199,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   @Override
   public void run() {
     idleStrategy.init();
+    MDC.put("actor-scheduler", actorThreadGroup.getSchedulerName());
 
     while (state == ActorThreadState.RUNNING) {
       try {


### PR DESCRIPTION
## Description

This PR configures [Log4J2 to be garbage free](https://logging.apache.org/log4j/2.x/manual/garbagefree.html), and avoids creation of new objects when changing the MDC on every actor call.

I set up a normal benchmark (`np-reduce-mdc-allocs`), and you can see the following allocation rate with the current snapshot:

![image](https://github.com/camunda/zeebe/assets/43373/dd949b6a-eb3b-4889-8263-1081d4e854cd)

And with this PR:

![image](https://github.com/camunda/zeebe/assets/43373/4fbdb2d0-161a-464a-9a38-d5d90dbf3d55)

Note that there is still some allocation - for example, when you do `Logger.getLogger`, but generally it's a lot less.

And in the grand scheme of things, it lops off about ~0.2GB of the allocation rate as reported by Pyroscope (so avg for the whole cluster was previously 4.6-4.7GB per unit, now it's 4.4-4.5GB). But it's an easy fix.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
