### PR TITLE
feat(engine): add signal catch event for event-based gateway

### DIFF
--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
@@ -102,7 +102,7 @@ public class ZeebeEventBasedGatewayValidationTest extends AbstractZeebeValidatio
         singletonList(
             expect(
                 EventBasedGateway.class,
-                "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer intermediate catch events."))
+                "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal intermediate catch events."))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeLinkEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeLinkEventValidationTest.java
@@ -122,7 +122,7 @@ public class ZeebeLinkEventValidationTest {
             "Event-based gateway must have at least 2 outgoing sequence flows."),
         expect(
             EventBasedGateway.class,
-            "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer intermediate catch events."));
+            "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal intermediate catch events."));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
@@ -117,7 +117,7 @@ public class LinkEventDefinitionTest {
         .contains("Element: Gateway_")
         .contains("ERROR: Event-based gateway must have at least 2 outgoing sequence flows.")
         .contains(
-            "ERROR: Event-based gateway must not have an outgoing sequence flow to other elements than message/timer intermediate catch events.");
+            "ERROR: Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal intermediate catch events.");
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds signal catch event for event-based gateway.

## Related issues
closes #14487 


## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
