### PR TITLE
Throw UnsupportedException when broadcasting signal for specific tenant

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
@@ -88,8 +88,7 @@ public final class BroadcastSignalCommandImpl
 
   @Override
   public BroadcastSignalCommandStep2 tenantId(final String tenantId) {
-    // todo(#13558): replace dummy implementation
-    return this;
+    throw new UnsupportedOperationException("Signals are not yet supported with multi-tenancy");
   }
 
   private void send(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
@@ -88,7 +88,9 @@ public final class BroadcastSignalCommandImpl
 
   @Override
   public BroadcastSignalCommandStep2 tenantId(final String tenantId) {
-    throw new UnsupportedOperationException("Signals are not yet supported with multi-tenancy");
+    throw new UnsupportedOperationException(
+        " Signals are not yet supported with multi-tenancy. "
+            + "See https://github.com/camunda/zeebe/issues/13336 for more details.");
   }
 
   private void send(

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/BroadcastSignalTest.java
@@ -157,14 +157,10 @@ public final class BroadcastSignalTest extends ClientTest {
     // given
     final BroadcastSignalCommandStep2 builder = client.newBroadcastSignalCommand().signalName("");
 
-    // when
-    final BroadcastSignalCommandStep2 builderWithTenant = builder.tenantId("custom tenant");
-
-    // then
-    // todo(#13558): verify that tenant id is set in the request
-    assertThat(builderWithTenant)
-        .describedAs("This method has no effect on the command builder while under development")
-        .isEqualTo(builder);
+    // when/then
+    assertThatThrownBy(() -> builder.tenantId("custom tenant"))
+        .describedAs("tenantId not supported on broadcast signal yet")
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   public static class Variables {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

To avoid users thinking they can use the `.tenantId(String)` to broadcast signals for a specific tenant, we should throw an unsupported exception.

The gateway does not yet support specifying a tenantId for the broadcasted signal in the grpc protocol, and the engine always considers all signal records to belong to the default tenant.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14522 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
