### PR TITLE
revert: create pi error messages are tenant-unaware

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -49,11 +49,11 @@ public final class CreateProcessInstanceProcessor
   private static final String ERROR_MESSAGE_NO_IDENTIFIER_SPECIFIED =
       "Expected at least a bpmnProcessId or a key greater than -1, but none given";
   private static final String ERROR_MESSAGE_NOT_FOUND_BY_PROCESS =
-      "Expected to find process definition with process ID '%s' and tenant ID '%s', but none found";
+      "Expected to find process definition with process ID '%s', but none found";
   private static final String ERROR_MESSAGE_NOT_FOUND_BY_PROCESS_AND_VERSION =
-      "Expected to find process definition with process ID '%s', tenant ID '%s', and version '%d', but none found";
+      "Expected to find process definition with process ID '%s' and version '%d', but none found";
   private static final String ERROR_MESSAGE_NOT_FOUND_BY_KEY =
-      "Expected to find process definition with key '%d' and tenant ID '%s', but none found";
+      "Expected to find process definition with key '%d', but none found";
   private static final String ERROR_MESSAGE_NO_NONE_START_EVENT =
       "Expected to create instance of process with none start event, but there is no such event";
 
@@ -358,8 +358,7 @@ public final class CreateProcessInstanceProcessor
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,
-              String.format(
-                  ERROR_MESSAGE_NOT_FOUND_BY_PROCESS, bufferAsString(bpmnProcessId), tenantId)));
+              String.format(ERROR_MESSAGE_NOT_FOUND_BY_PROCESS, bufferAsString(bpmnProcessId))));
     }
   }
 
@@ -376,7 +375,6 @@ public final class CreateProcessInstanceProcessor
               String.format(
                   ERROR_MESSAGE_NOT_FOUND_BY_PROCESS_AND_VERSION,
                   bufferAsString(bpmnProcessId),
-                  tenantId,
                   version)));
     }
   }
@@ -388,8 +386,7 @@ public final class CreateProcessInstanceProcessor
     } else {
       return Either.left(
           new Rejection(
-              RejectionType.NOT_FOUND,
-              String.format(ERROR_MESSAGE_NOT_FOUND_BY_KEY, key, tenantId)));
+              RejectionType.NOT_FOUND, String.format(ERROR_MESSAGE_NOT_FOUND_BY_KEY, key)));
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -263,7 +263,7 @@ public class CreateProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
             String.format(
-                "Expected to find process definition with process ID '%s' and tenant ID '%s', but none found",
+                "Expected to find process definition with process ID '%s', but none found",
                 processId, fakeTenantId));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionRejectionTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import org.junit.Rule;
@@ -80,8 +79,8 @@ public class ResourceDeletionRejectionTest {
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
             String.format(
-                "Expected to find process definition with process ID '%s' and tenant ID '%s', but none found",
-                processId, TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+                "Expected to find process definition with process ID '%s', but none found",
+                processId));
   }
 
   @Test
@@ -104,8 +103,8 @@ public class ResourceDeletionRejectionTest {
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
             String.format(
-                "Expected to find process definition with process ID '%s', tenant ID '%s', and version '%d', but none found",
-                processId, TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1));
+                "Expected to find process definition with process ID '%s' and version '%d', but none found",
+                processId, 1));
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
@@ -273,7 +273,7 @@ public final class CreateProcessInstanceTest {
     assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
         .hasMessageContaining(
-            "Expected to find process definition with process ID 'non-existing' and tenant ID '<default>', but none found");
+            "Expected to find process definition with process ID 'non-existing', but none found");
   }
 
   @Test
@@ -284,8 +284,7 @@ public final class CreateProcessInstanceTest {
 
     assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
-        .hasMessageContaining(
-            "Expected to find process definition with key '123' and tenant ID '<default>', but none found");
+        .hasMessageContaining("Expected to find process definition with key '123', but none found");
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceWithResultTest.java
@@ -146,8 +146,7 @@ public final class CreateProcessInstanceWithResultTest {
 
     assertThatThrownBy(() -> command.join())
         .isInstanceOf(ClientException.class)
-        .hasMessageContaining(
-            "Expected to find process definition with key '123' and tenant ID '<default>', but none found");
+        .hasMessageContaining("Expected to find process definition with key '123', but none found");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Reverts the CreateProcessInstanceProcessor error messages into their tenant-unaware state since tenant information doesn't provide a lot of value, but breaks a lot of existing code.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14390 
related to #13279

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
