### PR TITLE
Migrate backup acceptance IT to new testing infra

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
@@ -13,32 +13,30 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import feign.FeignException;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
-import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.PartitionBackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.StateCode;
 import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
-import io.zeebe.containers.ZeebeBrokerNode;
-import io.zeebe.containers.ZeebeNode;
-import io.zeebe.containers.ZeebePort;
-import io.zeebe.containers.cluster.ZeebeCluster;
-import io.zeebe.containers.engine.ContainerEngine;
 import java.time.Duration;
+import java.util.Map;
 import org.agrona.CloseHelper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.groups.Tuple;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -54,46 +52,30 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * maintain consistency via checkpoint records. Other test suites should be set up for this.
  */
 @Testcontainers
+@ZeebeIntegration
 final class S3BackupAcceptanceIT {
-  private static final Network NETWORK = Network.newNetwork();
-
   private final String bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
   @Container
-  private final MinioContainer minio =
-      new MinioContainer().withNetwork(NETWORK).withDomain("minio.local", bucketName);
+  private final MinioContainer minio = new MinioContainer().withDomain("minio.local", bucketName);
 
-  private final ZeebeCluster cluster =
-      ZeebeCluster.builder()
-          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
-          .withNetwork(NETWORK)
+  @RegisterExtension
+  @SuppressWarnings("unused")
+  final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(() -> Map.of("minio", minio));
+
+  // cannot auto start, as we need minio to be started before we can configure the brokers
+  @TestZeebe(autoStart = false)
+  private final TestCluster cluster =
+      TestCluster.builder()
           .withBrokersCount(2)
           .withGatewaysCount(1)
           .withReplicationFactor(1)
           .withPartitionsCount(2)
           .withEmbeddedGateway(false)
-          .withBrokerConfig(this::configureBroker)
           .withNodeConfig(this::configureNode)
           .build();
 
-  @RegisterExtension
-  @SuppressWarnings("unused")
-  final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(cluster::getNodes);
-
-  @Container
-  private final ContainerEngine engine =
-      ContainerEngine.builder()
-          .withDebugReceiverPort(SocketUtil.getNextAddress().getPort())
-          .withAutoAcknowledge(true)
-          .withCluster(cluster)
-          .build();
-
   private S3BackupStore store;
-
-  @AfterAll
-  static void afterAll() {
-    CloseHelper.quietCloseAll(NETWORK);
-  }
 
   @BeforeEach
   void beforeEach() {
@@ -111,6 +93,11 @@ final class S3BackupAcceptanceIT {
     try (final var client = S3BackupStore.buildClient(config)) {
       client.createBucket(builder -> builder.bucket(config.bucketName()).build()).join();
     }
+
+    // we have to configure the cluster here, after minio is started, as otherwise we won't have
+    // access to the exposed port
+    cluster.brokers().values().forEach(this::configureBroker);
+    cluster.start().awaitCompleteTopology();
   }
 
   @AfterEach
@@ -121,8 +108,8 @@ final class S3BackupAcceptanceIT {
   @Test
   void shouldTakeBackup() {
     // given
-    final var actuator = BackupActuator.of(cluster.getAvailableGateway());
-    try (final var client = engine.createClient()) {
+    final var actuator = BackupActuator.ofAddress(cluster.availableGateway().monitoringAddress());
+    try (final var client = cluster.newClientBuilder().build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
 
@@ -154,8 +141,8 @@ final class S3BackupAcceptanceIT {
   @Test
   void shouldListBackups() {
     // given
-    final var actuator = BackupActuator.of(cluster.getAvailableGateway());
-    try (final var client = engine.createClient()) {
+    final var actuator = BackupActuator.ofAddress(cluster.availableGateway().monitoringAddress());
+    try (final var client = cluster.newClientBuilder().build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
 
@@ -178,7 +165,7 @@ final class S3BackupAcceptanceIT {
   @Test
   void shouldDeleteBackup() {
     // given
-    final var actuator = BackupActuator.of(cluster.getAvailableGateway());
+    final var actuator = BackupActuator.ofAddress(cluster.availableGateway().monitoringAddress());
     final long backupId = 1;
     actuator.take(backupId);
     waitUntilBackupIsCompleted(actuator, backupId);
@@ -197,19 +184,23 @@ final class S3BackupAcceptanceIT {
                     .isEqualTo(404));
   }
 
-  private void configureBroker(final ZeebeBrokerNode<?> broker) {
-    broker
-        .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "S3")
-        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME", bucketName)
-        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ENDPOINT", minio.internalEndpoint())
-        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_REGION", minio.region())
-        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ACCESSKEY", minio.accessKey())
-        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_SECRETKEY", minio.secretKey())
-        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS", "true");
+  private void configureBroker(final TestStandaloneBroker broker) {
+    broker.withBrokerConfig(
+        cfg -> {
+          final var backup = cfg.getData().getBackup();
+          final var s3 = backup.getS3();
+
+          backup.setStore(BackupStoreType.S3);
+          s3.setBucketName(bucketName);
+          s3.setEndpoint(minio.externalEndpoint());
+          s3.setRegion(minio.region());
+          s3.setAccessKey(minio.accessKey());
+          s3.setSecretKey(minio.secretKey());
+          s3.setForcePathStyleAccess(true);
+        });
   }
 
-  private void configureNode(final ZeebeNode<?> node) {
-    node.withEnv("MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE", "*").dependsOn(minio);
-    node.addExposedPort(ZeebePort.MONITORING.getPort());
+  private void configureNode(final TestApplication<?> node) {
+    node.withProperty("management.endpoints.web.exposure.include", "*");
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3RestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3RestoreAcceptanceIT.java
@@ -15,49 +15,52 @@ import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
-import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
-import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.restore.BackupNotFoundException;
 import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
 import io.camunda.zeebe.shared.management.openapi.models.StateCode;
 import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
-import io.zeebe.containers.ZeebeContainer;
 import java.time.Duration;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
+@ZeebeIntegration
 final class S3RestoreAcceptanceIT {
-  private static final Network NETWORK = Network.newNetwork();
   private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
   private static final long BACKUP_ID = 1;
 
   @Container
   private static final MinioContainer MINIO =
-      new MinioContainer().withNetwork(NETWORK).withDomain("minio.local", BUCKET_NAME);
+      new MinioContainer().withDomain("minio.local", BUCKET_NAME);
 
-  @Container
-  private final ZeebeContainer zeebe =
-      new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
-          .withNetwork(NETWORK)
-          .dependsOn(MINIO)
-          .withoutTopologyCheck()
-          .withEnv("MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE", "*")
-          .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "S3")
-          .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME", BUCKET_NAME)
-          .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ENDPOINT", MINIO.internalEndpoint())
-          .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_REGION", MINIO.region())
-          .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ACCESSKEY", MINIO.accessKey())
-          .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_SECRETKEY", MINIO.secretKey());
+  @TestZeebe(awaitCompleteTopology = false)
+  private final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker()
+          .withProperty("management.endpoints.web.exposure.include", "*")
+          .withBrokerConfig(
+              cfg -> {
+                final var backup = cfg.getData().getBackup();
+                final var s3 = backup.getS3();
+
+                backup.setStore(BackupStoreType.S3);
+                s3.setBucketName(BUCKET_NAME);
+                s3.setEndpoint(MINIO.externalEndpoint());
+                s3.setRegion(MINIO.region());
+                s3.setAccessKey(MINIO.accessKey());
+                s3.setSecretKey(MINIO.secretKey());
+                s3.setForcePathStyleAccess(true);
+              });
 
   @BeforeAll
   static void setupBucket() {
@@ -78,12 +81,8 @@ final class S3RestoreAcceptanceIT {
   @Test
   void shouldRunRestore() {
     // given
-    final var actuator = BackupActuator.of(zeebe);
-    try (final var client =
-        ZeebeClient.newClientBuilder()
-            .gatewayAddress(zeebe.getExternalGatewayAddress())
-            .usePlaintext()
-            .build()) {
+    final var actuator = BackupActuator.ofAddress(zeebe.monitoringAddress());
+    try (final var client = zeebe.newClientBuilder().build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
     final var response = actuator.take(BACKUP_ID);
@@ -124,12 +123,8 @@ final class S3RestoreAcceptanceIT {
   @Test
   void shouldFailForNonExistingBackup() {
     // given
-    final var actuator = BackupActuator.of(zeebe);
-    try (final var client =
-        ZeebeClient.newClientBuilder()
-            .gatewayAddress(zeebe.getExternalGatewayAddress())
-            .usePlaintext()
-            .build()) {
+    final var actuator = BackupActuator.ofAddress(zeebe.monitoringAddress());
+    try (final var client = zeebe.newClientBuilder().build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
     final var response = actuator.take(BACKUP_ID);


### PR DESCRIPTION
## Description

This PR migrates existing backup acceptance IT to the new testing infra. One of them could not be backported, as it relies on AWS picking up credentials via `System.getenv`, something we can't really mock without an isolated environment.

## Related issues

related to #14377

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
