### PR TITLE
feat(variables): set `tenantId` on `VariableRecord`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -69,12 +69,12 @@ public final class VariableBehavior {
       return;
     }
 
-    // TODO(#13388): pass tenant id to variable record
     variableRecord
         .setScopeKey(scopeKey)
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
-        .setBpmnProcessId(bpmnProcessId);
+        .setBpmnProcessId(bpmnProcessId)
+        .setTenantId(tenantId);
     for (final DocumentEntry entry : indexedDocument) {
       applyEntryToRecord(entry);
       setLocalVariable(variableRecord);
@@ -117,11 +117,11 @@ public final class VariableBehavior {
     long currentScope = scopeKey;
     long parentScope;
 
-    // TODO(#13388): pass tenant id to variable record
     variableRecord
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
-        .setBpmnProcessId(bpmnProcessId);
+        .setBpmnProcessId(bpmnProcessId)
+        .setTenantId(tenantId);
     while ((parentScope = variableState.getParentScopeKey(currentScope)) > 0) {
       final Iterator<DocumentEntry> entryIterator = indexedDocument.iterator();
 
@@ -176,12 +176,12 @@ public final class VariableBehavior {
       final int valueOffset,
       final int valueLength) {
 
-    // TODO(#13388): pass tenant id to variable record
     variableRecord
         .setScopeKey(scopeKey)
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
         .setBpmnProcessId(bpmnProcessId)
+        .setTenantId(tenantId)
         .setName(name)
         .setValue(value, valueOffset, valueLength);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.collection.Maps;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class TenantAwareProcessInstanceVariableTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
+  public static final String PROCESS_ID = "process";
+  private static final String TENANT_ID = "foo";
+
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  private long processDefinitionKey;
+
+  @Before
+  public void init() {
+    processDefinitionKey =
+        ENGINE_RULE
+            .deployment()
+            .withXmlResource(PROCESS)
+            .withTenantId(TENANT_ID)
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+  }
+
+  @Test
+  public void shouldAssignTenantOnVariableCreation() {
+    // when
+    final long processInstanceKey =
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables("{'x':1}")
+            .withTenantId(TENANT_ID)
+            .create();
+
+    // then
+    final Record<VariableRecordValue> variableRecord =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(variableRecord.getValue())
+        .hasScopeKey(processInstanceKey)
+        .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TENANT_ID)
+        .hasName("x")
+        .hasValue("1");
+  }
+
+  @Test
+  public void shouldAssignTenantOnVariableUpdate() {
+    // given
+    final long processInstanceKey =
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables("{'x':1}")
+            .withTenantId(TENANT_ID)
+            .create();
+
+    // when
+    ENGINE_RULE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Maps.of(entry("x", 2)))
+        .update();
+
+    // then
+    final Record<VariableRecordValue> variableUpdated =
+        RecordingExporter.variableRecords(VariableIntent.UPDATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(variableUpdated.getValue())
+        .hasScopeKey(processInstanceKey)
+        .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TENANT_ID)
+        .hasName("x")
+        .hasValue("2");
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ProcessInstanceVariableTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ProcessInstanceVariableTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -71,6 +72,7 @@ public final class ProcessInstanceVariableTest {
     Assertions.assertThat(variableRecord.getValue())
         .hasScopeKey(processInstanceKey)
         .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasName("x")
         .hasValue("1");
   }
@@ -97,6 +99,7 @@ public final class ProcessInstanceVariableTest {
     Assertions.assertThat(variableRecord.getValue())
         .hasScopeKey(processInstanceKey)
         .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasName("x")
         .hasValue("1");
   }
@@ -143,6 +146,7 @@ public final class ProcessInstanceVariableTest {
     Assertions.assertThat(variableRecord.getValue())
         .hasScopeKey(processInstanceKey)
         .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasName("y")
         .hasValue("1");
   }
@@ -168,6 +172,7 @@ public final class ProcessInstanceVariableTest {
     Assertions.assertThat(variableRecord.getValue())
         .hasScopeKey(processInstanceKey)
         .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasName("x")
         .hasValue("1");
   }
@@ -217,6 +222,7 @@ public final class ProcessInstanceVariableTest {
     Assertions.assertThat(variableRecord.getValue())
         .hasScopeKey(processInstanceKey)
         .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasName("x")
         .hasValue("2");
   }
@@ -263,6 +269,7 @@ public final class ProcessInstanceVariableTest {
     Assertions.assertThat(variableRecord.getValue())
         .hasScopeKey(processInstanceKey)
         .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasName("y")
         .hasValue("2");
   }
@@ -288,6 +295,7 @@ public final class ProcessInstanceVariableTest {
     Assertions.assertThat(variableRecord.getValue())
         .hasScopeKey(processInstanceKey)
         .hasProcessDefinitionKey(processDefinitionKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasName("x")
         .hasValue("2");
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.variable;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -26,6 +28,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey");
   private final LongProperty processDefinitionKeyProp = new LongProperty("processDefinitionKey");
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public VariableRecord() {
     declareProperty(nameProp)
@@ -33,7 +37,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
         .declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
-        .declareProperty(bpmnProcessIdProp);
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(tenantIdProp);
   }
 
   @Override
@@ -118,7 +123,11 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   @Override
   public String getTenantId() {
-    // todo(#13388): replace dummy implementation
-    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public VariableRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1176,6 +1176,40 @@ final class JsonSerializableToJsonTest {
         """
       },
 
+      // custom tenant
+      {
+        "VariableRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String name = "x";
+              final String value = "1";
+              final long scopeKey = 3;
+              final long processInstanceKey = 2;
+              final long processDefinitionKey = 4;
+              final String bpmnProcessId = "process";
+
+              return new VariableRecord()
+                  .setName(wrapString(name))
+                  .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value)))
+                  .setScopeKey(scopeKey)
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setProcessDefinitionKey(processDefinitionKey)
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setTenantId("tenant-test");
+            },
+        """
+        {
+          "scopeKey": 3,
+          "processInstanceKey": 2,
+          "processDefinitionKey": 4,
+          "bpmnProcessId": "process",
+          "name": "x",
+          "value": "1",
+          "tenantId": "tenant-test"
+        }
+        """
+      },
+
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// VariableDocumentRecord ////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #13388 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
