### PR TITLE
Handle add member request in the coordinator

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementAPI.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementAPI.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.api.TopologyManagementRequests.AddMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementResponses.TopologyChangeStatus;
+
+/** Defines the API for the topology management requests. */
+public interface TopologyManagementAPI {
+
+  ActorFuture<TopologyChangeStatus> addMembers(AddMembersRequest addMembersRequest);
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.api.TopologyManagementRequests.AddMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementResponses.TopologyChangeStatus;
+import io.camunda.zeebe.topology.serializer.TopologyRequestsSerializer;
+import java.time.Duration;
+
+/** Forwards all requests to the coordinator. */
+final class TopologyManagementRequestSender implements TopologyManagementAPI {
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+  private final ClusterCommunicationService communicationService;
+  private final MemberId coordinator;
+  private final ConcurrencyControl executor;
+  private final TopologyRequestsSerializer serializer;
+
+  public TopologyManagementRequestSender(
+      final ClusterCommunicationService communicationService,
+      final MemberId coordinator,
+      final TopologyRequestsSerializer serializer,
+      final ConcurrencyControl executor) {
+    this.communicationService = communicationService;
+    this.coordinator = coordinator;
+    this.executor = executor;
+    this.serializer = serializer;
+  }
+
+  @Override
+  public ActorFuture<TopologyChangeStatus> addMembers(final AddMembersRequest addMembersRequest) {
+    final ActorFuture<TopologyChangeStatus> resultFuture = executor.createFuture();
+    final var responseFuture =
+        communicationService.send(
+            TopologyRequestTopics.ADD_MEMBER.topic(),
+            addMembersRequest,
+            serializer::encode,
+            serializer::decodeTopologyChangeStatus,
+            coordinator,
+            TIMEOUT);
+    responseFuture
+        .thenAccept(resultFuture::complete)
+        .exceptionally(
+            error -> {
+              resultFuture.completeExceptionally(error);
+              return null;
+            });
+    return resultFuture;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequests.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequests.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import io.atomix.cluster.MemberId;
+import java.util.Set;
+
+/** Defines the supported requests for the topology management. */
+public final class TopologyManagementRequests {
+  public record AddMembersRequest(Set<MemberId> members) {}
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.api.TopologyManagementRequests.AddMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementResponses.StatusCode;
+import io.camunda.zeebe.topology.api.TopologyManagementResponses.TopologyChangeStatus;
+import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
+
+/**
+ * Handles the requests for the topology management. This is expected be running on the coordinator
+ * node.
+ */
+final class TopologyManagementRequestsHandler implements TopologyManagementAPI {
+
+  private final TopologyChangeCoordinator coordinator;
+  private final ConcurrencyControl executor;
+
+  public TopologyManagementRequestsHandler(
+      final TopologyChangeCoordinator coordinator, final ConcurrencyControl executor) {
+    this.coordinator = coordinator;
+    this.executor = executor;
+  }
+
+  @Override
+  public ActorFuture<TopologyChangeStatus> addMembers(final AddMembersRequest addMembersRequest) {
+    final ActorFuture<TopologyChangeStatus> responseFuture = executor.createFuture();
+    final var operations =
+        addMembersRequest.members().stream()
+            .map(MemberJoinOperation::new)
+            .map(TopologyChangeOperation.class::cast)
+            .toList();
+
+    final var operationApplied = coordinator.applyOperations(operations);
+    operationApplied.onComplete(
+        (topology, error) -> {
+          if (error == null) {
+            final var status =
+                new TopologyManagementResponses.TopologyChangeStatus(
+                    topology.version(), StatusCode.IN_PROGRESS);
+            responseFuture.complete(status);
+          } else {
+            responseFuture.completeExceptionally(error);
+          }
+        });
+
+    return responseFuture;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementResponses.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementResponses.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+public final class TopologyManagementResponses {
+
+  public record TopologyChangeStatus(long changeId, StatusCode status) {}
+
+  public enum StatusCode {
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.api.TopologyManagementResponses.TopologyChangeStatus;
+import io.camunda.zeebe.topology.serializer.TopologyRequestsSerializer;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+/** Server that receives the topology management requests */
+public final class TopologyRequestServer implements AutoCloseable {
+
+  private final TopologyManagementAPI topologyManagementAPI;
+  private final ClusterCommunicationService communicationService;
+  private final ConcurrencyControl executor;
+  private final TopologyRequestsSerializer serializer;
+
+  TopologyRequestServer(
+      final ClusterCommunicationService communicationService,
+      final TopologyRequestsSerializer serializer,
+      final TopologyManagementAPI topologyManagementAPI,
+      final ConcurrencyControl executor) {
+    this.topologyManagementAPI = topologyManagementAPI;
+    this.communicationService = communicationService;
+    this.serializer = serializer;
+    this.executor = executor;
+  }
+
+  void start() {
+    registerAddMemberRequestsHandler();
+  }
+
+  @Override
+  public void close() {
+    Stream.of(TopologyRequestTopics.values())
+        .toList()
+        .forEach(topic -> communicationService.unsubscribe(topic.topic()));
+  }
+
+  private void registerAddMemberRequestsHandler() {
+    communicationService.replyTo(
+        TopologyRequestTopics.ADD_MEMBER.topic(),
+        serializer::decodeAddMembersRequest,
+        request -> toCompletableFuture(topologyManagementAPI.addMembers(request)),
+        serializer::encode);
+  }
+
+  private CompletableFuture<TopologyChangeStatus> toCompletableFuture(
+      final ActorFuture<TopologyChangeStatus> resultFuture) {
+    final var future = new CompletableFuture<TopologyChangeStatus>();
+    executor.runOnCompletion(
+        resultFuture,
+        (status, error) -> {
+          if (error == null) {
+            future.complete(status);
+          } else {
+            future.completeExceptionally(error);
+          }
+        });
+    return future;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestTopics.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestTopics.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+public enum TopologyRequestTopics {
+  ADD_MEMBER("topology-member-add");
+  private final String topic;
+
+  TopologyRequestTopics(final String topic) {
+    this.topic = topic;
+  }
+
+  public String topic() {
+    return topic;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.serializer;
+
+import io.camunda.zeebe.topology.api.TopologyManagementRequests;
+import io.camunda.zeebe.topology.api.TopologyManagementRequests.AddMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementResponses.TopologyChangeStatus;
+
+public interface TopologyRequestsSerializer {
+  byte[] encode(AddMembersRequest addMembersRequest);
+
+  TopologyManagementRequests.AddMembersRequest decodeAddMembersRequest(byte[] encodedState);
+
+  byte[] encode(TopologyChangeStatus topologyChangeStatus);
+
+  TopologyChangeStatus decodeTopologyChangeStatus(byte[] encodedTopologyChangeStatus);
+}

--- a/topology/src/main/resources/proto/requests.proto
+++ b/topology/src/main/resources/proto/requests.proto
@@ -1,0 +1,22 @@
+syntax = 'proto3';
+package topology_requests;
+
+import "topology.proto";
+
+option java_package = "io.camunda.zeebe.topology.protocol";
+
+message AddMemberRequest {
+  repeated string memberIds = 1;
+}
+
+message TopologyChangeStatus {
+  int64 changeId = 1;
+  ChangeStatus status = 2;
+}
+
+enum ChangeStatus {
+  STATUS_UNKNOWN = 0;
+  IN_PROGRESS = 1;
+  COMPLETED = 2;
+  FAILED = 3;
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementAPITest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementAPITest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator;
+import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+// Test to verify that server handles requests from the clients. This test uses the actual
+// communicationService to ensure that request subscription and handling is done correctly.
+final class TopologyManagementAPITest {
+  private TopologyManagementAPI clientAPI;
+
+  private final RecordingChangeCoordinator recordingCoordinator = new RecordingChangeCoordinator();
+  private TopologyRequestServer requestServer;
+  private AtomixCluster gateway;
+  private AtomixCluster coordinator;
+  private final ClusterTopology initialTopology = ClusterTopology.init();
+
+  @BeforeEach
+  void setup() {
+    final var gatewayNode =
+        Node.builder().withId("gateway").withPort(SocketUtil.getNextAddress().getPort()).build();
+    final var coordinatorNode =
+        Node.builder().withId("0").withPort(SocketUtil.getNextAddress().getPort()).build();
+
+    gateway = createClusterNode(gatewayNode, List.of(gatewayNode, coordinatorNode));
+    coordinator = createClusterNode(coordinatorNode, List.of(gatewayNode, coordinatorNode));
+
+    final var gatewayStarted = gateway.start();
+    final var coordinatorStarted = coordinator.start();
+    CompletableFuture.allOf(gatewayStarted, coordinatorStarted).join();
+
+    clientAPI =
+        new TopologyManagementRequestSender(
+            gateway.getCommunicationService(),
+            coordinator.getMembershipService().getLocalMember().id(),
+            new ProtoBufSerializer(),
+            new TestConcurrencyControl());
+
+    requestServer =
+        new TopologyRequestServer(
+            coordinator.getCommunicationService(),
+            new ProtoBufSerializer(),
+            new TopologyManagementRequestsHandler(
+                recordingCoordinator, new TestConcurrencyControl()),
+            new TestConcurrencyControl());
+
+    requestServer.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    requestServer.close();
+    gateway.stop();
+    coordinator.stop();
+  }
+
+  private AtomixCluster createClusterNode(final Node localNode, final Collection<Node> nodes) {
+    return AtomixCluster.builder()
+        .withAddress(localNode.address())
+        .withMemberId(localNode.id().id())
+        .withMembershipProvider(new BootstrapDiscoveryProvider(nodes))
+        .withMembershipProtocol(new DiscoveryMembershipProtocol())
+        .build();
+  }
+
+  @Test
+  void shouldAddMembers() {
+    // given
+    final var request =
+        new TopologyManagementRequests.AddMembersRequest(Set.of(MemberId.from("1")));
+
+    // when
+    final var changeStatus = clientAPI.addMembers(request).join();
+
+    // then
+    assertThat(recordingCoordinator.getLastAppliedOperation())
+        .containsExactly(new MemberJoinOperation(MemberId.from("1")));
+    assertThat(changeStatus.changeId()).isEqualTo(initialTopology.version() + 1);
+  }
+
+  private final class RecordingChangeCoordinator implements TopologyChangeCoordinator {
+
+    private List<TopologyChangeOperation> lastAppliedOperation;
+
+    @Override
+    public ActorFuture<ClusterTopology> applyOperations(
+        final List<TopologyChangeOperation> operations) {
+      lastAppliedOperation = List.copyOf(operations);
+
+      return CompletableActorFuture.completed(initialTopology.startTopologyChange(operations));
+    }
+
+    @Override
+    public ActorFuture<Boolean> hasCompletedChanges(final long version) {
+      return CompletableActorFuture.completed(true);
+    }
+
+    public List<TopologyChangeOperation> getLastAppliedOperation() {
+      return lastAppliedOperation;
+    }
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.topology.serializer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.api.TopologyManagementRequests.AddMembersRequest;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossipState;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOp
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -59,6 +61,20 @@ final class ProtoBufSerializerTest {
     assertThat(decodedClusterTopology)
         .describedAs("Decoded clusterTopology must be equal to initial one")
         .isEqualTo(initialClusterTopology);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeAddMembersRequest() {
+    // given
+    final var addMembersRequest =
+        new AddMembersRequest(Set.of(MemberId.from("1"), MemberId.from("2")));
+
+    // when
+    final var encodedRequest = protoBufSerializer.encode(addMembersRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeAddMembersRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(addMembersRequest);
   }
 
   private static Stream<ClusterTopology> provideClusterTopologies() {


### PR DESCRIPTION
## Description

This PR adds necessary functionalities to mange a topology mangement requests from client (gateway) to server (coordinator broker). 
- Defines the API, and protobuf messages.
- Adds server for handling requests for topology Manager. `TopologyRequestServer` will be started by the ClusterTopologyRequestService in the coordinator.
- Add `TopologyManagementRequestSender` that sends requests to the server running in the coordinator. The gateway can use this to interact with the coordinator.
- Add support for handling request to add new members.

Note that the api might change as we are still discussing the user facing api - such as whether the add member request should take one member id or a list of member ids. We can easily change this later.

## Related issues

related #14462 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
