### PR TITLE
feat: new gateway cluster health metric

### DIFF
--- a/dist/src/main/resources/application-gateway.properties
+++ b/dist/src/main/resources/application-gateway.properties
@@ -9,3 +9,4 @@ management.endpoint.health.group.readiness.show-details=never
 management.endpoint.health.group.liveness.include=livenessGatewayClusterAwareness,\
   livenessGatewayPartitionLeaderAwareness,livenessMemory
 management.endpoint.health.group.liveness.show-details=always
+management.endpoint.health.status.order="down,out-of-service,unknown,degraded,up"

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
@@ -80,9 +80,9 @@ public class ClusterHealthIndicator implements HealthIndicator {
     final var hasOnlyHealthyPartitions = healthyPartitionsCount == partitionCount;
 
     if (hasOnlyUnhealthyPartitions) {
-      return Health.status("UNHEALTHY").withDetails(partitionDetails).build();
+      return Health.down().withDetails(partitionDetails).build();
     } else if (hasOnlyHealthyPartitions) {
-      return Health.status("HEALTHY").withDetails(partitionDetails).build();
+      return Health.up().withDetails(partitionDetails).build();
     } else {
       return Health.status("DEGRADED").withDetails(partitionDetails).build();
     }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.probes.health;
+
+import static java.util.Objects.requireNonNull;
+
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+/**
+ * The cluster health indicator signals if there are still any healthy partition available, if not
+ * then is set as down as no processing is happening. In the details also indicates the health
+ * status of all partitions.
+ */
+public class ClusterHealthIndicator implements HealthIndicator {
+
+  private final Supplier<Optional<BrokerClusterState>> clusterStateSupplier;
+  private boolean processing = false;
+
+  public ClusterHealthIndicator(final Supplier<Optional<BrokerClusterState>> clusterStateSupplier) {
+    this.clusterStateSupplier = requireNonNull(clusterStateSupplier);
+  }
+
+  @Override
+  public Health health() {
+    final var optClusterState = clusterStateSupplier.get();
+
+    if (optClusterState.isEmpty()) {
+      return Health.down().build();
+    } else {
+      if (optClusterState.get().getBrokers().isEmpty()) {
+        return Health.down().build();
+      } else {
+        if (!optClusterState.get().getPartitions().isEmpty()) {
+          processing = false;
+          final List<Integer> partitions = optClusterState.get().getPartitions();
+
+          final Map<String, PartitionHealthStatus> partitionDetails =
+              getPartitionsHealthStatus(partitions, optClusterState);
+
+          if (!processing) {
+            return Health.down().withDetails(partitionDetails).build();
+          } else {
+            return Health.up().withDetails(partitionDetails).build();
+          }
+        }
+        return Health.down().build();
+      }
+    }
+  }
+
+  Map<String, PartitionHealthStatus> getPartitionsHealthStatus(
+      final List<Integer> partitions, final Optional<BrokerClusterState> optClusterState) {
+    final Map<String, PartitionHealthStatus> partitionDetails = new HashMap<>();
+    partitions.forEach(
+        partition -> {
+          final int broker = optClusterState.get().getLeaderForPartition(partition);
+          final PartitionHealthStatus partitionHealthStatus =
+              optClusterState.get().getPartitionHealth(broker, partition);
+          partitionDetails.put(String.format("Partition %d", partition), partitionHealthStatus);
+          if (partitionHealthStatus == PartitionHealthStatus.HEALTHY) {
+            processing = true;
+          }
+        });
+    return partitionDetails;
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorAutoConfiguration.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorAutoConfiguration.java
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureBefore(HealthContributorAutoConfiguration.class)
 public class ClusterHealthIndicatorAutoConfiguration {
 
-  @Bean
+  @Bean(name = "clusterHealth")
   @ConditionalOnMissingBean(name = "gatewayClusterHealthIndicator")
   public ClusterHealthIndicator gatewayClusterHealthIndicator(
       final SpringGatewayBridge gatewayBridge) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorAutoConfiguration.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorAutoConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.probes.health;
+
+import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** {@link EnableAutoConfiguration Auto-configuration} for {@link ClusterHealthIndicator}. */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnEnabledHealthIndicator("gateway-cluster")
+@AutoConfigureBefore(HealthContributorAutoConfiguration.class)
+public class ClusterHealthIndicatorAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(name = "gatewayClusterHealthIndicator")
+  public ClusterHealthIndicator gatewayClusterHealthIndicator(
+      final SpringGatewayBridge gatewayBridge) {
+    return new ClusterHealthIndicator(gatewayBridge::getClusterState);
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
@@ -82,7 +82,7 @@ public class ClusterHealthIndicatorTest {
 
     // then
     assertThat(actualHealth).isNotNull();
-    assertThat(actualHealth.getStatus()).isEqualTo(new Status("HEALTHY"));
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.UP);
   }
 
   @Test
@@ -130,7 +130,7 @@ public class ClusterHealthIndicatorTest {
 
     // then
     assertThat(actualHealth).isNotNull();
-    assertThat(actualHealth.getStatus()).isEqualTo(new Status("UNHEALTHY"));
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
   }
 
   @Test

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.probes.health;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.junit.Test;
+import org.springframework.boot.actuate.health.Status;
+
+public class ClusterHealthIndicatorTest {
+
+  @Test
+  public void shouldRejectNullInConstructor() {
+    // when + then
+    assertThatThrownBy(() -> new ClusterHealthIndicator(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldReportDownIfSupplierReturnsEmpty() {
+    // given
+    final Supplier<Optional<BrokerClusterState>> stateSupplier = () -> Optional.empty();
+    final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  public void shouldReportDownIfListOfBrokersAnIsNotEmptyAndPartitionsIsEmpty() {
+    // given
+    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
+    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getPartitions()).thenReturn(List.of());
+
+    final Supplier<Optional<BrokerClusterState>> stateSupplier =
+        () -> Optional.of(mockClusterState);
+    final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  public void shouldReportUpIfHasHealthyPartition() {
+    // given
+    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
+    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getPartitions()).thenReturn(List.of(1));
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
+    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.HEALTHY);
+
+    final Supplier<Optional<BrokerClusterState>> stateSupplier =
+        () -> Optional.of(mockClusterState);
+    final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.UP);
+  }
+
+  @Test
+  public void shouldReportDownIfListOfBrokersIsEmpty() {
+    // given
+    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
+    when(mockClusterState.getBrokers()).thenReturn(emptyList());
+
+    final Supplier<Optional<BrokerClusterState>> stateSupplier =
+        () -> Optional.of(mockClusterState);
+    final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
@@ -73,7 +73,7 @@ public class GatewayHealthProbeIntegrationTest {
     }
 
     @Test
-    void shouldReportHealthyUpIfConnectedToBroker() {
+    void shouldReportHealthUpIfConnectedToBroker() {
       // given
       final var gateway = cluster.availableGateway();
       final var gatewayServerSpec =
@@ -99,7 +99,7 @@ public class GatewayHealthProbeIntegrationTest {
                         .when()
                         .get(PATH_TO_HEALTH_PROBE)
                         .then()
-                        .body("components.gatewayCluster.status", equalTo("HEALTHY")));
+                        .body("components.clusterHealth.status", equalTo("UP")));
       } catch (final ConditionTimeoutException e) {
         // it can happen that a single request takes too long and causes awaitility to timeout,
         // in which case we want to try a second time to run the request without timeout
@@ -108,7 +108,7 @@ public class GatewayHealthProbeIntegrationTest {
             .when()
             .get(PATH_TO_HEALTH_PROBE)
             .then()
-            .body("components.gatewayCluster.status", equalTo("HEALTHY"));
+            .body("components.clusterHealth.status", equalTo("UP"));
       }
     }
   }
@@ -168,7 +168,7 @@ public class GatewayHealthProbeIntegrationTest {
     }
 
     @Test
-    void shouldReportDownUpIfConnectedToBroker() {
+    void shouldReportDownIfNotConnectedToBroker() {
       // given
       final var gatewayServerSpec =
           new RequestSpecBuilder()
@@ -183,7 +183,7 @@ public class GatewayHealthProbeIntegrationTest {
       // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
       // gateway finds the broker
       try {
-        Awaitility.await("wait until status turns UP")
+        Awaitility.await("wait until status turns DOWN")
             .atMost(Duration.ofSeconds(10))
             .pollInterval(Duration.ofMillis(100))
             .untilAsserted(
@@ -193,7 +193,7 @@ public class GatewayHealthProbeIntegrationTest {
                         .when()
                         .get(PATH_TO_HEALTH_PROBE)
                         .then()
-                        .body("components.gatewayCluster.status", equalTo("DOWN")));
+                        .body("components.clusterHealth.status", equalTo("DOWN")));
       } catch (final ConditionTimeoutException e) {
         // it can happen that a single request takes too long and causes awaitility to timeout,
         // in which case we want to try a second time to run the request without timeout
@@ -202,7 +202,7 @@ public class GatewayHealthProbeIntegrationTest {
             .when()
             .get(PATH_TO_HEALTH_PROBE)
             .then()
-            .body("components.gatewayCluster.status", equalTo("DOWN"));
+            .body("components.clusterHealth.status", equalTo("DOWN"));
       }
     }
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR adds a new field to the health endpoint in the gateway that signals the processing health of the cluster, thus, it will be set as UP until there is at least one partition that is marked as healthy. It also shows the status of all partitions.

<img width="412" alt="Screenshot 2023-09-27 at 12 22 33" src="https://github.com/camunda/zeebe/assets/132340590/e4afbcdd-6758-4add-8438-532c4d23340e">

The objective of this info is to be used by console to display more information on the cluster health. The suggested granularity was UP (all partitions healthy), DEGRADED (at least one partition healthy), and DOWN (no processing happening at all). This can now be derived from the information exposed in this endpoint.
<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/13876

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
