### PR TITLE
[Backport release-8.3.0] Fail writing of checksum on IOException

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
@@ -85,6 +85,10 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
       writer.printf(FORMAT_FILE_CRC_LINE, entry.getKey(), Long.toHexString(entry.getValue()));
     }
     writer.flush();
+
+    if (writer.checkError()) {
+      throw new IOException("Expected to write the SFV Checksum, but failed during writing.");
+    }
   }
 
   public void setSnapshotDirectoryComment(final String headerComment) {


### PR DESCRIPTION
# Description
Backport of #14493 to `release-8.3.0`.

relates to camunda/zeebe#14486
original author: @Zelldon