### PR TITLE
Use new testing infrastructure for SnapshotWithExportersTest

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
@@ -12,171 +12,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
-import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
-import io.zeebe.containers.ZeebeContainer;
-import io.zeebe.containers.ZeebeVolume;
-import io.zeebe.containers.exporter.DebugReceiver;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+@ZeebeIntegration
 final class SnapshotWithExportersTest {
-
-  @Test
-  void shouldIncludeExportedPositionInSnapshot() {
-    // given
-    try (final var debugReceiver =
-        new DebugReceiver((record) -> {}, SocketUtil.getNextAddress(), true).start()) {
-      try (final var zeebe =
-          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
-              .withDebugExporter(debugReceiver.serverAddress().getPort())) {
-        zeebe.start();
-
-        final var partitions = PartitionsActuator.of(zeebe);
-
-        try (final var client =
-            ZeebeClient.newClientBuilder()
-                .gatewayAddress(zeebe.getExternalGatewayAddress())
-                .usePlaintext()
-                .build()) {
-
-          publishMessages(client);
-          final var exporterPosition =
-              Awaitility.await("Exported position is stable")
-                  .atMost(Duration.ofSeconds(30))
-                  .during(Duration.ofSeconds(5))
-                  .until(() -> partitions.query().get(1).exportedPosition(), hasStableValue());
-          assertThat(exporterPosition).isPositive();
-
-          // when
-          partitions.takeSnapshot();
-          final var snapshotId =
-              Awaitility.await("Snapshot is taken")
-                  .atMost(Duration.ofSeconds(60))
-                  .until(
-                      () ->
-                          Optional.ofNullable(partitions.query().get(1).snapshotId())
-                              .flatMap(FileBasedSnapshotId::ofFileName),
-                      Optional::isPresent)
-                  .orElseThrow();
-
-          // then
-          assertThat(snapshotId)
-              .returns(exporterPosition, FileBasedSnapshotId::getExportedPosition);
-        }
-      }
-    }
-  }
-
-  @Test
-  void shouldTakeSnapshotWhenExporterPositionIsMinusOne() {
-    // given -- broker with exporter that does not acknowledge anything
-    try (final var unresponsiveExporterTarget = new DebugReceiver((record) -> {}, false).start()) {
-      try (final var zeebe =
-          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
-              .withDebugExporter(unresponsiveExporterTarget.serverAddress().getPort())) {
-        zeebe.start();
-
-        try (final var client =
-            ZeebeClient.newClientBuilder()
-                .gatewayAddress(zeebe.getExternalGatewayAddress())
-                .usePlaintext()
-                .build()) {
-          publishMessages(client);
-        }
-
-        final var partitions = PartitionsActuator.of(zeebe);
-        Awaitility.await("Processed position is stable")
-            .atMost(Duration.ofSeconds(60))
-            .during(Duration.ofSeconds(5))
-            .until(() -> partitions.query().get(1).processedPosition(), hasStableValue());
-
-        partitions.takeSnapshot();
-
-        // then -- snapshot has exported position 0
-        final var snapshotWithExporters =
-            Awaitility.await("Snapshot is taken")
-                .atMost(Duration.ofSeconds(60))
-                .during(Duration.ofSeconds(5))
-                .until(
-                    () ->
-                        Optional.ofNullable(partitions.query().get(1).snapshotId())
-                            .flatMap(FileBasedSnapshotId::ofFileName),
-                    hasStableValue())
-                .orElseThrow();
-
-        Assertions.assertThat(snapshotWithExporters)
-            .returns(0L, FileBasedSnapshotId::getExportedPosition);
-      }
-    }
-  }
-
-  @Test
-  void shouldNotTakeNewSnapshotWhenAddingNewExporter() {
-    // given -- snapshot taken by broker without exporters
-    final var dataVolume = ZeebeVolume.newVolume();
-    final FileBasedSnapshotId snapshotWithoutExporters;
-    final FileBasedSnapshotId snapshotWithExporters;
-    try (final var zeebeWithoutExporter =
-        new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
-            .withZeebeData(dataVolume)) {
-      zeebeWithoutExporter.start();
-
-      try (final var client =
-          ZeebeClient.newClientBuilder()
-              .gatewayAddress(zeebeWithoutExporter.getExternalGatewayAddress())
-              .usePlaintext()
-              .build()) {
-        publishMessages(client);
-      }
-
-      final var partitions = PartitionsActuator.of(zeebeWithoutExporter);
-
-      partitions.takeSnapshot();
-      snapshotWithoutExporters =
-          Awaitility.await("Snapshot is taken")
-              .atMost(Duration.ofSeconds(60))
-              .until(
-                  () ->
-                      Optional.ofNullable(partitions.query().get(1).snapshotId())
-                          .flatMap(FileBasedSnapshotId::ofFileName),
-                  Optional::isPresent)
-              .orElseThrow();
-    }
-
-    // when -- taking snapshot on broker with exporters configured
-    try (final var debugReceiver =
-        new DebugReceiver((record) -> {}, SocketUtil.getNextAddress()).start()) {
-      try (final var zeebeWithExporter =
-          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
-              .withZeebeData(dataVolume)
-              .withDebugExporter(debugReceiver.serverAddress().getPort())) {
-        zeebeWithExporter.start();
-
-        final var partitions = PartitionsActuator.of(zeebeWithExporter);
-
-        partitions.takeSnapshot();
-        snapshotWithExporters =
-            Awaitility.await("Snapshot is taken")
-                .atMost(Duration.ofSeconds(60))
-                .during(Duration.ofSeconds(5))
-                .until(
-                    () ->
-                        Optional.ofNullable(partitions.query().get(1).snapshotId())
-                            .flatMap(FileBasedSnapshotId::ofFileName),
-                    hasStableValue())
-                .orElseThrow();
-      }
-    }
-
-    // then -- broker with exporter configured should not have taken a new backup
-    assertThat(snapshotWithExporters).isEqualTo(snapshotWithoutExporters);
-  }
 
   private void publishMessages(final ZeebeClient client) {
     IntStream.range(0, 10)
@@ -188,5 +38,123 @@ final class SnapshotWithExportersTest {
                     .correlationKey("msg-" + i)
                     .send()
                     .join());
+  }
+
+  @Nested
+  final class WithoutInitialExporterTest {
+    @TestZeebe private final TestStandaloneBroker zeebe = new TestStandaloneBroker();
+
+    private final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
+
+    @Test
+    void shouldNotTakeNewSnapshotWhenAddingNewExporter() {
+      // given -- snapshot taken by broker without exporters
+      final FileBasedSnapshotId snapshotWithoutExporters;
+      final FileBasedSnapshotId snapshotWithExporters;
+
+      try (final var client = zeebe.newClientBuilder().build()) {
+        publishMessages(client);
+      }
+
+      partitions.takeSnapshot();
+      snapshotWithoutExporters =
+          Awaitility.await("Snapshot is taken")
+              .atMost(Duration.ofSeconds(60))
+              .until(
+                  () ->
+                      Optional.ofNullable(partitions.query().get(1).snapshotId())
+                          .flatMap(FileBasedSnapshotId::ofFileName),
+                  Optional::isPresent)
+              .orElseThrow();
+      zeebe.stop();
+
+      // when -- taking snapshot on broker with exporters configured
+      zeebe.withRecordingExporter(true).start().awaitCompleteTopology();
+
+      partitions.takeSnapshot();
+      snapshotWithExporters =
+          Awaitility.await("Snapshot is taken")
+              .atMost(Duration.ofSeconds(60))
+              .during(Duration.ofSeconds(5))
+              .until(
+                  () ->
+                      Optional.ofNullable(partitions.query().get(1).snapshotId())
+                          .flatMap(FileBasedSnapshotId::ofFileName),
+                  hasStableValue())
+              .orElseThrow();
+
+      // then -- broker with exporter configured should not have taken a new backup
+      assertThat(snapshotWithExporters).isEqualTo(snapshotWithoutExporters);
+    }
+  }
+
+  @Nested
+  final class WithExporter {
+    @TestZeebe
+    private final TestStandaloneBroker zeebe =
+        new TestStandaloneBroker().withRecordingExporter(true);
+
+    private final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
+
+    @Test
+    void shouldIncludeExportedPositionInSnapshot() {
+      // given - a receiver who has "acknowledged" everything ever in history
+      try (final var client = zeebe.newClientBuilder().build()) {
+        publishMessages(client);
+      }
+
+      final var exporterPosition =
+          Awaitility.await("Exported position is stable")
+              .atMost(Duration.ofSeconds(30))
+              .during(Duration.ofSeconds(5))
+              .until(() -> partitions.query().get(1).exportedPosition(), hasStableValue());
+      assertThat(exporterPosition).isPositive();
+
+      // when
+      partitions.takeSnapshot();
+      final var snapshotId =
+          Awaitility.await("Snapshot is taken")
+              .atMost(Duration.ofSeconds(60))
+              .until(
+                  () ->
+                      Optional.ofNullable(partitions.query().get(1).snapshotId())
+                          .flatMap(FileBasedSnapshotId::ofFileName),
+                  Optional::isPresent)
+              .orElseThrow();
+
+      // then
+      assertThat(snapshotId).returns(exporterPosition, FileBasedSnapshotId::getExportedPosition);
+    }
+
+    @Test
+    void shouldTakeSnapshotWhenExporterPositionIsMinusOne() {
+      // given -- broker with exporter that does not acknowledge anything
+      RecordingExporter.autoAcknowledge(false);
+      try (final var client = zeebe.newClientBuilder().build()) {
+        publishMessages(client);
+      }
+
+      Awaitility.await("Processed position is stable")
+          .atMost(Duration.ofSeconds(60))
+          .during(Duration.ofSeconds(5))
+          .until(() -> partitions.query().get(1).processedPosition(), hasStableValue());
+
+      partitions.takeSnapshot();
+
+      // then -- snapshot has exported position 0
+      final var snapshotWithExporters =
+          Awaitility.await("Snapshot is taken")
+              .atMost(Duration.ofSeconds(60))
+              .during(Duration.ofSeconds(5))
+              .until(
+                  () ->
+                      Optional.ofNullable(partitions.query().get(1).snapshotId())
+                          .flatMap(FileBasedSnapshotId::ofFileName),
+                  hasStableValue())
+              .orElseThrow();
+
+      Assertions.assertThat(snapshotWithExporters)
+          .returns(0L, FileBasedSnapshotId::getExportedPosition);
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR migrates `SnapshotWithExportersTest` to the new testing infrastructure, and adds the capability to control auto-acknowledgment of the `RecordingExporter`. This is only a minimal ability which does not allow controlled acknowledgment, just toggling whether it will automatically acknowledge or not.

## Related issues

closes #14377 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
