### PR TITLE
fix: Fix flaky test shouldResumeExporting in ExportEndpointIT

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -79,7 +79,7 @@ final class ExportingEndpointIT {
     final var actuator = getActuator();
     actuator.pause();
 
-    startProcess();
+    client.newPublishMessageCommand().messageName("Test").correlationKey("1").messageId("1").send();
 
     final var recordsBeforePause =
         Awaitility.await()
@@ -89,7 +89,6 @@ final class ExportingEndpointIT {
 
     // when
     getActuator().resume();
-    startProcess();
 
     // then
     RecordingExporter.records().limit(recordsBeforePause + 1).await();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -56,7 +56,13 @@ final class ExportingEndpointIT {
   @Test
   void shouldPauseExporting() {
     // given
-    startProcess();
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("1")
+        .messageId("1")
+        .send()
+        .join();
 
     final var recordsBeforePause =
         Awaitility.await()
@@ -66,7 +72,6 @@ final class ExportingEndpointIT {
 
     // when
     getActuator().pause();
-    startProcess();
 
     // then
     RecordingExporter.records().limit(recordsBeforePause + 1).await();
@@ -79,7 +84,13 @@ final class ExportingEndpointIT {
     final var actuator = getActuator();
     actuator.pause();
 
-    client.newPublishMessageCommand().messageName("Test").correlationKey("1").messageId("1").send();
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("1")
+        .messageId("2")
+        .send()
+        .join();
 
     final var recordsBeforePause =
         Awaitility.await()
@@ -97,16 +108,6 @@ final class ExportingEndpointIT {
 
   private ExportingActuator getActuator() {
     return ExportingActuator.of(CLUSTER.availableGateway());
-  }
-
-  private void startProcess() {
-    client
-        .newCreateInstanceCommand()
-        .bpmnProcessId("processId")
-        .latestVersion()
-        .withResult()
-        .send()
-        .join();
   }
 
   private void allPartitionsPausedExporting() {


### PR DESCRIPTION
## Description

This PR fixes the flaky test shouldResumeExporting in ExportEndpointIT.

Since the cluster being used has more than one partition, it might happen that the start process command happens before the remaining partitions have received the process. That is because when a process gets deployed, it will be first sent to partition 1 and then forwarded to the remaining partitions.

Since the test here is only trying to assert that exporting gets resumed, then it is ok to just publish a message that will generate a record instead of deploying a process.
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/10628

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
