### PR TITLE
[Backport stable/8.2] fix(benchmark): use JDK_JAVA_OPTIONS for opts to be picked up by jib images

### DIFF
--- a/benchmarks/setup/cloud-default/simpleStarter.yaml
+++ b/benchmarks/setup/cloud-default/simpleStarter.yaml
@@ -19,7 +19,7 @@ spec:
         image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
-          - name: JAVA_OPTIONS
+          - name: JDK_JAVA_OPTIONS
             value: >-
               -Dapp.tls=true
               -Dapp.starter.rate=300

--- a/benchmarks/setup/cloud-default/starter.yaml
+++ b/benchmarks/setup/cloud-default/starter.yaml
@@ -20,7 +20,7 @@ spec:
           image: gcr.io/zeebe-io/starter:SNAPSHOT
           imagePullPolicy: Always
           env:
-            - name: JAVA_OPTIONS
+            - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dapp.starter.rate=100
                 -Dapp.tls=true

--- a/benchmarks/setup/cloud-default/timer.yaml
+++ b/benchmarks/setup/cloud-default/timer.yaml
@@ -19,7 +19,7 @@ spec:
         image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
-          - name: JAVA_OPTIONS
+          - name: JDK_JAVA_OPTIONS
             value: >-
               -Dapp.starter.rate=100
               -Dapp.tls=true

--- a/benchmarks/setup/cloud-default/worker.yaml
+++ b/benchmarks/setup/cloud-default/worker.yaml
@@ -20,7 +20,7 @@ spec:
           image: gcr.io/zeebe-io/worker:SNAPSHOT
           imagePullPolicy: Always
           env:
-            - name: JAVA_OPTIONS
+            - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.tls=true


### PR DESCRIPTION
# Description
Backport of #14528 to `stable/8.2`.

relates to #14047
original author: @megglos