### PR TITLE
feat: include `tenantId` in `EvaluatedDecision`

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client.api.response;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
 import java.util.List;
 
 public interface EvaluateDecisionResponse {
@@ -75,6 +74,5 @@ public interface EvaluateDecisionResponse {
   /**
    * @return the tenant identifier that owns this decision evaluation result
    */
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13557")
   String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecision.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecision.java
@@ -64,4 +64,9 @@ public interface EvaluatedDecision {
    * @return the record encoded as JSON
    */
   String toJson();
+
+  /**
+   * @return the tenant identifier that owns this decision evaluation result
+   */
+  String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluatedDecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluatedDecisionImpl.java
@@ -35,6 +35,7 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
   private final String decisionOutput;
   private final List<MatchedDecisionRule> matchedRules = new ArrayList<>();
   private final List<EvaluatedDecisionInput> evaluatedInputs = new ArrayList<>();
+  private final String tenantId;
 
   public EvaluatedDecisionImpl(
       final JsonMapper jsonMapper, final GatewayOuterClass.EvaluatedDecision evaluatedDecision) {
@@ -46,6 +47,7 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
     decisionVersion = evaluatedDecision.getDecisionVersion();
     decisionType = evaluatedDecision.getDecisionType();
     decisionOutput = evaluatedDecision.getDecisionOutput();
+    tenantId = evaluatedDecision.getTenantId();
 
     evaluatedDecision.getEvaluatedInputsList().stream()
         .map(evaluatedInput -> new EvaluatedDecisionInputImpl(jsonMapper, evaluatedInput))
@@ -94,6 +96,11 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
   @Override
   public List<MatchedDecisionRule> getMatchedRules() {
     return matchedRules;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 public class StandaloneDecisionEvaluationTest extends ClientTest {
 
   private static final long DECISION_KEY = 123L;
+  private static final String TENANT_ID = "foo";
   private static GatewayOuterClass.EvaluatedDecisionOutput evaluatedOutput;
   private static GatewayOuterClass.MatchedDecisionRule matchedRule;
   private static GatewayOuterClass.EvaluatedDecisionInput evaluatedInput;
@@ -79,6 +80,7 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
             .setDecisionVersion(1)
             .setDecisionType("TABLE")
             .setDecisionOutput("testOutput")
+            .setTenantId(TENANT_ID)
             .addEvaluatedInputs(evaluatedInput)
             .addMatchedRules(matchedRule)
             .build();
@@ -94,6 +96,7 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
             .setDecisionRequirementsKey(124L)
             .setFailedDecisionId("my-decision")
             .setFailureMessage("decision-evaluation-failure")
+            .setTenantId(TENANT_ID)
             .addEvaluatedDecisions(evaluatedDecision)
             .build();
   }
@@ -311,7 +314,7 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
         .isEqualTo(evaluateDecisionResponse.getFailedDecisionId());
     assertThat(response.getFailureMessage())
         .isEqualTo(evaluateDecisionResponse.getFailureMessage());
-    assertThat(response.getTenantId()).isEqualTo("");
+    assertThat(response.getTenantId()).isEqualTo(evaluateDecisionResponse.getTenantId());
 
     // assert EvaluatedDecision
     assertThat(response.getEvaluatedDecisions()).hasSize(1);
@@ -328,6 +331,7 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
         .isEqualTo(evaluatedDecision.getDecisionType());
     assertThat(evaluatedDecisionResponse.getDecisionOutput())
         .isEqualTo(evaluatedDecision.getDecisionOutput());
+    assertThat(evaluatedDecisionResponse.getTenantId()).isEqualTo(evaluatedDecision.getTenantId());
 
     // assert EvaluatedDecisionInput
     assertThat(evaluatedDecisionResponse.getEvaluatedInputs()).hasSize(1);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -176,7 +176,8 @@ public class DecisionBehavior {
         .setDecisionKey(decisionInfo.key())
         .setDecisionVersion(decisionInfo.version())
         .setDecisionType(evaluatedDecision.decisionType().name())
-        .setDecisionOutput(evaluatedDecision.decisionOutput());
+        .setDecisionOutput(evaluatedDecision.decisionOutput())
+        .setTenantId(decisionEvaluationEvent.getTenantId());
 
     evaluatedDecision
         .evaluatedInputs()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -342,6 +342,7 @@ public final class BusinessRuleTaskTest {
         .hasDecisionVersion(requiredDecision.getVersion())
         .hasDecisionType("DECISION_TABLE")
         .hasDecisionOutput("\"Jedi\"")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .satisfies(
             evaluatedDecision -> {
               assertThat(evaluatedDecision.getEvaluatedInputs()).hasSize(1);
@@ -371,6 +372,7 @@ public final class BusinessRuleTaskTest {
         .hasDecisionVersion(calledDecision.getVersion())
         .hasDecisionType("DECISION_TABLE")
         .hasDecisionOutput("\"Obi-Wan Kenobi\"")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .satisfies(
             evaluatedDecision -> {
               assertThat(evaluatedDecision.getEvaluatedInputs()).hasSize(2);
@@ -510,6 +512,7 @@ public final class BusinessRuleTaskTest {
         .hasDecisionVersion(requiredDecision.getVersion())
         .hasDecisionType("DECISION_TABLE")
         .hasDecisionOutput("null")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .satisfies(
             evaluatedDecision -> {
               assertThat(evaluatedDecision.getEvaluatedInputs()).isEmpty();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
@@ -155,6 +155,9 @@ public class TenantAwareBusinessRuleTaskTest {
         .hasDecisionRequirementsKey(calledDecision.getDecisionRequirementsKey())
         .hasDecisionRequirementsId(calledDecision.getDecisionRequirementsId())
         .hasTenantId(tenantOne);
+
+    final var evaluatedDecision = decisionEvaluationValue.getEvaluatedDecisions().get(0);
+    assertThat(evaluatedDecision).hasTenantId(tenantOne);
   }
 
   @Test
@@ -190,6 +193,9 @@ public class TenantAwareBusinessRuleTaskTest {
             Expected to evaluate decision 'jedi_or_sith', but \
             Assertion failure on evaluate the expression \
             'assert(lightsaberColor, lightsaberColor != null)': The condition is not fulfilled""");
+
+    final var evaluatedDecision = decisionEvaluationValue.getEvaluatedDecisions().get(0);
+    assertThat(evaluatedDecision).hasTenantId(tenantOne);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,7 +38,9 @@ public class TenantAwareBusinessRuleTaskTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
-  private static final String DMN_DECISION_TABLE = "/dmn/decision-table-with-assertions.dmn";
+  private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
+  private static final String DMN_DECISION_TABLE_WITH_ASSERTION =
+      "/dmn/decision-table-with-assertions.dmn";
 
   private static final String PROCESS_ID = "process";
   private static final String TASK_ID = "task";
@@ -62,8 +63,9 @@ public class TenantAwareBusinessRuleTaskTest {
         .done();
   }
 
-  @Before
-  public void init() {
+  @Test
+  public void shouldActivateBusinessRuleTask() {
+    // given
     final var process = processWithBusinessRuleTask();
 
     final var deployment =
@@ -79,10 +81,7 @@ public class TenantAwareBusinessRuleTaskTest {
             .collect(Collectors.toMap(DecisionRecordValue::getDecisionId, Function.identity()));
 
     ENGINE.deployment().withXmlResource("process.bpmn", process).withTenantId(tenantTwo).deploy();
-  }
 
-  @Test
-  public void shouldActivateBusinessRuleTask() {
     // when
     final var processInstanceKey =
         ENGINE
@@ -123,6 +122,23 @@ public class TenantAwareBusinessRuleTaskTest {
 
   @Test
   public void shouldWriteDecisionEvaluationEvent() {
+    // given
+    final var process = processWithBusinessRuleTask();
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource("process.bpmn", process)
+            .withXmlClasspathResource(DMN_DECISION_TABLE)
+            .withTenantId(tenantOne)
+            .deploy();
+
+    deployedDecisionsById =
+        deployment.getValue().getDecisionsMetadata().stream()
+            .collect(Collectors.toMap(DecisionRecordValue::getDecisionId, Function.identity()));
+
+    ENGINE.deployment().withXmlResource("process.bpmn", process).withTenantId(tenantTwo).deploy();
+
     // when
     final var processInstanceKey =
         ENGINE
@@ -162,6 +178,23 @@ public class TenantAwareBusinessRuleTaskTest {
 
   @Test
   public void shouldWriteDecisionEvaluationEventIfEvaluationFailed() {
+    // given
+    final var process = processWithBusinessRuleTask();
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource("process.bpmn", process)
+            .withXmlClasspathResource(DMN_DECISION_TABLE_WITH_ASSERTION)
+            .withTenantId(tenantOne)
+            .deploy();
+
+    deployedDecisionsById =
+        deployment.getValue().getDecisionsMetadata().stream()
+            .collect(Collectors.toMap(DecisionRecordValue::getDecisionId, Function.identity()));
+
+    ENGINE.deployment().withXmlResource("process.bpmn", process).withTenantId(tenantTwo).deploy();
+
     // when
     final var processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantOne).create();
@@ -200,6 +233,23 @@ public class TenantAwareBusinessRuleTaskTest {
 
   @Test
   public void shouldNotActivateBusinessRuleTask() {
+    // given
+    final var process = processWithBusinessRuleTask();
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource("process.bpmn", process)
+            .withXmlClasspathResource(DMN_DECISION_TABLE)
+            .withTenantId(tenantOne)
+            .deploy();
+
+    deployedDecisionsById =
+        deployment.getValue().getDecisionsMetadata().stream()
+            .collect(Collectors.toMap(DecisionRecordValue::getDecisionId, Function.identity()));
+
+    ENGINE.deployment().withXmlResource("process.bpmn", process).withTenantId(tenantTwo).deploy();
+
     // when
     final var processInstanceKey =
         ENGINE

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,7 +29,9 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
-  private static final String DMN_DECISION_TABLE = "/dmn/decision-table-with-assertions.dmn";
+  private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
+  private static final String DMN_DECISION_TABLE_WITH_ASSERTIONS =
+      "/dmn/decision-table-with-assertions.dmn";
   private static final String DECISION_ID = "jedi_or_sith";
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
@@ -40,14 +41,9 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
 
   private Map<String, DecisionRecordValue> deployedDecisionsById;
 
-  @Before
-  public void init() {
+  private void deployForTenant(final String process, final String tenant) {
     final var deployment =
-        ENGINE
-            .deployment()
-            .withXmlClasspathResource(DMN_DECISION_TABLE)
-            .withTenantId(tenantOne)
-            .deploy();
+        ENGINE.deployment().withXmlClasspathResource(process).withTenantId(tenant).deploy();
 
     deployedDecisionsById =
         deployment.getValue().getDecisionsMetadata().stream()
@@ -56,6 +52,9 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
 
   @Test
   public void shouldEvaluateDecision() {
+    // given
+    deployForTenant(DMN_DECISION_TABLE, tenantOne);
+
     // when
     final Record<DecisionEvaluationRecordValue> record =
         ENGINE
@@ -86,6 +85,9 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
 
   @Test
   public void shouldWriteDecisionEvaluationEventIfEvaluationFailed() {
+    // given
+    deployForTenant(DMN_DECISION_TABLE_WITH_ASSERTIONS, tenantOne);
+
     // when
     final Record<DecisionEvaluationRecordValue> record =
         ENGINE
@@ -119,6 +121,9 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
 
   @Test
   public void shouldRejectDecisionEvaluationWithCustomTenant() {
+    // given
+    deployForTenant(DMN_DECISION_TABLE, tenantOne);
+
     // when
     final Record<DecisionEvaluationRecordValue> record =
         ENGINE
@@ -144,6 +149,9 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
 
   @Test
   public void shouldRejectDecisionEvaluationWithDefaultTenant() {
+    // given
+    deployForTenant(DMN_DECISION_TABLE, tenantOne);
+
     // when
     final Record<DecisionEvaluationRecordValue> record =
         ENGINE

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
@@ -79,6 +79,9 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
         .hasDecisionRequirementsKey(calledDecision.getDecisionRequirementsKey())
         .hasDecisionRequirementsId(calledDecision.getDecisionRequirementsId())
         .hasTenantId(tenantOne);
+
+    final var evaluatedDecision = decisionEvaluationValue.getEvaluatedDecisions().get(0);
+    assertThat(evaluatedDecision).hasTenantId(tenantOne);
   }
 
   @Test
@@ -109,6 +112,9 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
             Expected to evaluate decision 'jedi_or_sith', but \
             Assertion failure on evaluate the expression \
             'assert(lightsaberColor, lightsaberColor != null)': The condition is not fulfilled""");
+
+    final var evaluatedDecision = record.getValue().getEvaluatedDecisions().get(0);
+    assertThat(evaluatedDecision).hasTenantId(tenantOne);
   }
 
   @Test

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -86,6 +86,9 @@
                 "decisionOutput": {
                   "enabled": false
                 },
+                "tenantId": {
+                  "type": "keyword"
+                },
                 "evaluatedInputs": {
                   "properties": {
                     "inputId": {

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -89,6 +89,9 @@
                 "decisionOutput": {
                   "enabled": false
                 },
+	            "tenantId": {
+	              "type": "keyword"
+	            },
                 "evaluatedInputs": {
                   "properties": {
                     "inputId": {

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -245,6 +245,8 @@ message EvaluatedDecision {
   repeated MatchedDecisionRule matchedRules = 7;
   // the decision inputs that were evaluated within this decision evaluation
   repeated EvaluatedDecisionInput evaluatedInputs = 8;
+  // the tenant identifier of the evaluated decision
+  string tenantId = 9;
 }
 
 message EvaluatedDecisionInput {

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -474,6 +474,11 @@
                 "name": "evaluatedInputs",
                 "type": "EvaluatedDecisionInput",
                 "is_repeated": true
+              },
+              {
+                "id": 9,
+                "name": "tenantId",
+                "type": "string"
               }
             ]
           },

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -204,7 +204,8 @@ public final class ResponseMapper {
               .setDecisionName(intermediateDecision.getDecisionName())
               .setDecisionVersion(intermediateDecision.getDecisionVersion())
               .setDecisionType(intermediateDecision.getDecisionType())
-              .setDecisionOutput(intermediateDecision.getDecisionOutput());
+              .setDecisionOutput(intermediateDecision.getDecisionOutput())
+              .setTenantId(intermediateDecision.getTenantId());
 
       intermediateDecision.getEvaluatedInputs().stream()
           .map(

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionTest.java
@@ -104,6 +104,8 @@ public class EvaluateDecisionTest extends GatewayTest {
         .isEqualTo(expectedIntermediateDecisionResult.getDecisionVersion());
     assertThat(intermediateResultResponse.getDecisionOutput())
         .isEqualTo(expectedIntermediateDecisionResult.getDecisionOutput());
+    assertThat(intermediateResultResponse.getTenantId())
+        .isEqualTo(expectedIntermediateDecisionResult.getTenantId());
 
     // assert EvaluatedInputRecord mapping
     assertThat(intermediateResultResponse.getEvaluatedInputsCount()).isOne();

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedInputValue;
 import io.camunda.zeebe.protocol.record.value.MatchedRuleValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,9 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
   private final ArrayProperty<MatchedRuleRecord> matchedRulesProp =
       new ArrayProperty<>("matchedRules", new MatchedRuleRecord());
 
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
   public EvaluatedDecisionRecord() {
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
@@ -50,7 +54,8 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
         .declareProperty(decisionTypeProp)
         .declareProperty(decisionOutputProp)
         .declareProperty(evaluatedInputsProp)
-        .declareProperty(matchedRulesProp);
+        .declareProperty(matchedRulesProp)
+        .declareProperty(tenantIdProp);
   }
 
   @Override
@@ -169,5 +174,15 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getDecisionTypeBuffer() {
     return decisionTypeProp.getValue();
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public EvaluatedDecisionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1562,6 +1562,7 @@ final class JsonSerializableToJsonTest {
               "decisionVersion":7,
               "decisionOutput":'"decision-output"',
               "decisionType":"DECISION_TABLE",
+              "tenantId": "<default>",
               "evaluatedInputs":[
                 {
                   "inputId":"input-id",
@@ -1587,6 +1588,115 @@ final class JsonSerializableToJsonTest {
           "evaluationFailureMessage":"evaluation-failure-message",
           "failedDecisionId":"failed-decision-id",
           "tenantId": "<default>"
+        }
+        """
+      },
+
+      // custom tenant
+      {
+        "DecisionEvaluationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var record =
+                  new DecisionEvaluationRecord()
+                      .setDecisionKey(1L)
+                      .setDecisionId("decision-id")
+                      .setDecisionName("decision-name")
+                      .setDecisionVersion(1)
+                      .setDecisionRequirementsKey(2L)
+                      .setDecisionRequirementsId("decision-requirements-id")
+                      .setDecisionOutput(toMessagePack("'decision-output'"))
+                      .setVariables(VARIABLES_MSGPACK)
+                      .setProcessDefinitionKey(3L)
+                      .setBpmnProcessId("bpmn-process-id")
+                      .setDecisionVersion(1)
+                      .setProcessInstanceKey(4L)
+                      .setElementInstanceKey(5L)
+                      .setElementId("element-id")
+                      .setEvaluationFailureMessage("evaluation-failure-message")
+                      .setFailedDecisionId("failed-decision-id")
+                      .setTenantId("tenant-test");
+
+              final var evaluatedDecisionRecord = record.evaluatedDecisions().add();
+              evaluatedDecisionRecord
+                  .setDecisionId("decision-id")
+                  .setDecisionName("decision-name")
+                  .setDecisionKey(6L)
+                  .setDecisionVersion(7)
+                  .setDecisionType("DECISION_TABLE")
+                  .setDecisionOutput(toMessagePack("'decision-output'"))
+                  .setTenantId("tenant-test");
+
+              evaluatedDecisionRecord
+                  .evaluatedInputs()
+                  .add()
+                  .setInputId("input-id")
+                  .setInputName("input-name")
+                  .setInputValue(toMessagePack("'input-value'"));
+
+              final var matchedRuleRecord = evaluatedDecisionRecord.matchedRules().add();
+              matchedRuleRecord.setRuleId("rule-id").setRuleIndex(1);
+
+              matchedRuleRecord
+                  .evaluatedOutputs()
+                  .add()
+                  .setOutputId("output-id")
+                  .setOutputName("output-name")
+                  .setOutputValue(toMessagePack("'output-value'"));
+
+              return record;
+            },
+        """
+        {
+          "decisionKey":1,
+          "decisionId":"decision-id",
+          "decisionName":"decision-name",
+          "decisionVersion":1,
+          "decisionRequirementsKey":2,
+          "decisionRequirementsId":"decision-requirements-id",
+          "decisionOutput":'"decision-output"',
+          "variables": {
+            "foo": "bar"
+          },
+          "processDefinitionKey":3,
+          "bpmnProcessId":"bpmn-process-id",
+          "processInstanceKey":4,
+          "elementInstanceKey":5,
+          "elementId":"element-id",
+          "evaluatedDecisions":[
+            {
+              "decisionId":"decision-id",
+              "decisionName":"decision-name",
+              "decisionKey":6,
+              "decisionVersion":7,
+              "decisionOutput":'"decision-output"',
+              "decisionType":"DECISION_TABLE",
+              "tenantId": "tenant-test",
+              "evaluatedInputs":[
+                {
+                  "inputId":"input-id",
+                  "inputName":"input-name",
+                  "inputValue":'"input-value"'
+                }
+              ],
+              "matchedRules":[
+                {
+                  "ruleId":"rule-id",
+                  "ruleIndex":1,
+                  "evaluatedOutputs":[
+                    {
+                      "outputId":"output-id",
+                      "outputName":"output-name",
+                      "outputValue":'"output-value"'
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "evaluationFailureMessage":"evaluation-failure-message",
+          "failedDecisionId":"failed-decision-id",
+          "tenantId": "tenant-test"
         }
         """
       },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableEvaluatedDecisionValue.Builder.class)
-public interface EvaluatedDecisionValue extends RecordValue {
+public interface EvaluatedDecisionValue extends RecordValue, TenantOwned {
 
   /**
    * @return the id of the evaluated decision


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #13777 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
