### PR TITLE
Connect ClusterTopologyManager and PartitionManager

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -56,7 +56,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private PartitionManagerImpl partitionManager;
   private BrokerAdminServiceImpl brokerAdminService;
   private JobStreamService jobStreamService;
-  private ClusterTopologyService partitionDistribution;
+  private ClusterTopologyService clusterTopologyService;
 
   public BrokerStartupContextImpl(
       final BrokerInfo brokerInfo,
@@ -249,11 +249,11 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
   @Override
   public ClusterTopologyService getClusterTopology() {
-    return partitionDistribution;
+    return clusterTopologyService;
   }
 
   @Override
   public void setClusterTopology(final ClusterTopologyService clusterTopologyService) {
-    partitionDistribution = clusterTopologyService;
+    this.clusterTopologyService = clusterTopologyService;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -46,6 +46,9 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             adminService.injectAdminAccess(partitionManager.createAdminAccess(adminService));
             adminService.injectPartitionInfoSource(partitionManager.getZeebePartitions());
             brokerStartupContext.setPartitionManager(partitionManager);
+            brokerStartupContext
+                .getClusterTopology()
+                .registerPartitionChangeExecutor(partitionManager);
             startupFuture.complete(brokerStartupContext);
           } catch (final Exception e) {
             startupFuture.completeExceptionally(e);
@@ -63,6 +66,8 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
       shutdownFuture.complete(null);
       return;
     }
+
+    brokerShutdownContext.getClusterTopology().removePartitionChangeExecutor();
 
     concurrencyControl.runOnCompletion(
         partitionManager.stop(),

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyService.java
@@ -10,9 +10,14 @@ package io.camunda.zeebe.broker.partitioning.topology;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 
 public interface ClusterTopologyService extends AsyncClosable {
   PartitionDistribution getPartitionDistribution();
+
+  void registerPartitionChangeExecutor(PartitionChangeExecutor executor);
+
+  void removePartitionChangeExecutor();
 
   ActorFuture<Void> start(BrokerStartupContext brokerStartupContext);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.topology.ClusterTopologyManagerService;
+import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
 import io.camunda.zeebe.topology.util.TopologyUtil;
 import java.nio.file.Path;
@@ -27,6 +28,23 @@ public class DynamicClusterTopologyService implements ClusterTopologyService {
   @Override
   public PartitionDistribution getPartitionDistribution() {
     return partitionDistribution;
+  }
+
+  @Override
+  public void registerPartitionChangeExecutor(final PartitionChangeExecutor executor) {
+    if (clusterTopologyManagerService != null) {
+      clusterTopologyManagerService.registerPartitionChangeExecutor(executor);
+    } else {
+      throw new IllegalStateException(
+          "Cannot register partition change executor before the topology manager is started");
+    }
+  }
+
+  @Override
+  public void removePartitionChangeExecutor() {
+    if (clusterTopologyManagerService != null) {
+      clusterTopologyManagerService.removePartitionChangeExecutor();
+    }
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticClusterTopologyService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticClusterTopologyService.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 
 public class StaticClusterTopologyService implements ClusterTopologyService {
 
@@ -19,6 +20,16 @@ public class StaticClusterTopologyService implements ClusterTopologyService {
   @Override
   public PartitionDistribution getPartitionDistribution() {
     return partitionDistribution;
+  }
+
+  @Override
+  public void registerPartitionChangeExecutor(final PartitionChangeExecutor executor) {
+    // do nothing. Static cluster topology cannot be changed.
+  }
+
+  @Override
+  public void removePartitionChangeExecutor() {
+    // do nothing. Static cluster topology cannot be changed.
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -186,6 +186,8 @@ class PartitionManagerStepTest {
               Collections.emptyList());
 
       testBrokerStartupContext.setPartitionManager(mockPartitionManager);
+      final ClusterTopologyService mockClusterTopology = mock(ClusterTopologyService.class);
+      testBrokerStartupContext.setClusterTopology(mockClusterTopology);
       shutdownFuture = CONCURRENCY_CONTROL.createFuture();
     }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -51,7 +51,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
   private Consumer<ClusterTopology> topologyGossiper;
   private final ActorFuture<Void> startFuture;
 
-  private final TopologyChangeAppliers changeAppliers;
+  private TopologyChangeAppliers changeAppliers;
   private final MemberId localMemberId;
 
   // Indicates whether there is a topology change operation in progress on this member.
@@ -60,12 +60,10 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
   ClusterTopologyManagerImpl(
       final ConcurrencyControl executor,
       final MemberId localMemberId,
-      final PersistedClusterTopology persistedClusterTopology,
-      final TopologyChangeAppliers changeAppliers) {
+      final PersistedClusterTopology persistedClusterTopology) {
     this.executor = executor;
     this.persistedClusterTopology = persistedClusterTopology;
     startFuture = executor.createFuture();
-    this.changeAppliers = changeAppliers;
     this.localMemberId = localMemberId;
   }
 
@@ -87,9 +85,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
                 .ifRightOrLeft(
                     updated -> {
                       future.complete(updated);
-                      if (shouldApplyTopologyChangeOperation(updatedTopology)) {
-                        applyTopologyChangeOperation(updatedTopology);
-                      }
+                      applyTopologyChangeOperation(updatedTopology);
                     },
                     future::completeExceptionally);
           } catch (final Exception e) {
@@ -166,9 +162,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
                     receivedTopology,
                     mergedTopology);
                 persistedClusterTopology.update(mergedTopology);
-                if (shouldApplyTopologyChangeOperation(mergedTopology)) {
-                  applyTopologyChangeOperation(mergedTopology);
-                }
+                applyTopologyChangeOperation(mergedTopology);
               }
             }
             result.complete(persistedClusterTopology.getTopology());
@@ -190,10 +184,16 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     // an extra precaution we check if there is an ongoing operation before applying
     // one.
     return !onGoingTopologyChangeOperation
-        && mergedTopology.pendingChangesFor(localMemberId).isPresent();
+        && mergedTopology.pendingChangesFor(localMemberId).isPresent()
+        // changeApplier is registered only after PartitionManager in the Broker is started.
+        && changeAppliers != null;
   }
 
   private void applyTopologyChangeOperation(final ClusterTopology mergedTopology) {
+    if (!shouldApplyTopologyChangeOperation(mergedTopology)) {
+      return;
+    }
+
     onGoingTopologyChangeOperation = true;
     final var operation = mergedTopology.pendingChangesFor(localMemberId).orElseThrow();
     LOG.info("Applying topology change operation {}", operation);
@@ -246,5 +246,14 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     } catch (final Exception e) {
       return Either.left(e);
     }
+  }
+
+  void registerTopologyChangeAppliers(final TopologyChangeAppliers topologyChangeAppliers) {
+    executor.run(
+        () -> {
+          changeAppliers = topologyChangeAppliers;
+          // Continue applying the topology change operation, after a broker restart.
+          applyTopologyChangeOperation(persistedClusterTopology.getTopology());
+        });
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -256,4 +256,8 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
           applyTopologyChangeOperation(persistedClusterTopology.getTopology());
         });
   }
