### PR TITLE
Migrate `MessageStartEventSubscriptionState` for Multi-Tenancy

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.state.migration.MigrationTaskState.State;
 import io.camunda.zeebe.engine.state.migration.to_8_3.DbDecisionMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_3.DbMessageMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_3.DbMessageStartEventSubscriptionMigrationState;
+import io.camunda.zeebe.engine.state.migration.to_8_3.DbMessageSubscriptionMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_3.DbProcessMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
@@ -110,6 +111,7 @@ public class DbMigrationState implements MutableMigrationState {
   private final DbMessageMigrationState messageMigrationState;
   private final DbMessageStartEventSubscriptionMigrationState
       messageStartEventSubscriptionMigrationState;
+  private final DbMessageSubscriptionMigrationState messageSubscriptionMigrationState;
 
   public DbMigrationState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -239,6 +241,8 @@ public class DbMigrationState implements MutableMigrationState {
     messageMigrationState = new DbMessageMigrationState(zeebeDb, transactionContext);
     messageStartEventSubscriptionMigrationState =
         new DbMessageStartEventSubscriptionMigrationState(zeebeDb, transactionContext);
+    messageSubscriptionMigrationState =
+        new DbMessageSubscriptionMigrationState(zeebeDb, transactionContext);
   }
 
   @Override
@@ -423,6 +427,11 @@ public class DbMigrationState implements MutableMigrationState {
   public void migrateMessageStartEventSubscriptionForMultiTenancy() {
     messageStartEventSubscriptionMigrationState
         .migrateMessageStartEventSubscriptionForMultiTenancy();
+  }
+
+  @Override
+  public void migrateMessageEventSubscriptionForMultiTenancy() {
+    messageSubscriptionMigrationState.migrateMessageSubscriptionForMultiTenancy();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/DbMessageSubscriptionMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/DbMessageSubscriptionMigrationState.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
+import io.camunda.zeebe.engine.state.message.MessageSubscription;
+import io.camunda.zeebe.engine.state.migration.to_8_3.legacy.LegacyMessageSubscriptionState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+
+public class DbMessageSubscriptionMigrationState {
+
+  private final LegacyMessageSubscriptionState from;
+  private final DbMessageSubscriptionState to;
+
+  public DbMessageSubscriptionMigrationState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    from = new LegacyMessageSubscriptionState(zeebeDb, transactionContext);
+    to = new DbMessageSubscriptionState(zeebeDb, transactionContext);
+  }
+
+  public void migrateMessageSubscriptionForMultiTenancy() {
+    // setting the tenant id key once, because it's the same for all steps below
+    to.tenantIdKey.wrapString(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    /*
+    - `DEPRECATED_MESSAGE_SUBSCRIPTION_BY_NAME_AND_CORRELATION_KEY` -> `MESSAGE_SUBSCRIPTION_BY_NAME_AND_CORRELATION_KEY`
+    - Prefix first part of composite key with tenant
+     */
+    from.getMessageNameAndCorrelationKeyColumnFamily()
+        .forEach(
+            (key, value) -> {
+              to.messageName.wrapBuffer(key.first().first().getBuffer());
+              to.correlationKey.wrapBuffer(key.first().second().getBuffer());
+              to.elementInstanceKey.wrapLong(key.second().getValue());
+              to.messageNameAndCorrelationKeyColumnFamily.insert(
+                  to.tenantAwareNameCorrelationAndElementInstanceKey, DbNil.INSTANCE);
+              from.getMessageNameAndCorrelationKeyColumnFamily().deleteExisting(key);
+            });
+  }
+
+  private static final class DbMessageSubscriptionState {
+    // (elementInstanceKey, messageName) => MessageSubscription
+    private final DbLong elementInstanceKey;
+    private final DbString messageName;
+    private final MessageSubscription messageSubscription;
+    private final DbCompositeKey<DbLong, DbString> elementKeyAndMessageName;
+    private final ColumnFamily<DbCompositeKey<DbLong, DbString>, MessageSubscription>
+        subscriptionColumnFamily;
+
+    // (tenant aware messageName, correlationKey, elementInstanceKey) => \0
+    private final DbString tenantIdKey;
+    private final DbString correlationKey;
+    private final DbTenantAwareKey<DbCompositeKey<DbString, DbString>>
+        tenantAwareNameAndCorrelationKey;
+    private final DbCompositeKey<DbTenantAwareKey<DbCompositeKey<DbString, DbString>>, DbLong>
+        tenantAwareNameCorrelationAndElementInstanceKey;
+    private final ColumnFamily<
+            DbCompositeKey<DbTenantAwareKey<DbCompositeKey<DbString, DbString>>, DbLong>, DbNil>
+        messageNameAndCorrelationKeyColumnFamily;
+
+    public DbMessageSubscriptionState(
+        final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+
+      elementInstanceKey = new DbLong();
+      messageName = new DbString();
+      messageSubscription = new MessageSubscription();
+      elementKeyAndMessageName = new DbCompositeKey<>(elementInstanceKey, messageName);
+      subscriptionColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_KEY,
+              transactionContext,
+              elementKeyAndMessageName,
+              messageSubscription);
+
+      tenantIdKey = new DbString();
+      correlationKey = new DbString();
+      tenantAwareNameAndCorrelationKey =
+          new DbTenantAwareKey<>(
+              tenantIdKey, new DbCompositeKey<>(messageName, correlationKey), PlacementType.PREFIX);
+      tenantAwareNameCorrelationAndElementInstanceKey =
+          new DbCompositeKey<>(tenantAwareNameAndCorrelationKey, elementInstanceKey);
+      messageNameAndCorrelationKeyColumnFamily =
+          zeebeDb.createColumnFamily(
+              ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_NAME_AND_CORRELATION_KEY,
+              transactionContext,
+              tenantAwareNameCorrelationAndElementInstanceKey,
+              DbNil.INSTANCE);
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigration.java
@@ -32,5 +32,6 @@ public class MultiTenancyMigration implements MigrationTask {
     migrationState.migrateDecisionStateForMultiTenancy();
     migrationState.migrateMessageStateForMultiTenancy();
     migrationState.migrateMessageStartEventSubscriptionForMultiTenancy();
+    migrationState.migrateMessageEventSubscriptionForMultiTenancy();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyMessageSubscriptionState.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_3.legacy;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.message.MessageSubscription;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+public final class LegacyMessageSubscriptionState
+    implements MutableMessageSubscriptionState,
+    MutablePendingMessageSubscriptionState,
+    StreamProcessorLifecycleAware {
+
+  // (elementInstanceKey, messageName) => MessageSubscription
+  private final DbLong elementInstanceKey;
+  private final DbString messageName;
+  private final MessageSubscription messageSubscription;
+  private final DbCompositeKey<DbLong, DbString> elementKeyAndMessageName;
+  private final ColumnFamily<DbCompositeKey<DbLong, DbString>, MessageSubscription>
+      subscriptionColumnFamily;
+
+  // (messageName, correlationKey, elementInstanceKey) => \0
+  private final DbString correlationKey;
+  private final DbCompositeKey<DbString, DbString> nameAndCorrelationKey;
+  private final DbCompositeKey<DbCompositeKey<DbString, DbString>, DbLong>
+      nameCorrelationAndElementInstanceKey;
+  private final ColumnFamily<DbCompositeKey<DbCompositeKey<DbString, DbString>, DbLong>, DbNil>
+      messageNameAndCorrelationKeyColumnFamily;
+
+  private final PendingMessageSubscriptionState transientState =
+      new PendingMessageSubscriptionState(this);
+
+  public LegacyMessageSubscriptionState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+
+    elementInstanceKey = new DbLong();
+    messageName = new DbString();
+    messageSubscription = new MessageSubscription();
+    elementKeyAndMessageName = new DbCompositeKey<>(elementInstanceKey, messageName);
+    subscriptionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_KEY,
+            transactionContext,
+            elementKeyAndMessageName,
+            messageSubscription);
+
+    correlationKey = new DbString();
+    nameAndCorrelationKey = new DbCompositeKey<>(messageName, correlationKey);
+    nameCorrelationAndElementInstanceKey =
+        new DbCompositeKey<>(nameAndCorrelationKey, elementInstanceKey);
+    messageNameAndCorrelationKeyColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_NAME_AND_CORRELATION_KEY,
+            transactionContext,
+            nameCorrelationAndElementInstanceKey,
+            DbNil.INSTANCE);
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    subscriptionColumnFamily.forEach(
+        subscription -> {
+          if (subscription.isCorrelating()) {
+            transientState.add(subscription.getRecord());
+          }
+        });
+  }
+
+  @Override
+  public MessageSubscription get(final long elementInstanceKey, final DirectBuffer messageName) {
+    this.messageName.wrapBuffer(messageName);
+    this.elementInstanceKey.wrapLong(elementInstanceKey);
+    return subscriptionColumnFamily.get(elementKeyAndMessageName);
+  }
+
+  @Override
+  public boolean existSubscriptionForElementInstance(
+      final long elementInstanceKey, final DirectBuffer messageName) {
+    this.elementInstanceKey.wrapLong(elementInstanceKey);
+    this.messageName.wrapBuffer(messageName);
+
+    return subscriptionColumnFamily.exists(elementKeyAndMessageName);
+  }
+
+  @Override
+  public void visitSubscriptions(
+      final DirectBuffer messageName,
+      final DirectBuffer correlationKey,
+      final MessageSubscriptionVisitor visitor) {
+
+    this.messageName.wrapBuffer(messageName);
+    this.correlationKey.wrapBuffer(correlationKey);
+
+    messageNameAndCorrelationKeyColumnFamily.whileEqualPrefix(
+        nameAndCorrelationKey,
+        (compositeKey, nil) -> {
+          return visitMessageSubscription(elementKeyAndMessageName, visitor);
+        });
+  }
+
+  @Override
+  public void put(final long key, final MessageSubscriptionRecord record) {
+    elementInstanceKey.wrapLong(record.getElementInstanceKey());
+    messageName.wrapBuffer(record.getMessageNameBuffer());
+
+    messageSubscription.setKey(key).setRecord(record).setCorrelating(false);
+
+    subscriptionColumnFamily.insert(elementKeyAndMessageName, messageSubscription);
+
+    correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
+    messageNameAndCorrelationKeyColumnFamily.insert(
+        nameCorrelationAndElementInstanceKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void updateToCorrelatingState(final MessageSubscriptionRecord record) {
+    final var messageKey = record.getMessageKey();
+    var messageVariables = record.getVariablesBuffer();
+    if (record == messageSubscription.getRecord()) {
+      // copy the buffer before loading the subscription to avoid that it is overridden
+      messageVariables = BufferUtil.cloneBuffer(record.getVariablesBuffer());
+    }
+
+    final var subscription = get(record.getElementInstanceKey(), record.getMessageNameBuffer());
+    if (subscription == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected subscription but not found. [element-instance-key: %d, message-name: %s]",
+              record.getElementInstanceKey(), record.getMessageName()));
+    }
+
+    // update the message key and the variables
+    subscription.getRecord().setMessageKey(messageKey).setVariables(messageVariables);
+
+    updateCorrelatingFlag(subscription, true);
+
+    transientState.add(record);
+  }
+
+  @Override
+  public void updateToCorrelatedState(final MessageSubscription subscription) {
+    updateCorrelatingFlag(subscription, false);
+    transientState.remove(subscription.getRecord());
+  }
+
+  @Override
+  public boolean remove(final long elementInstanceKey, final DirectBuffer messageName) {
+    this.elementInstanceKey.wrapLong(elementInstanceKey);
+    this.messageName.wrapBuffer(messageName);
+
+    final MessageSubscription messageSubscription =
+        subscriptionColumnFamily.get(elementKeyAndMessageName);
+
+    final boolean found = messageSubscription != null;
+    if (found) {
+      remove(messageSubscription);
+    }
+    return found;
+  }
+
+  @Override
+  public void remove(final MessageSubscription subscription) {
+    subscriptionColumnFamily.deleteExisting(elementKeyAndMessageName);
+
+    final var record = subscription.getRecord();
+    messageName.wrapBuffer(record.getMessageNameBuffer());
+    correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
+    messageNameAndCorrelationKeyColumnFamily.deleteExisting(nameCorrelationAndElementInstanceKey);
+
+    transientState.remove(subscription.getRecord());
+  }
+
+  private void updateCorrelatingFlag(
+      final MessageSubscription subscription, final boolean correlating) {
+    final var record = subscription.getRecord();
+    elementInstanceKey.wrapLong(record.getElementInstanceKey());
+    messageName.wrapBuffer(record.getMessageNameBuffer());
+
+    subscription.setCorrelating(correlating);
+    subscriptionColumnFamily.update(elementKeyAndMessageName, subscription);
+  }
+
+  private Boolean visitMessageSubscription(
+      final DbCompositeKey<DbLong, DbString> elementKeyAndMessageName,
+      final MessageSubscriptionVisitor visitor) {
+    final MessageSubscription messageSubscription =
+        subscriptionColumnFamily.get(elementKeyAndMessageName);
+
+    if (messageSubscription == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to find subscription with key %d and %s, but no subscription found",
+              elementKeyAndMessageName.first().getValue(), elementKeyAndMessageName.second()));
+    }
+    return visitor.visit(messageSubscription);
+  }
+
+  @Override
+  public void visitSubscriptionBefore(
+      final long deadline, final MessageSubscriptionVisitor visitor) {
+    transientState.visitSubscriptionBefore(deadline, visitor);
+  }
+
+  @Override
+  public void updateCommandSentTime(final MessageSubscriptionRecord record, final long sentTime) {
+    transientState.updateCommandSentTime(record, sentTime);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyMessageSubscriptionState.java
@@ -14,21 +14,11 @@ import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
-import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.MessageSubscription;
-import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
-import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
-import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
-import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.util.buffer.BufferUtil;
-import org.agrona.DirectBuffer;
 
-public final class LegacyMessageSubscriptionState
-    implements MutableMessageSubscriptionState,
-    MutablePendingMessageSubscriptionState,
-    StreamProcessorLifecycleAware {
+public final class LegacyMessageSubscriptionState {
 
   // (elementInstanceKey, messageName) => MessageSubscription
   private final DbLong elementInstanceKey;
@@ -45,9 +35,6 @@ public final class LegacyMessageSubscriptionState
       nameCorrelationAndElementInstanceKey;
   private final ColumnFamily<DbCompositeKey<DbCompositeKey<DbString, DbString>, DbLong>, DbNil>
       messageNameAndCorrelationKeyColumnFamily;
-
-  private final PendingMessageSubscriptionState transientState =
-      new PendingMessageSubscriptionState(this);
 
   public LegacyMessageSubscriptionState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -69,55 +56,12 @@ public final class LegacyMessageSubscriptionState
         new DbCompositeKey<>(nameAndCorrelationKey, elementInstanceKey);
     messageNameAndCorrelationKeyColumnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_NAME_AND_CORRELATION_KEY,
+            ZbColumnFamilies.DEPRECATED_MESSAGE_SUBSCRIPTION_BY_NAME_AND_CORRELATION_KEY,
             transactionContext,
             nameCorrelationAndElementInstanceKey,
             DbNil.INSTANCE);
   }
 
-  @Override
-  public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    subscriptionColumnFamily.forEach(
-        subscription -> {
-          if (subscription.isCorrelating()) {
-            transientState.add(subscription.getRecord());
-          }
-        });
-  }
-
-  @Override
-  public MessageSubscription get(final long elementInstanceKey, final DirectBuffer messageName) {
-    this.messageName.wrapBuffer(messageName);
-    this.elementInstanceKey.wrapLong(elementInstanceKey);
-    return subscriptionColumnFamily.get(elementKeyAndMessageName);
-  }
-
-  @Override
-  public boolean existSubscriptionForElementInstance(
-      final long elementInstanceKey, final DirectBuffer messageName) {
-    this.elementInstanceKey.wrapLong(elementInstanceKey);
-    this.messageName.wrapBuffer(messageName);
-
-    return subscriptionColumnFamily.exists(elementKeyAndMessageName);
-  }
-
-  @Override
-  public void visitSubscriptions(
-      final DirectBuffer messageName,
-      final DirectBuffer correlationKey,
-      final MessageSubscriptionVisitor visitor) {
-
-    this.messageName.wrapBuffer(messageName);
-    this.correlationKey.wrapBuffer(correlationKey);
-
-    messageNameAndCorrelationKeyColumnFamily.whileEqualPrefix(
-        nameAndCorrelationKey,
-        (compositeKey, nil) -> {
-          return visitMessageSubscription(elementKeyAndMessageName, visitor);
-        });
-  }
-
-  @Override
   public void put(final long key, final MessageSubscriptionRecord record) {
     elementInstanceKey.wrapLong(record.getElementInstanceKey());
     messageName.wrapBuffer(record.getMessageNameBuffer());
@@ -131,97 +75,8 @@ public final class LegacyMessageSubscriptionState
         nameCorrelationAndElementInstanceKey, DbNil.INSTANCE);
   }
 
-  @Override
-  public void updateToCorrelatingState(final MessageSubscriptionRecord record) {
-    final var messageKey = record.getMessageKey();
-    var messageVariables = record.getVariablesBuffer();
-    if (record == messageSubscription.getRecord()) {
-      // copy the buffer before loading the subscription to avoid that it is overridden
-      messageVariables = BufferUtil.cloneBuffer(record.getVariablesBuffer());
-    }
-
-    final var subscription = get(record.getElementInstanceKey(), record.getMessageNameBuffer());
-    if (subscription == null) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected subscription but not found. [element-instance-key: %d, message-name: %s]",
-              record.getElementInstanceKey(), record.getMessageName()));
-    }
-
-    // update the message key and the variables
-    subscription.getRecord().setMessageKey(messageKey).setVariables(messageVariables);
-
-    updateCorrelatingFlag(subscription, true);
-
-    transientState.add(record);
-  }
-
-  @Override
-  public void updateToCorrelatedState(final MessageSubscription subscription) {
-    updateCorrelatingFlag(subscription, false);
-    transientState.remove(subscription.getRecord());
-  }
-
-  @Override
-  public boolean remove(final long elementInstanceKey, final DirectBuffer messageName) {
-    this.elementInstanceKey.wrapLong(elementInstanceKey);
-    this.messageName.wrapBuffer(messageName);
-
-    final MessageSubscription messageSubscription =
-        subscriptionColumnFamily.get(elementKeyAndMessageName);
-
-    final boolean found = messageSubscription != null;
-    if (found) {
-      remove(messageSubscription);
-    }
-    return found;
-  }
-
-  @Override
-  public void remove(final MessageSubscription subscription) {
-    subscriptionColumnFamily.deleteExisting(elementKeyAndMessageName);
-
-    final var record = subscription.getRecord();
-    messageName.wrapBuffer(record.getMessageNameBuffer());
-    correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
-    messageNameAndCorrelationKeyColumnFamily.deleteExisting(nameCorrelationAndElementInstanceKey);
-
-    transientState.remove(subscription.getRecord());
-  }
-
-  private void updateCorrelatingFlag(
-      final MessageSubscription subscription, final boolean correlating) {
-    final var record = subscription.getRecord();
-    elementInstanceKey.wrapLong(record.getElementInstanceKey());
-    messageName.wrapBuffer(record.getMessageNameBuffer());
-
-    subscription.setCorrelating(correlating);
-    subscriptionColumnFamily.update(elementKeyAndMessageName, subscription);
-  }
-
-  private Boolean visitMessageSubscription(
-      final DbCompositeKey<DbLong, DbString> elementKeyAndMessageName,
-      final MessageSubscriptionVisitor visitor) {
-    final MessageSubscription messageSubscription =
-        subscriptionColumnFamily.get(elementKeyAndMessageName);
-
-    if (messageSubscription == null) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected to find subscription with key %d and %s, but no subscription found",
-              elementKeyAndMessageName.first().getValue(), elementKeyAndMessageName.second()));
-    }
-    return visitor.visit(messageSubscription);
-  }
-
-  @Override
-  public void visitSubscriptionBefore(
-      final long deadline, final MessageSubscriptionVisitor visitor) {
-    transientState.visitSubscriptionBefore(deadline, visitor);
-  }
-
-  @Override
-  public void updateCommandSentTime(final MessageSubscriptionRecord record, final long sentTime) {
-    transientState.updateCommandSentTime(record, sentTime);
+  public ColumnFamily<DbCompositeKey<DbCompositeKey<DbString, DbString>, DbLong>, DbNil>
+      getMessageNameAndCorrelationKeyColumnFamily() {
+    return messageNameAndCorrelationKeyColumnFamily;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -41,6 +41,8 @@ public interface MutableMigrationState extends MigrationState {
 
   void migrateMessageStartEventSubscriptionForMultiTenancy();
 
+  void migrateMessageEventSubscriptionForMultiTenancy();
+
   /**
    * Changes the state of a migration to FINISHED to indicate it has been executed.
    *


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
- `DEPRECATED_MESSAGE_SUBSCRIPTION_BY_NAME_AND_CORRELATION_KEY` -> `MESSAGE_SUBSCRIPTION_BY_NAME_AND_CORRELATION_KEY`
    - Prefix first part of composite key with tenant

## Related issues

<!-- Which issues are closed by this PR or are related -->

Relates to #14470

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
