### PR TITLE
Disable timer events for non-default tenants

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedMultiTenantFeaturesValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/UnsupportedMultiTenantFeaturesValidator.java
@@ -31,7 +31,7 @@ public final class UnsupportedMultiTenantFeaturesValidator {
   private static final EnumSet<BpmnElementType> REJECTED_ELEMENT_TYPES =
       EnumSet.noneOf(BpmnElementType.class);
   private static final EnumSet<BpmnEventType> UNSUPPORTED_EVENT_TYPES =
-      EnumSet.of(BpmnEventType.SIGNAL);
+      EnumSet.of(BpmnEventType.SIGNAL, BpmnEventType.TIMER);
 
   /**
    * Validates a list of processes for containing unsupported elements when used with multi-tenancy.

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.Collections;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -233,6 +234,7 @@ public final class TimerIncidentTest {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/zeebe/issues/13337")
   public void shouldCreateIncidentForCustomTenant() {
     // when
     final String tenantId = "acme";

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.time.Duration;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -149,7 +148,7 @@ public class TenantAwareSignalEventTest {
                     .endEvent()
                     .moveToLastGateway()
                     .intermediateCatchEvent()
-                    .timerWithDuration(Duration.ofMinutes(10))
+                    .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
                     .endEvent()
                     .done())
             .withTenantId("custom-tenant")

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerEventTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class TenantAwareTimerEventTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
+  private String processId;
+
+  @Before
+  public void setup() {
+    processId = Strings.newRandomValidBpmnId();
+  }
+
+  @Test
+  public void shouldCreateTimerForDefaultTenant() {
+    // when
+    final var deployed =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("timer-start")
+                    .timerWithDuration(Duration.ofMinutes(10))
+                    .endEvent()
+                    .done())
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .deploy();
+
+    // then
+    assertThat(deployed)
+        .describedAs("Expect that process with timer was deployed successful")
+        .hasIntent(DeploymentIntent.CREATED);
+
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CREATED)
+                .withProcessDefinitionKey(
+                    deployed.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey())
+                .getFirst())
+        .describedAs("Expect that timer was created")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithTimerForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("timer-start")
+                    .timerWithDuration(Duration.ofMinutes(10))
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['timer-start' of type 'TIMER' 'START_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithTimerCatchEventForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .intermediateCatchEvent("timer-catch")
+                    .timerWithDuration(Duration.ofMinutes(10))
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['timer-catch' of type 'TIMER' 'INTERMEDIATE_CATCH_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void
+      shouldRejectDeployProcessWithTimerCatchEventAttachedToEventBasedGatewayForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .eventBasedGateway()
+                    .intermediateCatchEvent("timer-catch-attached")
+                    .timerWithDuration(Duration.ofMinutes(10))
+                    .endEvent()
+                    .moveToLastGateway()
+                    .intermediateCatchEvent()
+                    .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['timer-catch-attached' of type 'TIMER' 'INTERMEDIATE_CATCH_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithTimerEventSubProcessEventForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .eventSubProcess(
+                        "timer-sub",
+                        sub ->
+                            sub.startEvent("timer-start-event-sub")
+                                .timerWithDuration(Duration.ofMinutes(10))
+                                .endEvent())
+                    .startEvent()
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['timer-start-event-sub' of type 'TIMER' 'START_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectDeployProcessWithTimerBoundaryEventForSpecificTenant() {
+    // when
+    final var rejection =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .manualTask()
+                    .boundaryEvent("timer-boundary")
+                    .timerWithDuration(Duration.ofMinutes(10))
+                    .endEvent()
+                    .done())
+            .withTenantId("custom-tenant")
+            .expectRejection()
+            .deploy();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            `process.xml`: - Process: %s
+                - ERROR: Processes belonging to custom tenants are not allowed to contain elements \
+            unsupported with multi-tenancy. Only the default tenant '<default>' supports these \
+            elements currently: ['timer-boundary' of type 'TIMER' 'BOUNDARY_EVENT']. \
+            See https://github.com/camunda/zeebe/issues/12653 for more details.
+            """
+                .formatted(processId));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This disables timer events for non-default tenants by rejecting processes with timer events if they are deployed for a tenant that is not the default tenant.

Support may still be added with:
- #14552 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14480 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
