### PR TITLE
fix(raft): reset term from last log if metastore is empty

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -249,6 +249,19 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     started = true;
 
     addCommitListener(new AwaitingReadyCommitListener());
+
+    if (!raftLog.isEmpty() && term == 0) {
+      // This will only happen when metastore is empty because the node has just restored from a
+      // backup. Backup only contains the logs. Other case, where this can happen is when the meta
+      // file was manually deleted to recover from an unexpected bug.
+      // In both cases, we should not restart the term from 0 because the assumption in raft is that
+      // the term always increase. After restore, it is safe to restart the term at the last log's
+      // term. During the first election, the term will be incremented by 1.
+      // In the second case, it is possible that the actual term is higher. But it is still safe to
+      // set it to last log's term because the actual term will be set when this node gets the first
+      // message from other healthy replicas.
+      setTerm(raftLog.getLastEntry().term());
+    }
   }
 
   private ThreadContext createThreadContext(

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftResetTermAfterRestoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftResetTermAfterRestoreTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.Rule;
+import org.junit.Test;
+
+// Regression test https://github.com/camunda/zeebe/issues/14509
+public class RaftResetTermAfterRestoreTest {
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(1);
+
+  @Test
+  public void shouldResetTermFromLastLogEntryIfMetastoreIsEmpty() throws Exception {
+    // given
+    raftRule.appendEntries(1);
+    final var raftServer = raftRule.getServers().stream().findFirst().get();
+    final var serverId =
+        raftServer.cluster().getLocalMember().memberId().id(); // There is only one server
+    final var termBeforeShutdown = raftServer.getTerm();
+    raftRule.shutdownServer(raftServer);
+    assertThat(termBeforeShutdown)
+        .isEqualTo(1); // We are relying on this assumption for later validation
+
+    // when
+
+    // Simulate the state after restore by deleting metastore
+    final var partitionDirectory = raftServer.getContext().getStorage().directory();
+    try (final Stream<Path> fileStream = Files.list(partitionDirectory.toPath())) {
+      final var metaFilePath =
+          fileStream
+              .filter(p -> p.getFileName().toString().endsWith("meta"))
+              .findFirst()
+              .orElseThrow(() -> new RuntimeException("No meta file found"));
+      Files.delete(metaFilePath);
+    }
+
+    raftRule.joinCluster(serverId);
+
+    // then
+    assertThat(raftRule.getLeader().orElseThrow().getTerm())
+        .describedAs("Should reset term by reading the last entry in the log")
+        .isEqualTo(2);
+  }
+}


### PR DESCRIPTION
## Description

After restoring from a backup, metastore will be empty because backup contains only journal segments. Since metastore is empty, previously raft node re-starts the term at 0. This caused issues in election, because accepting or rejecting a poll request is also based on the last log entry's term. When the term restarts at 0, the last log entry's term can be higher than the local term which results in unexpected election results. To prevent this case we have to start the term at the term of the last log entry.

Alternate is to include meta file in the backup. But this doesn't have much benefit because no other data in the metastore is useful after restore. In some cases, it might even cause issues if restore starts with a different configuration than in the backup.

## Related issues

closes #14509 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
