### PR TITLE
Migrate `MessageStartEventSubscriptionState` for Multi-Tenancy

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.migration.MigrationTaskState.State;
 import io.camunda.zeebe.engine.state.migration.to_8_3.DbDecisionMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_3.DbMessageMigrationState;
+import io.camunda.zeebe.engine.state.migration.to_8_3.DbMessageStartEventSubscriptionMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_3.DbProcessMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
@@ -107,6 +108,8 @@ public class DbMigrationState implements MutableMigrationState {
   private final DbProcessMigrationState processMigrationState;
   private final DbDecisionMigrationState decisionMigrationState;
   private final DbMessageMigrationState messageMigrationState;
+  private final DbMessageStartEventSubscriptionMigrationState
+      messageStartEventSubscriptionMigrationState;
 
   public DbMigrationState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -234,6 +237,8 @@ public class DbMigrationState implements MutableMigrationState {
     processMigrationState = new DbProcessMigrationState(zeebeDb, transactionContext);
     decisionMigrationState = new DbDecisionMigrationState(zeebeDb, transactionContext);
     messageMigrationState = new DbMessageMigrationState(zeebeDb, transactionContext);
+    messageStartEventSubscriptionMigrationState =
+        new DbMessageStartEventSubscriptionMigrationState(zeebeDb, transactionContext);
   }
 
   @Override
@@ -412,6 +417,12 @@ public class DbMigrationState implements MutableMigrationState {
   @Override
   public void migrateMessageStateForMultiTenancy() {
     messageMigrationState.migrateMessageStateForMultiTenancy();
+  }
+
+  @Override
+  public void migrateMessageStartEventSubscriptionForMultiTenancy() {
+    messageStartEventSubscriptionMigrationState
+        .migrateMessageStartEventSubscriptionForMultiTenancy();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/DbMessageStartEventSubscriptionMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/DbMessageStartEventSubscriptionMigrationState.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
+import io.camunda.zeebe.engine.state.message.DbMessageStartEventSubscriptionState;
+import io.camunda.zeebe.engine.state.message.MessageStartEventSubscription;
+import io.camunda.zeebe.engine.state.migration.to_8_3.legacy.LegacyMessageStartEventSubscriptionState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+
+public class DbMessageStartEventSubscriptionMigrationState {
+
+  private final LegacyMessageStartEventSubscriptionState from;
+  private final DbMessageStartEventSubscriptionState to;
+
+  public DbMessageStartEventSubscriptionMigrationState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    from = new LegacyMessageStartEventSubscriptionState(zeebeDb, transactionContext);
+    to = new DbMessageStartEventSubscriptionState(zeebeDb, transactionContext);
+  }
+
+  public void migrateMessageStartEventSubscriptionForMultiTenancy() {
+    // setting the tenant id key once, because it's the same for all steps below
+    to.tenantIdKey.wrapString(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    /*
+    - `DEPRECATED_MESSAGE_START_EVENT_SUBSCRIPTION_BY_NAME_AND_KEY` -> `MESSAGE_START_EVENT_SUBSCRIPTION_BY_NAME_AND_KEY`
+    - Prefix first part of composite key with tenant
+    - Set tenant on value
+     */
+    from.getSubscriptionsColumnFamily()
+        .forEach(
+            (key, value) -> {
+              value.getRecord().setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+              to.messageName.wrapBuffer(key.first().getBuffer());
+              to.processDefinitionKey.wrapLong(key.second().getValue());
+              to.subscriptionsColumnFamily.insert(to.messageNameAndProcessDefinitionKey, value);
+              from.getSubscriptionsColumnFamily().deleteExisting(key);
+            });
+
+    /*
+    - `DEPRECATED_MESSAGE_START_EVENT_SUBSCRIPTION_BY_KEY_AND_NAME` -> `MESSAGE_START_EVENT_SUBSCRIPTION_BY_KEY_AND_NAME`
+    - Prefix second part of composite key with tenant
+     */
+    from.getSubscriptionsOfProcessDefinitionKeyColumnFamily()
+        .forEach(
+            (key, value) -> {
+              to.processDefinitionKey.wrapLong(key.first().getValue());
+              to.messageName.wrapBuffer(key.second().getBuffer());
+              to.subscriptionsOfProcessDefinitionKeyColumnFamily.insert(
+                  to.processDefinitionKeyAndMessageName, DbNil.INSTANCE);
+              from.getSubscriptionsOfProcessDefinitionKeyColumnFamily().deleteExisting(key);
+            });
+  }
+
+  private static final class DbMessageStartEventSubscriptionState {
+
+    private final DbString tenantIdKey;
+    private final DbString messageName;
+    private final DbTenantAwareKey<DbString> tenantAwareMessageName;
+    private final DbLong processDefinitionKey;
+
+    // (tenant aware messageName, processDefinitionKey => MessageSubscription)
+    private final DbCompositeKey<DbTenantAwareKey<DbString>, DbLong>
+        messageNameAndProcessDefinitionKey;
+    private final ColumnFamily<
+            DbCompositeKey<DbTenantAwareKey<DbString>, DbLong>, MessageStartEventSubscription>
+        subscriptionsColumnFamily;
+    private final MessageStartEventSubscription messageStartEventSubscription =
+        new MessageStartEventSubscription();
+
+    // (processDefinitionKey, tenant aware messageName) => \0  : to find existing subscriptions of a
+    // process
+    private final DbCompositeKey<DbLong, DbTenantAwareKey<DbString>>
+        processDefinitionKeyAndMessageName;
+    private final ColumnFamily<DbCompositeKey<DbLong, DbTenantAwareKey<DbString>>, DbNil>
+        subscriptionsOfProcessDefinitionKeyColumnFamily;
+
+    public DbMessageStartEventSubscriptionState(
+        final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+      tenantIdKey = new DbString();
+      messageName = new DbString();
+      tenantAwareMessageName =
+          new DbTenantAwareKey<>(tenantIdKey, messageName, PlacementType.PREFIX);
+      processDefinitionKey = new DbLong();
+      messageNameAndProcessDefinitionKey =
+          new DbCompositeKey<>(tenantAwareMessageName, processDefinitionKey);
+      subscriptionsColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.MESSAGE_START_EVENT_SUBSCRIPTION_BY_NAME_AND_KEY,
+              transactionContext,
+              messageNameAndProcessDefinitionKey,
+              messageStartEventSubscription);
+
+      processDefinitionKeyAndMessageName =
+          new DbCompositeKey<>(processDefinitionKey, tenantAwareMessageName);
+      subscriptionsOfProcessDefinitionKeyColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.MESSAGE_START_EVENT_SUBSCRIPTION_BY_KEY_AND_NAME,
+              transactionContext,
+              processDefinitionKeyAndMessageName,
+              DbNil.INSTANCE);
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigration.java
@@ -31,5 +31,6 @@ public class MultiTenancyMigration implements MigrationTask {
     migrationState.migrateProcessStateForMultiTenancy();
     migrationState.migrateDecisionStateForMultiTenancy();
     migrationState.migrateMessageStateForMultiTenancy();
+    migrationState.migrateMessageStartEventSubscriptionForMultiTenancy();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyMessageStartEventSubscriptionState.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3.legacy;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import org.agrona.DirectBuffer;
+
+public final class LegacyMessageStartEventSubscriptionState
+    implements MutableMessageStartEventSubscriptionState {
+
+  private final DbString messageName;
+  private final DbLong processDefinitionKey;
+
+  // (messageName, processDefinitionKey => MessageSubscription)
+  private final DbCompositeKey<DbString, DbLong> messageNameAndProcessDefinitionKey;
+  private final ColumnFamily<DbCompositeKey<DbString, DbLong>, MessageStartEventSubscription>
+      subscriptionsColumnFamily;
+  private final MessageStartEventSubscription messageStartEventSubscription =
+      new MessageStartEventSubscription();
+
+  // (processDefinitionKey, messageName) => \0  : to find existing subscriptions of a process
+  private final DbCompositeKey<DbLong, DbString> processDefinitionKeyAndMessageName;
+  private final ColumnFamily<DbCompositeKey<DbLong, DbString>, DbNil>
+      subscriptionsOfProcessDefinitionKeyColumnFamily;
+
+  public DbMessageStartEventSubscriptionState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    messageName = new DbString();
+    processDefinitionKey = new DbLong();
+    messageNameAndProcessDefinitionKey = new DbCompositeKey<>(messageName, processDefinitionKey);
+    subscriptionsColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.MESSAGE_START_EVENT_SUBSCRIPTION_BY_NAME_AND_KEY,
+            transactionContext,
+            messageNameAndProcessDefinitionKey,
+            messageStartEventSubscription);
+
+    processDefinitionKeyAndMessageName = new DbCompositeKey<>(processDefinitionKey, messageName);
+    subscriptionsOfProcessDefinitionKeyColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.MESSAGE_START_EVENT_SUBSCRIPTION_BY_KEY_AND_NAME,
+            transactionContext,
+            processDefinitionKeyAndMessageName,
+            DbNil.INSTANCE);
+  }
+
+  @Override
+  public void put(final long key, final MessageStartEventSubscriptionRecord subscription) {
+    messageStartEventSubscription.setKey(key).setRecord(subscription);
+
+    messageName.wrapBuffer(subscription.getMessageNameBuffer());
+    processDefinitionKey.wrapLong(subscription.getProcessDefinitionKey());
+    subscriptionsColumnFamily.upsert(
+        messageNameAndProcessDefinitionKey, messageStartEventSubscription);
+    subscriptionsOfProcessDefinitionKeyColumnFamily.upsert(
+        processDefinitionKeyAndMessageName, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void remove(final long processDefinitionKey, final DirectBuffer messageName) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    this.messageName.wrapBuffer(messageName);
+
+    subscriptionsColumnFamily.deleteExisting(messageNameAndProcessDefinitionKey);
+    subscriptionsOfProcessDefinitionKeyColumnFamily.deleteExisting(
+        processDefinitionKeyAndMessageName);
+  }
+
+  @Override
+  public boolean exists(final MessageStartEventSubscriptionRecord subscription) {
+    messageName.wrapBuffer(subscription.getMessageNameBuffer());
+    processDefinitionKey.wrapLong(subscription.getProcessDefinitionKey());
+
+    return subscriptionsColumnFamily.exists(messageNameAndProcessDefinitionKey);
+  }
+
+  @Override
+  public void visitSubscriptionsByProcessDefinition(
+      final long processDefinitionKey, final MessageStartEventSubscriptionVisitor visitor) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+
+    subscriptionsOfProcessDefinitionKeyColumnFamily.whileEqualPrefix(
+        this.processDefinitionKey,
+        (key, value) -> {
+          final var subscription =
+              subscriptionsColumnFamily.get(messageNameAndProcessDefinitionKey);
+
+          if (subscription != null) {
+            visitor.visit(subscription);
+          }
+        });
+  }
+
+  @Override
+  public void visitSubscriptionsByMessageName(
+      final DirectBuffer messageName, final MessageStartEventSubscriptionVisitor visitor) {
+
+    this.messageName.wrapBuffer(messageName);
+    subscriptionsColumnFamily.whileEqualPrefix(
+        this.messageName,
+        (key, value) -> {
+          visitor.visit(value);
+        });
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyMessageStartEventSubscriptionState.java
@@ -22,14 +22,12 @@ public final class LegacyMessageStartEventSubscriptionState {
 
   private final DbString messageName;
   private final DbLong processDefinitionKey;
-
   // (messageName, processDefinitionKey => MessageSubscription)
   private final DbCompositeKey<DbString, DbLong> messageNameAndProcessDefinitionKey;
   private final ColumnFamily<DbCompositeKey<DbString, DbLong>, MessageStartEventSubscription>
       subscriptionsColumnFamily;
   private final MessageStartEventSubscription messageStartEventSubscription =
       new MessageStartEventSubscription();
-
   // (processDefinitionKey, messageName) => \0  : to find existing subscriptions of a process
   private final DbCompositeKey<DbLong, DbString> processDefinitionKeyAndMessageName;
   private final ColumnFamily<DbCompositeKey<DbLong, DbString>, DbNil>
@@ -65,5 +63,15 @@ public final class LegacyMessageStartEventSubscriptionState {
         messageNameAndProcessDefinitionKey, messageStartEventSubscription);
     subscriptionsOfProcessDefinitionKeyColumnFamily.upsert(
         processDefinitionKeyAndMessageName, DbNil.INSTANCE);
+  }
+
+  public ColumnFamily<DbCompositeKey<DbString, DbLong>, MessageStartEventSubscription>
+      getSubscriptionsColumnFamily() {
+    return subscriptionsColumnFamily;
+  }
+
+  public ColumnFamily<DbCompositeKey<DbLong, DbString>, DbNil>
+      getSubscriptionsOfProcessDefinitionKeyColumnFamily() {
+    return subscriptionsOfProcessDefinitionKeyColumnFamily;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -39,6 +39,8 @@ public interface MutableMigrationState extends MigrationState {
 
   void migrateMessageStateForMultiTenancy();
 
+  void migrateMessageStartEventSubscriptionForMultiTenancy();
+
   /**
    * Changes the state of a migration to FINISHED to indicate it has been executed.
    *

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -53,6 +53,10 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
     bpmnProcessIdProp.setValue(record.getBpmnProcessIdBuffer());
     messageNameProp.setValue(record.getMessageNameBuffer());
     startEventIdProp.setValue(record.getStartEventIdBuffer());
+    processInstanceKeyProp.setValue(record.getProcessInstanceKey());
+    messageKeyProp.setValue(record.getMessageKey());
+    correlationKeyProp.setValue(record.getCorrelationKeyBuffer());
+    variablesProp.setValue(record.getVariablesBuffer());
     tenantIdProp.setValue(record.getTenantId());
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
- `DEPRECATED_MESSAGE_START_EVENT_SUBSCRIPTION_BY_NAME_AND_KEY` -> `MESSAGE_START_EVENT_SUBSCRIPTION_BY_NAME_AND_KEY`
    - Prefix first part of composite key with tenant
    - Set tenant on value
- `DEPRECATED_MESSAGE_START_EVENT_SUBSCRIPTION_BY_KEY_AND_NAME` -> `MESSAGE_START_EVENT_SUBSCRIPTION_BY_KEY_AND_NAME`
    - Prefix second part of composite key with tenant

## Related issues

<!-- Which issues are closed by this PR or are related -->

Relates to #14470 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
