### PR TITLE
Remove members that are left from the ClusterTopology

### DIFF
--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -75,4 +75,9 @@ public final class ClusterTopologyAssert
     assertThat(actual.changes().pendingOperations()).hasSize(expectedSize);
     return this;
   }
+
+  public void doesNotHaveMember(final int id) {
+    final MemberId memberId = MemberId.from(String.valueOf(id));
+    assertThat(actual.members()).doesNotContainKey(memberId);
+  }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -76,8 +76,14 @@ public final class ClusterTopologyAssert
     return this;
   }
 
-  public void doesNotHaveMember(final int id) {
+  public ClusterTopologyAssert doesNotHaveMember(final int id) {
     final MemberId memberId = MemberId.from(String.valueOf(id));
     assertThat(actual.members()).doesNotContainKey(memberId);
+    return this;
+  }
+
+  public ClusterTopologyAssert hasVersion(final long version) {
+    assertThat(actual.version()).isEqualTo(version);
+    return this;
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -179,7 +179,7 @@ final class ClusterTopologyManagerTest {
                 ClusterTopologyAssert.assertThatClusterTopology(
                         clusterTopologyManager.getClusterTopology().join())
                     .hasPendingOperationsWithSize(0)
-                    .hasMemberWithState(1, MemberState.State.LEFT));
+                    .doesNotHaveMember(1));
     assertThat(gossipState.get())
         .describedAs("Updated topology is gossiped")
         .isEqualTo(clusterTopologyManager.getClusterTopology().join());
@@ -204,7 +204,7 @@ final class ClusterTopologyManagerTest {
                 ClusterTopologyAssert.assertThatClusterTopology(
                         clusterTopologyManager.getClusterTopology().join())
                     .hasPendingOperationsWithSize(0)
-                    .hasMemberWithState(1, MemberState.State.LEFT));
+                    .doesNotHaveMember(1));
     assertThat(gossipState.get())
         .describedAs("Updated topology is gossiped")
         .isEqualTo(clusterTopologyManager.getClusterTopology().join());

--- a/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
@@ -132,6 +132,25 @@ class ClusterTopologyTest {
   }
 
   @Test
+  void shouldIncrementVersionWhenChangeIsCompleted() {
+    // given
+    final var initialTopology =
+        ClusterTopology.init()
+            .addMember(member(1), MemberState.initializeAsActive(Map.of()))
+            .startTopologyChange(List.of(new PartitionLeaveOperation(member(1), 1)));
+
+    // when
+    final var updatedTopology =
+        initialTopology.advanceTopologyChange(member(1), MemberState::toLeft);
+
+    // then
+    ClusterTopologyAssert.assertThatClusterTopology(updatedTopology)
+        .doesNotHaveMember(1)
+        .hasPendingOperationsWithSize(0)
+        .hasVersion(initialTopology.version() + 1);
+  }
+
+  @Test
   void shouldMergeClusterTopologyChanges() {
     final var initialTopology =
         ClusterTopology.init()


### PR DESCRIPTION
## Description

When the member leave operation is applied, it marks the member as LEFT, but is not immediately removed from the `ClusterTopology`. This is required so that other brokers can correctly merge the changes to `ClusterTopology`. But these members must be removed eventually. In this PR, we achieve this by making the broker that applies the last change do the garbage collection. When the last change is applied, it removes all members that are marked as left and increment the `ClusterTopology` version. This ensures that other brokers can correctly merge the changes.

Alternatively, we discussed that coordinator can remove members after a specific time period. This is not required at the moment because currently there is no use in keeping the old members in the topology. But, we can revisit it when we add automatic node join. 

## Related issues

closes #14353 

