### PR TITLE
Update to Java 21

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: "true"
   java-version:
     description: The JDK version to setup
-    default: "17"
+    default: "21"
     required: false
   maven-cache-key-modifier:
     description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,7 @@ jobs:
       - uses: actions/setup-java@v3.13.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v2.8.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@
 Zeebe is a multi-module maven project. To build all components,
 run the command: `mvn clean install -DskipTests` in the root folder.
 
-> NOTE: All Java modules in Zeebe are built and tested with JDK 17. Most modules use language level
-> 17, exceptions are: zeebe-bpmn-model, zeebe-client-java, zeebe-gateway-protocol,
+> NOTE: All Java modules in Zeebe are built and tested with JDK 21. Most modules use language level
+> 21, exceptions are: zeebe-bpmn-model, zeebe-client-java, zeebe-gateway-protocol,
 > zeebe-gateway-protocol-impl, zeebe-protocol and zeebe-protocol-jackson which use language level 8
 >
 > NOTE: The Go client and zbctl are built and tested with Go 1.15

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@
 # has trouble with custom versioning schemes
 ARG BASE_IMAGE="ubuntu:jammy"
 ARG BASE_DIGEST="sha256:9b8dec3bf938bc80fbe758d856e96fdfab5f56c39d44b0cff351e847bb1b01ea"
-ARG JDK_IMAGE="eclipse-temurin:17-jdk-jammy"
-ARG JDK_DIGEST="sha256:6455851f5a22cef64df3b302dea13caa270c09731cf4c9f32ab3404edbefb586"
+ARG JDK_IMAGE="eclipse-temurin:21-jdk-jammy"
+ARG JDK_DIGEST="sha256:e9efd127b780ee8223e7e567817e1a66bbf65bf516387838e42fe69fb8a96463"
 
 # set to "build" to build zeebe from scratch instead of using a distball
 ARG DIST="distball"

--- a/backup-stores/testkit/pom.xml
+++ b/backup-stores/testkit/pom.xml
@@ -20,12 +20,6 @@
 
   <name>Zeebe Backup Store Testkit</name>
 
-  <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/benchmarks/project/pom.xml
+++ b/benchmarks/project/pom.xml
@@ -26,7 +26,7 @@
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 
     <!-- java version -->
-    <version.java>17</version.java>
+    <version.java>21</version.java>
 
     <!-- dependency versions -->
     <version.config>1.4.2</version.config>
@@ -141,6 +141,9 @@
             <artifactId>jib-maven-plugin</artifactId>
             <version>${plugin.version.jib}</version>
             <configuration>
+              <from>
+                <image>eclipse-temurin:21</image>
+              </from>
               <to>
                 <image>gcr.io/zeebe-io/starter:SNAPSHOT</image>
               </to>
@@ -161,6 +164,9 @@
             <artifactId>jib-maven-plugin</artifactId>
             <version>${plugin.version.jib}</version>
             <configuration>
+              <from>
+                <image>eclipse-temurin:21</image>
+              </from>
               <to>
                 <image>gcr.io/zeebe-io/worker:SNAPSHOT</image>
               </to>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <version.java>17</version.java>
+    <version.java>21</version.java>
 
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <!-- disable jdk8 javadoc checks on release build -->

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -21,12 +21,6 @@
 
   <name>Zeebe Scheduler</name>
 
-  <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.agrona</groupId>


### PR DESCRIPTION
Updates the base image to `eclipse-temurin:21` and instructs maven to build with Java 21.
Some modules stay on Java 8 of course but these already have overrides in their maven poms.

Closes #13716 