### PR TITLE
Support multi-tenancy for incidents

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -63,7 +63,8 @@ public final class BpmnIncidentBehavior {
         .setElementId(context.getElementId())
         .setVariableScopeKey(variableScopeKey)
         .setErrorType(failure.getErrorType())
-        .setErrorMessage(failure.getMessage());
+        .setErrorMessage(failure.getMessage())
+        .setTenantId(context.getTenantId());
 
     final var key = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(key, IncidentIntent.CREATED, incidentRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
-import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -27,7 +26,6 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
-import java.util.List;
 
 public final class ResolveIncidentProcessor implements TypedRecordProcessor<IncidentRecord> {
 
@@ -67,10 +65,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
   public void processRecord(final TypedRecord<IncidentRecord> command) {
     final long key = command.getKey();
 
-    final List<String> authorizedTenants =
-        (List<String>) command.getAuthorizations().get(Authorization.AUTHORIZED_TENANTS);
-    final var incident = incidentState.getIncidentRecord(key, authorizedTenants);
-
+    final var incident = incidentState.getIncidentRecord(key, command.getAuthorizations());
     if (incident == null) {
       final var errorMessage = String.format(NO_INCIDENT_FOUND_MSG, key);
       rejectResolveCommand(command, errorMessage, RejectionType.NOT_FOUND);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -26,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
+import java.util.List;
 
 public final class ResolveIncidentProcessor implements TypedRecordProcessor<IncidentRecord> {
 
@@ -65,7 +67,10 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
   public void processRecord(final TypedRecord<IncidentRecord> command) {
     final long key = command.getKey();
 
-    final var incident = incidentState.getIncidentRecord(key);
+    final List<String> authorizedTenants =
+        (List<String>) command.getAuthorizations().get(Authorization.AUTHORIZED_TENANTS);
+    final var incident = incidentState.getIncidentRecord(key, authorizedTenants);
+
     if (incident == null) {
       final var errorMessage = String.format(NO_INCIDENT_FOUND_MSG, key);
       rejectResolveCommand(command, errorMessage, RejectionType.NOT_FOUND);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -146,6 +146,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
             .setElementId(job.getElementIdBuffer())
             .setElementInstanceKey(job.getElementInstanceKey())
             .setJobKey(jobKey)
+            .setTenantId(job.getTenantId())
             .setVariableScopeKey(job.getElementInstanceKey());
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -167,7 +167,8 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
         .setElementId(value.getElementIdBuffer())
         .setElementInstanceKey(value.getElementInstanceKey())
         .setJobKey(key)
-        .setVariableScopeKey(value.getElementInstanceKey());
+        .setVariableScopeKey(value.getElementInstanceKey())
+        .setTenantId(value.getTenantId());
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -162,6 +162,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
         .setProcessInstanceKey(job.getProcessInstanceKey())
         .setElementId(job.getElementIdBuffer())
         .setElementInstanceKey(job.getElementInstanceKey())
+        .setTenantId(job.getTenantId())
         .setJobKey(key)
         .setVariableScopeKey(job.getElementInstanceKey());
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/IncidentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/IncidentState.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
-import java.util.List;
+import java.util.Map;
 import java.util.function.ObjLongConsumer;
 
 public interface IncidentState {
@@ -17,7 +17,7 @@ public interface IncidentState {
 
   IncidentRecord getIncidentRecord(long incidentKey);
 
-  IncidentRecord getIncidentRecord(long incidentKey, final List<String> tenantIds);
+  IncidentRecord getIncidentRecord(long incidentKey, final Map<String, Object> authorizations);
 
   long getProcessInstanceIncidentKey(long processInstanceKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/IncidentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/IncidentState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import java.util.List;
 import java.util.function.ObjLongConsumer;
 
 public interface IncidentState {
@@ -15,6 +16,8 @@ public interface IncidentState {
   int MISSING_INCIDENT = -1;
 
   IncidentRecord getIncidentRecord(long incidentKey);
+
+  IncidentRecord getIncidentRecord(long incidentKey, final List<String> tenantIds);
 
   long getProcessInstanceIncidentKey(long processInstanceKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.state.immutable.IncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import java.util.List;
 import java.util.function.ObjLongConsumer;
 
 public final class DbIncidentState implements MutableIncidentState {
@@ -114,6 +115,16 @@ public final class DbIncidentState implements MutableIncidentState {
     final Incident incident = incidentColumnFamily.get(this.incidentKey);
     if (incident != null) {
       return incident.getRecord();
+    }
+    return null;
+  }
+
+  @Override
+  public IncidentRecord getIncidentRecord(
+      final long incidentKey, final List<String> authorizedTenantIds) {
+    final IncidentRecord incident = getIncidentRecord(incidentKey);
+    if (incident != null && authorizedTenantIds.contains(incident.getTenantId())) {
+      return incident;
     }
     return null;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.instance;
 
+import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import java.util.List;
+import java.util.Map;
 import java.util.function.ObjLongConsumer;
 
 public final class DbIncidentState implements MutableIncidentState {
@@ -121,9 +123,10 @@ public final class DbIncidentState implements MutableIncidentState {
 
   @Override
   public IncidentRecord getIncidentRecord(
-      final long incidentKey, final List<String> authorizedTenantIds) {
+      final long incidentKey, final Map<String, Object> authorizations) {
     final IncidentRecord incident = getIncidentRecord(incidentKey);
-    if (incident != null && authorizedTenantIds.contains(incident.getTenantId())) {
+    if (incident != null
+        && getAuthorizedTenantIds(authorizations).contains(incident.getTenantId())) {
       return incident;
     }
     return null;
@@ -168,5 +171,9 @@ public final class DbIncidentState implements MutableIncidentState {
       final IncidentRecord incidentRecord = getIncidentRecord(processIncidentKey);
       resolver.accept(incidentRecord, processIncidentKey);
     }
+  }
+
+  private List<String> getAuthorizedTenantIds(final Map<String, Object> authorizations) {
+    return (List<String>) authorizations.get(Authorization.AUTHORIZED_TENANTS);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValueAssert;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -54,6 +55,12 @@ public class BusinessRuleTaskIncidentTest {
 
   private IncidentRecordValueAssert assertIncidentCreated(
       final long processInstanceKey, final long elementInstanceKey) {
+    return assertIncidentCreated(
+        processInstanceKey, elementInstanceKey, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  private IncidentRecordValueAssert assertIncidentCreated(
+      final long processInstanceKey, final long elementInstanceKey, final String tenantId) {
     final var incidentRecord =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -61,6 +68,7 @@ public class BusinessRuleTaskIncidentTest {
     return Assertions.assertThat(incidentRecord.getValue())
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(elementInstanceKey)
+        .hasTenantId(tenantId)
         .hasJobKey(-1L)
         .hasVariableScopeKey(elementInstanceKey);
   }
@@ -360,5 +368,35 @@ public class BusinessRuleTaskIncidentTest {
                 .exists())
         .describedAs("business rule task is successfully completed")
         .isTrue();
+  }
+
+  @Test
+  public void shouldCreateIncidentOnBusinessRuleTaskForCustomTenant() {
+    // given
+    final String tenantId = "acme";
+    engine
+        .deployment()
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                b ->
+                    b.zeebeCalledDecisionId("unknown_decision_id")
+                        .zeebeResultVariable(RESULT_VARIABLE)))
+        .withTenantId(tenantId)
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    final var taskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+            .withTenantId(tenantId)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, taskActivating.getKey(), tenantId);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ConditionIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ConditionIncidentTest.java
@@ -33,27 +33,26 @@ import org.junit.Test;
 public final class ConditionIncidentTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
-  private static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess("process")
-      .startEvent()
-      .exclusiveGateway("xor")
-      .sequenceFlowId("s1")
-      .conditionExpression("foo < 5")
-      .endEvent()
-      .moveToLastGateway()
-      .sequenceFlowId("s2")
-      .conditionExpression("foo > 10")
-      .endEvent()
-      .done();
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .exclusiveGateway("xor")
+          .sequenceFlowId("s1")
+          .conditionExpression("foo < 5")
+          .endEvent()
+          .moveToLastGateway()
+          .sequenceFlowId("s2")
+          .conditionExpression("foo > 10")
+          .endEvent()
+          .done();
+
   @Rule
   public RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
   @BeforeClass
   public static void init() {
-    ENGINE
-        .deployment()
-        .withXmlResource(PROCESS)
-        .deploy();
+    ENGINE.deployment().withXmlResource(PROCESS).deploy();
   }
 
   @Test
@@ -128,15 +127,16 @@ public final class ConditionIncidentTest {
   public void shouldCreateIncidentOnConditionCatchEventWithCustomTenant() {
     // given
     final String tenantId = "acme";
-    ENGINE
-        .deployment()
-        .withXmlResource(PROCESS)
-        .withTenantId(tenantId)
-        .deploy();
+    ENGINE.deployment().withXmlResource(PROCESS).withTenantId(tenantId).deploy();
 
     // when
     final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId("process").withVariable("foo", "bar").withTenantId(tenantId).create();
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withVariable("foo", "bar")
+            .withTenantId(tenantId)
+            .create();
 
     // then
     final Record<IncidentRecordValue> incidentEvent =
@@ -145,8 +145,7 @@ public final class ConditionIncidentTest {
             .withIntent(IncidentIntent.CREATED)
             .getFirst();
 
-    Assertions.assertThat(incidentEvent.getValue())
-        .hasTenantId(tenantId);
+    Assertions.assertThat(incidentEvent.getValue()).hasTenantId(tenantId);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -148,6 +149,7 @@ public final class ErrorEventIncidentTest {
             .getFirst();
 
     Assertions.assertThat(incidentEvent.getValue())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
         .hasErrorMessage(
             "Expected to throw an error event with the code 'other-error', but it was not caught. Available error events are [error]");

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EventSubProcessIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EventSubProcessIncidentTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -142,7 +143,8 @@ public class EventSubProcessIncidentTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId("event_sub_proc")
         .hasElementInstanceKey(failureEvent.getKey())
-        .hasVariableScopeKey(failureEvent.getKey());
+        .hasVariableScopeKey(failureEvent.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     assertThat(incidentEventValue.getErrorMessage())
         .contains("Assertion failure on evaluate the expression");

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EventSubscriptionIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EventSubscriptionIncidentTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Arrays;
@@ -292,6 +293,7 @@ public final class EventSubscriptionIncidentTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId(failureEvent.getValue().getElementId())
         .hasElementInstanceKey(failureEvent.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasJobKey(-1L);
   }
 
@@ -327,6 +329,7 @@ public final class EventSubscriptionIncidentTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId(failureEvent.getValue().getElementId())
         .hasElementInstanceKey(failureEvent.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasJobKey(-1L);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentHelper.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValueAssert;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+
+public class IncidentHelper {
+
+  public static IncidentRecordValueAssert assertIncidentCreated(
+      final Record<IncidentRecordValue> incident,
+      final Record<ProcessInstanceRecordValue> elementInstance) {
+    return assertIncidentCreated(incident, elementInstance, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  public static IncidentRecordValueAssert assertIncidentCreated(
+      final Record<IncidentRecordValue> incident,
+      final Record<ProcessInstanceRecordValue> elementInstance,
+      final String tenantId) {
+    return Assertions.assertThat(incident.getValue())
+        .hasElementInstanceKey(elementInstance.getKey())
+        .hasElementId(elementInstance.getValue().getElementId())
+        .hasTenantId(tenantId);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobActivationIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobActivationIncidentTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -102,7 +103,8 @@ public final class JobActivationIncidentTest {
         .hasBpmnProcessId(processId)
         .hasProcessDefinitionKey(processDefinitionKey)
         .hasProcessInstanceKey(processInstanceKey)
-        .hasElementId("task");
+        .hasElementId("task")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -97,6 +98,7 @@ public class JobWorkerElementIncidentTest {
         .hasErrorMessage("Expected result of the expression 'x' to be 'STRING', but was 'NULL'.")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasJobKey(-1L)
         .hasVariableScopeKey(recordThatLeadsToIncident.getKey());
   }
@@ -127,6 +129,7 @@ public class JobWorkerElementIncidentTest {
             "Expected result of the expression 'false' to be 'STRING', but was 'BOOLEAN'.")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasJobKey(-1L)
         .hasVariableScopeKey(recordThatLeadsToIncident.getKey());
   }
@@ -199,6 +202,7 @@ public class JobWorkerElementIncidentTest {
         .hasErrorMessage("Expected result of the expression 'x' to be 'NUMBER', but was 'NULL'.")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasJobKey(-1L)
         .hasVariableScopeKey(recordThatLeadsToIncident.getKey());
   }
@@ -232,6 +236,7 @@ public class JobWorkerElementIncidentTest {
             "Expected result of the expression 'false' to be 'NUMBER', but was 'BOOLEAN'.")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasJobKey(-1L)
         .hasVariableScopeKey(recordThatLeadsToIncident.getKey());
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -100,7 +101,8 @@ public final class MappingIncidentTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId("failingTask")
         .hasElementInstanceKey(failureCommand.getKey())
-        .hasVariableScopeKey(failureCommand.getKey());
+        .hasVariableScopeKey(failureCommand.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     assertThat(incidentEventValue.getErrorMessage())
         .contains("Assertion failure on evaluate the expression");
@@ -152,7 +154,8 @@ public final class MappingIncidentTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId("service")
         .hasElementInstanceKey(failureEvent.getKey())
-        .hasVariableScopeKey(failureEvent.getKey());
+        .hasVariableScopeKey(failureEvent.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     assertThat(incidentEvent.getValue().getErrorMessage())
         .contains("Assertion failure on evaluate the expression");
@@ -213,7 +216,8 @@ public final class MappingIncidentTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId("failingTask")
         .hasElementInstanceKey(failureEvent.getKey())
-        .hasVariableScopeKey(failureEvent.getKey());
+        .hasVariableScopeKey(failureEvent.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     assertThat(incidentEvent.getValue().getErrorMessage())
         .contains("Assertion failure on evaluate the expression");
@@ -276,7 +280,8 @@ public final class MappingIncidentTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId("failingTask")
         .hasElementInstanceKey(failureEvent.getKey())
-        .hasVariableScopeKey(failureEvent.getKey());
+        .hasVariableScopeKey(failureEvent.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     assertThat(incidentResolvedEvent.getValue().getErrorMessage())
         .contains("Assertion failure on evaluate the expression");

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import static io.camunda.zeebe.engine.processing.incident.IncidentHelper.assertIncidentCreated;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
@@ -101,9 +102,7 @@ public final class MultiInstanceIncidentTest {
             .withElementId(ELEMENT_ID)
             .getFirst();
 
-    Assertions.assertThat(incident.getValue())
-        .hasElementInstanceKey(elementInstance.getKey())
-        .hasElementId(elementInstance.getValue().getElementId())
+    assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             "Expected result of the expression 'items' to be 'ARRAY', but was 'NULL'.");
@@ -131,9 +130,7 @@ public final class MultiInstanceIncidentTest {
             .withElementId(ELEMENT_ID)
             .getFirst();
 
-    Assertions.assertThat(incident.getValue())
-        .hasElementInstanceKey(elementInstance.getKey())
-        .hasElementId(elementInstance.getValue().getElementId())
+    assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             "Expected result of the expression '"
@@ -166,9 +163,7 @@ public final class MultiInstanceIncidentTest {
             .withElementId(ELEMENT_ID)
             .getFirst();
 
-    Assertions.assertThat(incident.getValue())
-        .hasElementInstanceKey(elementInstance.getKey())
-        .hasElementId(elementInstance.getValue().getElementId())
+    assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             """

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.ProcessInstances;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -166,6 +167,7 @@ public class OutputMappingIncidentTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId(elementId)
         .hasElementInstanceKey(failureCommand.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasVariableScopeKey(failureCommand.getKey());
 
     assertThat(incidentEvent.getValue().getErrorMessage())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/UserTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/UserTaskIncidentTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValueAssert;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -51,6 +52,12 @@ public class UserTaskIncidentTest {
 
   private IncidentRecordValueAssert assertIncidentCreated(
       final long processInstanceKey, final long elementInstanceKey) {
+    return assertIncidentCreated(
+        processInstanceKey, elementInstanceKey, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  private IncidentRecordValueAssert assertIncidentCreated(
+      final long processInstanceKey, final long elementInstanceKey, final String tenantId) {
     final var incidentRecord =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -59,7 +66,8 @@ public class UserTaskIncidentTest {
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(elementInstanceKey)
         .hasJobKey(-1L)
-        .hasVariableScopeKey(elementInstanceKey);
+        .hasVariableScopeKey(elementInstanceKey)
+        .hasTenantId(tenantId);
   }
 
   // --------------------------------------------------------------------------
@@ -642,6 +650,32 @@ public class UserTaskIncidentTest {
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             "Expected result of the expression '[1,2,3]' to be one of '[DATE_TIME, STRING]', but was 'ARRAY'");
+  }
+
+  @Test
+  public void shouldCreateIncidentOnUserTaskForCustomTenant() {
+    // given
+    final String tenantId = "acme";
+    ENGINE
+        .deployment()
+        .withXmlResource(processWithUserTask(u -> u.zeebeFollowUpDateExpression("[1,2,3]")))
+        .withTenantId(tenantId)
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    final var userTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.USER_TASK)
+            .withTenantId(tenantId)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, userTaskActivating.getKey(), tenantId);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/IncidentStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/IncidentStateTest.java
@@ -212,5 +212,6 @@ public final class IncidentStateTest {
     assertThat(expectedRecord.getErrorMessageBuffer())
         .isEqualTo(storedRecord.getErrorMessageBuffer());
     assertThat(expectedRecord.getErrorType()).isEqualTo(storedRecord.getErrorType());
+    assertThat(expectedRecord.getTenantId()).isEqualTo(storedRecord.getTenantId());
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -152,15 +152,7 @@ public class StreamProcessingComposite implements CommandWriter {
 
   @Override
   public long writeCommand(final long key, final Intent intent, final UnifiedRecordValue value) {
-    final var writer =
-        streams
-            .newRecord(getLogName(partitionId))
-            .recordType(RecordType.COMMAND)
-            .key(key)
-            .intent(intent)
-            .authorizations(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
-            .event(value);
-    return writeActor.submit(writer::write).join();
+    return writeCommand(key, intent, value, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Override
@@ -215,13 +207,24 @@ public class StreamProcessingComposite implements CommandWriter {
   @Override
   public long writeCommandOnPartition(
       final int partition, final long key, final Intent intent, final UnifiedRecordValue value) {
+    return writeCommandOnPartition(
+        partition, key, intent, value, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Override
+  public long writeCommandOnPartition(
+      final int partition,
+      final long key,
+      final Intent intent,
+      final UnifiedRecordValue value,
+      final String... authorizedTenants) {
     final var writer =
         streams
             .newRecord(getLogName(partition))
             .key(key)
             .recordType(RecordType.COMMAND)
             .intent(intent)
-            .authorizations(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .authorizations(authorizedTenants)
             .event(value);
     return writeActor.submit(writer::write).join();
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -230,6 +230,17 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
     return streamProcessingComposite.writeCommandOnPartition(partition, key, intent, value);
   }
 
+  @Override
+  public long writeCommandOnPartition(
+      final int partition,
+      final long key,
+      final Intent intent,
+      final UnifiedRecordValue value,
+      final String... authorizedTenants) {
+    return streamProcessingComposite.writeCommandOnPartition(
+        partition, key, intent, value, authorizedTenants);
+  }
+
   public void snapshot() {
     final var partitionId = startPartitionId;
     streamProcessingComposite.snapshot(partitionId);

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -33,4 +33,11 @@ public interface CommandWriter {
 
   long writeCommandOnPartition(
       int partitionId, long key, Intent intent, UnifiedRecordValue recordValue);
+
+  long writeCommandOnPartition(
+      int partitionId,
+      long key,
+      Intent intent,
+      UnifiedRecordValue recordValue,
+      final String... authorizedTenants);
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -59,20 +58,6 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     jobKeyProp.setValue(record.getJobKey());
     variableScopeKeyProp.setValue(record.getVariableScopeKey());
     tenantIdProp.setValue(record.getTenantId());
-  }
-
-  public IncidentRecord initFromProcessInstanceFailure(
-      final long key, final ProcessInstanceRecord processInstanceEvent) {
-
-    setElementInstanceKey(key);
-    setBpmnProcessId(processInstanceEvent.getBpmnProcessIdBuffer());
-    setProcessDefinitionKey(processInstanceEvent.getProcessDefinitionKey());
-    setProcessInstanceKey(processInstanceEvent.getProcessInstanceKey());
-    setTenantId(processInstanceEvent.getTenantId());
-    setElementId(processInstanceEvent.getElementIdBuffer());
-    setVariableScopeKey(key);
-
-    return this;
   }
 
   @JsonIgnore

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -32,6 +32,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final LongProperty variableScopeKeyProp = new LongProperty("variableScopeKey", -1L);
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public IncidentRecord() {
     declareProperty(errorTypeProp)
@@ -42,7 +44,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
         .declareProperty(elementIdProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(jobKeyProp)
-        .declareProperty(variableScopeKeyProp);
+        .declareProperty(variableScopeKeyProp)
+        .declareProperty(tenantIdProp);
   }
 
   public void wrap(final IncidentRecord record) {
@@ -55,6 +58,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     jobKeyProp.setValue(record.getJobKey());
     variableScopeKeyProp.setValue(record.getVariableScopeKey());
+    tenantIdProp.setValue(record.getTenantId());
   }
 
   public IncidentRecord initFromProcessInstanceFailure(
@@ -64,6 +68,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     setBpmnProcessId(processInstanceEvent.getBpmnProcessIdBuffer());
     setProcessDefinitionKey(processInstanceEvent.getProcessDefinitionKey());
     setProcessInstanceKey(processInstanceEvent.getProcessInstanceKey());
+    setTenantId(processInstanceEvent.getTenantId());
     setElementId(processInstanceEvent.getElementIdBuffer());
     setVariableScopeKey(key);
 
@@ -182,7 +187,11 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
 
   @Override
   public String getTenantId() {
-    // todo(#13426): replace dummy implementation
-    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public IncidentRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/IncidentRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/IncidentRecordStream.java
@@ -47,4 +47,8 @@ public final class IncidentRecordStream
   public IncidentRecordStream withJobKey(final long jobKey) {
     return valueFilter(v -> v.getJobKey() == jobKey);
   }
+
+  public IncidentRecordStream withTenantId(final String tenantId) {
+    return valueFilter(v -> v.getTenantId().equals(tenantId));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Ensure that Incidents are owned by a tenant, and only commands authorized for the owning tenant may resolve incidents.

:warning: Based on #14466 and should be merged after it.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13426 
relates to #13346 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
