### PR TITLE
Fix process version cache to prevent different proceses referencing the same version info

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionInfo.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionInfo.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
@@ -26,6 +27,11 @@ public final class VersionInfo extends UnpackedObject implements DbValue {
 
   public VersionInfo() {
     declareProperty(highestVersionProp).declareProperty(knownVersions);
+  }
+
+  public VersionInfo(final VersionInfo other) {
+    this();
+    wrap(BufferUtil.createCopy(other));
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionManager.java
@@ -45,16 +45,17 @@ public final class VersionManager {
   }
 
   private VersionInfo getVersionInfo() {
-    final var versionInfo =
-        versionByTenantCache.computeIfAbsent(
-            new TenantIdAndResourceId(tenantIdKey.toString(), idKey.toString()),
-            (key) -> versionInfoColumnFamily.get(tenantAwareIdKey));
+    return versionByTenantCache.computeIfAbsent(
+        new TenantIdAndResourceId(tenantIdKey.toString(), idKey.toString()),
+        (key) -> {
+          final var persistedVersionInfo = versionInfoColumnFamily.get(tenantAwareIdKey);
 
-    if (versionInfo == null) {
-      return new VersionInfo().setHighestVersionIfHigher(initialValue);
-    }
-
-    return versionInfo;
+          if (persistedVersionInfo == null) {
+            return new VersionInfo().setHighestVersionIfHigher(initialValue);
+          } else {
+            return new VersionInfo(persistedVersionInfo);
+          }
+        });
   }
 
   public void addResourceVersion(final String resourceId, final long value, final String tenantId) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionManager.java
@@ -26,7 +26,7 @@ public final class VersionManager {
   private final DbString idKey;
   private final DbString tenantIdKey;
   private final DbTenantAwareKey<DbString> tenantAwareIdKey;
-  private final VersionInfo nextVersion = new VersionInfo();
+  private final VersionInfo versionInfo = new VersionInfo();
   private final Object2ObjectHashMap<TenantIdAndResourceId, VersionInfo> versionByTenantCache;
 
   public VersionManager(
@@ -40,7 +40,7 @@ public final class VersionManager {
     idKey = new DbString();
     tenantAwareIdKey = new DbTenantAwareKey<>(tenantIdKey, idKey, PlacementType.PREFIX);
     versionInfoColumnFamily =
-        zeebeDb.createColumnFamily(columnFamily, transactionContext, tenantAwareIdKey, nextVersion);
+        zeebeDb.createColumnFamily(columnFamily, transactionContext, tenantAwareIdKey, versionInfo);
     versionByTenantCache = new Object2ObjectHashMap<>();
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

t's an issue with the caching of process versions. There is a scenario in which different keys in the cache reference the same value object. Because of this versions of different processes can influence each other.

1. If we deploy a process we store it in the state using a shared object (nextVersion) (this name is still bad btw)
2. If get the version info we search in the cache. If we can't find it we get it from the state and store this in the cache.
3. Since getting it from the state wraps the values in the same object it means the entries in the cache all reference this same object. So if the object changes it changes for all entries.

We can fix it by making sure we copy the value from the state before storing it in the cache.

## Related issues

<!-- Which issues are closed by this PR or are related -->

I am convinced that all these version related issues are resolved by this PR (thank @korthout for this list 🙇)

closes #14309 
closes #14366 
closes #14055 


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
