### PR TITLE
fix: use different retention policy

### DIFF
--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -84,8 +84,8 @@ jobs:
         --set camunda-platform.operate.image.repository=gcr.io/zeebe-io/operate
         --set camunda-platform.operate.image.tag=${{ needs.benchmark-data.outputs.operate }}    
         --set camunda-platform.elasticsearch.volumeClaimTemplate.resources.requests.storage=128Gi
-        --set camunda-platform.retentionPolicy.zeebeIndexMaxSize=30
-        --set camunda-platform.retentionPolicy.schedule="0 * * * *"
+        --set camunda-platform.retentionPolicy.enabled=false
+        --set retentionPolicy.enabled=true
   setup-latency-benchmark:
     name: Latency Benchmark
     uses: ./.github/workflows/benchmark.yml


### PR DESCRIPTION
## Description

With the recent release https://github.com/zeebe-io/benchmark-helm/releases/tag/zeebe-benchmark-0.1.19 we support now a more fine granular retention policy which we want to use for our operate-zeebe mixed benchmarks

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->
See related PR for the retention policy https://github.com/zeebe-io/benchmark-helm/pull/95