### PR TITLE
[Backport stable/8.2] fix(atomix): do not close over whole payload

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -248,8 +248,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
             () -> {
               responseFuture.completeExceptionally(
                   new TimeoutException(
-                      String.format(
-                          "Request %s to %s timed out in %s", message, address, timeout)));
+                      String.format("Request %s to %s timed out in %s", type, address, timeout)));
               openFutures.remove(responseFuture);
             },
             timeout.toNanos(),


### PR DESCRIPTION
# Description
Backport of #14664 to `stable/8.2`.

relates to #14663
original author: @npepinpe