### PR TITLE
fix(restore): use backup from any broker

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ClusteredBackupRestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ClusteredBackupRestoreTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import com.google.cloud.storage.BucketInfo;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
+import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
+import io.camunda.zeebe.qa.util.testcontainers.GcsContainer;
+import io.camunda.zeebe.shared.management.openapi.models.BackupInfo;
+import io.camunda.zeebe.shared.management.openapi.models.StateCode;
+import io.camunda.zeebe.shared.management.openapi.models.TakeBackupResponse;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.time.Duration;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class ClusteredBackupRestoreTest {
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @Container private static final GcsContainer GCS = new GcsContainer();
+
+  @BeforeAll
+  static void setupBucket() throws Exception {
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withoutAuthentication()
+            .withHost(GCS.externalEndpoint())
+            .withBucketName(BUCKET_NAME)
+            .build();
+
+    try (final var client = GcsBackupStore.buildClient(config)) {
+      client.create(BucketInfo.of(BUCKET_NAME));
+    }
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/14496")
+  void shouldRestoreWithFewerBrokers() {
+    // given
+    final var backupId = 22;
+
+    // when -- take a backup with 3 brokers, each with one partition
+    try (final var cluster =
+        new TestClusterBuilder()
+            .withBrokersCount(3)
+            .withPartitionsCount(3)
+            .withReplicationFactor(1)
+            .withBrokerConfig(broker -> configureBackupStore(broker.brokerConfig()))
+            .build()
+            .start()
+            .awaitCompleteTopology()) {
+      final var actuator = BackupActuator.ofAddress(cluster.availableGateway().monitoringAddress());
+
+      try (final var client = cluster.newClientBuilder().build()) {
+        IntStream.range(0, 30)
+            .forEach(
+                (i) ->
+                    client
+                        .newPublishMessageCommand()
+                        .messageName("name")
+                        .correlationKey(Integer.toString(i))
+                        .send()
+                        .join());
+      }
+
+      assertThat(actuator.take(backupId)).isInstanceOf(TakeBackupResponse.class);
+
+      Awaitility.await("until a backup exists with the given ID")
+          .atMost(Duration.ofSeconds(60))
+          .ignoreExceptions() // 404 NOT_FOUND throws exception
+          .untilAsserted(
+              () -> {
+                final var status = actuator.status(backupId);
+                assertThat(status)
+                    .extracting(BackupInfo::getBackupId, BackupInfo::getState)
+                    .containsExactly((long) backupId, StateCode.COMPLETED);
+              });
+    }
+
+    // then -- restoring with one broker is successful
+    try (final var restoreApp =
+        new TestRestoreApp()
+            .withBrokerConfig(
+                brokerCfg -> {
+                  configureBackupStore(brokerCfg);
+                  brokerCfg.getCluster().setClusterSize(1);
+                  brokerCfg.getCluster().setPartitionsCount(3);
+                  brokerCfg.getCluster().setReplicationFactor(1);
+                })
+            .withBackupId(backupId)) {
+
+      assertThatNoException().isThrownBy(() -> restoreApp.start());
+    }
+  }
+
+  private static void configureBackupStore(final BrokerCfg brokerCfg) {
+    final var backup = brokerCfg.getData().getBackup();
+
+    final var storeConfig = new GcsBackupStoreConfig();
+    storeConfig.setAuth(GcsBackupStoreAuth.NONE);
+    storeConfig.setBucketName(BUCKET_NAME);
+    storeConfig.setHost(GCS.externalEndpoint());
+
+    backup.setStore(BackupStoreType.GCS);
+    backup.setGcs(storeConfig);
+  }
+}

--- a/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
@@ -26,9 +26,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.slf4j.Logger;
@@ -40,19 +38,14 @@ public class PartitionRestoreService {
   final BackupStore backupStore;
   final int partitionId;
 
-  // All members of the cluster. A backup could have been taken by any broker. So we have to iterate
-  // over all of them to find a valid backup for this partition with the given id.
-  final Set<Integer> brokerIds;
   final Path rootDirectory;
   private final RaftPartition partition;
 
-  public PartitionRestoreService(
-      final BackupStore backupStore, final RaftPartition partition, final Set<Integer> brokerIds) {
+  public PartitionRestoreService(final BackupStore backupStore, final RaftPartition partition) {
     this.backupStore = backupStore;
     partitionId = partition.id().id();
     rootDirectory = partition.dataDirectory().toPath();
     this.partition = partition;
-    this.brokerIds = brokerIds;
   }
 
   /**
@@ -214,32 +207,16 @@ public class PartitionRestoreService {
 
   private CompletionStage<BackupIdentifier> findValidBackup(final long checkpointId) {
     LOG.info("Searching for a completed backup with id {}", checkpointId);
-    final var futures =
-        brokerIds.stream()
-            .map(brokerId -> new BackupIdentifierImpl(brokerId, partitionId, checkpointId))
-            .map(backupStore::getStatus)
-            .toList();
-
-    return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+    return backupStore
+        .list(
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(), Optional.of(partitionId), Optional.of(checkpointId)))
         .thenApply(
-            ignore -> {
-              final var backupStatuses = futures.stream().map(CompletableFuture::join).toList();
-              return findCompletedBackup(backupStatuses)
-                  .orElseThrow(
-                      () -> {
-                        LOG.error(
-                            "Could not find a valid backup with id {}. Found {}",
-                            checkpointId,
-                            backupStatuses);
-                        return new BackupNotFoundException(checkpointId);
-                      });
-            });
-  }
-
-  private Optional<BackupIdentifier> findCompletedBackup(final List<BackupStatus> backupStatuses) {
-    return backupStatuses.stream()
-        .filter(s -> s.statusCode() == BackupStatusCode.COMPLETED)
-        .findFirst()
-        .map(BackupStatus::id);
+            statuses ->
+                statuses.stream()
+                    .filter(status -> status.statusCode() == BackupStatusCode.COMPLETED)
+                    .map(BackupStatus::id)
+                    .findAny()
+                    .orElseThrow(() -> new BackupNotFoundException(checkpointId)));
   }
 }

--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -96,7 +96,7 @@ class PartitionRestoreServiceTest {
             PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
     final var raftPartition =
         new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile());
-    restoreService = new PartitionRestoreService(backupStore, raftPartition, Set.of(1, 2));
+    restoreService = new PartitionRestoreService(backupStore, raftPartition);
 
     journal =
         SegmentedJournal.builder()


### PR DESCRIPTION
This fixes #14496 by searching for matching backups taken by any broker instead of  enumerating possible broker ids based on the current configuration.