### PR TITLE
refactor(broker): (de-)register partitions in startup process

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.partitioning;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
 import io.camunda.zeebe.broker.partitioning.startup.steps.PartitionDirectoryStep;
+import io.camunda.zeebe.broker.partitioning.startup.steps.PartitionRegistrationStep;
 import io.camunda.zeebe.broker.partitioning.startup.steps.RaftBootstrapStep;
 import io.camunda.zeebe.broker.partitioning.startup.steps.RaftJoinStep;
 import io.camunda.zeebe.broker.partitioning.startup.steps.SnapshotStoreStep;
@@ -64,7 +65,8 @@ public final class Partition {
                 new PartitionDirectoryStep(),
                 new SnapshotStoreStep(),
                 new RaftBootstrapStep(),
-                new ZeebePartitionStep())));
+                new ZeebePartitionStep(),
+                new PartitionRegistrationStep())));
   }
 
   public static Partition joining(final PartitionStartupContext context) {
@@ -75,7 +77,8 @@ public final class Partition {
                 new PartitionDirectoryStep(),
                 new SnapshotStoreStep(),
                 new RaftJoinStep(),
-                new ZeebePartitionStep())));
+                new ZeebePartitionStep(),
+                new PartitionRegistrationStep())));
   }
 
   public ActorFuture<Partition> start() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
