### PR TITLE
refactor(qa): migrate gateway tests to new infra

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayGrpcHealthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayGrpcHealthIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 @ZeebeIntegration
 class GatewayGrpcHealthIT {
 
-  // can never be ready nor await the complete topology without a gateway
+  // can never be ready nor await the complete topology without a broker
   @TestZeebe(awaitReady = false, awaitCompleteTopology = false)
   private final TestStandaloneGateway gateway = new TestStandaloneGateway();
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayGrpcHealthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayGrpcHealthIT.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.it.gateway;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
-import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.grpc.ManagedChannel;
 import io.grpc.health.v1.HealthCheckRequest;
 import io.grpc.health.v1.HealthCheckResponse;
@@ -18,28 +20,22 @@ import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.health.v1.HealthGrpc;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.protobuf.services.HealthStatusManager;
-import io.zeebe.containers.ZeebeGatewayContainer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
+@ZeebeIntegration
 class GatewayGrpcHealthIT {
 
-  @Container
-  private final ZeebeGatewayContainer zeebeGatewayContainer =
-      new ZeebeGatewayContainer(ZeebeTestContainerDefaults.defaultTestImage())
-          .withoutTopologyCheck();
+  // can never be ready nor await the complete topology without a gateway
+  @TestZeebe(awaitReady = false, awaitCompleteTopology = false)
+  private final TestStandaloneGateway gateway = new TestStandaloneGateway();
 
   @ParameterizedTest
   @ValueSource(strings = {GatewayGrpc.SERVICE_NAME, HealthStatusManager.SERVICE_NAME_ALL_SERVICES})
   void shouldReturnServingStatusWhenGatewayIsStarted(final String serviceName) {
     // given
     final ManagedChannel channel =
-        NettyChannelBuilder.forTarget(zeebeGatewayContainer.getExternalGatewayAddress())
-            .usePlaintext()
-            .build();
+        NettyChannelBuilder.forTarget(gateway.gatewayAddress()).usePlaintext().build();
     final HealthCheckResponse response;
 
     // when


### PR DESCRIPTION
## Description

This PR migrates two gateway tests to use the new testing infrastructure. One notable point is there's no way to express dependency relationships between containers and the apps (note: sounds like a good new feature to contribute ;)), so we set up and start the app in the `BeforeAll`.

## Related issues

related to #14377

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
