### PR TITLE
fix(raft): provide an error when rejecting reconfiguration

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -137,7 +137,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     // See https://groups.google.com/forum/#!topic/raft-dev/t4xj6dJTP6E
     if (configuring() || initializing() || jointConsensus()) {
       return CompletableFuture.completedFuture(
-          logResponse(ReconfigureResponse.builder().withStatus(RaftResponse.Status.ERROR).build()));
+          logResponse(
+              ReconfigureResponse.builder()
+                  .withStatus(RaftResponse.Status.ERROR)
+                  .withError(Type.CONFIGURATION_ERROR)
+                  .build()));
     }
 
     // If the configuration request index is less than the last known configuration index for


### PR DESCRIPTION
Noticed because we had an NPE, causing a flaky test: https://github.com/camunda/zeebe/actions/runs/6258005195/job/16991630677