### PR TITLE
Authorize tenants to operate on process instances

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceHandler.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.auth.impl.TenantAuthorizationCheckerImpl;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -56,6 +57,13 @@ public final class CancelProcessInstanceHandler implements ProcessInstanceComman
         || !elementInstance.canTerminate()
         || elementInstance.getParentKey() > 0) {
 
+      commandContext.reject(
+          RejectionType.NOT_FOUND, String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
+      return false;
+    }
+
+    if (!TenantAuthorizationCheckerImpl.fromAuthorizationMap(command.getAuthorizations())
+        .isAuthorized(elementInstance.getValue().getTenantId())) {
       commandContext.reject(
           RejectionType.NOT_FOUND, String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
       return false;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -42,7 +42,6 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationActivateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationVariableInstructionValue;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -61,11 +60,6 @@ public final class ProcessInstanceModificationProcessor
 
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "Expected to modify process instance but no process instance found with key '%d'";
-  private static final String ERROR_MESSAGE_PROCESS_INSTANCE_BELONGS_TO_SPECIFIC_TENANT =
-      "Expected to modify process instance but process instance belongs to tenant '%s'"
-          + " while modification is not yet supported with multi-tenancy."
-          + " Only process instances belonging to the default tenant '<default>' can be modified."
-          + " See https://github.com/camunda/zeebe/issues/13288 for more details.";
   private static final String ERROR_MESSAGE_ACTIVATE_ELEMENT_NOT_FOUND =
       "Expected to modify instance of process '%s' but it contains one or more activate instructions"
           + " with an element that could not be found: '%s'";
@@ -180,15 +174,6 @@ public final class ProcessInstanceModificationProcessor
       final String reason = String.format(ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND, eventKey);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, reason);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, reason);
-      return;
-    }
-
-    final String tenantId = processInstance.getValue().getTenantId();
-    if (!Objects.equals(tenantId, TenantOwned.DEFAULT_TENANT_IDENTIFIER)) {
-      final String reason =
-          String.format(ERROR_MESSAGE_PROCESS_INSTANCE_BELONGS_TO_SPECIFIC_TENANT, tenantId);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
-      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
       return;
     }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class TenantAwareCancelProcessInstanceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCancelInstanceForDefaultTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .create();
