### PR TITLE
[Backport stable/8.3] fix(raft): member type can be updated reliably

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -400,6 +400,8 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     if (member.getType() == Type.ACTIVE) {
       remoteActiveMembers.add(context);
       hasRemoteActiveMembers = true;
+    } else if (remoteActiveMembers.remove(context)) {
+      hasRemoteActiveMembers = !remoteActiveMembers.isEmpty();
     }
 
     if (member.getType() != Type.INACTIVE) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/Configuration.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/Configuration.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -58,8 +59,8 @@ public record Configuration(
     this.index = index;
     this.term = term;
     this.time = time;
-    this.newMembers = ImmutableList.copyOf(newMembers);
-    this.oldMembers = ImmutableList.copyOf(oldMembers);
+    this.newMembers = copyMembers(newMembers);
+    this.oldMembers = copyMembers(oldMembers);
   }
 
   public Configuration(
@@ -76,5 +77,14 @@ public record Configuration(
     all.addAll(newMembers);
     all.addAll(oldMembers);
     return all;
+  }
+
+  private static Collection<RaftMember> copyMembers(final Collection<RaftMember> members) {
+    final var copied = ImmutableList.<RaftMember>builderWithExpectedSize(members.size());
+    for (final var member : members) {
+      copied.add(
+          new DefaultRaftMember(member.memberId(), member.getType(), member.getLastUpdated()));
+    }
+    return copied.build();
   }
 }


### PR DESCRIPTION
# Description
Backport of #14669 to `stable/8.3`.

relates to camunda/zeebe#14548
original author: @oleschoenburg