+
+  public void removeTopologyChangeAppliers() {
+    executor.run(() -> changeAppliers = null);
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -165,4 +165,8 @@ public final class ClusterTopologyManagerService extends Actor {
         new TopologyChangeAppliersImpl(
             partitionChangeExecutor, new NoopTopologyMembershipChangeExecutor()));
   }
+
+  public void removePartitionChangeExecutor() {
+    clusterTopologyManager.removeTopologyChangeAppliers();
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -18,13 +18,11 @@ import io.camunda.zeebe.topology.TopologyInitializer.FileInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.GossipInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.StaticInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.SyncInitializer;
-import io.camunda.zeebe.topology.changes.NoopPartitionChangeExecutor;
 import io.camunda.zeebe.topology.changes.NoopTopologyMembershipChangeExecutor;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.topology.changes.TopologyChangeAppliersImpl;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinatorImpl;
-import io.camunda.zeebe.topology.changes.TopologyMembershipChangeExecutor;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiper;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
 import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
@@ -52,22 +50,6 @@ public final class ClusterTopologyManagerService extends Actor {
       final ClusterCommunicationService communicationService,
       final ClusterMembershipService memberShipService,
       final ClusterTopologyGossiperConfig config) {
-    this(
-        dataRootDirectory,
-        communicationService,
-        memberShipService,
-        config,
-        new NoopPartitionChangeExecutor(),
-        new NoopTopologyMembershipChangeExecutor());
-  }
-
-  public ClusterTopologyManagerService(
-      final Path dataRootDirectory,
-      final ClusterCommunicationService communicationService,
-      final ClusterMembershipService memberShipService,
-      final ClusterTopologyGossiperConfig config,
-      final PartitionChangeExecutor partitionChangeExecutor,
-      final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor) {
     try {
       FileUtil.ensureDirectoryExists(dataRootDirectory);
     } catch (final IOException e) {
@@ -78,12 +60,7 @@ public final class ClusterTopologyManagerService extends Actor {
     topologyFile = dataRootDirectory.resolve(TOPOLOGY_FILE_NAME);
     persistedClusterTopology = new PersistedClusterTopology(topologyFile, new ProtoBufSerializer());
     clusterTopologyManager =
-        new ClusterTopologyManagerImpl(
-            this,
-            localMemberId,
-            persistedClusterTopology,
-            new TopologyChangeAppliersImpl(
-                partitionChangeExecutor, topologyMembershipChangeExecutor));
+        new ClusterTopologyManagerImpl(this, localMemberId, persistedClusterTopology);
     clusterTopologyGossiper =
         new ClusterTopologyGossiper(
             this,
@@ -179,5 +156,13 @@ public final class ClusterTopologyManagerService extends Actor {
   @Override
   protected void onActorClosing() {
     clusterTopologyGossiper.closeAsync();
+  }
+
+  public void registerPartitionChangeExecutor(
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    // TODO: pass concrete TopologyMembershipChangeExecutor
+    clusterTopologyManager.registerTopologyChangeAppliers(
+        new TopologyChangeAppliersImpl(
+            partitionChangeExecutor, new NoopTopologyMembershipChangeExecutor()));
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -89,10 +89,7 @@ final class ClusterTopologyManagerTest {
 
     final ClusterTopologyManagerImpl clusterTopologyManager =
         new ClusterTopologyManagerImpl(
-            new TestConcurrencyControl(),
-            localMemberId,
-            persistedClusterTopology,
-            operationsAppliers);
+            new TestConcurrencyControl(), localMemberId, persistedClusterTopology);
     clusterTopologyManager.setTopologyGossiper(gossipHandler);
     return clusterTopologyManager;
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -67,7 +67,7 @@ final class ClusterTopologyManagerTest {
   private ActorFuture<ClusterTopologyManagerImpl> startTopologyManager(
       final TopologyInitializer topologyInitializer,
       final TopologyChangeAppliers operationsAppliers) {
-    final var clusterTopologyManager = createTopologyManager(operationsAppliers);
+    final var clusterTopologyManager = createTopologyManager();
 
     final ActorFuture<ClusterTopologyManagerImpl> startFuture = new TestActorFuture<>();
 
@@ -76,6 +76,7 @@ final class ClusterTopologyManagerTest {
         .onComplete(
             (ignore, error) -> {
               if (error == null) {
+                clusterTopologyManager.registerTopologyChangeAppliers(operationsAppliers);
                 startFuture.complete(clusterTopologyManager);
               } else {
                 startFuture.completeExceptionally(error);
@@ -84,9 +85,7 @@ final class ClusterTopologyManagerTest {
     return startFuture;
   }
 
-  private ClusterTopologyManagerImpl createTopologyManager(
-      final TopologyChangeAppliers operationsAppliers) {
-
+  private ClusterTopologyManagerImpl createTopologyManager() {
     final ClusterTopologyManagerImpl clusterTopologyManager =
         new ClusterTopologyManagerImpl(
             new TestConcurrencyControl(), localMemberId, persistedClusterTopology);


### PR DESCRIPTION
## Description

`PartitionManager` is registered as the handler to execute topology changes related to Partitions. Since `PartitionManager` is started after `ClusterTopologySerive`, it has to register itself to the ClusterTopologyService. Until it is registered, no topology change operation can be executed by the topology manager. When it is registered, topology manager starts topology change if there was anything pending. This also ensures that any pending changes will continue after a broker restart.

There are no integration tests for this yet. We have to first expose some API so that we can trigger topology changes and monitor them in tests.

## Related issues

closes #14159

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
