### PR TITLE
[Backport stable/8.1] fix(raft): reset term from last log if metastore is empty

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftResetTermAfterRestoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftResetTermAfterRestoreTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.Rule;
+import org.junit.Test;
+
+// Regression test https://github.com/camunda/zeebe/issues/14509
+public class RaftResetTermAfterRestoreTest {
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(1);
+
+  @Test
+  public void shouldResetTermFromLastLogEntryIfMetastoreIsEmpty() throws Exception {
+    // given
+    raftRule.appendEntries(1);
+    final var raftServer = raftRule.getServers().stream().findFirst().get();
+    final var serverId =
+        raftServer.cluster().getLocalMember().memberId().id(); // There is only one server
+    final var termBeforeShutdown = raftServer.getTerm();
+    raftRule.shutdownServer(raftServer);
+    assertThat(termBeforeShutdown)
+        .isEqualTo(1); // We are relying on this assumption for later validation
+
+    // when
+
+    // Simulate the state after restore by deleting metastore
+    final var partitionDirectory = raftServer.getContext().getStorage().directory();
+    try (final Stream<Path> fileStream = Files.list(partitionDirectory.toPath())) {
+      final var metaFilePath =
+          fileStream
+              .filter(p -> p.getFileName().toString().endsWith("meta"))
+              .findFirst()
+              .orElseThrow(() -> new RuntimeException("No meta file found"));
+      Files.delete(metaFilePath);
+    }
+
+    raftRule.joinCluster(serverId);
+
+    // then
+    assertThat(raftRule.getLeader().orElseThrow().getTerm())
+        .describedAs("Should reset term by reading the last entry in the log")
+        .isEqualTo(2);
+  }
+}


### PR DESCRIPTION
After restoring from a backup, metastore will be empty because backup contains only journal segments. Since metastore is empty, previously raft node re-starts the term at 0. This caused issues in election, because accepting or rejecting a poll request is also based on the last log entry's term. When the term restarts at 0, the last log entry's term can be higher than the local term which results in unexpected election results. To prevent this case we have to start the term at the term of the last log entry.

Alternate is to include meta file in the backup. But this doesn't have much benefit because no other data in the metastore is useful after restore. In some cases, it might even cause issues if restore starts with a different configuration than in the backup.

(cherry picked from commit fb4bd88f85f24f2be33a62838ade11bb9e623b26)

Backport of #14518 