### PR TITLE
[Backport stable/8.2] fix(raft): reset term from last log if metastore is empty

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -235,6 +235,19 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     started = true;
 
     addCommitListener(new AwaitingReadyCommitListener());
+
+    if (!raftLog.isEmpty() && term == 0) {
+      // This will only happen when metastore is empty because the node has just restored from a
+      // backup. Backup only contains the logs. Other case, where this can happen is when the meta
+      // file was manually deleted to recover from an unexpected bug.
+      // In both cases, we should not restart the term from 0 because the assumption in raft is that
+      // the term always increase. After restore, it is safe to restart the term at the last log's
+      // term. During the first election, the term will be incremented by 1.
+      // In the second case, it is possible that the actual term is higher. But it is still safe to
+      // set it to last log's term because the actual term will be set when this node gets the first
+      // message from other healthy replicas.
+      setTerm(raftLog.getLastEntry().term());
+    }
   }
 
   private ThreadContext createThreadContext(

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftResetTermAfterRestoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftResetTermAfterRestoreTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.Rule;
+import org.junit.Test;
+
+// Regression test https://github.com/camunda/zeebe/issues/14509
+public class RaftResetTermAfterRestoreTest {
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(1);
+
+  @Test
+  public void shouldResetTermFromLastLogEntryIfMetastoreIsEmpty() throws Exception {
+    // given
+    raftRule.appendEntries(1);
+    final var raftServer = raftRule.getServers().stream().findFirst().get();
+    final var serverId =
+        raftServer.cluster().getLocalMember().memberId().id(); // There is only one server
+    final var termBeforeShutdown = raftServer.getTerm();
+    raftRule.shutdownServer(raftServer);
+    assertThat(termBeforeShutdown)
+        .isEqualTo(1); // We are relying on this assumption for later validation
+
+    // when
+
+    // Simulate the state after restore by deleting metastore
+    final var partitionDirectory = raftServer.getContext().getStorage().directory();
+    try (final Stream<Path> fileStream = Files.list(partitionDirectory.toPath())) {
+      final var metaFilePath =
+          fileStream
+              .filter(p -> p.getFileName().toString().endsWith("meta"))
+              .findFirst()
+              .orElseThrow(() -> new RuntimeException("No meta file found"));
+      Files.delete(metaFilePath);
+    }
+
+    raftRule.joinCluster(serverId);
+
+    // then
+    assertThat(raftRule.getLeader().orElseThrow().getTerm())
+        .describedAs("Should reset term by reading the last entry in the log")
+        .isEqualTo(2);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #14518 to `stable/8.2`.

relates to #14509
original author: @deepthidevaki