### PR TITLE
Standalone decision evaluation MT E2E tests

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -51,7 +51,6 @@ import java.util.function.Supplier;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -317,22 +316,6 @@ public class MultiTenancyOverIdentityIT {
           .withMessageContaining(
               "Expected to handle gRPC request DeployResource with tenant identifier 'tenant-b'")
           .withMessageContaining("but tenant is not authorized to perform this request");
-    }
-  }
-
-  @Test
-  @Disabled("Not yet supported: https://github.com/camunda/zeebe/issues/14497")
-  void shouldDenyDeployProcessWhenNoTenantAssociated() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-      // when
-      final Future<DeploymentEvent> result =
-          client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send();
-
-      // then
-      assertThat(result)
-          .describedAs("Expect that process can be deployed for the default tenant")
-          .succeedsWithin(Duration.ofSeconds(10));
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -131,7 +131,7 @@ public class MultiTenancyOverIdentityIT {
   private static final GenericContainer<?> IDENTITY =
       new GenericContainer<>(
               DockerImageName.parse("camunda/identity")
-                  .withTag(System.getProperty("identity.docker.image.version", "SNAPSHOT")))
+                  .withTag(System.getProperty("identity.docker.image.version", "8.3.0-alpha6")))
           .withImagePullPolicy(
               System.getProperty("identity.docker.image.version", "SNAPSHOT").equals("SNAPSHOT")
                   ? PullPolicy.alwaysPull()

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -190,6 +190,8 @@ public class MultiTenancyOverIdentityIT {
           .withNetworkAliases("identity");
 
   @AutoCloseResource private static final TestStandaloneBroker ZEEBE = new TestStandaloneBroker();
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
 
   @SuppressWarnings("unused")
   @RegisterExtension
@@ -235,10 +237,10 @@ public class MultiTenancyOverIdentityIT {
 
     awaitCamundaRealmAvailabilityOnKeycloak();
 
-    associateTenantsWithClient(List.of(DEFAULT_TENANT, "tenant-a"), ZEEBE_CLIENT_ID_TENANT_A);
-    associateTenantsWithClient(List.of(DEFAULT_TENANT, "tenant-b"), ZEEBE_CLIENT_ID_TENANT_B);
+    associateTenantsWithClient(List.of(DEFAULT_TENANT, TENANT_A), ZEEBE_CLIENT_ID_TENANT_A);
+    associateTenantsWithClient(List.of(DEFAULT_TENANT, TENANT_B), ZEEBE_CLIENT_ID_TENANT_B);
     associateTenantsWithClient(
-        List.of(DEFAULT_TENANT, "tenant-a", "tenant-b"), ZEEBE_CLIENT_ID_TENANT_A_AND_B);
+        List.of(DEFAULT_TENANT, TENANT_A, TENANT_B), ZEEBE_CLIENT_ID_TENANT_A_AND_B);
   }
 
   @BeforeEach
@@ -284,7 +286,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newDeployResourceCommand()
               .addProcessModel(process, "process.bpmn")
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send();
 
       // then
@@ -303,7 +305,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newDeployResourceCommand()
               .addProcessModel(process, "process.bpmn")
-              .tenantId("tenant-b")
+              .tenantId(TENANT_B)
               .send();
 
       // then
@@ -340,7 +342,7 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
     }
@@ -348,7 +350,7 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-b")
+          .tenantId(TENANT_B)
           .send()
           .join();
     }
@@ -360,7 +362,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newDeployResourceCommand()
               .addProcessModel(processV2, "process.bpmn")
-              .tenantId("tenant-b")
+              .tenantId(TENANT_B)
               .send();
 
       // then
@@ -369,7 +371,7 @@ public class MultiTenancyOverIdentityIT {
           .describedAs("Process version is incremented for tenant-b but not for tenant-a")
           .extracting(deploymentEvent -> deploymentEvent.getProcesses().get(0))
           .extracting(Process::getVersion, Process::getTenantId)
-          .containsExactly(2, "tenant-b");
+          .containsExactly(2, TENANT_B);
     }
   }
 
@@ -382,7 +384,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newDeployResourceCommand()
               .addProcessModel(process, "process.bpmn")
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send()
               .join()
               .getProcesses()
@@ -396,7 +398,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newCreateInstanceCommand()
               .processDefinitionKey(processDefinitionKey)
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send();
 
       // then
@@ -414,7 +416,7 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
     }
@@ -426,7 +428,7 @@ public class MultiTenancyOverIdentityIT {
               .newCreateInstanceCommand()
               .bpmnProcessId(processId)
               .latestVersion()
-              .tenantId("tenant-b")
+              .tenantId(TENANT_B)
               .send();
 
       // then
@@ -449,7 +451,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newDeployResourceCommand()
               .addProcessModel(process, "process.bpmn")
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send()
               .join()
               .getProcesses()
@@ -465,7 +467,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newCreateInstanceCommand()
               .processDefinitionKey(processDefinitionKey)
-              .tenantId("tenant-b")
+              .tenantId(TENANT_B)
               .send();
 
       // then
@@ -486,7 +488,7 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
     }