+
+    // when
+    final var cancelled =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .forAuthorizedTenants(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .cancel();
+
+    // then
+    assertThat(cancelled)
+        .describedAs("Expect that cancellation was successful")
+        .hasIntent(ProcessInstanceIntent.ELEMENT_TERMINATED);
+  }
+
+  @Test
+  public void shouldRejectCancelInstanceForUnauthorizedTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId("custom-tenant")
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process").withTenantId("custom-tenant").create();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .forAuthorizedTenants("another-tenant")
+            .expectRejection()
+            .cancel();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to cancel a process instance with key '%s', but no such process was found"
+                .formatted(processInstanceKey));
+  }
+
+  @Test
+  public void shouldCancelInstanceForSpecificTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId("custom-tenant")
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process").withTenantId("custom-tenant").create();
+
+    // when
+    final var cancelled =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .forAuthorizedTenants("custom-tenant")
+            .cancel();
+
+    // then
+    assertThat(cancelled)
+        .describedAs("Expect that cancellation was successful")
+        .hasIntent(ProcessInstanceIntent.ELEMENT_TERMINATED);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
@@ -93,6 +93,7 @@ public class TenantAwareProcessInstanceVariableTest {
         .variables()
         .ofScope(processInstanceKey)
         .withDocument(Maps.of(entry("x", 2)))
+        .forAuthorizedTenants(TENANT_ID)
         .update();
 
     // then

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class TenantAwareUpdateVariablesTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldUpdateVariablesForDefaultTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .create();
+
+    // when
+    final var updated =
+        ENGINE
+            .variables()
+            .ofScope(processInstanceKey)
+            .forAuthorizedTenants(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .withDocument(Map.of("foo", "bar"))
+            .update();
+
+    // then
+    assertThat(updated)
+        .describedAs("Expect that update was successful")
+        .hasIntent(VariableDocumentIntent.UPDATED);
+  }
+
+  @Test
+  public void shouldRejectUpdateVariablesForUnauthorizedTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId("custom-tenant")
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process").withTenantId("custom-tenant").create();
+
+    // when
+    final var rejection =
+        ENGINE
+            .variables()
+            .ofScope(processInstanceKey)
+            .forAuthorizedTenants("another-tenant")
+            .withDocument(Map.of("foo", "bar"))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to update variables for element with key '%s', but no such element was found"
+                .formatted(processInstanceKey));
+  }
+
+  @Test
+  public void shouldUpdateVariablesForSpecificTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId("custom-tenant")
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process").withTenantId("custom-tenant").create();
+
+    // when
+    final var updated =
+        ENGINE
+            .variables()
+            .ofScope(processInstanceKey)
+            .forAuthorizedTenants("custom-tenant")
+            .withDocument(Map.of("foo", "bar"))
+            .update();
+
+    // then
+    assertThat(updated)
+        .describedAs("Expect that update was successful")
+        .hasIntent(VariableDocumentIntent.UPDATED);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -140,12 +140,18 @@ public class StreamProcessingComposite implements CommandWriter {
 
   @Override
   public long writeCommand(final Intent intent, final UnifiedRecordValue value) {
+    return writeCommand(intent, value, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Override
+  public long writeCommand(
+      final Intent intent, final UnifiedRecordValue value, final String... authorizedTenants) {
     final var writer =
         streams
             .newRecord(getLogName(partitionId))
             .recordType(RecordType.COMMAND)
             .intent(intent)
-            .authorizations(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .authorizations(authorizedTenants)
             .event(value);
     return writeActor.submit(writer::write).join();
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -196,6 +196,12 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   }
 
   @Override
+  public long writeCommand(
+      final Intent intent, final UnifiedRecordValue value, final String... authorizedTenants) {
+    return streamProcessingComposite.writeCommand(intent, value, authorizedTenants);
+  }
+
+  @Override
   public long writeCommand(final long key, final Intent intent, final UnifiedRecordValue value) {
     return streamProcessingComposite.writeCommand(key, intent, value);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -14,6 +14,9 @@ public interface CommandWriter {
 
   long writeCommand(final Intent intent, final UnifiedRecordValue recordValue);
 
+  long writeCommand(
+      final Intent intent, final UnifiedRecordValue recordValue, String... authorizedTenants);
+
   long writeCommand(long key, Intent intent, UnifiedRecordValue recordValue);
 
   long writeCommand(

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/VariableClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/VariableClient.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.camunda.zeebe.test.util.MsgPackUtil;
@@ -42,6 +43,7 @@ public final class VariableClient {
 
   private LongFunction<Record<VariableDocumentRecordValue>> expectation =
       SUCCESSFUL_EXPECTATION_SUPPLIER;
+  private String[] authorizedTenants = new String[] {TenantOwned.DEFAULT_TENANT_IDENTIFIER};
 
   public VariableClient(final CommandWriter writer) {
     this.writer = writer;
@@ -73,6 +75,11 @@ public final class VariableClient {
     return this;
   }
 
+  public VariableClient forAuthorizedTenants(final String... authorizedTenants) {
+    this.authorizedTenants = authorizedTenants;
+    return this;
+  }
+
   public VariableClient expectRejection() {
     expectation = REJECTION_EXPECTATION_SUPPLIER;
     return this;
@@ -80,7 +87,8 @@ public final class VariableClient {
 
   public Record<VariableDocumentRecordValue> update() {
     final long position =
-        writer.writeCommand(VariableDocumentIntent.UPDATE, variableDocumentRecord);
+        writer.writeCommand(
+            VariableDocumentIntent.UPDATE, variableDocumentRecord, authorizedTenants);
     return expectation.apply(position);
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

> **Note**
> This pull request also re-enabled process instance modification for custom tenants.

The process instance operations (cancellation, modification, and update variables) are already fully functional for both default and custom tenants. However, they still allowed any tenant to operate on them, even when they are not authorized.

This adds authorization checks to these operations verifying that the referenced entity belongs to a tenant that the requester has access to.

Tests are added to verify the correct behavior of the three operations for:
- the default tenant
- a custom tenant
- a different tenant than the one owning the process instances

These checks should preferably be build into the db/state layer, similar to #14256, where data is only provided to processors where the requester has access to. We consider this tech debt that can be improved upon later.

While this closes #13288, it leaves some efforts open in #13638:
- `VariableDocumentRecord` does not have `tenantId`
- and the `tenantId` is not part of the response

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13288 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
