### PR TITLE
Migrate `ProcessState` and `VersionManager` for multi-tenancy

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -55,8 +55,9 @@ public final class DbProcessState implements MutableProcessState {
       processesByTenantAndProcessIdAndVersionCache = new HashMap<>();
   private final Map<String, Long2ObjectHashMap<DeployedProcess>> processByTenantAndKeyCache;
 
-  // process
+  /** [tenant id | process definition key] => process */
   private final ColumnFamily<DbTenantAwareKey<DbLong>, PersistedProcess> processColumnFamily;
+
   private final DbLong processDefinitionKey;
   private final PersistedProcess persistedProcess;
   private final DbString tenantIdKey;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -84,6 +84,11 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
     return bufferAsString(tenantIdProp.getValue());
   }
 
+  public PersistedProcess setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
   public enum PersistedProcessState {
     ACTIVE(0),
     PENDING_DELETION(1);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -386,6 +386,10 @@ public class DbMigrationState implements MutableMigrationState {
   }
 
   @Override
+  public void migrateProcessStateForMultiTenancy() {
+  }
+
+  @Override
   public void markMigrationFinished(final String identifier) {
     migrationIdentifier.wrapString(identifier);
     migrationStateColumnFamily.insert(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -456,10 +456,11 @@ public class DbMigrationState implements MutableMigrationState {
 
   @Override
   public void migrateProcessStateForMultiTenancy() {
+    tenantIdKey.wrapString(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
     deprecatedProcessCacheColumnFamily.forEach(
         (key, value) -> {
           value.setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-          tenantIdKey.wrapString(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
           processDefinitionKey.wrapLong(key.getValue());
           processColumnFamily.insert(tenantAwareProcessDefinitionKey, value);
           deprecatedProcessCacheColumnFamily.deleteExisting(key);
@@ -468,7 +469,6 @@ public class DbMigrationState implements MutableMigrationState {
     deprecatedProcessCacheByIdAndVersionColumnFamily.forEach(
         (key, value) -> {
           value.setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-          tenantIdKey.wrapString(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
           processId.wrapBuffer(value.getBpmnProcessId());
           processVersion.wrapLong(value.getVersion());
           processByIdAndVersionColumnFamily.insert(tenantAwareProcessIdAndVersionKey, value);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionRequirementsMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessDefinitionVersionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDefinitionMigration;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -35,7 +36,8 @@ public class DbMigratorImpl implements DbMigrator {
           new ProcessInstanceByProcessDefinitionMigration(),
           new ProcessDefinitionVersionMigration(),
           new JobTimeoutCleanupMigration(),
-          new JobBackoffCleanupMigration());
+          new JobBackoffCleanupMigration(),
+          new MultiTenancyMigration());
   // Be mindful of https://github.com/camunda/zeebe/issues/7248. In particular, that issue
   // should be solved first, before adding any migration that can take a long time
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/DbProcessMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/DbProcessMigrationState.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.DbForeignKey.MatchType;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
+import io.camunda.zeebe.engine.state.deployment.Digest;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
+import io.camunda.zeebe.engine.state.deployment.VersionInfo;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+
+public final class DbProcessMigrationState {
+  private final DbLong processDefinitionKey;
+  private final PersistedProcess persistedProcess;
+
+  /** [process definition key] => process */
+  private final ColumnFamily<DbLong, PersistedProcess> deprecatedProcessCacheColumnFamily;
+
+  private final DbString tenantIdKey;
+  private final DbTenantAwareKey<DbLong> tenantAwareProcessDefinitionKey;
+
+  /** [tenant id | process definition key] => process */
+  private final ColumnFamily<DbTenantAwareKey<DbLong>, PersistedProcess> processColumnFamily;
+
+  private final DbString processId;
+  private final DbLong processVersion;
+  private final DbCompositeKey<DbString, DbLong> idAndVersionKey;
+
+  /** [process id | process version] => process */
+  private final ColumnFamily<DbCompositeKey<DbString, DbLong>, PersistedProcess>
+      deprecatedProcessCacheByIdAndVersionColumnFamily;
+
+  private final DbTenantAwareKey<DbCompositeKey<DbString, DbLong>>
+      tenantAwareProcessIdAndVersionKey;
+
+  /** [tenant id | process id | process version] => process */
+  private final ColumnFamily<DbTenantAwareKey<DbCompositeKey<DbString, DbLong>>, PersistedProcess>
+      processByIdAndVersionColumnFamily;
+
+  private final Digest digest;
+  private final DbForeignKey<DbString> fkProcessId;
+
+  /** [process id] => digest */
+  private final ColumnFamily<DbForeignKey<DbString>, Digest> deprecatedDigestByIdColumnFamily;
+
+  private final DbTenantAwareKey<DbString> tenantAwareProcessId;
+  private final DbForeignKey<DbTenantAwareKey<DbString>> fkTenantAwareProcessId;
+
+  /** [tenant id | process id] => digest */
+  private final ColumnFamily<DbForeignKey<DbTenantAwareKey<DbString>>, Digest>
+      digestByIdColumnFamily;
+
+  private final DbString processIdKey;
+  private final VersionInfo versionInfo;
+
+  /** [process id] => version info */
+  private final ColumnFamily<DbString, VersionInfo> deprecatedNextValueColumnFamily;
+
+  private final DbString idKey;
+  private final DbTenantAwareKey<DbString> tenantAwareIdKey;
+
+  /** [tenant id | (process) id] => version info */
+  private final ColumnFamily<DbTenantAwareKey<DbString>, VersionInfo> versionInfoColumnFamily;
+
+  public DbProcessMigrationState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    processDefinitionKey = new DbLong();
+    persistedProcess = new PersistedProcess();
+    deprecatedProcessCacheColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEPRECATED_PROCESS_CACHE,
+            transactionContext,
+            processDefinitionKey,
+            persistedProcess);
+
+    tenantIdKey = new DbString();
+    tenantAwareProcessDefinitionKey =
+        new DbTenantAwareKey<>(tenantIdKey, processDefinitionKey, PlacementType.PREFIX);
+    processColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PROCESS_CACHE,
+            transactionContext,
+            tenantAwareProcessDefinitionKey,
+            persistedProcess);
+
+    processId = new DbString();
+    processVersion = new DbLong();
+    idAndVersionKey = new DbCompositeKey<>(processId, processVersion);
+    deprecatedProcessCacheByIdAndVersionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEPRECATED_PROCESS_CACHE_BY_ID_AND_VERSION,
+            transactionContext,
+            idAndVersionKey,
+            persistedProcess);
+
+    tenantAwareProcessIdAndVersionKey =
+        new DbTenantAwareKey<>(tenantIdKey, idAndVersionKey, PlacementType.PREFIX);
+    processByIdAndVersionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PROCESS_CACHE_BY_ID_AND_VERSION,
+            transactionContext,
+            tenantAwareProcessIdAndVersionKey,
+            persistedProcess);
+
+    digest = new Digest();
+    fkProcessId =
+        new DbForeignKey<>(
+            processId,
+            ZbColumnFamilies.DEPRECATED_PROCESS_CACHE_BY_ID_AND_VERSION,
+            MatchType.Prefix);
+    deprecatedDigestByIdColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEPRECATED_PROCESS_CACHE_DIGEST_BY_ID,
+            transactionContext,
+            fkProcessId,
+            digest);
+
+    tenantAwareProcessId = new DbTenantAwareKey<>(tenantIdKey, processId, PlacementType.PREFIX);
+    fkTenantAwareProcessId =
+        new DbForeignKey<>(
+            tenantAwareProcessId,
+            ZbColumnFamilies.PROCESS_CACHE_BY_ID_AND_VERSION,
+            MatchType.Prefix);
+    digestByIdColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PROCESS_CACHE_DIGEST_BY_ID,
+            transactionContext,
+            fkTenantAwareProcessId,
+            digest);
+
+    processIdKey = new DbString();
+    versionInfo = new VersionInfo();
+    deprecatedNextValueColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEPRECATED_PROCESS_VERSION,
+            transactionContext,
+            processIdKey,
+            versionInfo);
+
+    idKey = new DbString();
+    tenantAwareIdKey = new DbTenantAwareKey<>(tenantIdKey, idKey, PlacementType.PREFIX);
+    versionInfoColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PROCESS_VERSION, transactionContext, tenantAwareIdKey, versionInfo);
+  }
+
+  public void migrateProcessStateForMultiTenancy() {
+    tenantIdKey.wrapString(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    deprecatedProcessCacheColumnFamily.forEach(
+        (key, value) -> {
+          value.setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+          processDefinitionKey.wrapLong(key.getValue());
+          processColumnFamily.insert(tenantAwareProcessDefinitionKey, value);
+          deprecatedProcessCacheColumnFamily.deleteExisting(key);
+        });
+
+    deprecatedProcessCacheByIdAndVersionColumnFamily.forEach(
+        (key, value) -> {
+          value.setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+          processId.wrapBuffer(value.getBpmnProcessId());
+          processVersion.wrapLong(value.getVersion());
+          processByIdAndVersionColumnFamily.insert(tenantAwareProcessIdAndVersionKey, value);
+          deprecatedProcessCacheByIdAndVersionColumnFamily.deleteExisting(key);
+        });
+
+    deprecatedDigestByIdColumnFamily.forEach(
+        (key, value) -> {
+          processId.wrapBuffer(key.inner().getBuffer());
+          digestByIdColumnFamily.insert(fkTenantAwareProcessId, value);
+          deprecatedDigestByIdColumnFamily.deleteExisting(key);
+        });
+
+    deprecatedNextValueColumnFamily.forEach(
+        (key, value) -> {
+          idKey.wrapBuffer(key.getBuffer());
+          versionInfoColumnFamily.insert(tenantAwareIdKey, value);
+          deprecatedNextValueColumnFamily.deleteExisting(key);
+        });
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import io.camunda.zeebe.engine.state.migration.MigrationTask;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+
+/**
+ * This migration is used to extend the data with tenant information. Before this migration, no
+ * tenant information was stored in the state. Therefore, we're considering all existing data to be
+ * part of the default tenant.
+ *
+ * <p>This migration will set the tenant id of all existing data to the default tenant id. Both in
+ * values and in keys. When the key has changed, the data is moved to a new column family.
+ */
+public class MultiTenancyMigration implements MigrationTask {
+
+  @Override
+  public String getIdentifier() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public void runMigration(final MutableProcessingState processingState) {
+    final var migrationState = processingState.getMigrationState();
+    migrationState.migrateProcessStateForMultiTenancy();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -33,6 +33,8 @@ public interface MutableMigrationState extends MigrationState {
 
   void migrateProcessDefinitionVersions();
 
+  void migrateProcessStateForMultiTenancy();
+
   /**
    * Changes the state of a migration to FINISHED to indicate it has been executed.
    *

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigrationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.state.immutable.MigrationState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class MultiTenancyMigrationTest {
+
+  final MultiTenancyMigration sut = new MultiTenancyMigration();
+
+  @Nested
+  class MockBasedTests {
+
+    @Test
+    void migrationNeededWhenMigrationNotFinished() {
+      // given
+      final var mockProcessingState = mock(ProcessingState.class);
+      final var migrationState = mock(MigrationState.class);
+      when(mockProcessingState.getMigrationState()).thenReturn(migrationState);
+      when(migrationState.isMigrationFinished(anyString())).thenReturn(false);
+
+      // when
+      final var actual = sut.needsToRun(mockProcessingState);
+
+      // then
+      assertThat(actual).isTrue();
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigrationTest.java
@@ -7,15 +7,31 @@
  */
 package io.camunda.zeebe.engine.state.migration.to_8_3;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.deployment.DbProcessState;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.MigrationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.migration.to_8_3.legacy.LegacyProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 public class MultiTenancyMigrationTest {
 
@@ -37,6 +53,60 @@ public class MultiTenancyMigrationTest {
 
       // then
       assertThat(actual).isTrue();
+    }
+  }
+
+  @Nested
+  @ExtendWith(ProcessingStateExtension.class)
+  class MigrateProcessStateForMultiTenancyTest {
+
+    private ZeebeDb<ZbColumnFamilies> zeebeDb;
+    private MutableProcessingState processingState;
+    private TransactionContext transactionContext;
+
+    private LegacyProcessState legacyState;
+    private DbProcessState processState;
+
+    @BeforeEach
+    void setup() {
+      legacyState = new LegacyProcessState(zeebeDb, transactionContext);
+      processState = new DbProcessState(zeebeDb, transactionContext);
+    }
+
+    @Test
+    void shouldMigrateProcessColumnFamily() {
+      // given
+      final var model = Bpmn.createExecutableProcess("processId").startEvent().done();
+      legacyState.putProcess(
+          123,
+          new ProcessRecord()
+              .setKey(123)
+              .setBpmnProcessId("processId")
+              .setVersion(1)
+              .setResourceName("resourceName")
+              .setResource(wrapString(Bpmn.convertToString(model)))
+              .setChecksum(wrapString("checksum")));
+
+      // when
+      sut.runMigration(processingState);
+
+      // then
+      assertThat(processState.getProcessByKeyAndTenant(123, TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+          .extracting(
+              p -> bufferAsString(p.getBpmnProcessId()),
+              DeployedProcess::getVersion,
+              DeployedProcess::getState,
+              p -> bufferAsString(p.getResourceName()),
+              DeployedProcess::getTenantId,
+              p -> bufferAsString(p.getResource()))
+          .containsExactly(
+              "processId",
+              1,
+              PersistedProcessState.ACTIVE,
+              "resourceName",
+              TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+              Bpmn.convertToString(model));
+      assertThat(legacyState.getProcessByKey(123)).isNull();
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3.legacy;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.DbForeignKey.MatchType;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.processing.deployment.model.BpmnFactory;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.Digest;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.stream.impl.state.NextValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToLongFunction;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.Long2ObjectHashMap;
+import org.agrona.collections.Object2LongHashMap;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.io.DirectBufferInputStream;
+
+/**
+ * This is a copy of {@link io.camunda.zeebe.engine.state.immutable.ProcessState} from 8.2.13. It is
+ * used to test the migration of the process state to 8.3.0.
+ */
+public final class LegacyProcessState {
+  private static final int DEFAULT_VERSION_VALUE = 0;
+
+  private final BpmnTransformer transformer = BpmnFactory.createTransformer();
+  private final ProcessRecord processRecordForDeployments = new ProcessRecord();
+
+  private final Map<DirectBuffer, Long2ObjectHashMap<DeployedProcess>>
+      processesByProcessIdAndVersion = new HashMap<>();
+  private final Long2ObjectHashMap<DeployedProcess> processesByKey;
+
+  // process
+  private final ColumnFamily<DbLong, PersistedProcess> processColumnFamily;
+  private final DbLong processDefinitionKey;
+  private final PersistedProcess persistedProcess;
+
+  private final ColumnFamily<DbCompositeKey<DbString, DbLong>, PersistedProcess>
+      processByIdAndVersionColumnFamily;
+  private final DbLong processVersion;
+  private final DbCompositeKey<DbString, DbLong> idAndVersionKey;
+
+  private final DbString processId;
+  private final DbForeignKey<DbString> fkProcessId;
+
+  private final ColumnFamily<DbForeignKey<DbString>, Digest> digestByIdColumnFamily;
+  private final Digest digest = new Digest();
+
+  private final LegacyProcessVersionManager versionManager;
+
+  public LegacyProcessState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    processDefinitionKey = new DbLong();
+    persistedProcess = new PersistedProcess();
+    processColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEPRECATED_PROCESS_CACHE,
+            transactionContext,
+            processDefinitionKey,
+            persistedProcess);
+
+    processId = new DbString();
+    processVersion = new DbLong();
+    idAndVersionKey = new DbCompositeKey<>(processId, processVersion);
+    processByIdAndVersionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEPRECATED_PROCESS_CACHE_BY_ID_AND_VERSION,
+            transactionContext,
+            idAndVersionKey,
+            persistedProcess);
+
+    fkProcessId =
+        new DbForeignKey<>(
+            processId,
+            ZbColumnFamilies.DEPRECATED_PROCESS_CACHE_BY_ID_AND_VERSION,
+            MatchType.Prefix);
+    digestByIdColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEPRECATED_PROCESS_CACHE_DIGEST_BY_ID,
+            transactionContext,
+            fkProcessId,
+            digest);
+
+    processesByKey = new Long2ObjectHashMap<>();
+
+    versionManager =
+        new LegacyProcessVersionManager(DEFAULT_VERSION_VALUE, zeebeDb, transactionContext);
+  }
+
+  public void putDeployment(final DeploymentRecord deploymentRecord) {
+    for (final ProcessMetadata metadata : deploymentRecord.processesMetadata()) {
+      for (final DeploymentResource resource : deploymentRecord.getResources()) {
+        if (resource.getResourceName().equals(metadata.getResourceName())) {
+          processRecordForDeployments.reset();
+          processRecordForDeployments.wrap(metadata, resource.getResource());
+          putProcess(metadata.getKey(), processRecordForDeployments);
+        }
+      }
+    }
+  }
+
+  public void putLatestVersionDigest(
+      final DirectBuffer processIdBuffer, final DirectBuffer digest) {
+    processId.wrapBuffer(processIdBuffer);
+    this.digest.set(digest);
+
+    digestByIdColumnFamily.upsert(fkProcessId, this.digest);
+  }
+
+  public void putProcess(final long key, final ProcessRecord processRecord) {
+    persistProcess(key, processRecord);
+    updateLatestVersion(processRecord);
+    putLatestVersionDigest(
+        processRecord.getBpmnProcessIdBuffer(), processRecord.getChecksumBuffer());
+  }
+
+  private void persistProcess(final long processDefinitionKey, final ProcessRecord processRecord) {
+    persistedProcess.wrap(processRecord, processDefinitionKey);
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    processColumnFamily.upsert(this.processDefinitionKey, persistedProcess);
+
+    processId.wrapBuffer(processRecord.getBpmnProcessIdBuffer());
+    processVersion.wrapLong(processRecord.getVersion());
+
+    processByIdAndVersionColumnFamily.upsert(idAndVersionKey, persistedProcess);
+  }
+
+  private void updateLatestVersion(final ProcessRecord processRecord) {
+    processId.wrapBuffer(processRecord.getBpmnProcessIdBuffer());
+    final var bpmnProcessId = processRecord.getBpmnProcessId();
+
+    final var currentVersion = versionManager.getCurrentProcessVersion(bpmnProcessId);
+    final var nextVersion = processRecord.getVersion();
+
+    if (nextVersion > currentVersion) {
+      versionManager.setProcessVersion(bpmnProcessId, nextVersion);
+    }
+  }
+
+  // is called on getters, if process is not in memory
+  private DeployedProcess updateInMemoryState(final PersistedProcess persistedProcess) {
+
+    // we have to copy to store this in cache
+    final byte[] bytes = new byte[persistedProcess.getLength()];
+    final MutableDirectBuffer buffer = new UnsafeBuffer(bytes);
+    persistedProcess.write(buffer, 0);
+
+    final PersistedProcess copiedProcess = new PersistedProcess();
+    copiedProcess.wrap(buffer, 0, persistedProcess.getLength());
+
+    final BpmnModelInstance modelInstance =
+        readModelInstanceFromBuffer(copiedProcess.getResource());
+    final List<ExecutableProcess> definitions = transformer.transformDefinitions(modelInstance);
+
+    final ExecutableProcess executableProcess =
+        definitions.stream()
+            .filter(w -> BufferUtil.equals(persistedProcess.getBpmnProcessId(), w.getId()))
+            .findFirst()
+            .orElseThrow();
+
+    final DeployedProcess deployedProcess = new DeployedProcess(executableProcess, copiedProcess);
+
+    addProcessToInMemoryState(deployedProcess);
+
+    return deployedProcess;
+  }
+
+  private BpmnModelInstance readModelInstanceFromBuffer(final DirectBuffer buffer) {
+    try (final DirectBufferInputStream stream = new DirectBufferInputStream(buffer)) {
+      return Bpmn.readModelFromStream(stream);
+    }
+  }
+
+  private void addProcessToInMemoryState(final DeployedProcess deployedProcess) {
+    final DirectBuffer bpmnProcessId = deployedProcess.getBpmnProcessId();
+    processesByKey.put(deployedProcess.getKey(), deployedProcess);
+
+    final Long2ObjectHashMap<DeployedProcess> versionMap =
+        processesByProcessIdAndVersion.computeIfAbsent(
+            bpmnProcessId, id -> new Long2ObjectHashMap<>());
+
+    final int version = deployedProcess.getVersion();
+    versionMap.put(version, deployedProcess);
+  }
+
+  public DeployedProcess getLatestProcessVersionByProcessId(final DirectBuffer processIdBuffer) {
+    final Long2ObjectHashMap<DeployedProcess> versionMap =
+        processesByProcessIdAndVersion.get(processIdBuffer);
+
+    processId.wrapBuffer(processIdBuffer);
+    final long latestVersion = versionManager.getCurrentProcessVersion(processIdBuffer);
+
+    DeployedProcess deployedProcess;
+    if (versionMap == null) {
+      deployedProcess = lookupProcessByIdAndPersistedVersion(latestVersion);
+    } else {
+      deployedProcess = versionMap.get(latestVersion);
+      if (deployedProcess == null) {
+        deployedProcess = lookupProcessByIdAndPersistedVersion(latestVersion);
+      }
+    }
+    return deployedProcess;
+  }
+
+  public DeployedProcess getProcessByProcessIdAndVersion(
+      final DirectBuffer processId, final int version) {
+    final Long2ObjectHashMap<DeployedProcess> versionMap =
+        processesByProcessIdAndVersion.get(processId);
+
+    if (versionMap != null) {
+      final DeployedProcess deployedProcess = versionMap.get(version);
+      return deployedProcess != null ? deployedProcess : lookupPersistenceState(processId, version);
+    } else {
+      return lookupPersistenceState(processId, version);
+    }
+  }
+
+  public DeployedProcess getProcessByKey(final long key) {
+    final DeployedProcess deployedProcess = processesByKey.get(key);
+
+    if (deployedProcess != null) {
+      return deployedProcess;
+    } else {
+      return lookupPersistenceStateForProcessByKey(key);
+    }
+  }
+
+  public Collection<DeployedProcess> getProcesses() {
+    updateCompleteInMemoryState();
+    return processesByKey.values();
+  }
+
+  public Collection<DeployedProcess> getProcessesByBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    updateCompleteInMemoryState();
+
+    final Long2ObjectHashMap<DeployedProcess> processesByVersions =
+        processesByProcessIdAndVersion.get(bpmnProcessId);
+
+    if (processesByVersions != null) {
+      return processesByVersions.values();
+    }
+    return Collections.emptyList();
+  }
+
+  public DirectBuffer getLatestVersionDigest(final DirectBuffer processIdBuffer) {
+    processId.wrapBuffer(processIdBuffer);
+    final Digest latestDigest = digestByIdColumnFamily.get(fkProcessId);
+    return latestDigest == null || digest.get().byteArray() == null ? null : latestDigest.get();
+  }
+
+  public int getProcessVersion(final String bpmnProcessId) {
+    return (int) versionManager.getCurrentProcessVersion(bpmnProcessId);
+  }
+
+  public <T extends ExecutableFlowElement> T getFlowElement(
+      final long processDefinitionKey, final DirectBuffer elementId, final Class<T> elementType) {
+
+    final var deployedProcess = getProcessByKey(processDefinitionKey);
+    if (deployedProcess == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to find a process deployed with key '%d' but not found.",
+              processDefinitionKey));
+    }
+
+    final var process = deployedProcess.getProcess();
+    final var element = process.getElementById(elementId, elementType);
+    if (element == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to find a flow element with id '%s' in process with key '%d' but not found.",
+              bufferAsString(elementId), processDefinitionKey));
+    }
+
+    return element;
+  }
+
+  public void clearCache() {
+    processesByKey.clear();
+    processesByProcessIdAndVersion.clear();
+    versionManager.clear();
+  }
+
+  private DeployedProcess lookupProcessByIdAndPersistedVersion(final long latestVersion) {
+    processVersion.wrapLong(latestVersion);
+
+    final PersistedProcess processWithVersionAndId =
+        processByIdAndVersionColumnFamily.get(idAndVersionKey);
+
+    if (processWithVersionAndId != null) {
+      return updateInMemoryState(processWithVersionAndId);
+    }
+    return null;
+  }
+
+  private DeployedProcess lookupPersistenceState(
+      final DirectBuffer processIdBuffer, final int version) {
+    processId.wrapBuffer(processIdBuffer);
+    processVersion.wrapLong(version);
+
+    final PersistedProcess processWithVersionAndId =
+        processByIdAndVersionColumnFamily.get(idAndVersionKey);
+
+    if (processWithVersionAndId != null) {
+      updateInMemoryState(processWithVersionAndId);
+
+      final Long2ObjectHashMap<DeployedProcess> newVersionMap =
+          processesByProcessIdAndVersion.get(processIdBuffer);
+
+      if (newVersionMap != null) {
+        return newVersionMap.get(version);
+      }
+    }
+    // does not exist in persistence and in memory state
+    return null;
+  }
+
+  private DeployedProcess lookupPersistenceStateForProcessByKey(final long processDefinitionKey) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+
+    final PersistedProcess processWithKey = processColumnFamily.get(this.processDefinitionKey);
+    if (processWithKey != null) {
+      updateInMemoryState(processWithKey);
+
+      return processesByKey.get(processDefinitionKey);
+    }
+    // does not exist in persistence and in memory state
+    return null;
+  }
+
+  private void updateCompleteInMemoryState() {
+    processColumnFamily.forEach(this::updateInMemoryState);
+  }
+
+  public static final class LegacyProcessVersionManager {
+
+    private final long initialValue;
+
+    private final ColumnFamily<DbString, NextValue> nextValueColumnFamily;
+    private final DbString processIdKey;
+    private final NextValue nextVersion = new NextValue();
+    private final Object2LongHashMap<String> versionCache;
+
+    public LegacyProcessVersionManager(
+        final long initialValue,
+        final ZeebeDb<ZbColumnFamilies> zeebeDb,
+        final TransactionContext transactionContext) {
+      this.initialValue = initialValue;
+
+      processIdKey = new DbString();
+      nextValueColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.DEPRECATED_PROCESS_VERSION,
+              transactionContext,
+              processIdKey,
+              nextVersion);
+      versionCache = new Object2LongHashMap<>(initialValue);
+    }
+
+    public void setProcessVersion(final String processId, final long value) {
+      processIdKey.wrapString(processId);
+      nextVersion.set(value);
+      nextValueColumnFamily.upsert(processIdKey, nextVersion);
+      versionCache.put(processId, value);
+    }
+
+    public long getCurrentProcessVersion(final String processId) {
+      processIdKey.wrapString(processId);
+      return getCurrentProcessVersion();
+    }
+
+    public long getCurrentProcessVersion(final DirectBuffer processId) {
+      processIdKey.wrapBuffer(processId);
+      return getCurrentProcessVersion();
+    }
+
+    private long getCurrentProcessVersion() {
+      return versionCache.computeIfAbsent(
+          processIdKey.toString(), (ToLongFunction<String>) (key) -> getProcessVersionFromDB());
+    }
+
+    private long getProcessVersionFromDB() {
+      final NextValue readValue = nextValueColumnFamily.get(processIdKey);
+
+      long currentValue = initialValue;
+      if (readValue != null) {
+        currentValue = readValue.get();
+      }
+      return currentValue;
+    }
+
+    public void clear() {
+      versionCache.clear();
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Migrates the `ProcessState` (and `VersionManager`) for multi-tenancy.

### ProcessState
- `DEPRECATED_PROCESS_CACHE` -> `PROCESS_CACHE`
    -  Prefix tenant to key
    - Set tenant in value (`PersistedProcess`)
- `DEPRECATED_PROCESS_CACHE_BY_ID_AND_VERSION` -> `PROCESS_CACHE_BY_ID_AND_VERSION`
    - Prefix tenant to key
    - Set tenant in value (`PersistedProcess`)
- `DEPRECATED_PROCESS_CACHE_DIGEST_BY_ID` -> `PROCESS_CACHE_DIGEST_BY_ID`
    - Prefix tenant to key

### VersionManager
- `DEPRECATED_PROCESS_VERSION` -> `PROCESS_VERSION`
    - Prefix tenant to key

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14425 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
