### PR TITLE
ci: fix e2e generation template naming

### DIFF
--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -70,11 +70,11 @@ jobs:
           - branch: 'main'
             generation_template: 'Zeebe SNAPSHOT'
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-major-minor-version) }}
-            generation_template: ${{ format('Camunda Platform {0}', needs.get-versions.outputs.latest-major-minor-patch-version) }}
+            generation_template: ${{ format('Camunda {0}', needs.get-versions.outputs.latest-major-minor-patch-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-major-minor-version) }}
-            generation_template: ${{ format('Camunda Platform {0}', needs.get-versions.outputs.previous-latest-major-minor-patch-version) }}
+            generation_template: ${{ format('Camunda {0}', needs.get-versions.outputs.previous-latest-major-minor-patch-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
-            generation_template: ${{ format('Camunda Platform {0}', needs.get-versions.outputs.previous-previous-latest-major-minor-patch-version) }}
+            generation_template: ${{ format('Camunda {0}', needs.get-versions.outputs.previous-previous-latest-major-minor-patch-version) }}
     name: Weekly E2E
     uses: ./.github/workflows/e2e-testbench.yaml
     with:


### PR DESCRIPTION
Generation were renamed from "Camund Platform" to "Camunda" + Version. This fixes our scripts that figure out the naming for the latest generation.