### PR TITLE
Add tenantId to PublishMessage request in Java Client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PublishMessageResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PublishMessageResponse.java
@@ -15,8 +15,6 @@
  */
 package io.camunda.zeebe.client.api.response;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
-
 public interface PublishMessageResponse {
 
   /**
@@ -31,6 +29,5 @@ public interface PublishMessageResponse {
    *
    * @return identifier of the tenant that owns the published message.
    */
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/13559")
   String getTenantId();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -52,6 +52,7 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
     builder = PublishMessageRequest.newBuilder();
     requestTimeout = configuration.getDefaultRequestTimeout();
     builder.setTimeToLive(configuration.getDefaultMessageTimeToLive().toMillis());
+    tenantId(configuration.getDefaultTenantId());
   }
 
   @Override
@@ -85,6 +86,12 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
   }
 
   @Override
+  public PublishMessageCommandStep3 tenantId(final String tenantId) {
+    builder.setTenantId(tenantId);
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<PublishMessageResponse> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     return this;
@@ -111,11 +118,5 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .publishMessage(request, streamObserver);
-  }
-
-  @Override
-  public PublishMessageCommandStep3 tenantId(final String tenantId) {
-    // todo(#13559): replace dummy implementation
-    return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/PublishMessageResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/PublishMessageResponseImpl.java
@@ -21,9 +21,11 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 public final class PublishMessageResponseImpl implements PublishMessageResponse {
 
   private final long key;
+  private final String tenantId;
 
   public PublishMessageResponseImpl(final GatewayOuterClass.PublishMessageResponse response) {
     key = response.getKey();
+    tenantId = response.getTenantId();
   }
 
   @Override
@@ -33,7 +35,6 @@ public final class PublishMessageResponseImpl implements PublishMessageResponse 
 
   @Override
   public String getTenantId() {
-    // todo(#13559): replace dummy implementation
-    return "";
+    return tenantId;
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
@@ -482,7 +482,11 @@ public final class RecordingGatewayService extends GatewayImplBase {
   public void onPublishMessageRequest(final long key) {
     addRequestHandler(
         PublishMessageRequest.class,
-        request -> PublishMessageResponse.newBuilder().setKey(key).build());
+        request ->
+            PublishMessageResponse.newBuilder()
+                .setKey(key)
+                .setTenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER)
+                .build());
   }
 
   public void onBroadcastSignalRequest(final long key) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Adds MT support for the PublishMessage command in the Java client.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13559

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
