### PR TITLE
[Backport stable/8.1] Don't subscribe to events when raising incident

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -77,26 +77,33 @@ public final class BpmnJobBehavior {
     this.jobMetrics = jobMetrics;
   }
 
-  public Either<Failure, ?> createNewJob(
-      final BpmnElementContext context, final ExecutableJobWorkerElement element) {
-    final var jobWorkerProperties = element.getJobWorkerProperties();
+  public Either<Failure, JobProperties> evaluateJobExpressions(
+      final ExecutableJobWorkerElement element, final BpmnElementContext context) {
+    final var jobWorkerProps = element.getJobWorkerProperties();
     final var scopeKey = context.getElementInstanceKey();
-    return evaluateJobExpressions(jobWorkerProperties, scopeKey)
-        .map(
-            jobProperties -> {
-              writeJobCreatedEvent(context, element, jobProperties);
-              jobMetrics.jobCreated(jobProperties.getType());
-              return null;
-            });
-  }
-
-  private Either<Failure, JobProperties> evaluateJobExpressions(
-      final JobWorkerProperties jobWorkerProps, final long scopeKey) {
     return Either.<Failure, JobProperties>right(new JobProperties())
         .flatMap(p -> evalTypeExp(jobWorkerProps, scopeKey).map(p::type))
         .flatMap(p -> evalRetriesExp(jobWorkerProps, scopeKey).map(p::retries))
         .flatMap(p -> evalAssigneeExp(jobWorkerProps, scopeKey).map(p::assignee))
         .flatMap(p -> evalCandidateGroupsExp(jobWorkerProps, scopeKey).map(p::candidateGroups));
+  }
+
+  public Either<Failure, ?> createNewJob(
+      final BpmnElementContext context, final ExecutableJobWorkerElement element) {
+    return evaluateJobExpressions(element, context)
+        .map(
+            jobProperties -> {
+              createNewJob(context, element, jobProperties);
+              return null;
+            });
+  }
+
+  public void createNewJob(
+      final BpmnElementContext context,
+      final ExecutableJobWorkerElement element,
+      final JobProperties jobProperties) {
+    writeJobCreatedEvent(context, element, jobProperties);
+    jobMetrics.jobCreated(jobProperties.getType());
   }
 
   private Either<Failure, String> evalTypeExp(
@@ -193,7 +200,7 @@ public final class BpmnJobBehavior {
     }
   }
 
-  private static final class JobProperties {
+  public static final class JobProperties {
     private String type;
     private Long retries;
     private String assignee;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -88,16 +88,6 @@ public final class BpmnJobBehavior {
         .flatMap(p -> evalCandidateGroupsExp(jobWorkerProps, scopeKey).map(p::candidateGroups));
   }
 
-  public Either<Failure, ?> createNewJob(
-      final BpmnElementContext context, final ExecutableJobWorkerElement element) {
-    return evaluateJobExpressions(element, context)
-        .map(
-            jobProperties -> {
-              createNewJob(context, element, jobProperties);
-              return null;
-            });
-  }
-
   public void createNewJob(
       final BpmnElementContext context,
       final ExecutableJobWorkerElement element,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -61,10 +61,10 @@ public final class CallActivityProcessor
   public void onActivate(final ExecutableCallActivity element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyInputMappings(context, element)
-        .flatMap(ok -> eventSubscriptionBehavior.subscribeToEvents(element, context))
         .flatMap(ok -> evaluateProcessId(context, element))
         .flatMap(this::getProcessForProcessId)
         .flatMap(this::checkProcessHasNoneStartEvent)
+        .flatMap(p -> eventSubscriptionBehavior.subscribeToEvents(element, context).map(ok -> p))
         .ifRightOrLeft(
             process -> {
               final var activated = stateTransitionBehavior.transitionToActivated(context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -154,9 +154,12 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
     public void onActivate(final ExecutableEndEvent element, final BpmnElementContext activating) {
       variableMappingBehavior
           .applyInputMappings(activating, element)
-          .flatMap(ok -> jobBehavior.createNewJob(activating, element))
+          .flatMap(ok -> jobBehavior.evaluateJobExpressions(element, activating))
           .ifRightOrLeft(
-              ok -> stateTransitionBehavior.transitionToActivated(activating),
+              jobProperties -> {
+                jobBehavior.createNewJob(activating, element, jobProperties);
+                stateTransitionBehavior.transitionToActivated(activating);
+              },
               failure -> incidentBehavior.createIncident(failure, activating));
     }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -45,9 +45,12 @@ public class IntermediateThrowEventProcessor
     if (element.getJobWorkerProperties() != null) {
       variableMappingBehavior
           .applyInputMappings(context, element)
-          .flatMap(ok -> jobBehavior.createNewJob(context, element))
+          .flatMap(ok -> jobBehavior.evaluateJobExpressions(element, context))
           .ifRightOrLeft(
-              ok -> stateTransitionBehavior.transitionToActivated(context),
+              jobProperties -> {
+                jobBehavior.createNewJob(context, element, jobProperties);
+                stateTransitionBehavior.transitionToActivated(context);
+              },
               failure -> incidentBehavior.createIncident(failure, context));
 
     } else {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.incident;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.JobWorkerElementBuilder;
@@ -340,6 +341,11 @@ public class JobWorkerElementIncidentTest {
 
   @Test
   public void shouldResolveIncidentWithMessageBoundaryEvent() {
+    assumeThat(elementBuilder.getElementType())
+        .describedAs(
+            "Only activities can have boundary events, this test is not relevant to job worker events")
+        .isIn(JobWorkerElementBuilderProvider.getSupportedActivities());
+
     // given
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
@@ -184,11 +184,11 @@ public final class TimerIncidentTest {
 
     // then
     assertThat(
-            RecordingExporter.processInstanceRecords()
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted()
-                .withRecordKey(incident.getValue().getElementInstanceKey()))
-        .extracting(Record::getIntent)
-        .contains(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+                .withRecordKey(incident.getValue().getElementInstanceKey())
+                .findAny())
+        .describedAs("Expect that element was activated")
+        .isPresent();
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
@@ -59,7 +59,7 @@ public final class TimerIncidentTest {
             ELEMENT_ID,
             serviceTaskBuilder ->
                 serviceTaskBuilder
-                    .zeebeJobTypeExpression("boundary_timer_test")
+                    .zeebeJobType("boundary_timer_test")
                     .boundaryEvent(
                         "boundary-event-1",
                         timerBoundaryEventBuilder ->

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerElementBuilderProvider.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerElementBuilderProvider.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -28,6 +29,14 @@ public final class JobWorkerElementBuilderProvider implements ArgumentsProvider 
   public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext)
       throws Exception {
     return builders().map(Arguments::of);
+  }
+
+  public static List<BpmnElementType> getSupportedActivities() {
+    return List.of(
+        BpmnElementType.SERVICE_TASK,
+        BpmnElementType.BUSINESS_RULE_TASK,
+        BpmnElementType.SCRIPT_TASK,
+        BpmnElementType.SEND_TASK);
   }
 
   public static Stream<JobWorkerElementBuilder> builders() {


### PR DESCRIPTION
## Description

<!-- Link to the PR that is back ported -->

Backport of #14421

>CONFLICT (content): Merge conflict in engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
error: could not apply 02e9c2a37c... refactor: always explicitly evaluate job expr

Since 8.2, Intermediate Throw Event has multiple different behaviors (implementations). In 8.1 it was still simple.

## Related issues

<!-- Link to the related issues of the origin PR -->

relates to #14420 
relates to https://github.com/camunda/zeebe/issues/14418
