### PR TITLE
Don't subscribe to events when raising incident

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -110,16 +110,6 @@ public final class BpmnJobBehavior {
             p -> evalFormIdExp(jobWorkerProps.getFormId(), scopeKey, tenantId).map(p::formKey));
   }
 
-  public Either<Failure, ?> createNewJob(
-      final BpmnElementContext context, final ExecutableJobWorkerElement element) {
-    return evaluateJobExpressions(element, context)
-        .map(
-            jobProperties -> {
-              createNewJob(context, element, jobProperties);
-              return null;
-            });
-  }
-
   public void createNewJob(
       final BpmnElementContext context,
       final ExecutableJobWorkerElement element,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -61,10 +61,10 @@ public final class CallActivityProcessor
   public void onActivate(final ExecutableCallActivity element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyInputMappings(context, element)
-        .flatMap(ok -> eventSubscriptionBehavior.subscribeToEvents(element, context))
         .flatMap(ok -> evaluateProcessId(context, element))
         .flatMap(processId -> getProcessForProcessId(processId, context.getTenantId()))
         .flatMap(this::checkProcessHasNoneStartEvent)
+        .flatMap(p -> eventSubscriptionBehavior.subscribeToEvents(element, context).map(ok -> p))
         .ifRightOrLeft(
             process -> {
               final var activated = stateTransitionBehavior.transitionToActivated(context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -180,9 +180,12 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
     public void onActivate(final ExecutableEndEvent element, final BpmnElementContext activating) {
       variableMappingBehavior
           .applyInputMappings(activating, element)
-          .flatMap(ok -> jobBehavior.createNewJob(activating, element))
+          .flatMap(ok -> jobBehavior.evaluateJobExpressions(element, activating))
           .ifRightOrLeft(
-              ok -> stateTransitionBehavior.transitionToActivated(activating),
+              jobProperties -> {
+                jobBehavior.createNewJob(activating, element, jobProperties);
+                stateTransitionBehavior.transitionToActivated(activating);
+              },
               failure -> incidentBehavior.createIncident(failure, activating));
     }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -149,9 +149,12 @@ public class IntermediateThrowEventProcessor
       if (element.getJobWorkerProperties() != null) {
         variableMappingBehavior
             .applyInputMappings(activating, element)
-            .flatMap(ok -> jobBehavior.createNewJob(activating, element))
+            .flatMap(ok -> jobBehavior.evaluateJobExpressions(element, activating))
             .ifRightOrLeft(
-                ok -> stateTransitionBehavior.transitionToActivated(activating),
+                jobProperties -> {
+                  jobBehavior.createNewJob(activating, element, jobProperties);
+                  stateTransitionBehavior.transitionToActivated(activating);
+                },
                 failure -> incidentBehavior.createIncident(failure, activating));
       }
     }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.incident;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.JobWorkerElementBuilder;
@@ -340,6 +341,11 @@ public class JobWorkerElementIncidentTest {
 
   @Test
   public void shouldResolveIncidentWithMessageBoundaryEvent() {
+    assumeThat(elementBuilder.getElementType())
+        .describedAs(
+            "Only activities can have boundary events, this test is not relevant to job worker events")
+        .isIn(JobWorkerElementBuilderProvider.getSupportedActivities());
+
     // given
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
@@ -61,7 +61,7 @@ public final class TimerIncidentTest {
             ELEMENT_ID,
             serviceTaskBuilder ->
                 serviceTaskBuilder
-                    .zeebeJobTypeExpression("boundary_timer_test")
+                    .zeebeJobType("boundary_timer_test")
                     .boundaryEvent(
                         "boundary-event-1",
                         timerBoundaryEventBuilder ->
@@ -80,7 +80,7 @@ public final class TimerIncidentTest {
             ELEMENT_ID,
             serviceTaskBuilder ->
                 serviceTaskBuilder
-                    .zeebeJobTypeExpression("boundary_timer_test")
+                    .zeebeJobType("boundary_timer_test")
                     .boundaryEvent(
                         "boundary-event-1",
                         timerBoundaryEventBuilder ->

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
@@ -264,11 +264,11 @@ public final class TimerIncidentTest {
 
     // then
     assertThat(
-            RecordingExporter.processInstanceRecords()
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted()
-                .withRecordKey(incident.getValue().getElementInstanceKey()))
-        .extracting(Record::getIntent)
-        .contains(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+                .withRecordKey(incident.getValue().getElementInstanceKey())
+                .findAny())
+        .describedAs("Expect that element was activated")
+        .isPresent();
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerElementBuilderProvider.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerElementBuilderProvider.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -28,6 +29,14 @@ public final class JobWorkerElementBuilderProvider implements ArgumentsProvider 
   public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext)
       throws Exception {
     return builders().map(Arguments::of);
+  }
+
+  public static List<BpmnElementType> getSupportedActivities() {
+    return List.of(
+        BpmnElementType.SERVICE_TASK,
+        BpmnElementType.BUSINESS_RULE_TASK,
+        BpmnElementType.SCRIPT_TASK,
+        BpmnElementType.SEND_TASK);
   }
 
   public static Stream<JobWorkerElementBuilder> builders() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This resolves a critical bug, where certain flow nodes subscribe to events when raising an incident. This bug would surface when resolving the incident, where the flow-node subscribes again to those events.

For example, a call activity may fail to activate due to the called process not being found. If the call activity has a boundary event attached, it would attempt to subscribe twice to it when resolving the respective incident.

The pull request adds tests for:
- call activity
- job worker tasks

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14418

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