@@ -501,7 +503,7 @@ public class MultiTenancyOverIdentityIT {
                   .endEvent()
                   .done(),
               "parent.bpmn")
-          .tenantId("tenant-b")
+          .tenantId(TENANT_B)
           .send()
           .join();
     }
@@ -512,7 +514,7 @@ public class MultiTenancyOverIdentityIT {
           .newCreateInstanceCommand()
           .bpmnProcessId("parent")
           .latestVersion()
-          .tenantId("tenant-b")
+          .tenantId(TENANT_B)
           .send();
 
       // then
@@ -536,7 +538,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newDeployResourceCommand()
               .addProcessModel(process, "process.bpmn")
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send()
               .join()
               .getProcesses()
@@ -552,7 +554,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newCreateInstanceCommand()
               .processDefinitionKey(processDefinitionKey)
-              .tenantId("tenant-b")
+              .tenantId(TENANT_B)
               .send();
 
       // then
@@ -576,7 +578,7 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
 
@@ -586,7 +588,7 @@ public class MultiTenancyOverIdentityIT {
               .newPublishMessageCommand()
               .messageName(messageName)
               .correlationKey("")
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send();
 
       // then
@@ -607,7 +609,7 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
 
@@ -617,7 +619,7 @@ public class MultiTenancyOverIdentityIT {
               .newPublishMessageCommand()
               .messageName(messageName)
               .correlationKey("")
-              .tenantId("tenant-b")
+              .tenantId(TENANT_B)
               .send();
 
       // then
@@ -638,14 +640,14 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
       client
           .newCreateInstanceCommand()
           .bpmnProcessId(processId)
           .latestVersion()
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
 
@@ -655,7 +657,7 @@ public class MultiTenancyOverIdentityIT {
               .newActivateJobsCommand()
               .jobType("type")
               .maxJobsToActivate(1)
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send();
 
       // then
@@ -673,14 +675,14 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
       client
           .newCreateInstanceCommand()
           .bpmnProcessId(processId)
           .latestVersion()
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
     }
@@ -692,7 +694,7 @@ public class MultiTenancyOverIdentityIT {
               .newActivateJobsCommand()
               .jobType("type")
               .maxJobsToActivate(1)
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send();
 
       // then
@@ -713,14 +715,14 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
       client
           .newCreateInstanceCommand()
           .bpmnProcessId(processId)
           .latestVersion()
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
 
@@ -729,7 +731,7 @@ public class MultiTenancyOverIdentityIT {
               .newActivateJobsCommand()
               .jobType("type")
               .maxJobsToActivate(1)
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send()
               .join()
               .getJobs()
@@ -754,14 +756,14 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
       client
           .newCreateInstanceCommand()
           .bpmnProcessId(processId)
           .latestVersion()
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
       activatedJob =
@@ -769,7 +771,7 @@ public class MultiTenancyOverIdentityIT {
               .newActivateJobsCommand()
               .jobType("type")
               .maxJobsToActivate(1)
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send()
               .join()
               .getJobs()
@@ -804,14 +806,14 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
       client
           .newCreateInstanceCommand()
           .bpmnProcessId(processId)
           .latestVersion()
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
 
@@ -844,14 +846,14 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
       client
           .newCreateInstanceCommand()
           .bpmnProcessId(processId)
           .latestVersion()
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
 
@@ -906,7 +908,7 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
 
@@ -915,7 +917,7 @@ public class MultiTenancyOverIdentityIT {
               .newCreateInstanceCommand()
               .bpmnProcessId(processId)
               .latestVersion()
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send()
               .join()
               .getProcessInstanceKey();
@@ -937,7 +939,7 @@ public class MultiTenancyOverIdentityIT {
       client
           .newDeployResourceCommand()
           .addProcessModel(process, "process.bpmn")
-          .tenantId("tenant-a")
+          .tenantId(TENANT_A)
           .send()
           .join();
 
@@ -946,7 +948,7 @@ public class MultiTenancyOverIdentityIT {
               .newCreateInstanceCommand()
               .bpmnProcessId(processId)
               .latestVersion()
-              .tenantId("tenant-a")
+              .tenantId(TENANT_A)
               .send()
               .join()
               .getProcessInstanceKey();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRecordStream.java
@@ -42,4 +42,8 @@ public class DecisionRecordStream
   public DecisionRecordStream withVersion(final int version) {
     return valueFilter(v -> v.getVersion() == version);
   }
+
+  public DecisionRecordStream withTenantId(final String tenantId) {
+    return valueFilter(v -> v.getTenantId().equals(tenantId));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds E2E tests for standalone decision evaluation.

The issue also describes an E2E test for business rule tasks. I have not implemented this. IMO it is not a sensible E2E test, as they are evaluated during process instance execution. There is no end to end, as the user doesn't have to send any commands to evaluate a business rule tasks, except for creating a process instance which is already covered.
I did add an extra unit test to verify that tenant A cannot reference the decision id of tenant B in a business rule task.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14563 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
