### PR TITLE
[Backport stable/8.2] fix(restore): use backup from any broker

### DIFF
--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -93,7 +93,7 @@ class PartitionRestoreServiceTest {
     final var raftPartition =
         new RaftPartition(
             PartitionId.from("raft", partitionId), null, dataDirectoryToRestore.toFile());
-    restoreService = new PartitionRestoreService(backupStore, raftPartition, Set.of(1, 2), nodeId);
+    restoreService = new PartitionRestoreService(backupStore, raftPartition, nodeId);
 
     journal =
         SegmentedJournal.builder()


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/14512.

I've removed the regression test because the test infrastructure does not exist in 8.2 and I feel confident that this fix is correct on 8.2 too.