### PR TITLE
Store commit index in meta store

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
@@ -186,4 +186,28 @@ public class MetaStoreSerializer {
     metaEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
     metaEncoder.lastFlushedIndex(index);
   }
+
+  public long readCommitIndex(final MutableDirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
+    metaDecoder.wrap(
+        buffer,
+        offset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    return metaDecoder.commitIndex();
+  }
+
+  public void writeCommitIndex(
+      final long index, final MutableDirectBuffer buffer, final int offset) {
+    headerEncoder
+        .wrap(buffer, offset)
+        .blockLength(metaEncoder.sbeBlockLength())
+        .templateId(metaEncoder.sbeTemplateId())
+        .schemaId(metaEncoder.sbeSchemaId())
+        .version(metaEncoder.sbeSchemaVersion());
+
+    metaEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
+    metaEncoder.commitIndex(index);
+  }
 }

--- a/atomix/cluster/src/main/resources/raft-entry-schema.xml
+++ b/atomix/cluster/src/main/resources/raft-entry-schema.xml
@@ -80,6 +80,7 @@
   <sbe:message name="Meta" id="6">
     <field name="term" id="0" type="uint64"/>
     <field name="lastFlushedIndex" id="1" type="uint64"/>
+    <field name="commitIndex" id="3" type="uint64" />
     <data name="votedFor" id="2" type="varDataEncoding"/>
   </sbe:message>
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -70,6 +70,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.agrona.LangUtil;
 import org.awaitility.Awaitility;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
@@ -233,6 +234,17 @@ public final class RaftRule extends ExternalResource {
 
   public void bootstrapNode(final String nodeId) throws Exception {
     bootstrapNode(nodeId, configurator);
+  }
+
+  public Thread bootstrapNodeAsync(final String nodeId) {
+    return Thread.startVirtualThread(
+        () -> {
+          try {
+            bootstrapNode(nodeId, configurator);
+          } catch (final Exception e) {
+            LangUtil.rethrowUnchecked(e);
+          }
+        });
   }
 
   public void bootstrapNode(final String nodeId, final Configurator configurator) throws Exception {
@@ -535,6 +547,10 @@ public final class RaftRule extends ExternalResource {
 
   private File getMemberDirectory(final Path directory, final String s) {
     return new File(directory.toFile(), s);
+  }
+
+  public Optional<RaftServer> getServer(final String id) {
+    return Optional.ofNullable(servers.get(id));
   }
 
   public Optional<RaftServer> getLeader() {

--- a/journal/src/main/java/io/camunda/zeebe/journal/JournalMetaStore.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/JournalMetaStore.java
@@ -36,6 +36,9 @@ public interface JournalMetaStore {
   /** Returns true if there is no known last flushed index. */
   boolean hasLastFlushedIndex();
 
+  /** Flushes any buffer to disk if backed by a file on disk. */
+  void flushMetaStore();
+
   class InMemory implements JournalMetaStore {
     private volatile long index = -1L;
 
@@ -58,5 +61,8 @@ public interface JournalMetaStore {
     public boolean hasLastFlushedIndex() {
       return index != -1L;
     }
+
+    @Override
+    public void flushMetaStore() {}
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsFlusher.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsFlusher.java
@@ -29,6 +29,7 @@ final class SegmentsFlusher {
   void setLastFlushedIndex(final long lastFlushedIndex) {
     this.lastFlushedIndex = lastFlushedIndex;
     metaStore.storeLastFlushedIndex(lastFlushedIndex);
+    metaStore.flushMetaStore();
   }
 
   long nextFlushIndex() {


### PR DESCRIPTION
## Description

This PR enables storing and restoring the last known commit index in the Raft meta store. To avoid a I/O performance hit, we now explicitly flush the meta store where appropriate instead of writing it using `DSYNC`. In that sense, we don't explicitly flush the commit index update in the meta store, though it will get flushed by the OS or when the `lastFlushedIndex` is updated.

> **Note**
> I did not check if it's really required to flush when setting the term or vote, but kept the existing behavior as is. We can assess that here as well if you'd like, but setting the term/vote is not really in the hot path, so I didn't think it was critical.

No integrity improvements were done, as it's slightly outside of scope - we still don't do checksum verification or the likes on the meta store, and we can always restore from no meta store of course.

## Related issues

closes #13790 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
