### PR TITLE
Allow immutable iteration of MsgPack ArrayValue

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -67,7 +67,7 @@ public class BpmnJobActivationBehavior {
     final Optional<JobStream> optionalJobStream =
         jobStreamer.streamFor(
             wrappedJobRecord.getTypeBuffer(),
-            jobActivationProperties -> jobActivationProperties.getTenantIds().contains(tenantId));
+            jobActivationProperties -> jobActivationProperties.tenantIds().contains(tenantId));
 
     if (optionalJobStream.isPresent()) {
       final JobStream jobStream = optionalJobStream.get();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -129,7 +129,7 @@ final class JobBatchCollector {
       final long key,
       final JobRecord jobRecord) {
     jobKeyIterator.add().setValue(key);
-    BufferUtil.copy(jobRecord, jobIterator.add());
+    jobIterator.add().copyFrom(jobRecord);
   }
 
   private Collection<DirectBuffer> collectVariableNames(final JobBatchRecord batchRecord) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
@@ -27,7 +26,6 @@ import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
 import org.agrona.collections.MutableReference;
 import org.agrona.collections.ObjectHashSet;
-import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * Collects jobs to be activated as part of a {@link JobBatchRecord}. Activate-able jobs are read
@@ -131,12 +129,7 @@ final class JobBatchCollector {
       final long key,
       final JobRecord jobRecord) {
     jobKeyIterator.add().setValue(key);
-    final JobRecord arrayValueJob = jobIterator.add();
-
-    // clone job record since buffer is reused during iteration
-    final var jobCopyBuffer = new UnsafeBuffer(ByteBuffer.allocate(jobRecord.getLength()));
-    jobRecord.write(jobCopyBuffer, 0);
-    arrayValueJob.wrap(jobCopyBuffer);
+    BufferUtil.copy(jobRecord, jobIterator.add());
   }
 
   private Collection<DirectBuffer> collectVariableNames(final JobBatchRecord batchRecord) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionInfo.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionInfo.java
@@ -23,7 +23,7 @@ public final class VersionInfo extends UnpackedObject implements DbValue {
   // can do to hide this name.
   private final LongProperty highestVersionProp = new LongProperty("nextValue", -1L);
   private final ArrayProperty<LongValue> knownVersions =
-      new ArrayProperty<>("knownVersions", new LongValue());
+      new ArrayProperty<>("knownVersions", LongValue::new);
 
   public VersionInfo() {
     declareProperty(highestVersionProp).declareProperty(knownVersions);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
@@ -21,7 +21,7 @@ public final class AwaitProcessInstanceResultMetadata extends UnpackedObject imp
   private final IntegerProperty requestStreamIdProperty =
       new IntegerProperty("requestStreamId", -1);
   private final ArrayProperty<StringValue> fetchVariablesProperty =
-      new ArrayProperty<>("fetchVariables", new StringValue());
+      new ArrayProperty<>("fetchVariables", StringValue::new);
 
   public AwaitProcessInstanceResultMetadata() {
     declareProperty(requestIdProperty)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
@@ -23,10 +23,10 @@ public final class EventScopeInstance extends UnpackedObject implements DbValue 
   private final BooleanProperty interruptedProp = new BooleanProperty("interrupted", false);
 
   private final ArrayProperty<StringValue> interruptingElementIdsProp =
-      new ArrayProperty<>("interrupting", new StringValue());
+      new ArrayProperty<>("interrupting", StringValue::new);
 
   private final ArrayProperty<StringValue> boundaryElementIdsProp =
-      new ArrayProperty<>("boundaryElementIds", new StringValue());
+      new ArrayProperty<>("boundaryElementIds", StringValue::new);
 
   public EventScopeInstance() {
     declareProperty(acceptingProp)

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -11,14 +11,16 @@ import io.camunda.zeebe.msgpack.MsgpackPropertyException;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.BaseValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public final class ArrayProperty<T extends BaseValue> extends BaseProperty<ArrayValue<T>>
     implements ValueArray<T> {
-  public ArrayProperty(final String keyString, final T innerValue) {
-    super(keyString, new ArrayValue<>(innerValue));
+  public ArrayProperty(final String keyString, final Supplier<T> innerValueFactory) {
+    super(keyString, new ArrayValue<>(innerValueFactory));
     isSet = true;
   }
 
@@ -43,10 +45,24 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
   }
 
   @Override
+  public T add(final int index) {
+    try {
+      return value.add(index);
+    } catch (final Exception e) {
+      throw new MsgpackPropertyException(getKey(), e);
+    }
+  }
+
+  @Override
   public Stream<T> stream() {
     // ArrayValue is not a thread-safe Iterable
     final var parallel = false;
     return StreamSupport.stream(spliterator(), parallel);
+  }
+
+  @Override
+  public Collection<T> asCollection() {
+    return value.asCollection();
   }
 
   public boolean isEmpty() {

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ValueArray.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ValueArray.java
@@ -7,10 +7,16 @@
  */
 package io.camunda.zeebe.msgpack.value;
 
+import java.util.Collection;
+import java.util.RandomAccess;
 import java.util.stream.Stream;
 
-public interface ValueArray<T> extends Iterable<T> {
+public interface ValueArray<T> extends Iterable<T>, RandomAccess {
   T add();
 
+  T add(final int index);
+
   Stream<T> stream();
+
+  Collection<T> asCollection();
 }

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.msgpack;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
@@ -28,19 +29,16 @@ import java.util.stream.StreamSupport;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public final class ArrayValueTest {
 
-  @Rule public final ExpectedException exception = ExpectedException.none();
   private final MsgPackWriter writer = new MsgPackWriter();
   private final MsgPackReader reader = new MsgPackReader();
-  private final ArrayValue<IntegerValue> array = new ArrayValue<>(new IntegerValue());
+  private final ArrayValue<IntegerValue> array = new ArrayValue<>(IntegerValue::new);
 
   @Test
-  public void shouldAppendValues() {
+  void shouldAppendValues() {
     // when
     addIntValues(array, 1, 2, 3);
 
@@ -50,14 +48,14 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldAddValueAtBeginning() {
+  void shouldAddValueAtBeginning() {
     // given
     addIntValues(array, 1, 2, 3);
 
     // when
-    // reset iterator to append at beginning
-    array.iterator();
-    addIntValues(array, 4, 5, 6);
+    array.add(0).setValue(4);
+    array.add(1).setValue(5);
+    array.add(2).setValue(6);
 
     // then
     encodeAndDecode(array);
@@ -65,14 +63,14 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldAddValueInBetween() {
+  void shouldAddValueInBetween() {
     // given
     addIntValues(array, 1, 2, 3);
 
     // when
-    final Iterator<IntegerValue> iterator = array.iterator();
-    iterator.next();
-    addIntValues(array, 4, 5, 6);
+    array.add(1).setValue(4);
+    array.add(2).setValue(5);
+    array.add(3).setValue(6);
 
     // then
     encodeAndDecode(array);
@@ -80,15 +78,11 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldAddValuesAtEndAfterRead() {
+  void shouldAddValuesAtEnd() {
     // given
     addIntValues(array, 1, 2, 3);
 
     // when
-    final Iterator<IntegerValue> iterator = array.iterator();
-    iterator.next();
-    iterator.next();
-    iterator.next();
     addIntValues(array, 4, 5, 6);
 
     // then
@@ -97,7 +91,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldUpdateValues() {
+  void shouldUpdateValues() {
     // given
     addIntValues(array, 1, 2, 3);
 
@@ -113,7 +107,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldSerializeValuesAfterPartialRead() {
+  void shouldSerializeValuesAfterPartialRead() {
     // given
     addIntValues(array, 1, 2, 3);
 
@@ -128,7 +122,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldRemoveValueAtBeginning() {
+  void shouldRemoveValueAtBeginning() {
     // given
     addIntValues(array, 1, 2, 3);
 
@@ -143,7 +137,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldRemoveValueInBetween() {
+  void shouldRemoveValueInBetween() {
     // given
     addIntValues(array, 1, 2, 3);
 
@@ -159,7 +153,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldRemoveValueAtEnd() {
+  void shouldRemoveValueAtEnd() {
     // given
     addIntValues(array, 1, 2, 3);
 
@@ -176,7 +170,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldRemoveAllValues() {
+  void shouldRemoveAllValues() {
     // given
     addIntValues(array, 1, 2, 3);
 
@@ -195,7 +189,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldNotInvalidElementOnRemove() {
+  void shouldNotInvalidElementOnRemove() {
     // given
     addIntValues(array, 1, 2, 3);
 
@@ -205,15 +199,15 @@ public final class ArrayValueTest {
     iterator.remove();
 
     // then
-    assertThat(element.getValue()).isEqualTo(1);
+    assertThat(element.getValue()).isOne();
     encodeAndDecode(array);
     assertIntValues(array, 2, 3);
   }
 
   @Test
-  public void shouldUpdateWithSmallerValue() {
+  void shouldUpdateWithSmallerValue() {
     // given
-    final ArrayValue<StringValue> array = new ArrayValue<>(new StringValue());
+    final ArrayValue<StringValue> array = new ArrayValue<>(StringValue::new);
     addStringValues(array, "foo", "bar", "baz");
 
     // when
@@ -231,9 +225,9 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldUpdateWithBiggerValue() {
+  void shouldUpdateWithBiggerValue() {
     // given
-    final ArrayValue<StringValue> array = new ArrayValue<>(new StringValue());
+    final ArrayValue<StringValue> array = new ArrayValue<>(StringValue::new);
     addStringValues(array, "foo", "bar", "baz");
 
     // when
@@ -251,16 +245,12 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldIncreaseInternalBufferWhenAddingToEnd() {
+  void shouldIncreaseInternalBufferWhenAddingToEnd() {
     // given
     final int valueCount = 10_000;
 
     final Integer[] values =
-        IntStream.iterate(0, (i) -> ++i)
-            .limit(valueCount)
-            .boxed()
-            .collect(Collectors.toList())
-            .toArray(new Integer[valueCount]);
+        IntStream.iterate(0, (i) -> ++i).limit(valueCount).boxed().toArray(Integer[]::new);
 
     // when
     addIntValues(array, values);
@@ -271,7 +261,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldIncreaseInternalBufferWhenAddingToBeginning() {
+  void shouldIncreaseInternalBufferWhenAddingToBeginning() {
     // given
     final int valueCount = 10_000;
     final List<Integer> generatedList =
@@ -282,10 +272,9 @@ public final class ArrayValueTest {
     final Integer[] values = generatedList.toArray(new Integer[valueCount]);
 
     // when
-    for (final Integer value : values) {
-      // reset cursor to first position
-      array.iterator();
-      array.add().setValue(value);
+    array.add().setValue(values[0]);
+    for (int i = 1; i < values.length; i++) {
+      array.add(0).setValue(values[i]);
     }
 
     // then
@@ -296,14 +285,14 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldSerializeUndeclaredProperties() {
+  void shouldSerializeUndeclaredProperties() {
     // given
-    final ArrayValue<Foo> fooArray = new ArrayValue<>(new Foo());
+    final ArrayValue<Foo> fooArray = new ArrayValue<>(Foo::new);
     fooArray.add().setFoo("foo").setBar("bar");
 
     final DirectBuffer buffer = encode(fooArray);
 
-    final ArrayValue<Bar> barArray = new ArrayValue<>(new Bar());
+    final ArrayValue<Bar> barArray = new ArrayValue<>(Bar::new);
 
     // when
     decode(barArray, buffer);
@@ -317,27 +306,19 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldThrowExceptionIfNoNextElementExists() {
-    // then
-    exception.expect(NoSuchElementException.class);
-    exception.expectMessage("No more elements left");
-
-    // when
-    array.iterator().next();
+  void shouldThrowExceptionIfNoNextElementExists() {
+    // when - then
+    assertThatThrownBy(() -> array.iterator().next()).isInstanceOf(NoSuchElementException.class);
   }
 
   @Test
-  public void shouldThrowExceptionIfRemoveWithoutNext() {
-    // then
-    exception.expect(IllegalStateException.class);
-    exception.expectMessage("No element available to remove, call next() before");
-
-    // when
-    array.iterator().remove();
+  void shouldThrowExceptionIfRemoveWithoutNext() {
+    // when - then
+    assertThatThrownBy(() -> array.iterator().remove()).isInstanceOf(IllegalStateException.class);
   }
 
   @Test
-  public void shouldThrowExceptionIfRemoveIsCalledTwice() {
+  void shouldThrowExceptionIfRemoveIsCalledTwice() {
     // given
     array.add().setValue(1);
     final Iterator<IntegerValue> iterator = array.iterator();
@@ -345,18 +326,14 @@ public final class ArrayValueTest {
     iterator.next();
     iterator.remove();
 
-    // then
-    exception.expect(IllegalStateException.class);
-    exception.expectMessage("No element available to remove, call next() before");
-
-    // when
-    iterator.remove();
+    // when - then
+    assertThatThrownBy(iterator::remove).isInstanceOf(IllegalStateException.class);
   }
 
   @Test
-  public void shouldWriteJson() {
+  void shouldWriteJson() {
     // given
-    final ArrayValue<MinimalPOJO> array = new ArrayValue<>(new MinimalPOJO());
+    final ArrayValue<MinimalPOJO> array = new ArrayValue<>(MinimalPOJO::new);
     array.add().setLongProp(1);
     array.add().setLongProp(2);
     array.add().setLongProp(3);
@@ -367,12 +344,11 @@ public final class ArrayValueTest {
     array.writeJSON(builder);
 
     // then
-    assertThat(builder.toString())
-        .isEqualTo("[{\"longProp\":1},{\"longProp\":2},{\"longProp\":3}]");
+    assertThat(builder).hasToString("[{\"longProp\":1},{\"longProp\":2},{\"longProp\":3}]");
   }
 
   @Test
-  public void shouldReturnTrueIfIsEmptyIsCalledWithoutElements() {
+  void shouldReturnTrueIfIsEmptyIsCalledWithoutElements() {
     // given no elements are added
     // when
     final boolean isEmpty = array.isEmpty();
@@ -382,7 +358,7 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldReturnFalseIfIsEmptyIsCalledWithElements() {
+  void shouldReturnFalseIfIsEmptyIsCalledWithElements() {
     // given
     addIntValues(array, 1);
 
@@ -395,13 +371,13 @@ public final class ArrayValueTest {
 
   // Helpers
 
-  protected void addIntValues(final ArrayValue<IntegerValue> array, final Integer... values) {
+  private void addIntValues(final ArrayValue<IntegerValue> array, final Integer... values) {
     for (final Integer value : values) {
       array.add().setValue(value);
     }
   }
 
-  protected void assertIntValues(final ArrayValue<IntegerValue> array, final Integer... expected) {
+  private void assertIntValues(final ArrayValue<IntegerValue> array, final Integer... expected) {
     final List<Integer> values =
         StreamSupport.stream(array.spliterator(), false)
             .map(IntegerValue::getValue)
@@ -409,13 +385,13 @@ public final class ArrayValueTest {
     assertThat(values).containsExactly(expected);
   }
 
-  protected void addStringValues(final ArrayValue<StringValue> array, final String... values) {
+  private void addStringValues(final ArrayValue<StringValue> array, final String... values) {
     for (final String value : values) {
       array.add().wrap(BufferUtil.wrapString(value));
     }
   }
 
-  protected void assertStringValues(final ArrayValue<StringValue> array, final String... expected) {
+  private void assertStringValues(final ArrayValue<StringValue> array, final String... expected) {
     final List<String> values =
         StreamSupport.stream(array.spliterator(), false)
             .map(StringValue::getValue)
@@ -425,12 +401,12 @@ public final class ArrayValueTest {
     assertThat(values).containsExactly(expected);
   }
 
-  protected void encodeAndDecode(final BaseValue value) {
+  private void encodeAndDecode(final BaseValue value) {
     final DirectBuffer buffer = encode(value);
     decode(value, buffer);
   }
 
-  protected DirectBuffer encode(final BaseValue value) {
+  private DirectBuffer encode(final BaseValue value) {
     final int encodedLength = value.getEncodedLength();
     final MutableDirectBuffer buffer = new UnsafeBuffer(new byte[encodedLength]);
 
@@ -440,24 +416,20 @@ public final class ArrayValueTest {
     return buffer;
   }
 
-  protected void decode(final BaseValue value, final DirectBuffer buffer) {
+  private void decode(final BaseValue value, final DirectBuffer buffer) {
     value.reset();
 
     reader.wrap(buffer, 0, buffer.capacity());
     value.read(reader);
   }
 
-  class Foo extends UnpackedObject {
+  private static final class Foo extends UnpackedObject {
 
     private final StringProperty fooProp = new StringProperty("foo");
     private final StringProperty barProp = new StringProperty("bar");
 
-    Foo() {
+    private Foo() {
       declareProperty(fooProp).declareProperty(barProp);
-    }
-
-    public String getFoo() {
-      return BufferUtil.bufferAsString(fooProp.getValue());
     }
 
     public Foo setFoo(final String foo) {
@@ -465,21 +437,16 @@ public final class ArrayValueTest {
       return this;
     }
 
-    public String getBar() {
-      return BufferUtil.bufferAsString(barProp.getValue());
-    }
-
-    public Foo setBar(final String bar) {
+    void setBar(final String bar) {
       barProp.setValue(bar);
-      return this;
     }
   }
 
-  class Bar extends UnpackedObject {
+  private static final class Bar extends UnpackedObject {
 
     private final StringProperty barProp = new StringProperty("bar");
 
-    Bar() {
+    private Bar() {
       declareProperty(barProp);
     }
 
@@ -487,9 +454,8 @@ public final class ArrayValueTest {
       return BufferUtil.bufferAsString(barProp.getValue());
     }
 
-    public Bar setBar(final String bar) {
+    void setBar(final String bar) {
       barProp.setValue(bar);
-      return this;
     }
   }
 }

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -369,6 +369,38 @@ public final class ArrayValueTest {
     assertThat(isEmpty).isFalse();
   }
 
+  @Test
+  void shouldBeEqual() {
+    // given
+    final var other = new ArrayValue<>(IntegerValue::new);
+    addIntValues(array, 1, 2, 3);
+    array.iterator(); // force flush
+
+    // when
+    other.add().setValue(1);
+    other.add().setValue(2);
+    other.add().setValue(3);
+
+    // then - fails because it's not flushed
+    assertThat((Object) other).isEqualTo(array);
+  }
+
+  @Test
+  void shouldHashLatestModification() {
+    // given
+    final var other = new ArrayValue<>(IntegerValue::new);
+    addIntValues(array, 1, 2, 3);
+    array.iterator(); // force flush
+
+    // when
+    other.add().setValue(1);
+    other.add().setValue(2);
+    other.add().setValue(3);
+
+    // then - fails because it's not flushed
+    assertThat((Object) other).hasSameHashCodeAs(array);
+  }
+
   // Helpers
 
   private void addIntValues(final ArrayValue<IntegerValue> array, final Integer... values) {

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArray.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArray.java
@@ -15,7 +15,7 @@ public final class POJOArray extends UnpackedObject {
   protected final ArrayProperty<MinimalPOJO> simpleArrayProp;
 
   public POJOArray() {
-    simpleArrayProp = new ArrayProperty<>("simpleArray", new MinimalPOJO());
+    simpleArrayProp = new ArrayProperty<>("simpleArray", MinimalPOJO::new);
 
     declareProperty(simpleArrayProp);
   }

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArrayTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArrayTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.msgpack.value.ValueArray;
+import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -216,13 +217,9 @@ public final class POJOArrayTest {
             });
 
     pojo.wrap(buffer);
-    final Iterator<MinimalPOJO> iterator = pojo.simpleArray().iterator();
-    iterator.next();
-    iterator.next();
-    iterator.next();
 
     // when
-    pojo.simpleArrayProp.add().setLongProp(999L);
+    pojo.simpleArrayProp.add(3).setLongProp(999L);
 
     // then
     final int writeLength = pojo.getLength();
@@ -368,10 +365,10 @@ public final class POJOArrayTest {
     pojo.wrap(buffer);
     final Iterator<MinimalPOJO> iterator = pojo.simpleArray().iterator();
     iterator.next();
-    pojo.simpleArray().add().setLongProp(999L);
+    pojo.simpleArray().add(1).setLongProp(999L);
 
     // then
-    exception.expect(IllegalStateException.class);
+    exception.expect(ConcurrentModificationException.class);
 
     // when
     iterator.remove();

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -53,7 +53,7 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
 
   private final ArrayProperty<EvaluatedDecisionRecord> evaluatedDecisionsProp =
-      new ArrayProperty<>("evaluatedDecisions", new EvaluatedDecisionRecord());
+      new ArrayProperty<>("evaluatedDecisions", EvaluatedDecisionRecord::new);
 
   private final StringProperty evaluationFailureMessageProp =
       new StringProperty("evaluationFailureMessage", "");

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -38,10 +38,10 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
   private final BinaryProperty decisionOutputProp = new BinaryProperty("decisionOutput");
 
   private final ArrayProperty<EvaluatedInputRecord> evaluatedInputsProp =
-      new ArrayProperty<>("evaluatedInputs", new EvaluatedInputRecord());
+      new ArrayProperty<>("evaluatedInputs", EvaluatedInputRecord::new);
 
   private final ArrayProperty<MatchedRuleRecord> matchedRulesProp =
-      new ArrayProperty<>("matchedRules", new MatchedRuleRecord());
+      new ArrayProperty<>("matchedRules", MatchedRuleRecord::new);
 
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
@@ -28,7 +28,7 @@ public final class MatchedRuleRecord extends UnifiedRecordValue implements Match
   private final IntegerProperty ruleIndexProp = new IntegerProperty("ruleIndex");
 
   private final ArrayProperty<EvaluatedOutputRecord> evaluatedOutputsProp =
-      new ArrayProperty<>("evaluatedOutputs", new EvaluatedOutputRecord());
+      new ArrayProperty<>("evaluatedOutputs", EvaluatedOutputRecord::new);
 
   public MatchedRuleRecord() {
     declareProperty(ruleIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -29,19 +29,19 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
   public static final String PROCESSES = "processesMetadata";
 
   private final ArrayProperty<DeploymentResource> resourcesProp =
-      new ArrayProperty<>(RESOURCES, new DeploymentResource());
+      new ArrayProperty<>(RESOURCES, DeploymentResource::new);
 
   private final ArrayProperty<ProcessMetadata> processesMetadataProp =
-      new ArrayProperty<>(PROCESSES, new ProcessMetadata());
+      new ArrayProperty<>(PROCESSES, ProcessMetadata::new);
 
   private final ArrayProperty<DecisionRecord> decisionMetadataProp =
-      new ArrayProperty<>("decisionsMetadata", new DecisionRecord());
+      new ArrayProperty<>("decisionsMetadata", DecisionRecord::new);
 
   private final ArrayProperty<DecisionRequirementsMetadataRecord> decisionRequirementsMetadataProp =
-      new ArrayProperty<>("decisionRequirementsMetadata", new DecisionRequirementsMetadataRecord());
+      new ArrayProperty<>("decisionRequirementsMetadata", DecisionRequirementsMetadataRecord::new);
 
   private final ArrayProperty<FormMetadataRecord> formMetadataProp =
-      new ArrayProperty<>("formMetadata", new FormMetadataRecord());
+      new ArrayProperty<>("formMetadata", FormMetadataRecord::new);
 
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -34,12 +34,12 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final IntegerProperty maxJobsToActivateProp =
       new IntegerProperty("maxJobsToActivate", -1);
   private final ArrayProperty<LongValue> jobKeysProp =
-      new ArrayProperty<>("jobKeys", new LongValue());
-  private final ArrayProperty<JobRecord> jobsProp = new ArrayProperty<>("jobs", new JobRecord());
+      new ArrayProperty<>("jobKeys", LongValue::new);
+  private final ArrayProperty<JobRecord> jobsProp = new ArrayProperty<>("jobs", JobRecord::new);
   private final ArrayProperty<StringValue> tenantIdsProp =
-      new ArrayProperty<>("tenantIds", new StringValue());
+      new ArrayProperty<>("tenantIds", StringValue::new);
   private final ArrayProperty<StringValue> variablesProp =
-      new ArrayProperty<>("variables", new StringValue());
+      new ArrayProperty<>("variables", StringValue::new);
   private final BooleanProperty truncatedProp = new BooleanProperty("truncated", false);
 
   public JobBatchRecord() {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
@@ -20,7 +20,7 @@ public final class MessageBatchRecord extends UnifiedRecordValue
     implements MessageBatchRecordValue {
 
   private final ArrayProperty<LongValue> messageKeysProp =
-      new ArrayProperty<>("messageKeys", new LongValue());
+      new ArrayProperty<>("messageKeys", LongValue::new);
 
   public MessageBatchRecord() {
     declareProperty(messageKeysProp);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -39,10 +39,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private final LongProperty processInstanceKeyProperty =
       new LongProperty("processInstanceKey", -1);
   private final ArrayProperty<StringValue> fetchVariablesProperty =
-      new ArrayProperty<>("fetchVariables", new StringValue());
+      new ArrayProperty<>("fetchVariables", StringValue::new);
 
   private final ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructionsProperty =
-      new ArrayProperty<>("startInstructions", new ProcessInstanceCreationStartInstruction());
+      new ArrayProperty<>("startInstructions", ProcessInstanceCreationStartInstruction::new);
 
   public ProcessInstanceCreationRecord() {
     declareProperty(bpmnProcessIdProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
@@ -35,10 +35,10 @@ public final class ProcessInstanceModificationActivateInstruction extends Object
   private final ArrayProperty<ProcessInstanceModificationVariableInstruction>
       variableInstructionsProperty =
           new ArrayProperty<>(
-              "variableInstructions", new ProcessInstanceModificationVariableInstruction());
+              "variableInstructions", ProcessInstanceModificationVariableInstruction::new);
 
   private final ArrayProperty<LongValue> ancestorScopeKeysProperty =
-      new ArrayProperty<>("ancestorScopeKeys", new LongValue());
+      new ArrayProperty<>("ancestorScopeKeys", LongValue::new);
 
   public ProcessInstanceModificationActivateInstruction() {
     declareProperty(elementIdProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -26,15 +26,15 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   private final ArrayProperty<ProcessInstanceModificationTerminateInstruction>
       terminateInstructionsProperty =
           new ArrayProperty<>(
-              "terminateInstructions", new ProcessInstanceModificationTerminateInstruction());
+              "terminateInstructions", ProcessInstanceModificationTerminateInstruction::new);
   private final ArrayProperty<ProcessInstanceModificationActivateInstruction>
       activateInstructionsProperty =
           new ArrayProperty<>(
-              "activateInstructions", new ProcessInstanceModificationActivateInstruction());
+              "activateInstructions", ProcessInstanceModificationActivateInstruction::new);
 
   @Deprecated(since = "8.1.3")
   private final ArrayProperty<LongValue> activatedElementInstanceKeys =
-      new ArrayProperty<>("activatedElementInstanceKeys", new LongValue());
+      new ArrayProperty<>("activatedElementInstanceKeys", LongValue::new);
 
   public ProcessInstanceModificationRecord() {
     declareProperty(processInstanceKeyProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
-import java.util.List;
 import org.agrona.DirectBuffer;
 
 /**
@@ -49,5 +48,5 @@ public interface JobActivationProperties extends BufferReader, BufferWriter {
    *
    * @return the identifiers of the tenants for which to activate jobs
    */
-  List<String> getTenantIds();
+  Collection<String> tenantIds();
 }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImplTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImplTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.stream.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.util.List;
+
+final class JobActivationPropertiesImplTest {
+  @RegressionTest("https://github.com/camunda/zeebe/issues/14624")
+  void shouldIterateTenantsImmutably() {
+    // given
+    final var properties = new JobActivationPropertiesImpl().setTenantIds(List.of("foo", "bar"));
+    final var firstIterator = properties.tenantIds().iterator();
+    final var secondIterator = properties.tenantIds().iterator();
+
+    // when
+    firstIterator.next();
+    final var foo = secondIterator.next();
+    final var bar = firstIterator.next();
+
+    // then
+    assertThat(foo).isEqualTo("foo");
+    assertThat(bar).isEqualTo("bar");
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobStreamLifecycleIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobStreamLifecycleIT.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
 import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.jobstream.AbstractJobStreamsAssert;
 import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
@@ -21,7 +22,6 @@ import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.time.Duration;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @AutoCloseResources
@@ -32,18 +32,14 @@ final class JobStreamLifecycleIT {
       TestCluster.builder()
           .withReplicationFactor(2)
           .withBrokersCount(2)
-          .withGatewaysCount(1)
+          .withGatewaysCount(2)
           .withEmbeddedGateway(false)
           .build();
 
-  @AutoCloseResource private static ZeebeClient client;
+  private final TestGateway<?> gateway = CLUSTER.availableGateway();
+  @AutoCloseResource private final ZeebeClient client = gateway.newClientBuilder().build();
 
   private final String jobType = Strings.newRandomValidBpmnId();
-
-  @BeforeAll
-  static void beforeAll() {
-    client = CLUSTER.newClientBuilder().build();
-  }
 
   @Test
   void shouldRegisterStream() {
@@ -64,7 +60,7 @@ final class JobStreamLifecycleIT {
     Awaitility.await("until stream is registered")
         .untilAsserted(
             () ->
-                JobStreamActuatorAssert.assertThat(gatewayActuator())
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
                     .clientStreams()
                     .haveExactlyAll(
                         1,
@@ -114,7 +110,7 @@ final class JobStreamLifecycleIT {
     Awaitility.await("until streams are registered")
         .untilAsserted(
             () ->
-                JobStreamActuatorAssert.assertThat(gatewayActuator())
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
                     .clientStreams()
                     .haveJobType(2, jobType));
 
@@ -131,44 +127,57 @@ final class JobStreamLifecycleIT {
   }
 
   @Test
-  void shouldAggregateStreams() {
-    // given - two logically equivalent streams
-    final var commandA =
-        client
-            .newStreamJobsCommand()
-            .jobType(jobType)
-            .consumer(ignored -> {})
-            .fetchVariables("foo", "bar")
-            .timeout(Duration.ofMillis(500))
-            .workerName("command");
-    final var commandB =
-        client
-            .newStreamJobsCommand()
-            .jobType(jobType)
-            .consumer(ignored -> {})
-            .fetchVariables("foo", "bar")
-            .timeout(Duration.ofMillis(500))
-            .workerName("command");
+  void shouldAggregateStream() {
+    // given - two logically equivalent streams on different gateways
+    //noinspection resource
+    final var otherGateway =
+        CLUSTER.gateways().values().stream()
+            .filter(g -> !g.nodeId().equals(gateway.nodeId()))
+            .findAny()
+            .orElseThrow();
+    try (final var otherClient = otherGateway.newClientBuilder().build()) {
+      final var commandA =
+          client
+              .newStreamJobsCommand()
+              .jobType(jobType)
+              .consumer(ignored -> {})
+              .fetchVariables("foo", "bar")
+              .timeout(Duration.ofMillis(500))
+              .workerName("command");
+      final var commandB =
+          otherClient
+              .newStreamJobsCommand()
+              .jobType(jobType)
+              .consumer(ignored -> {})
+              .fetchVariables("foo", "bar")
+              .timeout(Duration.ofMillis(500))
+              .workerName("command");
 
-    // when - both streams are opened and registered on the gateway as individual client streams
-    commandA.send();
-    commandB.send();
-    Awaitility.await("until streams are registered")
-        .untilAsserted(
-            () ->
-                JobStreamActuatorAssert.assertThat(gatewayActuator())
-                    .clientStreams()
-                    .haveJobType(2, jobType));
-
-    // then - only one stream is registered on each broker as it is aggregated per gateway
-    for (int nodeId = 0; nodeId < 2; nodeId++) {
-      final var actuator = brokerActuator(nodeId);
-      Awaitility.await("until stream is registered on broker '%d'".formatted(nodeId))
+      // when - both streams are opened and registered on the gateway as individual client streams
+      commandA.send();
+      commandB.send();
+      Awaitility.await("until streams are registered")
           .untilAsserted(
-              () ->
-                  JobStreamActuatorAssert.assertThat(actuator)
-                      .remoteStreams()
-                      .haveConsumerCount(1, jobType, 2));
+              () -> {
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
+                    .clientStreams()
+                    .haveJobType(1, jobType);
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(otherGateway))
+                    .clientStreams()
+                    .haveJobType(1, jobType);
+              });
+
+      // then - only one stream is registered on each broker as it is aggregated per gateway, with
+      // two consumers
+      for (int nodeId = 0; nodeId < 2; nodeId++) {
+        final var actuator = brokerActuator(nodeId);
+        Awaitility.await("until stream is registered on broker '%d'".formatted(nodeId))
+            .untilAsserted(
+                () ->
+                    JobStreamActuatorAssert.assertThat(actuator)
+                        .remoteStreams()
+                        .haveConsumerCount(1, jobType, 2));
+      }
     }
   }
 
@@ -180,7 +189,7 @@ final class JobStreamLifecycleIT {
     Awaitility.await("until stream is fully registered")
         .untilAsserted(
             () ->
-                JobStreamActuatorAssert.assertThat(gatewayActuator())
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
                     .clientStreams()
                     .haveConnectedTo(1, jobType, 0, 1));
 
@@ -191,7 +200,7 @@ final class JobStreamLifecycleIT {
     Awaitility.await("until no gateway streams are registered")
         .untilAsserted(
             () ->
-                JobStreamActuatorAssert.assertThat(gatewayActuator())
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
                     .clientStreams()
                     .doNotHaveJobType(jobType));
     for (int nodeId = 0; nodeId < 2; nodeId++) {
@@ -216,7 +225,7 @@ final class JobStreamLifecycleIT {
     Awaitility.await("until gateway streams are fully connected")
         .untilAsserted(
             () ->
-                JobStreamActuatorAssert.assertThat(gatewayActuator())
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
                     .clientStreams()
                     .haveConnectedTo(2, jobType, 0, 1));
     stream.cancel(true);
@@ -225,7 +234,7 @@ final class JobStreamLifecycleIT {
     Awaitility.await("until gateway has only one stream")
         .untilAsserted(
             () ->
-                JobStreamActuatorAssert.assertThat(gatewayActuator())
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
                     .clientStreams()
                     .haveConnectedTo(1, jobType, 0, 1));
     for (int nodeId = 0; nodeId < 2; nodeId++) {
@@ -247,7 +256,7 @@ final class JobStreamLifecycleIT {
     Awaitility.await("until gateway streams are fully connected")
         .untilAsserted(
             () ->
-                JobStreamActuatorAssert.assertThat(gatewayActuator())
+                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
                     .clientStreams()
                     .haveConnectedTo(2, jobType, 0, 1));
 
@@ -265,10 +274,6 @@ final class JobStreamLifecycleIT {
                       .remoteStreams()
                       .doNotHaveJobType(jobType));
     }
-  }
-
-  private JobStreamActuator gatewayActuator() {
-    return JobStreamActuator.of(CLUSTER.availableGateway());
   }
 
   private JobStreamActuator brokerActuator(final int nodeId) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/JobStreamEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/JobStreamEndpointIT.java
@@ -7,19 +7,18 @@
  */
 package io.camunda.zeebe.it.management;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert.RemoteJobStreamsAssert;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteJobStream;
-import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteStreamId;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.time.Duration;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -27,11 +26,12 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 @AutoCloseResources
 final class JobStreamEndpointIT {
-  @TestZeebe private static final TestStandaloneBroker BROKER = new TestStandaloneBroker();
+  @TestZeebe
+  private static final TestCluster CLUSTER =
+      TestCluster.builder().withGatewaysCount(2).withEmbeddedGateway(false).build();
 
-  @AutoCloseResource private final ZeebeClient client = BROKER.newClientBuilder().build();
-
-  private final JobStreamActuator actuator = JobStreamActuator.of(BROKER);
+  private final TestGateway<?> gateway = CLUSTER.availableGateway();
+  @AutoCloseResource private final ZeebeClient client = gateway.newClientBuilder().build();
 
   @AfterEach
   void afterEach() {
@@ -39,12 +39,12 @@ final class JobStreamEndpointIT {
     client.close();
 
     // avoid flakiness between tests by waiting until the registries are empty
+    final var actuator = JobStreamActuator.of(gateway);
     Awaitility.await("until no streams are registered")
         .untilAsserted(
             () -> {
-              final var streams = actuator.list();
-              assertThat(streams.remote()).isEmpty();
-              assertThat(streams.client()).isEmpty();
+              JobStreamActuatorAssert.assertThat(actuator).remoteStreams().isEmpty();
+              JobStreamActuatorAssert.assertThat(actuator).clientStreams().isEmpty();
             });
   }
 
@@ -68,66 +68,69 @@ final class JobStreamEndpointIT {
         .fetchVariables("bar", "barz")
         .send();
 
-    // when
-    final var streams =
-        Awaitility.await("until all streams are registered")
-            .until(actuator::listRemote, list -> list.size() == 2);
-
     // then
-    assertThat(streams)
-        .anySatisfy(
-            stream -> {
-              assertThat(stream.jobType()).isEqualTo("foo");
-              assertThat(stream.metadata().worker()).isEqualTo("foo");
-              assertThat(stream.metadata().timeout()).isEqualTo(Duration.ofMillis(100L));
-              assertThat(stream.metadata().fetchVariables())
-                  .containsExactlyInAnyOrder("foo", "fooz");
-            })
-        .anySatisfy(
-            stream -> {
-              assertThat(stream.jobType()).isEqualTo("bar");
-              assertThat(stream.metadata().worker()).isEqualTo("bar");
-              assertThat(stream.metadata().timeout()).isEqualTo(Duration.ofMillis(250));
-              assertThat(stream.metadata().fetchVariables())
-                  .containsExactlyInAnyOrder("bar", "barz");
-            });
+    final var brokerActuator = JobStreamActuator.of(CLUSTER.brokers().get(MemberId.from("0")));
+    Awaitility.await("until foo stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(brokerActuator)
+                    .remoteStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType("foo"),
+                        RemoteJobStreamsAssert.hasWorker("foo"),
+                        RemoteJobStreamsAssert.hasTimeout(100L),
+                        RemoteJobStreamsAssert.hasFetchVariables("foo", "fooz")));
+    Awaitility.await("until bar stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(brokerActuator)
+                    .remoteStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType("bar"),
+                        RemoteJobStreamsAssert.hasWorker("bar"),
+                        RemoteJobStreamsAssert.hasTimeout(250L),
+                        RemoteJobStreamsAssert.hasFetchVariables("bar", "barz")));
   }
 
   @Test
   void shouldListMultipleRemoteConsumers() {
     // given
-    client
-        .newStreamJobsCommand()
-        .jobType("foo")
-        .consumer(ignored -> {})
-        .workerName("foo")
-        .timeout(Duration.ofMillis(100))
-        .fetchVariables("foo", "fooz")
-        .send();
-    client
-        .newStreamJobsCommand()
-        .jobType("foo")
-        .consumer(ignored -> {})
-        .workerName("foo")
-        .timeout(Duration.ofMillis(100))
-        .fetchVariables("foo", "fooz")
-        .send();
+    //noinspection resource
+    final var otherGateway =
+        CLUSTER.gateways().values().stream()
+            .filter(g -> !g.nodeId().equals(gateway.nodeId()))
+            .findAny()
+            .orElseThrow();
+    try (final var otherClient = otherGateway.newClientBuilder().build()) {
+      client
+          .newStreamJobsCommand()
+          .jobType("foo")
+          .consumer(ignored -> {})
+          .workerName("foo")
+          .timeout(Duration.ofMillis(100))
+          .fetchVariables("foo", "fooz")
+          .send();
+      otherClient
+          .newStreamJobsCommand()
+          .jobType("foo")
+          .consumer(ignored -> {})
+          .workerName("foo")
+          .timeout(Duration.ofMillis(100))
+          .fetchVariables("foo", "fooz")
+          .send();
 
-    // when
-    final var streams =
-        Awaitility.await("until all streams are registered")
-            .atMost(Duration.ofSeconds(60))
-            .until(
-                actuator::listRemote,
-                list -> list.size() == 1 && list.get(0).consumers().size() == 2);
-
-    // then
-    assertThat(streams)
-        .first(InstanceOfAssertFactories.type(RemoteJobStream.class))
-        .extracting(RemoteJobStream::consumers)
-        .asInstanceOf(InstanceOfAssertFactories.list(RemoteStreamId.class))
-        .extracting(RemoteStreamId::receiver)
-        .containsExactly("0", "0");
+      // then
+      final var brokerActuator = JobStreamActuator.of(CLUSTER.brokers().get(MemberId.from("0")));
+      Awaitility.await("until all streams are registered")
+          .untilAsserted(
+              () ->
+                  JobStreamActuatorAssert.assertThat(brokerActuator)
+                      .remoteStreams()
+                      .haveConsumerReceiver(
+                          1, "foo", gateway.nodeId().id(), otherGateway.nodeId().id()));
+    }
   }
 
   @Test
@@ -150,30 +153,29 @@ final class JobStreamEndpointIT {
         .fetchVariables("bar", "barz")
         .send();
 
-    // when
-    final var streams =
-        Awaitility.await("until all streams are registered")
-            .until(actuator::listClient, list -> list.size() == 2);
-
     // then
-    assertThat(streams)
-        .anySatisfy(
-            stream -> {
-              assertThat(stream.jobType()).isEqualTo("foo");
-              assertThat(stream.metadata().worker()).isEqualTo("foo");
-              assertThat(stream.metadata().timeout()).isEqualTo(Duration.ofMillis(100));
-              assertThat(stream.metadata().fetchVariables())
-                  .containsExactlyInAnyOrder("foo", "fooz");
-              assertThat(stream.id()).isNotNull();
-            })
-        .anySatisfy(
-            stream -> {
-              assertThat(stream.jobType()).isEqualTo("bar");
-              assertThat(stream.metadata().worker()).isEqualTo("bar");
-              assertThat(stream.metadata().timeout()).isEqualTo(Duration.ofMillis(250));
-              assertThat(stream.metadata().fetchVariables())
-                  .containsExactlyInAnyOrder("bar", "barz");
-              assertThat(stream.id()).isNotNull();
-            });
+    final var actuator = JobStreamActuator.of(gateway);
+    Awaitility.await("until foo stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(actuator)
+                    .clientStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType("foo"),
+                        RemoteJobStreamsAssert.hasWorker("foo"),
+                        RemoteJobStreamsAssert.hasTimeout(100L),
+                        RemoteJobStreamsAssert.hasFetchVariables("foo", "fooz")));
+    Awaitility.await("until bar stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(actuator)
+                    .clientStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType("bar"),
+                        RemoteJobStreamsAssert.hasWorker("bar"),
+                        RemoteJobStreamsAssert.hasTimeout(250L),
+                        RemoteJobStreamsAssert.hasFetchVariables("bar", "barz")));
   }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/AbstractJobStreamsAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/AbstractJobStreamsAssert.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.qa.util.jobstream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.ClientJobStream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.JobStream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteJobStream;
+import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteStreamId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -141,6 +142,23 @@ public abstract class AbstractJobStreamsAssert<
     return VerboseCondition.verboseCondition(
         stream -> stream.consumers().size() == count,
         "a stream with '%d' consumers".formatted(count),
+        stream -> " but actual consumers are '%s'".formatted(stream.consumers()));
+  }
+
+  /**
+   * Returns a condition which checks that a stream consumers contains exactly the given receivers,
+   * in any order.
+   */
+  public static Condition<RemoteJobStream> hasConsumerReceivers(
+      final Collection<String> receivers) {
+    return VerboseCondition.verboseCondition(
+        stream ->
+            stream.consumers().size() == receivers.size()
+                && stream.consumers().stream()
+                    .map(RemoteStreamId::receiver)
+                    .collect(Collectors.toSet())
+                    .containsAll(receivers),
+        "a stream with consumer receivers '%s'".formatted(receivers),
         stream -> " but actual consumers are '%s'".formatted(stream.consumers()));
   }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/JobStreamActuatorAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/JobStreamActuatorAssert.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.qa.util.jobstream;
 import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.ClientJobStream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteJobStream;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -104,6 +105,22 @@ public final class JobStreamActuatorAssert
         final int expectedCount, final String jobType, final int consumerCount) {
       return haveExactly(
           expectedCount, AllOf.allOf(hasJobType(jobType), hasConsumerCount(consumerCount)));
+    }
+
+    /**
+     * Asserts that the given service contains exactly {@code expectedCount} streams with the given
+     * job type and the expected consumer receivers (in any order).
+     *
+     * @param expectedCount the exact count of streams to find
+     * @param jobType the expected type of the streams
+     * @param receivers the expected consumer receivers
+     * @return itself for chaining
+     */
+    public RemoteJobStreamsAssert haveConsumerReceiver(
+        final int expectedCount, final String jobType, final String... receivers) {
+      final var collection = Arrays.asList(receivers);
+      return haveExactly(
+          expectedCount, AllOf.allOf(hasJobType(jobType), hasConsumerReceivers(collection)));
     }
 
     @Override

--- a/util/src/main/java/io/camunda/zeebe/util/buffer/BufferReader.java
+++ b/util/src/main/java/io/camunda/zeebe/util/buffer/BufferReader.java
@@ -23,4 +23,14 @@ public interface BufferReader {
    * @param length the length of the values to read
    */
   void wrap(DirectBuffer buffer, int offset, int length);
+
+  /**
+   * Copies the contents of {@code source} into a newly allocated buffer before reading it back.
+   *
+   * @param source the source writer
+   * @throws NullPointerException if source is null
+   */
+  default void copyFrom(final BufferWriter source) {
+    BufferUtil.copy(source, this);
+  }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
@@ -77,6 +77,18 @@ public final class BufferUtil {
   }
 
   /**
+   * Copies the contents of the source writer into the destination reader via a fresh intermediate
+   * buffer.
+   *
+   * @param source the buffer to copy from
+   * @param dest the buffer to write to
+   */
+  public static void copy(final BufferWriter source, final BufferReader dest) {
+    final var buffer = createCopy(source);
+    dest.wrap(buffer, 0, buffer.capacity());
+  }
+
+  /**
    * Creates a new instance of the src buffer class and copies the underlying bytes.
    *
    * @param src the buffer to copy from

--- a/util/src/main/java/io/camunda/zeebe/util/buffer/BufferWriter.java
+++ b/util/src/main/java/io/camunda/zeebe/util/buffer/BufferWriter.java
@@ -29,4 +29,14 @@ public interface BufferWriter {
    * @param offset the offset in the buffer that the writer begins writing at
    */
   void write(MutableDirectBuffer buffer, int offset);
+
+  /**
+   * Writes this instance into a newly allocated buffer before reading it back using {@code dest}.
+   *
+   * @param dest the destination reader
+   * @throws NullPointerException if dest is null
+   */
+  default void copyTo(final BufferReader dest) {
+    BufferUtil.copy(this, dest);
+  }
 }


### PR DESCRIPTION
## Description

This PR ensures iterating over a MsgPack `ArrayValue` does not mutate the value itself, i.e. it's immutable. This means all read operations over ALL MsgPack values are now immutable, making them partially thread safe if you can guarantee no more writes.

This is done by trading off the previous garbage-free property of the iteration in favor of a much simpler list based approach. To highlight, let's recap what the previous implementation did:

### "Garbage-free" implementation

`ArrayValue` worked by keeping an internal, expandable byte buffer. Whenever a new item was added to the array, it was reusing the same `innerValue` - think of it like an in-memory buffer for the next added value. So if you had an `ArrayValue` of integers, then the `innerValue` would be one pre-allocated instance of `IntegerValue` which would get reused. Every time you called `add`, it would do two things:

1. If the current `innerValue` was set, it would serialize it using a `MsgPackWriter` to its internal byte buffer at the current index. _This is how you could use the iterator to decide where to insert elements in the array, a feature we seldom used_. To do so, it might have to shift left or right the existing elements in order to make some space.
2. It would then reset the current `innerValue`, increment the element count, and return the `innerValue` so you could then modify it.

One important thing to note - when modifying the `innerValue`, that change was not immediately reflected on the `ArrayValue` internal byte buffer. It was only reflected if `add`, `write`, or `iterator` was called - at which point we'd do a so called `flush` operation and write the `innerValue` (and again, possibly shift elements around to make space) to the internal buffer.

When you would call `iterator`, then, we always had to first `flush` the `innerValue`, then reset some internal iteration state, and then since the iteration state is just part of `ArrayValue`, we'd return `this`. Calling `next` and so on would then modify the internal state (including `innerValue` and where you could insert/remove elements from in the internal buffer), and as such as not immutable.

That said, iterating was purely garbage free, so long as you didn't add or remove any elements. Adding/removing elements was obviously not garbage free since you had to write them back to the buffer, which would sometimes need to be grown to accommodate the immediate serialization.

> **Note**
> Since we only kept the serialized values in memory, the memory footprint of an `ArrayValue` with 100 integers was typically lighter than keeping, say 100 `IntegerValue` instances in memory due to the boxing overhead. That said, there was a trade-off on reading since you had to deserialize every time, which could be non-negligible for things like more complex values.

### Proposal

The proposal is to allow a little bit of garbage, but greatly simplify how the `ArrayValue` works, as well as making it fully read-immutable **and** fixing comparison of array values (yes, comparison didn't work, which was a bit of a surprise since `equals` is generally well implemented on almost all base values).

First, we get rid of the internal buffer and the reusable `innerValue`. Instead, we'll use a dumb `ArrayList` and allocate new inner values (e.g. `new IntegerValue`) via a given factory. 

> **Note**
> We can mitigate garbage here by either using a factory which pools objects, or using `ReusableObjectList` as well - though that one had some bugs, which is why I omitted it here :upside_down_face: 

This means the memory footprint is now slightly higher - every instance has some overhead, plus the overhead of the `ArrayList` itself. However, this has some nice properties:

- We can make `ArrayValue` a `RandomAccess` collection, and easily implement `size`, `isEmpty`, `get(index)`, `add(index)`, etc. 
- We can get garbage-free iteration by using a dumb `for (int i = 0; i < array.size(); i++)` and the `get(index)` method.

Unfortunately calling `iterator` (or using with an enhanced for-loop) on `ArrayValue` is likely not garbage free, though I suspect that the JIT will eventually perform scalar replacement for basic cases. I haven't verified this because I suck at JIT visualization, but it would be a nice time to start ;) Just looking at the byte code it's quite clear we're allocating, versus the C-like for-each loop which is obviously not.

You can still use the `iterator` of course for the additional protection against concurrent modification - but if you're sure, and you have a large array, then the dumb C-like for-each loop will be slightly faster typically (based on old JMH benchmark - I'd have to recreate/rerun these to see if that's still true in Java 21).

### :warning: Downside

**One big caveat here**: there were some use cases where we assumed (correctly or incorrectly?) that adding an element an `ArrayValue` would effectively copy it. Basically, whenever you called add, or iterator, etc., it would serialize anything from the `innerValue` and put it in the internal buffer. That was creating a copy of the value (and possibly growing the buffer), which made it "safer" transparently reuse the `innerValue`. With this change, in some cases, you would have to think if you need a copy of the `innerValue`'s actual value, and if so manually copy them.

For example, when adding jobs to the `JobBatchRecord#getJobs` property, we would pass the same buffer (into which we had previously copied the job) to the `ArrayValue`. Since it would serialize it to the internal buffer, it was effectively a new copy. Now that we would use just a new instance of `JobRecord`, it wouldn't, so it's a bit of a behavior change. Nothing crazy though.

### Fazit

I think the simplicity, immutability, and equality improvements are worth the slight memory usage increase, as I don't expect we often have large arrays (by this I mean not their contents, but a lot of elements). Could be wrong though :upside_down_face: 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
