### PR TITLE
Multi-tenancy support for job activation in the java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client;
 
 import java.time.Duration;
+import java.util.List;
 
 public final class ClientProperties {
 
@@ -34,6 +35,11 @@ public final class ClientProperties {
    * @see ZeebeClientBuilder#defaultTenantId(String)
    */
   public static final String DEFAULT_TENANT_ID = "zeebe.client.tenantId";
+
+  /**
+   * @see ZeebeClientBuilder#defaultJobWorkerTenantIds(List)
+   */
+  public static final String DEFAULT_JOB_WORKER_TENANT_IDS = "zeebe.client.worker.tenantIds";
 
   /**
    * @see ZeebeClientBuilder#numJobWorkerExecutionThreads(int)

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import io.grpc.ClientInterceptor;
 import java.time.Duration;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -55,6 +56,12 @@ public interface ZeebeClientBuilder {
    *     io.camunda.zeebe.client.api.command.CommandWithTenantStep#DEFAULT_TENANT_IDENTIFIER}.
    */
   ZeebeClientBuilder defaultTenantId(String tenantId);
+
+  /**
+   * @param tenantIds the tenant identifiers which are used for job-activation commands when no
+   *     tenant identifiers are set. The default value is an empty list.
+   */
+  ZeebeClientBuilder defaultJobWorkerTenantIds(List<String> tenantIds);
 
   /**
    * @param maxJobsActive Default value for {@link JobWorkerBuilderStep3#maxJobsActive(int)}.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -59,7 +59,8 @@ public interface ZeebeClientBuilder {
 
   /**
    * @param tenantIds the tenant identifiers which are used for job-activation commands when no
-   *     tenant identifiers are set. The default value is a list containing the <default> tenant id.
+   *     tenant identifiers are set. The default value contains only {@link
+   *     io.camunda.zeebe.client.api.command.CommandWithTenantStep#DEFAULT_TENANT_IDENTIFIER}.
    */
   ZeebeClientBuilder defaultJobWorkerTenantIds(List<String> tenantIds);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -59,7 +59,7 @@ public interface ZeebeClientBuilder {
 
   /**
    * @param tenantIds the tenant identifiers which are used for job-activation commands when no
-   *     tenant identifiers are set. The default value is an empty list.
+   *     tenant identifiers are set. The default value is a list containing the <default> tenant id.
    */
   ZeebeClientBuilder defaultJobWorkerTenantIds(List<String> tenantIds);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -33,6 +33,11 @@ public interface ZeebeClientConfiguration {
   String getDefaultTenantId();
 
   /**
+   * @see ZeebeClientBuilder#defaultJobWorkerTenantIds(List)
+   */
+  List<String> getDefaultJobWorkerTenantIds();
+
+  /**
    * @see ZeebeClientBuilder#numJobWorkerExecutionThreads(int)
    */
   int getNumJobWorkerExecutionThreads();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client.api.command;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
 import java.util.List;
 
 public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantStep<T> {
@@ -35,19 +34,10 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * @since 8.3
    */
   @Override
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
   T tenantId(String tenantId);
 
   /**
-   * <strong>Experimental: This method is under development, and as such using it may have no effect
-   * on the command builder when called. While unimplemented, it simply returns the command builder
-   * instance unchanged. This method already exists for software that is building support for
-   * multi-tenancy, and already wants to use this API during its development. As support for
-   * multi-tenancy is added to Zeebe, each of the commands that implement this method may start to
-   * take effect. Until this warning is removed, anything described below may not yet have taken
-   * effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Specifies the tenants that may own any entities (e.g. process definition, process instances,
+   * Specifies the tenants that may own any entities (e.g. process definition, process instances,
    * etc.) resulting from this command.
    *
    * <h1>One or more tenants</h1>
@@ -55,25 +45,22 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
    * jobs will be owned by the tenant that owns the corresponding process instance.
    *
+   * <p>Each time this method is called, the existing tenant IDs are cleared and only the tenant IDs
+   * passed to this method are added.
+   *
    * @param tenantIds the identifiers of the tenants to specify for this command, e.g. {@code
    *     ["ACME", "OTHER"]}
    * @return the builder for this command with the tenants specified
    * @see #tenantId(String)
    * @since 8.3
    */
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
   T tenantIds(List<String> tenantIds);
 
   /**
-   * <strong>Experimental: This method is under development, and as such using it may have no effect
-   * on the command builder when called. While unimplemented, it simply returns the command builder
-   * instance unchanged. This method already exists for software that is building support for
-   * multi-tenancy, and already wants to use this API during its development. As support for
-   * multi-tenancy is added to Zeebe, each of the commands that implement this method may start to
-   * take effect. Until this warning is removed, anything described below may not yet have taken
-   * effect, and the interface and its description are subject to change.</strong>
+   * Shorthand method for {@link #tenantIds(List)}.
    *
-   * <p>Shorthand method for {@link #tenantIds(List)}.
+   * <p>Each time this method is called, the existing tenant IDs are cleared and only the tenant IDs
+   * passed to this method are added.
    *
    * @param tenantIds the identifiers of the tenants to specify for this command, e.g. {@code
    *     ["ACME", "OTHER"]}
@@ -81,6 +68,5 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * @see #tenantIds(List)
    * @since 8.3
    */
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
   T tenantIds(String... tenantIds);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -45,9 +45,6 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
    * jobs will be owned by the tenant that owns the corresponding process instance.
    *
-   * <p>Each time this method is called, the existing tenant IDs are cleared and only the tenant IDs
-   * passed to this method are added.
-   *
    * @param tenantIds the identifiers of the tenants to specify for this command, e.g. {@code
    *     ["ACME", "OTHER"]}
    * @return the builder for this command with the tenants specified
@@ -58,9 +55,6 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
 
   /**
    * Shorthand method for {@link #tenantIds(List)}.
-   *
-   * <p>Each time this method is called, the existing tenant IDs are cleared and only the tenant IDs
-   * passed to this method are added.
    *
    * @param tenantIds the identifiers of the tenants to specify for this command, e.g. {@code
    *     ["ACME", "OTHER"]}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -57,13 +57,14 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String DEFAULT_TENANT_ID_VAR = "ZEEBE_DEFAULT_TENANT_ID";
   public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
       "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
-  private static final String TENANT_ID_LIST_SEPARATOR = ", ";
+  private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private boolean applyEnvironmentVariableOverrides = true;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   private String gatewayAddress = DEFAULT_GATEWAY_ADDRESS;
   private String defaultTenantId = CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER;
-  private List<String> defaultJobWorkerTenantIds = Collections.emptyList();
+  private List<String> defaultJobWorkerTenantIds =
+      Collections.singletonList(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   private int jobWorkerMaxJobsActive = 32;
   private int numJobWorkerExecutionThreads = 1;
   private String defaultJobWorkerName = "default";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -57,7 +57,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String DEFAULT_TENANT_ID_VAR = "ZEEBE_DEFAULT_TENANT_ID";
   public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
       "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
-  private static final String LIST_SEPARATOR = ", ";
+  private static final String TENANT_ID_LIST_SEPARATOR = ", ";
   private boolean applyEnvironmentVariableOverrides = true;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
@@ -203,7 +203,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     if (properties.containsKey(ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS)) {
       final String tenantIdsList =
           properties.getProperty(ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS);
-      final List<String> tenantIds = Arrays.asList(tenantIdsList.split(LIST_SEPARATOR));
+      final List<String> tenantIds = Arrays.asList(tenantIdsList.split(TENANT_ID_LIST_SEPARATOR));
       defaultJobWorkerTenantIds(tenantIds);
     }
 
@@ -445,7 +445,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
     if (Environment.system().isDefined(DEFAULT_JOB_WORKER_TENANT_IDS_VAR)) {
       final String tenantIdsList = Environment.system().get(DEFAULT_JOB_WORKER_TENANT_IDS_VAR);
-      final List<String> tenantIds = Arrays.asList(tenantIdsList.split(LIST_SEPARATOR));
+      final List<String> tenantIds = Arrays.asList(tenantIdsList.split(TENANT_ID_LIST_SEPARATOR));
       defaultJobWorkerTenantIds(tenantIds);
     }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -31,6 +31,8 @@ import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.grpc.ClientInterceptor;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
@@ -99,6 +101,7 @@ public class ZeebeClientCloudBuilderImpl
 
     // todo(#14106): allow default tenant id setting for cloud client
     innerBuilder.defaultTenantId("");
+    innerBuilder.defaultJobWorkerTenantIds(Collections.emptyList());
 
     return this;
   }
@@ -119,6 +122,14 @@ public class ZeebeClientCloudBuilderImpl
   @Override
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/14106")
   public ZeebeClientCloudBuilderStep4 defaultTenantId(final String tenantId) {
+    Loggers.LOGGER.debug(
+        "Multi-tenancy in Camunda 8 SaaS will be supported with https://github.com/camunda/zeebe/issues/14106.");
+    return this;
+  }
+
+  @Override
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/14106")
+  public ZeebeClientBuilder defaultJobWorkerTenantIds(final List<String> tenantIds) {
     Loggers.LOGGER.debug(
         "Multi-tenancy in Camunda 8 SaaS will be supported with https://github.com/camunda/zeebe/issues/14106.");
     return this;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -58,6 +58,7 @@ public final class ActivateJobsCommandImpl
     requestTimeout(config.getDefaultRequestTimeout());
     timeout(config.getDefaultJobTimeout());
     workerName(config.getDefaultJobWorkerName());
+    tenantIds(config.getDefaultJobWorkerTenantIds());
   }
 
   @Override
@@ -129,13 +130,13 @@ public final class ActivateJobsCommandImpl
 
   @Override
   public ActivateJobsCommandStep3 tenantId(final String tenantId) {
-    // todo(#13560): replace dummy implementation
+    builder.addTenantIds(tenantId);
     return this;
   }
 
   @Override
   public ActivateJobsCommandStep3 tenantIds(final List<String> tenantIds) {
-    // todo(#13560): replace dummy implementation
+    builder.addAllTenantIds(tenantIds);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -50,7 +50,6 @@ public final class ActivateJobsCommandImpl
 
   private final Set<String> defaultTenantIds;
   private final Set<String> customTenantIds;
-  private boolean areCustomTenantIdsSet;
 
   public ActivateJobsCommandImpl(
       final GatewayStub asyncStub,
@@ -66,7 +65,6 @@ public final class ActivateJobsCommandImpl
     workerName(config.getDefaultJobWorkerName());
     defaultTenantIds = new HashSet<>(config.getDefaultJobWorkerTenantIds());
     customTenantIds = new HashSet<>();
-    areCustomTenantIdsSet = false;
   }
 
   @Override
@@ -114,10 +112,10 @@ public final class ActivateJobsCommandImpl
   @Override
   public ZeebeFuture<ActivateJobsResponse> send() {
 
-    if (areCustomTenantIdsSet) {
-      builder.addAllTenantIds(customTenantIds);
-    } else {
+    if (customTenantIds.isEmpty()) {
       builder.addAllTenantIds(defaultTenantIds);
+    } else {
+      builder.addAllTenantIds(customTenantIds);
     }
 
     final ActivateJobsRequest request = builder.build();
@@ -145,14 +143,12 @@ public final class ActivateJobsCommandImpl
 
   @Override
   public ActivateJobsCommandStep3 tenantId(final String tenantId) {
-    areCustomTenantIdsSet = true;
     customTenantIds.add(tenantId);
     return this;
   }
 
   @Override
   public ActivateJobsCommandStep3 tenantIds(final List<String> tenantIds) {
-    areCustomTenantIdsSet = true;
     customTenantIds.clear();
     customTenantIds.addAll(tenantIds);
     return this;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -61,7 +61,9 @@ public final class StreamJobsCommandImpl
     this.retryPredicate = retryPredicate;
     builder = StreamActivatedJobsRequest.newBuilder();
 
-    timeout(config.getDefaultJobTimeout()).workerName(config.getDefaultJobWorkerName());
+    timeout(config.getDefaultJobTimeout());
+    workerName(config.getDefaultJobWorkerName());
+    tenantIds(config.getDefaultJobWorkerTenantIds());
   }
 
   @Override
@@ -133,13 +135,13 @@ public final class StreamJobsCommandImpl
 
   @Override
   public StreamJobsCommandStep3 tenantId(final String tenantId) {
-    // todo(#13560): replace dummy implementation
+    builder.addTenantIds(tenantId);
     return this;
   }
 
   @Override
   public StreamJobsCommandStep3 tenantIds(final List<String> tenantIds) {
-    // todo(#13560): replace dummy implementation
+    builder.addAllTenantIds(tenantIds);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -55,7 +55,6 @@ public final class StreamJobsCommandImpl
 
   private final Set<String> defaultTenantIds;
   private final Set<String> customTenantIds;
-  private boolean areCustomTenantIdsSet;
 
   public StreamJobsCommandImpl(
       final GatewayStub asyncStub,
@@ -72,7 +71,6 @@ public final class StreamJobsCommandImpl
 
     defaultTenantIds = new HashSet<>(config.getDefaultJobWorkerTenantIds());
     customTenantIds = new HashSet<>();
-    areCustomTenantIdsSet = false;
   }
 
   @Override
@@ -84,10 +82,10 @@ public final class StreamJobsCommandImpl
   @Override
   public ZeebeFuture<StreamJobsResponse> send() {
 
-    if (areCustomTenantIdsSet) {
-      builder.addAllTenantIds(customTenantIds);
-    } else {
+    if (customTenantIds.isEmpty()) {
       builder.addAllTenantIds(defaultTenantIds);
+    } else {
+      builder.addAllTenantIds(customTenantIds);
     }
 
     final StreamActivatedJobsRequest request = builder.build();
@@ -151,14 +149,12 @@ public final class StreamJobsCommandImpl
 
   @Override
   public StreamJobsCommandStep3 tenantId(final String tenantId) {
-    areCustomTenantIdsSet = true;
     customTenantIds.add(tenantId);
     return this;
   }
 
   @Override
   public StreamJobsCommandStep3 tenantIds(final List<String> tenantIds) {
-    areCustomTenantIdsSet = true;
     customTenantIds.clear();
     customTenantIds.addAll(tenantIds);
     return this;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -36,6 +36,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final long processDefinitionKey;
   private final String elementId;
   private final long elementInstanceKey;
+  private final String tenantId;
   private final String worker;
   private final int retries;
   private final long deadline;
@@ -64,6 +65,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
     processDefinitionKey = job.getProcessDefinitionKey();
     elementId = job.getElementId();
     elementInstanceKey = job.getElementInstanceKey();
+    tenantId = job.getTenantId();
   }
 
   @Override
@@ -160,8 +162,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
 
   @Override
   public String getTenantId() {
-    // todo(#13560): replace dummy implementation
-    return "";
+    return tenantId;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -89,7 +89,8 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultTenantId())
           .isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
       assertThat(configuration.getDefaultJobWorkerStreamEnabled()).isFalse();
-      assertThat(configuration.getDefaultJobWorkerTenantIds()).isEmpty();
+      assertThat(configuration.getDefaultJobWorkerTenantIds())
+          .containsExactly(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
     }
   }
 
@@ -618,7 +619,8 @@ public final class ZeebeClientTest extends ClientTest {
     builder.build();
 
     // then
-    assertThat(builder.getDefaultJobWorkerTenantIds()).isEmpty();
+    assertThat(builder.getDefaultJobWorkerTenantIds())
+        .containsExactly(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Test
@@ -640,7 +642,7 @@ public final class ZeebeClientTest extends ClientTest {
     // given
     final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
     final Properties properties = new Properties();
-    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, String.join(", ", tenantIdList));
+    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, String.join(",", tenantIdList));
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
     builder.withProperties(properties);
 
@@ -655,7 +657,7 @@ public final class ZeebeClientTest extends ClientTest {
   public void shouldSetDefaultJobWorkerTenantIdsFromEnvVarWithClientBuilder() {
     // given
     final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
-    Environment.system().put(DEFAULT_JOB_WORKER_TENANT_IDS_VAR, String.join(", ", tenantIdList));
+    Environment.system().put(DEFAULT_JOB_WORKER_TENANT_IDS_VAR, String.join(",", tenantIdList));
 
     // when
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
@@ -672,7 +674,7 @@ public final class ZeebeClientTest extends ClientTest {
     final Properties properties = new Properties();
     properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, propertyTenantId);
     final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
-    Environment.system().put(DEFAULT_JOB_WORKER_TENANT_IDS_VAR, String.join(", ", tenantIdList));
+    Environment.system().put(DEFAULT_JOB_WORKER_TENANT_IDS_VAR, String.join(",", tenantIdList));
     final String setterTenantId = "setter-tenant";
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
     builder.defaultJobWorkerTenantIds(Arrays.asList(setterTenantId));
@@ -690,7 +692,7 @@ public final class ZeebeClientTest extends ClientTest {
     final ZeebeClientCloudBuilderImpl builder = new ZeebeClientCloudBuilderImpl();
     final Properties properties = new Properties();
     final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
-    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, String.join(", ", tenantIdList));
+    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, String.join(",", tenantIdList));
     builder.withProperties(properties);
 
     // when

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -16,11 +16,13 @@
 package io.camunda.zeebe.client;
 
 import static io.camunda.zeebe.client.ClientProperties.CLOUD_REGION;
+import static io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CA_CERTIFICATE_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_TENANT_ID_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.KEEP_ALIVE_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.OVERRIDE_AUTHORITY_VAR;
@@ -45,6 +47,8 @@ import io.camunda.zeebe.client.impl.util.EnvironmentRule;
 import io.camunda.zeebe.client.util.ClientTest;
 import java.io.FileNotFoundException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -85,6 +89,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultTenantId())
           .isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
       assertThat(configuration.getDefaultJobWorkerStreamEnabled()).isFalse();
+      assertThat(configuration.getDefaultJobWorkerTenantIds()).isEmpty();
     }
   }
 
@@ -595,6 +600,121 @@ public final class ZeebeClientTest extends ClientTest {
     // when
     final ZeebeClientCloudBuilderImpl builderWithTenantId =
         (ZeebeClientCloudBuilderImpl) builder.defaultTenantId(tenantId);
+
+    // then
+    // todo(#14106): verify that tenant id is set in the builder
+    assertThat(builderWithTenantId)
+        .describedAs(
+            "This method has no effect on the cloud client builder while under development")
+        .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldUseDefaultJobWorkerTenantIds() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getDefaultJobWorkerTenantIds()).isEmpty();
+  }
+
+  @Test
+  public void shouldSetDefaultJobWorkerTenantIdsFromSetterWithClientBuilder() {
+    // given
+    final String overrideTenant = "override-tenant";
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.defaultJobWorkerTenantIds(Arrays.asList(overrideTenant));
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getDefaultJobWorkerTenantIds()).containsExactly(overrideTenant);
+  }
+
+  @Test
+  public void shouldSetDefaultJobWorkerTenantIdsFromPropertyWithClientBuilder() {
+    // given
+    final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
+    final Properties properties = new Properties();
+    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, String.join(", ", tenantIdList));
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.withProperties(properties);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getDefaultJobWorkerTenantIds()).containsExactlyElementsOf(tenantIdList);
+  }
+
+  @Test
+  public void shouldSetDefaultJobWorkerTenantIdsFromEnvVarWithClientBuilder() {
+    // given
+    final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
+    Environment.system().put(DEFAULT_JOB_WORKER_TENANT_IDS_VAR, String.join(", ", tenantIdList));
+
+    // when
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.build();
+
+    // then
+    assertThat(builder.getDefaultJobWorkerTenantIds()).containsExactlyElementsOf(tenantIdList);
+  }
+
+  @Test
+  public void shouldSetFinalDefaultJobWorkerTenantIdsFromEnvVarWithClientBuilder() {
+    // given
+    final String propertyTenantId = "test-tenant";
+    final Properties properties = new Properties();
+    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, propertyTenantId);
+    final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
+    Environment.system().put(DEFAULT_JOB_WORKER_TENANT_IDS_VAR, String.join(", ", tenantIdList));
+    final String setterTenantId = "setter-tenant";
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.defaultJobWorkerTenantIds(Arrays.asList(setterTenantId));
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getDefaultJobWorkerTenantIds()).containsExactlyElementsOf(tenantIdList);
+  }
+
+  @Test
+  public void shouldNotSetDefaultJobWorkerTenantIdsFromPropertyWithCloudClientBuilder() {
+    // given
+    final ZeebeClientCloudBuilderImpl builder = new ZeebeClientCloudBuilderImpl();
+    final Properties properties = new Properties();
+    final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
+    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, String.join(", ", tenantIdList));
+    builder.withProperties(properties);
+
+    // when
+    final ZeebeClient client =
+        builder
+            .withClusterId("clusterId")
+            .withClientId("clientId")
+            .withClientSecret("clientSecret")
+            .build();
+
+    // then
+    // todo(#14106): verify that tenant ids are set in the request
+    assertThat(client.getConfiguration().getDefaultJobWorkerTenantIds()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotSetDefaultJobWorkerTenantIdsFromSetterWithCloudClientBuilder() {
+    // given
+    final ZeebeClientCloudBuilderImpl builder = new ZeebeClientCloudBuilderImpl();
+    final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
+
+    // when
+    final ZeebeClientCloudBuilderImpl builderWithTenantId =
+        (ZeebeClientCloudBuilderImpl) builder.defaultJobWorkerTenantIds(tenantIdList);
 
     // then
     // todo(#14106): verify that tenant id is set in the builder

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.impl.worker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
@@ -106,6 +107,7 @@ final class JobStreamImplTest {
             .setType("type")
             .setWorker("worker")
             .setTimeout(Duration.ofSeconds(10).toMillis())
+            .addTenantIds(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER)
             .addFetchVariable("foo")
             .addFetchVariable("bar")
             .build();

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -19,7 +19,6 @@ import static io.camunda.zeebe.client.util.JsonUtil.fromJsonAsMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
@@ -52,6 +51,7 @@ public final class ActivateJobsTest extends ClientTest {
             .setRetries(34)
             .setDeadline(1231)
             .setVariables("{\"key\": \"val\"}")
+            .setTenantId("test-tenant-1")
             .build();
 
     final ActivatedJob activatedJob2 =
@@ -69,6 +69,7 @@ public final class ActivateJobsTest extends ClientTest {
             .setRetries(334)
             .setDeadline(3131)
             .setVariables("{\"bar\": 3}")
+            .setTenantId("test-tenant-2")
             .build();
 
     gatewayService.onActivateJobsRequest(activatedJob1, activatedJob2);
@@ -81,6 +82,7 @@ public final class ActivateJobsTest extends ClientTest {
             .maxJobsToActivate(3)
             .timeout(Duration.ofMillis(1000))
             .workerName("worker1")
+            .tenantIds("test-tenant-1", "test-tenant-2")
             .send()
             .join();
 
@@ -102,7 +104,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob1.getVariables());
-    assertThat(job.getTenantId()).isEqualTo("");
+    assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
 
     job = response.getJobs().get(1);
     assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());
@@ -119,6 +121,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob2.getVariables());
+    assertThat(job.getTenantId()).isEqualTo(activatedJob2.getTenantId());
 
     final ActivateJobsRequest request = gatewayService.getLastRequest();
     assertThat(request.getType()).isEqualTo("foo");
@@ -251,51 +254,56 @@ public final class ActivateJobsTest extends ClientTest {
   @Test
   public void shouldAllowSpecifyingTenantIdsAsList() {
     // given
-    final ActivateJobsCommandStep3 builder =
-        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3);
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .tenantIds(Arrays.asList("tenant1", "tenant2"))
+        .send()
+        .join();
 
     // when
-    final ActivateJobsCommandStep3 builderWithTenants =
-        builder.tenantIds(Arrays.asList("tenant1", "tenant2"));
+    final ActivateJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    // todo(#13560): verify that tenant ids are set in the request
-    assertThat(builderWithTenants)
-        .describedAs("This method has no effect on the command builder while under development")
-        .isEqualTo(builder);
+    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
   }
 
   @Test
   public void shouldAllowSpecifyingTenantIdsAsVarArgs() {
     // given
-    final ActivateJobsCommandStep3 builder =
-        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3);
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .tenantIds("tenant1", "tenant2")
+        .send()
+        .join();
 
     // when
-    final ActivateJobsCommandStep3 builderWithTenants = builder.tenantIds("tenant1", "tenant2");
+    final ActivateJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    // todo(#13560): verify that tenant ids are set in the request
-    assertThat(builderWithTenants)
-        .describedAs("This method has no effect on the command builder while under development")
-        .isEqualTo(builder);
+    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
   }
 
   @Test
   public void shouldAllowSpecifyingTenantIds() {
     // given
-    final ActivateJobsCommandStep3 builder =
-        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3);
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .tenantId("tenant1")
+        .tenantId("tenant2")
+        .send()
+        .join();
 
     // when
-    final ActivateJobsCommandStep3 builderWithTenants =
-        builder.tenantId("tenant1").tenantId("tenant2");
+    final ActivateJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    // todo(#13560): verify that tenant ids are set in the request
-    assertThat(builderWithTenants)
-        .describedAs("This method has no effect on the command builder while under development")
-        .isEqualTo(builder);
+    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -266,7 +266,7 @@ public final class ActivateJobsTest extends ClientTest {
     final ActivateJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
+    assertThat(request.getTenantIdsList()).containsExactlyInAnyOrder("tenant1", "tenant2");
   }
 
   @Test
@@ -284,7 +284,7 @@ public final class ActivateJobsTest extends ClientTest {
     final ActivateJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
+    assertThat(request.getTenantIdsList()).containsExactlyInAnyOrder("tenant1", "tenant2");
   }
 
   @Test
@@ -296,6 +296,7 @@ public final class ActivateJobsTest extends ClientTest {
         .maxJobsToActivate(3)
         .tenantId("tenant1")
         .tenantId("tenant2")
+        .tenantId("tenant2")
         .send()
         .join();
 
@@ -303,7 +304,7 @@ public final class ActivateJobsTest extends ClientTest {
     final ActivateJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
+    assertThat(request.getTenantIdsList()).containsExactlyInAnyOrder("tenant1", "tenant2");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/StreamJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/StreamJobsTest.java
@@ -264,7 +264,7 @@ public final class StreamJobsTest extends ClientTest {
     final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
+    assertThat(request.getTenantIdsList()).containsExactlyInAnyOrder("tenant1", "tenant2");
   }
 
   @Test
@@ -282,7 +282,7 @@ public final class StreamJobsTest extends ClientTest {
     final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
+    assertThat(request.getTenantIdsList()).containsExactlyInAnyOrder("tenant1", "tenant2");
   }
 
   @Test
@@ -294,6 +294,7 @@ public final class StreamJobsTest extends ClientTest {
         .consumer(ignored -> {})
         .tenantId("tenant1")
         .tenantId("tenant2")
+        .tenantId("tenant2")
         .send()
         .join();
 
@@ -301,6 +302,6 @@ public final class StreamJobsTest extends ClientTest {
     final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");
+    assertThat(request.getTenantIdsList()).containsExactlyInAnyOrder("tenant1", "tenant2");
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/StreamJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/StreamJobsTest.java
@@ -262,7 +262,6 @@ public final class StreamJobsTest extends ClientTest {
 
     // when
     final StreamActivatedJobsRequest request = gatewayService.getLastRequest();
-    ;
 
     // then
     assertThat(request.getTenantIdsList()).containsExactly("tenant1", "tenant2");


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Support multi-tenancy for job activation (`ActivateJobsCommand` and `StreamJobsCommand`) in the Java client.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13560 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
