### PR TITLE
test(raft): await until new configuration is replicated

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -212,10 +212,14 @@ final class ReconfigurationTest {
               new DefaultRaftMember(id3, Type.ACTIVE, Instant.now()),
               new DefaultRaftMember(id4, Type.ACTIVE, Instant.now()));
 
-      assertThat(m1.cluster().getMembers()).containsExactlyInAnyOrderElementsOf(expected);
-      assertThat(m2.cluster().getMembers()).containsExactlyInAnyOrderElementsOf(expected);
-      assertThat(m3.cluster().getMembers()).containsExactlyInAnyOrderElementsOf(expected);
-      assertThat(m4.cluster().getMembers()).containsExactlyInAnyOrderElementsOf(expected);
+      Awaitility.await("All members have configuration with 4 active members")
+          .untilAsserted(
+              () ->
+                  assertThat(List.of(m1, m2, m3, m4))
+                      .allSatisfy(
+                          member ->
+                              assertThat(member.cluster().getMembers())
+                                  .containsExactlyInAnyOrderElementsOf(expected)));
     }
 
     @Test
@@ -341,11 +345,14 @@ final class ReconfigurationTest {
       // then - all members show a configuration with 2 active members
       final var expected =
           others.stream().map(server -> server.cluster().getLocalMember()).toList();
-      assertThat(others)
-          .allSatisfy(
-              member ->
-                  assertThat(member.cluster().getMembers())
-                      .containsExactlyInAnyOrderElementsOf(expected));
+      Awaitility.await("All members have configuration with 2 active members")
+          .untilAsserted(
+              () ->
+                  assertThat(others)
+                      .allSatisfy(
+                          member ->
+                              assertThat(member.cluster().getMembers())
+                                  .containsExactlyInAnyOrderElementsOf(expected)));
     }
 
     @Test


### PR DESCRIPTION
## Description

It is possible that one of the member receives the new configuration a bit late. So to avoid flaky test, we have to wait for a while until the configuration is updated.

## Related issues

closes #14592 

