### PR TITLE
Remove scheduler dependency from zeebe-expression-language module

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -110,6 +110,12 @@
       <artifactId>guava</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.camunda.feel</groupId>
+      <artifactId>feel-engine</artifactId>
+      <version>1.16.1</version>
+    </dependency>
+
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -113,7 +113,6 @@
     <dependency>
       <groupId>org.camunda.feel</groupId>
       <artifactId>feel-engine</artifactId>
-      <version>1.16.1</version>
     </dependency>
 
     <!-- TEST DEPENDENCIES -->

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.processing.variable.VariableStateEvaluationContextLookup;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 
 public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
@@ -56,7 +58,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final JobStreamer jobStreamer) {
     expressionBehavior =
         new ExpressionProcessor(
-            ExpressionLanguageFactory.createExpressionLanguage(),
+            ExpressionLanguageFactory.createExpressionLanguage(
+                new ZeebeFeelEngineClock(ActorClock.current())),
             new VariableStateEvaluationContextLookup(processingState.getVariableState()));
 
     variableBehavior =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/clock/ZeebeFeelEngineClock.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/clock/ZeebeFeelEngineClock.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.el.impl;
+package io.camunda.zeebe.engine.processing.bpmn.clock;
 
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.time.Instant;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -9,21 +9,27 @@ package io.camunda.zeebe.engine.processing.deployment.model;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidator;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 
 public final class BpmnFactory {
 
   public static BpmnTransformer createTransformer() {
-    return new BpmnTransformer(createExpressionLanguage());
+    return new BpmnTransformer(
+        createExpressionLanguage(new ZeebeFeelEngineClock(ActorClock.current())));
   }
 
   public static BpmnValidator createValidator(final ExpressionProcessor expressionProcessor) {
-    return new BpmnValidator(createExpressionLanguage(), expressionProcessor);
+    return new BpmnValidator(
+        createExpressionLanguage(new ZeebeFeelEngineClock(ActorClock.current())),
+        expressionProcessor);
   }
 
-  private static ExpressionLanguage createExpressionLanguage() {
-    return ExpressionLanguageFactory.createExpressionLanguage();
+  private static ExpressionLanguage createExpressionLanguage(
+      final ZeebeFeelEngineClock zeebeFeelEngineClock) {
+    return ExpressionLanguageFactory.createExpressionLanguage(zeebeFeelEngineClock);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -11,12 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -32,7 +34,8 @@ class UserTaskTransformerTest {
   private static final String TASK_ID = "user-task";
 
   private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(ActorClock.current()));
   private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
 
   private BpmnModelInstance processWithUserTask(final Consumer<UserTaskBuilder> userTaskModifier) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -12,7 +12,9 @@ import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import io.camunda.zeebe.el.EvaluationContext;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.stream.Stream;
@@ -26,7 +28,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ExpressionProcessorTest {
 
   private static final ExpressionLanguage EXPRESSION_LANGUAGE =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(ActorClock.current()));
   private static final EvaluationContext EMPTY_LOOKUP = x -> null;
   private static final EvaluationContextLookup DEFAULT_CONTEXT_LOOKUP = scope -> EMPTY_LOOKUP;
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.el.impl.FeelExpressionLanguage;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
@@ -45,7 +46,7 @@ public class ProcessMessageStartEventMessageNameValidatorTest {
 
     final var sutValidator =
         new ProcessMessageStartEventMessageNameValidator(
-            new FeelExpressionLanguage(ActorClock.current()));
+            new FeelExpressionLanguage(new ZeebeFeelEngineClock(ActorClock.current())));
 
     // when
     assertThatNoException()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessSignalStartEventSignalNameValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessSignalStartEventSignalNameValidatorTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.el.impl.FeelExpressionLanguage;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
@@ -45,7 +46,7 @@ public class ProcessSignalStartEventSignalNameValidatorTest {
 
     final var sutValidator =
         new ProcessSignalStartEventSignalNameValidator(
-            new FeelExpressionLanguage(ActorClock.current()));
+            new FeelExpressionLanguage(new ZeebeFeelEngineClock(ActorClock.current())));
 
     // when
     assertThatNoException()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import io.camunda.zeebe.model.bpmn.validation.ValidationVisitor;
 import io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebeDesignTimeValidators;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,7 +52,8 @@ public class ProcessValidationUtil {
   private static ValidationResults validate(final BpmnModelInstance model) {
     final ModelWalker walker = new ModelWalker(model);
     final ExpressionLanguage expressionLanguage =
-        ExpressionLanguageFactory.createExpressionLanguage();
+        ExpressionLanguageFactory.createExpressionLanguage(
+            new ZeebeFeelEngineClock(ActorClock.current()));
     final EvaluationContextLookup emptyLookup = scopeKey -> name -> null;
     final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
     final ValidationVisitor visitor =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ExpressionTransformer;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import io.camunda.zeebe.model.bpmn.validation.ValidationVisitor;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -460,7 +462,8 @@ public final class ZeebeRuntimeValidationTest {
   private static ValidationResults validate(final BpmnModelInstance model) {
     final ModelWalker walker = new ModelWalker(model);
     final ExpressionLanguage expressionLanguage =
-        ExpressionLanguageFactory.createExpressionLanguage();
+        ExpressionLanguageFactory.createExpressionLanguage(
+            new ZeebeFeelEngineClock(ActorClock.current()));
     final EvaluationContextLookup emptyLookup = scopeKey -> name -> null;
     final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
     final ValidationVisitor visitor =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -13,8 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +41,8 @@ public final class VariableInputMappingTransformerTest {
 
   private final VariableMappingTransformer transformer = new VariableMappingTransformer();
   private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(ActorClock.current()));
 
   @Parameters(name = "with {0} to {2}")
   public static Object[][] parameters() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -14,8 +14,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.util.List;
 import org.junit.Test;
 
@@ -23,7 +25,8 @@ public final class VariableMappingTransformerTest {
 
   private final VariableMappingTransformer transformer = new VariableMappingTransformer();
   private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(ActorClock.current()));
 
   @Test
   public void shouldCreateValidExpression() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -13,8 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +29,8 @@ public final class VariableOutputMappingTransformerTest {
 
   private final VariableMappingTransformer transformer = new VariableMappingTransformer();
   private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(ActorClock.current()));
 
   public static Object[][] parametersSuccessfulEvaluationToObject() {
     return new Object[][] {

--- a/expression-language/pom.xml
+++ b/expression-language/pom.xml
@@ -27,11 +27,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-scheduler</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-feel-integration</artifactId>
     </dependency>
 

--- a/expression-language/src/main/java/io/camunda/zeebe/el/Expression.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/Expression.java
@@ -24,7 +24,7 @@ public interface Expression {
   Optional<String> getVariableName();
 
   /**
-   * @return {@code true} if it is an static expression that does not require additional context
+   * @return {@code true} if it is a static expression that does not require additional context
    *     variables
    */
   boolean isStatic();

--- a/expression-language/src/main/java/io/camunda/zeebe/el/ExpressionLanguageFactory.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/ExpressionLanguageFactory.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.el;
 
 import io.camunda.zeebe.el.impl.FeelExpressionLanguage;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import org.camunda.feel.FeelEngineClock;
 
 /** The entry point to create the default {@link ExpressionLanguage}. */
 public class ExpressionLanguageFactory {
@@ -16,7 +16,7 @@ public class ExpressionLanguageFactory {
   /**
    * @return a new instance of the {@link ExpressionLanguage}
    */
-  public static ExpressionLanguage createExpressionLanguage() {
-    return new FeelExpressionLanguage(ActorClock.current());
+  public static ExpressionLanguage createExpressionLanguage(final FeelEngineClock feelEngineClock) {
+    return new FeelExpressionLanguage(feelEngineClock);
   }
 }

--- a/expression-language/src/main/java/io/camunda/zeebe/el/impl/FeelExpressionLanguage.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/impl/FeelExpressionLanguage.java
@@ -18,10 +18,10 @@ import io.camunda.zeebe.el.impl.feel.FeelVariableContext;
 import io.camunda.zeebe.feel.impl.FeelFunctionProvider;
 import io.camunda.zeebe.feel.impl.FeelToMessagePackTransformer;
 import io.camunda.zeebe.feel.impl.MessagePackValueMapper;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.util.regex.Pattern;
 import org.camunda.feel.FeelEngine;
 import org.camunda.feel.FeelEngine.Failure;
+import org.camunda.feel.FeelEngineClock;
 import org.camunda.feel.syntaxtree.ParsedExpression;
 import org.camunda.feel.syntaxtree.Val;
 import scala.util.Either;
@@ -42,12 +42,12 @@ public final class FeelExpressionLanguage implements ExpressionLanguage {
 
   private final FeelEngine feelEngine;
 
-  public FeelExpressionLanguage(final ActorClock clock) {
+  public FeelExpressionLanguage(final FeelEngineClock clock) {
     feelEngine =
         new FeelEngine.Builder()
             .customValueMapper(new MessagePackValueMapper())
             .functionProvider(new FeelFunctionProvider())
-            .clock(new ZeebeFeelEngineClock(clock))
+            .clock(clock)
             .build();
   }
 

--- a/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationContextTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationContextTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.el;
 import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.el.util.TestFeelEngineClock;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.junit.Test;
@@ -17,7 +18,7 @@ import org.junit.Test;
 public class EvaluationContextTest {
 
   private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(new TestFeelEngineClock());
 
   @Test
   public void stringVariable() {

--- a/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.el;
 import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.el.util.TestFeelEngineClock;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.Period;
@@ -21,7 +22,7 @@ import org.junit.Test;
 public class EvaluationResultTest {
 
   private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(new TestFeelEngineClock());
 
   @Test
   public void staticString() {

--- a/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.impl.StaticExpression;
+import io.camunda.zeebe.el.util.TestFeelEngineClock;
 import java.util.Map;
 import org.junit.Test;
 
@@ -19,7 +20,7 @@ public class ExpressionLanguageTest {
   private static final EvaluationContext EMPTY_CONTEXT = name -> null;
 
   private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(new TestFeelEngineClock());
 
   @Test
   public void shouldParseStaticStringValue() {

--- a/expression-language/src/test/java/io/camunda/zeebe/el/FeelCycleFunctionTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/FeelCycleFunctionTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.el;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.el.util.TestFeelEngineClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.Map;
 import org.junit.Test;
@@ -18,7 +19,7 @@ public class FeelCycleFunctionTest {
   private static final EvaluationContext EMPTY_CONTEXT = x -> null;
 
   private final ExpressionLanguage expressionLanguage =
-      ExpressionLanguageFactory.createExpressionLanguage();
+      ExpressionLanguageFactory.createExpressionLanguage(new TestFeelEngineClock());
 
   @Test
   public void emptyDuration() {

--- a/expression-language/src/test/java/io/camunda/zeebe/el/FeelExpressionTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/FeelExpressionTest.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.impl.FeelExpressionLanguage;
-import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import io.camunda.zeebe.el.util.TestFeelEngineClock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -22,7 +22,7 @@ public class FeelExpressionTest {
 
   private static final EvaluationContext EMPTY_CONTEXT = name -> null;
 
-  private final ControlledActorClock clock = new ControlledActorClock();
+  private final TestFeelEngineClock clock = new TestFeelEngineClock();
 
   private final ExpressionLanguage expressionLanguage = new FeelExpressionLanguage(clock);
 

--- a/expression-language/src/test/java/io/camunda/zeebe/el/util/TestFeelEngineClock.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/util/TestFeelEngineClock.java
@@ -14,14 +14,14 @@ import org.camunda.feel.FeelEngineClock;
 
 public class TestFeelEngineClock implements FeelEngineClock {
 
-  private long currentTime = -1;
+  private Instant currentTime = null;
 
   @Override
   public ZonedDateTime getCurrentTime() {
-    return Instant.ofEpochMilli(currentTime).atZone(ZoneId.systemDefault());
+    return currentTime.atZone(ZoneId.systemDefault());
   }
 
   public void setCurrentTime(final Instant currentTime) {
-    this.currentTime = currentTime.toEpochMilli();
+    this.currentTime = currentTime;
   }
 }

--- a/expression-language/src/test/java/io/camunda/zeebe/el/util/TestFeelEngineClock.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/util/TestFeelEngineClock.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.el.util;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.camunda.feel.FeelEngineClock;
+
+public class TestFeelEngineClock implements FeelEngineClock {
+
+  private long currentTime = -1;
+
+  @Override
+  public ZonedDateTime getCurrentTime() {
+    return Instant.ofEpochMilli(currentTime).atZone(ZoneId.systemDefault());
+  }
+
+  public void setCurrentTime(final Instant currentTime) {
+    this.currentTime = currentTime.toEpochMilli();
+  }
+}


### PR DESCRIPTION
## Description

Removes scheduler dependency from zeebe-expression-language module. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9609

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
