### PR TITLE
Cache for forms

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
@@ -63,6 +64,7 @@ public final class DeploymentCreateProcessor
   private final DeploymentTransformer deploymentTransformer;
   private final ProcessState processState;
   private final DecisionState decisionState;
+  private final FormState formState;
   private final TimerInstanceState timerInstanceState;
   private final CatchEventBehavior catchEventBehavior;
   private final KeyGenerator keyGenerator;
@@ -82,6 +84,7 @@ public final class DeploymentCreateProcessor
       final CommandDistributionBehavior distributionBehavior) {
     processState = processingState.getProcessState();
     decisionState = processingState.getDecisionState();
+    formState = processingState.getFormState();
     timerInstanceState = processingState.getTimerState();
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -120,6 +123,9 @@ public final class DeploymentCreateProcessor
     }
     if (command.getValue().hasDmnResources()) {
       decisionState.clearCache();
+    }
+    if (command.getValue().hasForms()) {
+      formState.clearCache();
     }
 
     if (error instanceof final ResourceTransformationFailedException exception) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.Object2ObjectHashMap;
 
 public class DbFormState implements MutableFormState {
 
@@ -37,6 +38,8 @@ public class DbFormState implements MutableFormState {
   private final DbTenantAwareKey<DbCompositeKey<DbString, DbLong>> tenantAwareIdAndVersionKey;
   private final ColumnFamily<DbTenantAwareKey<DbCompositeKey<DbString, DbLong>>, PersistedForm>
       formByIdAndVersionColumnFamily;
+  private final Object2ObjectHashMap<String, Object2ObjectHashMap<DirectBuffer, PersistedForm>>
+      formByTenantAndIdCache;
 
   public DbFormState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -63,6 +66,8 @@ public class DbFormState implements MutableFormState {
     versionManager =
         new VersionManager(
             DEFAULT_VERSION_VALUE, zeebeDb, ZbColumnFamilies.FORM_VERSION, transactionContext);
+
+    formByTenantAndIdCache = new Object2ObjectHashMap<>();
   }
 
   @Override
@@ -76,12 +81,19 @@ public class DbFormState implements MutableFormState {
     formByIdAndVersionColumnFamily.upsert(tenantAwareIdAndVersionKey, dbPersistedForm);
 
     updateLatestVersion(record);
+    updateLatestFormCache();
   }
 
   @Override
   public Optional<PersistedForm> findLatestFormById(
       final DirectBuffer formId, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
+    final PersistedForm cachedForm =
+        formByTenantAndIdCache.getOrDefault(tenantId, new Object2ObjectHashMap<>()).get(formId);
+    if (cachedForm != null) {
+      return Optional.of(cachedForm);
+    }
+
     dbFormId.wrapBuffer(formId);
     final long latestVersion = versionManager.getLatestResourceVersion(formId, tenantId);
     formVersion.wrapLong(latestVersion);
@@ -96,10 +108,23 @@ public class DbFormState implements MutableFormState {
     return Optional.ofNullable(formsByKey.get(tenantAwareFormKey)).map(PersistedForm::copy);
   }
 
+  @Override
+  public void clearCache() {
+    formByTenantAndIdCache.clear();
+    versionManager.clear();
+  }
+
   private void updateLatestVersion(final FormRecord formRecord) {
     final var formId = formRecord.getFormId();
     final var version = formRecord.getVersion();
     final var tenantId = formRecord.getTenantId();
     versionManager.addResourceVersion(formId, version, tenantId);
+  }
+
+  private void updateLatestFormCache() {
+    final Object2ObjectHashMap<DirectBuffer, PersistedForm> formIdMap =
+        formByTenantAndIdCache.computeIfAbsent(
+            dbPersistedForm.getTenantId(), id -> new Object2ObjectHashMap<>());
+    formIdMap.put(dbPersistedForm.getFormId(), dbPersistedForm);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
@@ -31,4 +31,6 @@ public interface FormState {
    * @return the form, or {@link Optional#empty()} if no form is deployed with the given key
    */
   Optional<PersistedForm> findFormByKey(long formKey, final String tenantId);
+
+  void clearCache();
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -171,4 +171,10 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
         .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
         .anyMatch(x -> x.endsWith(".dmn"));
   }
+
+  public boolean hasForms() {
+    return getResources().stream()
+        .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
+        .anyMatch(x -> x.endsWith(".form"));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR improve the performance of retrieving the latest form by `formId` and `tenantId` by adding a cache layer

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14562 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
