### PR TITLE
Make DbFormState tenant-aware

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -62,7 +62,8 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
                     .map(
                         noDuplicates -> {
                           final FormMetadataRecord formRecord = deployment.formMetadata().add();
-                          appendMetadataToFormRecord(formRecord, formId, resource);
+                          appendMetadataToFormRecord(
+                              formRecord, formId, resource, deployment.getTenantId());
                           writeFormRecord(formRecord, resource);
 
                           return null;
@@ -105,7 +106,10 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
   }
 
   private void appendMetadataToFormRecord(
-      final FormMetadataRecord formRecord, final String formId, final DeploymentResource resource) {
+      final FormMetadataRecord formRecord,
+      final String formId,
+      final DeploymentResource resource,
+      final String tenantId) {
     final LongSupplier newFormKey = keyGenerator::nextKey;
     final DirectBuffer checksum = checksumGenerator.apply(resource);
 
@@ -114,7 +118,7 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
     formRecord.setResourceName(resource.getResourceName());
 
     formState
-        .findLatestFormById(wrapString(formRecord.getFormId()), formRecord.getTenantId())
+        .findLatestFormById(wrapString(formRecord.getFormId()), tenantId)
         .ifPresentOrElse(
             latestForm -> {
               final int latestVersion = latestForm.getVersion();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -116,6 +116,7 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
     formRecord.setFormId(formId);
     formRecord.setChecksum(checksum);
     formRecord.setResourceName(resource.getResourceName());
+    formRecord.setTenantId(tenantId);
 
     formState
         .findLatestFormById(wrapString(formRecord.getFormId()), tenantId)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
@@ -85,7 +85,8 @@ public class DbFormState implements MutableFormState {
     dbFormId.wrapBuffer(formId);
     final long latestVersion = versionManager.getLatestResourceVersion(formId, tenantId);
     formVersion.wrapLong(latestVersion);
-    return Optional.ofNullable(formByIdAndVersionColumnFamily.get(tenantAwareIdAndVersionKey));
+    return Optional.ofNullable(formByIdAndVersionColumnFamily.get(tenantAwareIdAndVersionKey))
+        .map(PersistedForm::copy);
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareFormLinkingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareFormLinkingTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TenantAwareFormLinkingTest {
+  private static final String PROCESS_ID = "processId";
+  private static final String FORM_ID = "Form_0w7r08e";
+  private static final String TEST_FORM = "/form/test-form-1.form";
+  private static final String TENANT = "tenant";
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldActivateUserTask() {
+    // when
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask()
+                .zeebeFormId(FORM_ID)
+                .endEvent()
+                .done())
+        .withXmlClasspathResource(TEST_FORM)
+        .withTenantId(TENANT)
+        .deploy();
+    final long processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .onlyEvents()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.USER_TASK)
+                .limit(2))
+        .extracting(r -> r.getValue().getTenantId())
+        .containsOnly(TENANT);
+  }
+
+  @Test
+  public void shouldNotActivateUserTask() {
+    // when
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask()
+                .zeebeFormId(FORM_ID)
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+    engine.deployment().withXmlClasspathResource(TEST_FORM).withTenantId("otherTenant").deploy();
+    final long processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT).create();
+
+    // then
+    assertThat(
+            RecordingExporter.incidentRecords()
+                .onlyEvents()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(1))
+        .extracting(
+            r -> r.getValue().getErrorType(),
+            r -> r.getValue().getErrorMessage(),
+            r -> r.getValue().getTenantId())
+        .containsExactly(
+            tuple(
+                ErrorType.FORM_NOT_FOUND,
+                """
+                Expected to find a form with id '%s', but no form with this id is found, at least \
+                a form with this id should be available. To resolve the Incident please deploy a \
+                form with the same id"""
+                    .formatted(FORM_ID),
+                TENANT));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateMultiTenantTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateMultiTenantTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.deployment;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableFormState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.test.util.Strings;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class FormStateMultiTenantTest {
+
+  private static final String TENANT_1 = "tenant1";
+  private static final String TENANT_2 = "tenant2";
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
+
+  private MutableFormState formState;
+  private MutableProcessingState processingState;
+  private KeyGenerator keyGenerator;
+
+  @Before
+  public void setUp() {
+    processingState = stateRule.getProcessingState();
+    formState = processingState.getFormState();
+    keyGenerator = processingState.getKeyGenerator();
+  }
+
+  @Test
+  public void shouldPutFormForDifferentTenants() {
+    final long formKey = keyGenerator.nextKey();
+    final String formId = Strings.newRandomValidBpmnId();
+    final int version = 1;
+    final var tenant1Form = createFormRecord(formKey, formId, version, TENANT_1);
+    final var tenant2Form = createFormRecord(formKey, formId, version, TENANT_2);
+
+    // when
+    formState.storeFormRecord(tenant1Form);
+    formState.storeFormRecord(tenant2Form);
+
+    // then
+    var form1 = formState.findFormByKey(formKey, TENANT_1).orElseThrow();
+    var form2 = formState.findFormByKey(formKey, TENANT_2).orElseThrow();
+    assertPersistedForm(form1, formKey, formId, version, TENANT_1);
+    assertPersistedForm(form2, formKey, formId, version, TENANT_2);
+
+    form1 = formState.findLatestFormById(wrapString(formId), TENANT_1).orElseThrow();
+    form2 = formState.findLatestFormById(wrapString(formId), TENANT_2).orElseThrow();
+    assertPersistedForm(form1, formKey, formId, version, TENANT_1);
+    assertPersistedForm(form2, formKey, formId, version, TENANT_2);
+  }
+
+  private FormRecord createFormRecord(
+      final long key, final String id, final int version, final String tenant) {
+    return new FormRecord()
+        .setFormKey(key)
+        .setFormId(id)
+        .setVersion(version)
+        .setResourceName("resourceName")
+        .setResource(wrapString("resource"))
+        .setChecksum(wrapString("checksum"))
+        .setTenantId(tenant);
+  }
+
+  private void assertPersistedForm(
+      final PersistedForm persistedForm,
+      final long expectedKey,
+      final String expectedId,
+      final int expectedVersion,
+      final String expectedTenant) {
+    assertThat(persistedForm)
+        .extracting(
+            PersistedForm::getFormKey,
+            form -> bufferAsString(form.getFormId()),
+            PersistedForm::getVersion,
+            PersistedForm::getTenantId)
+        .describedAs("Gets correct form for tenant")
+        .containsExactly(expectedKey, expectedId, expectedVersion, expectedTenant);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Wraps the keys of the CF's in this state with a tenantId. The tenantId is prefixed so we can easily lookup forms by tenant.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14555 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
