### PR TITLE
Allow filtering picked job streams by activation properties

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamer.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
 import java.util.Optional;
+import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 
 public final class RemoteJobStreamer implements JobStreamer {
@@ -34,7 +35,8 @@ public final class RemoteJobStreamer implements JobStreamer {
   }
 
   @Override
-  public Optional<JobStream> streamFor(final DirectBuffer jobType) {
-    return delegate.streamFor(jobType).map(RemoteJobStream::new);
+  public Optional<JobStream> streamFor(
+      final DirectBuffer jobType, final Predicate<JobActivationProperties> filter) {
+    return delegate.streamFor(jobType, filter).map(RemoteJobStream::new);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingJobStreamer.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingJobStreamer.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 
 public class RecordingJobStreamer implements JobStreamer {
@@ -31,7 +32,9 @@ public class RecordingJobStreamer implements JobStreamer {
   }
 
   @Override
-  public Optional<JobStream> streamFor(final DirectBuffer jobType) {
+  public Optional<JobStream> streamFor(
+      final DirectBuffer jobType, final Predicate<JobActivationProperties> ignored) {
+    // TODO: filter by activation properties using the predicate :)
     return Optional.ofNullable(jobStreams.get(jobType));
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamer.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.transport.stream.api;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Optional;
+import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 
 /**
@@ -24,6 +25,20 @@ import org.agrona.DirectBuffer;
 public interface RemoteStreamer<M extends BufferReader, P extends BufferWriter> {
   /**
    * Returns a valid stream for the given streamType, or {@link Optional#empty()} if there is none.
+   *
+   * <p>The predicate should return false to exclude streams from the list of possible streams.
+   *
+   * @param streamType the job type to look for
+   * @param filter a filter to include/exclude eligible job streams based on their properties
+   * @return a job stream which matches the type and given filter, or {@link Optional#empty()} if
+   *     none match
    */
-  Optional<RemoteStream<M, P>> streamFor(DirectBuffer streamType);
+  Optional<RemoteStream<M, P>> streamFor(DirectBuffer streamType, Predicate<M> filter);
+
+  /**
+   * Returns a valid stream for the given streamType, or {@link Optional#empty()} if there is none.
+   */
+  default Optional<RemoteStream<M, P>> streamFor(final DirectBuffer jobType) {
+    return streamFor(jobType, ignored -> true);
+  }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -59,9 +61,13 @@ public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWr
   }
 
   @Override
-  public Optional<RemoteStream<M, P>> streamFor(final DirectBuffer streamType) {
+  public Optional<RemoteStream<M, P>> streamFor(
+      final DirectBuffer streamType, final Predicate<M> filter) {
     final UnsafeBuffer streamTypeBuffer = new UnsafeBuffer(streamType);
-    final var consumers = registry.get(streamTypeBuffer);
+    final var consumers =
+        registry.get(streamTypeBuffer).stream()
+            .filter(s -> filter.test(s.metadata()))
+            .collect(Collectors.toSet());
     if (consumers.isEmpty()) {
       return Optional.empty();
     }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Objects;
 import java.util.UUID;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -65,7 +66,7 @@ final class RemoteStreamerTest {
     // given
     final var type = new UnsafeBuffer(BufferUtil.wrapString("foo"));
     final var streamId = new StreamId(UUID.randomUUID(), MemberId.from("a"));
-    final var metadata = new TestMetadata();
+    final var metadata = new TestMetadata(1);
     registry.add(type, streamId.streamId(), streamId.receiver(), metadata);
 
     // when
@@ -76,11 +77,33 @@ final class RemoteStreamerTest {
   }
 
   @Test
+  void shouldFilterStreamForWithPredicate() {
+    // given
+    final var type = new UnsafeBuffer(BufferUtil.wrapString("foo"));
+    final var streamAId = new StreamId(UUID.randomUUID(), MemberId.from("a"));
+    final var streamAMeta = new TestMetadata(1);
+    final var streamBId = new StreamId(UUID.randomUUID(), MemberId.from("b"));
+    final var streamBMeta = new TestMetadata(2);
+    registry.add(type, streamBId.streamId(), streamBId.receiver(), streamBMeta);
+    registry.add(type, streamAId.streamId(), streamAId.receiver(), streamAMeta);
+
+    // when
+    final var streamA = streamer.streamFor(type, m -> m.id() == 1).orElseThrow();
+    final var streamB = streamer.streamFor(type, m -> m.id() == 2).orElseThrow();
+    final var empty = streamer.streamFor(type, Objects::isNull);
+
+    // then
+    assertThat(streamA.metadata()).isSameAs(streamAMeta);
+    assertThat(streamB.metadata()).isSameAs(streamBMeta);
+    assertThat(empty).isEmpty();
+  }
+
+  @Test
   void shouldPush() {
     // given - a registry which returns a set of consumers sorted by their member IDs
     final var type = new UnsafeBuffer(BufferUtil.wrapString("foo"));
     final var streamId = new StreamId(UUID.randomUUID(), MemberId.from("a"));
-    final var metadata = new TestMetadata();
+    final var metadata = new TestMetadata(1);
     final var payload = new TestPayload(1);
     registry.add(type, streamId.streamId(), streamId.receiver(), metadata);
 
@@ -111,7 +134,7 @@ final class RemoteStreamerTest {
     public void write(final MutableDirectBuffer buffer, final int offset) {}
   }
 
-  private record TestMetadata() implements BufferReader {
+  private record TestMetadata(int id) implements BufferReader {
 
     @Override
     public void wrap(final DirectBuffer buffer, final int offset, final int length) {}


### PR DESCRIPTION
## Description

This PR allows filtering eligible job streams before returning them to the engine. This enables use cases such as only selecting job streams with matching tenants.

There are no integration tests because the engine part is not yet done as far as I'm aware.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
