### PR TITLE
Reject processes with signal events for non-default tenants

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedMultiTenantFeaturesValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedMultiTenantFeaturesValidator.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import org.agrona.DirectBuffer;
+
+public final class UnsupportedMultiTenantFeaturesValidator {
+
+  private static final EnumSet<BpmnElementType> REJECTED_ELEMENT_TYPES =
+      EnumSet.noneOf(BpmnElementType.class);
+  private static final EnumSet<BpmnEventType> UNSUPPORTED_EVENT_TYPES =
+      EnumSet.of(BpmnEventType.SIGNAL);
+
+  /**
+   * Validates a list of processes for containing unsupported elements when used with multi-tenancy.
+   * Not all features are available for multi-tenancy yet. While multi-tenancy is enabled, all
+   * features are available for the default tenant.
+   *
+   * @param resource the resource file that's getting validated
+   * @param executableProcesses the list of processes in this resource
+   * @param tenantId the identifier of the tenant that owns the processes
+   * @return an Either of which the left contains the failure message if any unsupported elements
+   *     are found and the owning tenant is non-default.
+   */
+  public static Either<Failure, ?> validate(
+      final DeploymentResource resource,
+      final List<ExecutableProcess> executableProcesses,
+      final String tenantId) {
+
+    if (Objects.equals(tenantId, TenantOwned.DEFAULT_TENANT_IDENTIFIER)) {
+      // All elements are supported when the default tenant is used
+      return Either.right(null);
+    }
+
+    final List<Failure> failures = new ArrayList<>();
+    executableProcesses.forEach(
+        executableProcess ->
+            hasUnsupportedElement(resource, executableProcess).ifLeft(failures::add));
+
+    if (failures.isEmpty()) {
+      return Either.right(null);
+    } else {
+      final StringWriter writer = new StringWriter();
+      failures.forEach(failure -> writer.write(failure.getMessage()));
+      return Either.left(new Failure(writer.toString()));
+    }
+  }
+
+  /**
+   * Checks a given process for any elements that are unsupported with multi-tenancy.
+   *
+   * @param resource the resource file that's getting validated
+   * @param executableProcess the process we are validating
+   * @return an Either of which the left contains the failure message if any unsupported elements
+   *     have been found
+   */
+  private static Either<Failure, ?> hasUnsupportedElement(
+      final DeploymentResource resource, final ExecutableProcess executableProcess) {
+    final var unsupportedElementsInProcess = findUnsupportedElementsInProcess(executableProcess);
+
+    if (unsupportedElementsInProcess.isEmpty()) {
+      return Either.right(null);
+    }
+
+    final String failureMessage =
+        createFailureMessage(resource, executableProcess, unsupportedElementsInProcess);
+    return Either.left(new Failure(failureMessage));
+  }
+
+  /**
+   * Finds all elements in a process that are unsupported with multi-tenancy.
+   *
+   * @param executableProcess the process
+   * @return a list of all unsupported elements in the given process
+   */
+  private static List<ExecutableFlowNode> findUnsupportedElementsInProcess(
+      final ExecutableProcess executableProcess) {
+
+    return executableProcess.getFlowElements().stream()
+        .map(
+            flowElement ->
+                flowElement instanceof ExecutableMultiInstanceBody
+                    ? ((ExecutableMultiInstanceBody) flowElement).getInnerActivity()
+                    : flowElement)
+        .filter(
+            flowElement ->
+                REJECTED_ELEMENT_TYPES.contains(flowElement.getElementType())
+                    || UNSUPPORTED_EVENT_TYPES.contains(flowElement.getEventType()))
+        .map(ExecutableFlowNode.class::cast)
+        .sorted(Comparator.comparing(ExecutableFlowNode::getId))
+        .toList();
+  }
+
+  /**
+   * Create a descriptive failure message which will be part of the rejection message. It mentions
+   * which resource and process contain the issue. It also lists information about the elements that
+   * are unsupported.
+   *
+   * @param resource the resource file that we've validated for loops
+   * @param executableProcess the process that we've validated for loops
+   * @param unsupportedElements a list of unsupported elements.
+   * @return a descriptive failure message
+   */
+  private static String createFailureMessage(
+      final DeploymentResource resource,
+      final ExecutableProcess executableProcess,
+      final List<ExecutableFlowNode> unsupportedElements) {
+
+    final List<ElementInfo> unsupportedElementsInfo =
+        unsupportedElements.stream().map(ElementInfo::new).toList();
+    final var failureMessage =
+        """
+        Processes belonging to custom tenants are not allowed to contain elements unsupported with multi-tenancy. \
+        Only the default tenant '<default>' supports these elements currently: %s. \
+        See https://github.com/camunda/zeebe/issues/12653 for more details."""
+            .formatted(String.join(" > ", unsupportedElementsInfo.toString()));
+    return createFormattedFailureMessage(resource, executableProcess, failureMessage);
+  }
+
+  private static String createFormattedFailureMessage(
+      final DeploymentResource resource,
+      final ExecutableProcess executableProcess,
+      final String message) {
+    final StringWriter writer = new StringWriter();
+    writer.write(
+        String.format(
+            "`%s`: - Process: %s",
+            resource.getResourceName(), BufferUtil.bufferAsString(executableProcess.getId())));
+    writer.write("\n");
+    writer.write("    - ERROR: ");
+    writer.write(message);
+    writer.write("\n");
+    return writer.toString();
+  }
+
+  record ElementInfo(DirectBuffer id, BpmnElementType elementType, BpmnEventType eventType) {
+    public ElementInfo(final AbstractFlowElement element) {
+      this(element.getId(), element.getElementType(), element.getEventType());
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder builder = new StringBuilder();
+      builder.append("'%s'".formatted(BufferUtil.bufferAsString(id)));
+
+      if (eventType == null || eventType == BpmnEventType.UNSPECIFIED) {
+        builder.append(" of type '%s'".formatted(elementType));
+      } else {
+        builder.append(" of type '%s' '%s'".formatted(eventType, elementType));
+      }
+
+      return builder.toString();
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -77,7 +77,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
 
                 return checkForDuplicateBpmnId(definition, resource, deployment)
                     .flatMap(
-                        unused -> {
+                        ok -> {
                           if (enableStraightThroughProcessingLoopDetector) {
                             return StraightThroughProcessingLoopValidator.validate(
                                 resource, executableProcesses);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.BpmnFactory;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.validation.StraightThroughProcessingLoopValidator;
+import io.camunda.zeebe.engine.processing.deployment.model.validation.UnsupportedMultiTenantFeaturesValidator;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
@@ -76,6 +77,10 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
                 final var executableProcesses = bpmnTransformer.transformDefinitions(definition);
 
                 return checkForDuplicateBpmnId(definition, resource, deployment)
+                    .flatMap(
+                        ok ->
+                            UnsupportedMultiTenantFeaturesValidator.validate(
+                                resource, executableProcesses, deployment.getTenantId()))
                     .flatMap(
                         ok -> {
                           if (enableStraightThroughProcessingLoopDetector) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class TenantAwareSignalEventTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
+  private String processId;
+  private String signalName;
+
+  @Before
+  public void setup() {
+    processId = Strings.newRandomValidBpmnId();
+    signalName = "signal-%s".formatted(processId);
+  }
+
+  @Test
+  public void shouldBroadcastSignalForDefaultTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent("signal-start")
+                .signal(signalName)
+                .endEvent()
+                .done())
+        .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .deploy();
+
+    // when
+    final var broadcasted = ENGINE.signal().withSignalName(signalName).broadcast();
+
+    // then
+    assertThat(broadcasted)
+        .describedAs("Expect that signal was broadcasted successful")
+        .hasIntent(SignalIntent.BROADCASTED);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withBpmnProcessId(processId)
+                .withElementId("signal-start")
+                .getFirst())
+        .describedAs("Expect that process instance was created")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithSignalForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("signal-start")
+                    .signal(signalName)
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['signal-start' of type 'SIGNAL' 'START_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithSignalCatchEventForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .intermediateCatchEvent("signal-catch")
+                    .signal(signalName)
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['signal-catch' of type 'SIGNAL' 'INTERMEDIATE_CATCH_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void
+      shouldRejectDeployProcessWithSignalCatchEventAttachedToEventBasedGatewayForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .eventBasedGateway()
+                    .intermediateCatchEvent("signal-catch-attached")
+                    .signal(signalName)
+                    .endEvent()
+                    .moveToLastGateway()
+                    .intermediateCatchEvent()
+                    .timerWithDuration(Duration.ofMinutes(10))
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['signal-catch-attached' of type 'SIGNAL' 'INTERMEDIATE_CATCH_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithSignalEventSubProcessEventForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .eventSubProcess(
+                        "signal-sub",
+                        sub ->
+                            sub.startEvent("signal-start-event-sub").signal(signalName).endEvent())
+                    .startEvent()
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['signal-start-event-sub' of type 'SIGNAL' 'START_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithSignalBoundaryEventForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .manualTask()
+                    .boundaryEvent("signal-boundary")
+                    .signal(signalName)
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['signal-boundary' of type 'SIGNAL' 'BOUNDARY_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithSignalThrowEventForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .intermediateThrowEvent("signal-throw")
+                    .signal(signalName)
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['signal-throw' of type 'SIGNAL' 'INTERMEDIATE_THROW_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithSignalEndEventForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .endEvent("signal-end")
+                    .signal(signalName)
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['signal-end' of type 'SIGNAL' 'END_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Rejects process deployments containing signal events when the process is deployed for a specific (i.e. non-default) tenant.

This pull request sets up the infrastructure to reject processes containing any unsupported elements.

A typical error message looks like:
```
Expected to deploy new resources, but encountered the following errors:
            `process.xml`: - Process: my_process_containing_unsupported_elements
                - ERROR: Processes belonging to custom tenants are not allowed to contain elements unsupported with multi-tenancy. Only the default tenant '<default>' supports these elements currently: ['my-signal-start' of type 'SIGNAL' 'START_EVENT']. See https://github.com/camunda/zeebe/issues/12653 for more details.
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14521

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
