### PR TITLE
Use new test infra for AdvertisedAddressTest

### DIFF
--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.util.unit.DataSize;
 
 /** Represents an instance of the {@link StandaloneBroker} Spring application. */
 @SuppressWarnings("UnusedReturnValue")
@@ -40,6 +41,12 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     config.getNetwork().getCommandApi().setPort(SocketUtil.getNextAddress().getPort());
     config.getNetwork().getInternalApi().setPort(SocketUtil.getNextAddress().getPort());
     config.getGateway().getNetwork().setPort(SocketUtil.getNextAddress().getPort());
+
+    // set a smaller default log segment size since we pre-allocate, which might be a lot in tests
+    // for local development; also lower the watermarks for local testing
+    config.getData().setLogSegmentSize(DataSize.ofMegabytes(16));
+    config.getData().getDisk().getFreeSpace().setProcessing(DataSize.ofMegabytes(128));
+    config.getData().getDisk().getFreeSpace().setReplication(DataSize.ofMegabytes(64));
 
     //noinspection resource
     withBean("uninitializedBrokerCfg", config, BrokerCfg.class);

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -215,7 +215,8 @@ final class ZeebeIntegrationExtension
 
   private Path createManagedDirectory(final Store store, final String prefix) {
     try {
-      final var directory = Files.createTempDirectory(prefix);
+      // add the common junit prefix to clearly indicate these are test folders
+      final var directory = Files.createTempDirectory("junit-" + prefix);
       store.put(directory, new DirectoryResource(directory));
       return directory;
     } catch (final IOException e) {


### PR DESCRIPTION
## Description

This PR refactors `AdvertistedAddressTest` to use the new testing infrastructure, showcasing how to use Toxiproxy with local services.

## Related issues

related to #14377 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
