### PR TITLE
Add a basic qa test to verify a cluster can start when dynamic topology is enabled

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -172,8 +172,8 @@ public final class BrokerTopologyManagerImpl extends Actor
     // correct value even when the dynamic ClusterTopology is disabled.
     if (newTopology.getClusterSize() == BrokerClusterStateImpl.UNINITIALIZED_CLUSTER_SIZE) {
       newTopology.setClusterSize(distributedBrokerInfo.getClusterSize());
+      newTopology.setPartitionsCount(distributedBrokerInfo.getPartitionsCount());
     }
-    newTopology.setPartitionsCount(distributedBrokerInfo.getPartitionsCount());
     newTopology.setReplicationFactor(distributedBrokerInfo.getReplicationFactor());
 
     final int nodeId = distributedBrokerInfo.getNodeId();
@@ -224,6 +224,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
           // Overwrite clusterSize. ClusterTopology is the source of truth.
           newTopology.setClusterSize(clusterTopology.clusterSize());
+          newTopology.setPartitionsCount(clusterTopology.getPartitionCount());
 
           LOG.debug(
               "Received new cluster topology with clusterSize {}", newTopology.getClusterSize());

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -224,7 +224,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
           // Overwrite clusterSize. ClusterTopology is the source of truth.
           newTopology.setClusterSize(clusterTopology.clusterSize());
-          newTopology.setPartitionsCount(clusterTopology.getPartitionCount());
+          newTopology.setPartitionsCount(clusterTopology.partitionCount());
 
           LOG.debug(
               "Received new cluster topology with clusterSize {}", newTopology.getClusterSize());

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/topology/dynamic/DynamicClusterTopologyServiceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/topology/dynamic/DynamicClusterTopologyServiceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering.topology.dynamic;
+
+import static io.camunda.zeebe.test.util.asserts.TopologyAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+final class DynamicClusterTopologyServiceTest {
+  private static final int PARTITIONS_COUNT = 3;
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(3)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(1)
+          .withBrokerConfig(this::configureDynamicClusterTopology)
+          .build();
+
+  @Test
+  void shouldStartClusterWithDynamicTopology() {
+    try (final var client = cluster.newClientBuilder().build()) {
+      final var topology = client.newTopologyRequest().send().join();
+      assertThat(topology)
+          .describedAs(
+              "Expected topology to have %d partitions distributed over 3 brokers",
+              PARTITIONS_COUNT)
+          .hasLeaderForPartition(1, 0)
+          .hasLeaderForPartition(2, 1)
+          .hasLeaderForPartition(3, 2);
+    }
+  }
+
+  private void configureDynamicClusterTopology(
+      final MemberId memberId, final TestStandaloneBroker broker) {
+    broker.withBrokerConfig(
+        b -> {
+          b.getExperimental().getFeatures().setEnableDynamicClusterTopology(true);
+          if (!memberId.id().equals("0")) {
+            // not coordinator. Give wrong configuration to verify that it is overwritten by dynamic
+            // cluster topology. Note that this would not work in production because the engine
+            // still reads the partition count from the static configuration, so message correlation
+            // would not work.
+            b.getCluster().setPartitionsCount(1);
+          }
+        });
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
 
 /** Convenience class to assert certain properties of a Zeebe cluster {@link Topology}. */
 @SuppressWarnings("UnusedReturnValue")
@@ -237,6 +238,23 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
             partitionId, leaders.stream().map(PartitionBroker::brokerInfo).toList());
       }
     }
+
+    return myself;
+  }
+
+  public TopologyAssert hasLeaderForPartition(final int partitionId, final int expectedLeaderId) {
+    isNotNull();
+
+    final Map<Integer, List<PartitionBroker>> partitionMap = buildPartitionsMap();
+
+    Assertions.assertThat(partitionMap).containsKey(partitionId);
+    final var partitionBrokers = partitionMap.get(partitionId);
+    final var leader =
+        partitionBrokers.stream()
+            .filter(p -> p.partitionInfo.isLeader())
+            .map(p -> p.brokerInfo.getNodeId())
+            .findFirst();
+    Assertions.assertThat(leader).hasValue(expectedLeaderId);
 
     return myself;
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -196,10 +196,8 @@ public record ClusterTopology(
             .count();
   }
 
-  public int getPartitionCount() {
-    return members.values().stream()
-        .flatMap(m -> m.partitions().keySet().stream())
-        .collect(Collectors.toSet())
-        .size();
+  public int partitionCount() {
+    return (int)
+        members.values().stream().flatMap(m -> m.partitions().keySet().stream()).distinct().count();
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -195,4 +195,11 @@ public record ClusterTopology(
                         && entry.getValue().state() != State.UNINITIALIZED)
             .count();
   }
+
+  public int getPartitionCount() {
+    return members.values().stream()
+        .flatMap(m -> m.partitions().keySet().stream())
+        .collect(Collectors.toSet())
+        .size();
+  }
 }


### PR DESCRIPTION
- Add a basic qa test to verify that cluster can start when dynamic topology management is enabled. The test only verifies that the cluster is started and the topology is as expected.
- Even though we don't allow changing `paritionCount`, it makes sense to read it from the `ClusterTopology`. So the gateway topology manager is updated to calculate partition count from cluster topology.

related to #13765