### PR TITLE
Fail writing of checksum on IOException

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
@@ -85,6 +85,10 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
       writer.printf(FORMAT_FILE_CRC_LINE, entry.getKey(), Long.toHexString(entry.getValue()));
     }
     writer.flush();
+
+    if (writer.checkError()) {
+      throw new IOException("Expected to write the SFV Checksum, but failed during writing.");
+    }
   }
 
   public void setSnapshotDirectoryComment(final String headerComment) {


### PR DESCRIPTION
## Description


PrintWriter doesn't fail on write error, so we have to check it on our own

https://docs.oracle.com/javase/8/docs/api/java/io/PrintWriter.html
> Methods in this class never throw I/O exceptions, although some of its constructors may. The client may inquire as to whether any errors have occurred by invoking checkError().



TIL; Thanks for finding this @oleschoenburg 👍🏼 

------


_Why are we using a print writer in the first place you may ask?_

Because it is convenient we have to write a certain format and can directly use `printf` and other methods like println etc., which made the code clearer.

Furthermore, writing to a given stream (#dependency injection) makes it easier to test, see existing but also new tests.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/14486