@@ -10,7 +10,10 @@ package io.camunda.zeebe.broker.partitioning.startup;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -19,7 +22,10 @@ import java.nio.file.Path;
 
 public final class PartitionStartupContext {
   private final ActorSchedulingService schedulingService;
+  private final TopologyManager topologyManager;
   private final ConcurrencyControl concurrencyControl;
+  private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
+  private final BrokerHealthCheckService healthCheckService;
   private final PartitionManagementService partitionManagementService;
   private final PartitionMetadata partitionMetadata;
   private final RaftPartitionFactory raftPartitionFactory;
@@ -35,13 +41,19 @@ public final class PartitionStartupContext {
   public PartitionStartupContext(
       final ActorSchedulingService schedulingService,
       final ConcurrencyControl concurrencyControl,
+      final TopologyManager topologyManager,
+      final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
+      final BrokerHealthCheckService healthCheckService,
       final PartitionManagementService partitionManagementService,
       final PartitionMetadata partitionMetadata,
       final RaftPartitionFactory raftPartitionFactory,
       final ZeebePartitionFactory zeebePartitionFactory,
       final BrokerCfg brokerConfig) {
     this.schedulingService = schedulingService;
+    this.topologyManager = topologyManager;
     this.concurrencyControl = concurrencyControl;
+    this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
+    this.healthCheckService = healthCheckService;
     this.partitionManagementService = partitionManagementService;
     this.partitionMetadata = partitionMetadata;
     this.raftPartitionFactory = raftPartitionFactory;
@@ -60,6 +72,18 @@ public final class PartitionStartupContext {
 
   public ConcurrencyControl concurrencyControl() {
     return concurrencyControl;
+  }
+
+  public TopologyManager topologyManager() {
+    return topologyManager;
+  }
+
+  public DiskSpaceUsageMonitor diskSpaceUsageMonitor() {
+    return diskSpaceUsageMonitor;
+  }
+
+  public BrokerHealthCheckService brokerHealthCheckService() {
+    return healthCheckService;
   }
 
   public PartitionManagementService partitionManagementService() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupAndTransitionContextImpl;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupContext;
@@ -91,7 +90,6 @@ public final class ZeebePartitionFactory {
   private final CommandApiService commandApiService;
   private final ClusterServices clusterServices;
   private final ExporterRepository exporterRepository;
-  private final BrokerHealthCheckService healthCheckService;
   private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private final AtomixServerTransport gatewayBrokerTransport;
   private final JobStreamer jobStreamer;
@@ -107,7 +105,6 @@ public final class ZeebePartitionFactory {
       final CommandApiService commandApiService,
       final ClusterServices clusterServices,
       final ExporterRepository exporterRepository,
-      final BrokerHealthCheckService healthCheckService,
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final AtomixServerTransport gatewayBrokerTransport,
       final JobStreamer jobStreamer,
@@ -121,7 +118,6 @@ public final class ZeebePartitionFactory {
     this.commandApiService = commandApiService;
     this.clusterServices = clusterServices;
     this.exporterRepository = exporterRepository;
-    this.healthCheckService = healthCheckService;
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.jobStreamer = jobStreamer;
@@ -168,8 +164,6 @@ public final class ZeebePartitionFactory {
 
     final ZeebePartition zeebePartition =
         new ZeebePartition(context, newTransitionBehavior, STARTUP_STEPS);
-
-    healthCheckService.registerMonitoredPartition(zeebePartition.getPartitionId(), zeebePartition);
     return zeebePartition;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.startup.steps;
+
+import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionHealthBroadcaster;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.startup.StartupStep;
+
+public final class PartitionRegistrationStep implements StartupStep<PartitionStartupContext> {
+
+  @Override
+  public String getName() {
+    return "Partition Registration";
+  }
+
+  @Override
+  public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
+    final var result = context.concurrencyControl().<PartitionStartupContext>createFuture();
+    final var partitionId = context.partitionMetadata().id().id();
+    final var zeebePartition = context.zeebePartition();
+    final var topologyManager = context.topologyManager();
+    zeebePartition.addFailureListener(
+        new PartitionHealthBroadcaster(partitionId, topologyManager::onHealthChanged));
+    context.diskSpaceUsageMonitor().addDiskUsageListener(zeebePartition);
+    context.brokerHealthCheckService().registerMonitoredPartition(partitionId, zeebePartition);
+    result.complete(context);
+    return result;
+  }
+
+  @Override
+  public ActorFuture<PartitionStartupContext> shutdown(final PartitionStartupContext context) {
+    final var result = context.concurrencyControl().<PartitionStartupContext>createFuture();
+
+    final var partitionId = context.partitionMetadata().id().id();
+    context.diskSpaceUsageMonitor().removeDiskUsageListener(context.zeebePartition());
+    context.brokerHealthCheckService().removeMonitoredPartition(partitionId);
+    // TODO: Find a way to remove the partition from the topology manager
+
+    result.complete(context);
+    return result;
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManager.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManager.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import io.camunda.zeebe.util.health.HealthStatus;
+
 /**
  * Maintains the cluster topology.
  *
@@ -20,4 +22,6 @@ public interface TopologyManager {
   void removeTopologyPartitionListener(TopologyPartitionListener listener);
 
   void addTopologyPartitionListener(TopologyPartitionListener listener);
+
+  void onHealthChanged(int partitionId, HealthStatus status);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -220,12 +220,7 @@ public final class TopologyManagerImpl extends Actor
         });
   }
 
-  private void notifyPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
-    for (final TopologyPartitionListener listener : topologyPartitionListeners) {
-      LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, member));
-    }
-  }
-
+  @Override
   public void onHealthChanged(final int partitionId, final HealthStatus status) {
     actor.run(
         () -> {
@@ -238,5 +233,11 @@ public final class TopologyManagerImpl extends Actor
           }
           publishTopologyChanges();
         });
+  }
+
+  private void notifyPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
+    for (final TopologyPartitionListener listener : topologyPartitionListeners) {
+      LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, member));
+    }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -178,6 +178,7 @@ public final class ZeebePartition extends Actor
 
           removeListeners();
           context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth.getName());
+          context.getComponentHealthMonitor().removeComponent(context.getRaftPartition().name());
 
           final var inactiveTransitionFuture = transitionToInactive();
 


### PR DESCRIPTION
This adds more code than it removes but hopefully makes the partition startup process easier to follow because registration of a partition with various checkers and monitors now occurs in one central place: `PartitionRegistrationStep` where we also take care of de-registering and removing listeners.

Relates to #14085 