### PR TITLE
ArrayValue thread-safe iteration

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionInfo.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionInfo.java
@@ -23,7 +23,7 @@ public final class VersionInfo extends UnpackedObject implements DbValue {
   // can do to hide this name.
   private final LongProperty highestVersionProp = new LongProperty("nextValue", -1L);
   private final ArrayProperty<LongValue> knownVersions =
-      new ArrayProperty<>("knownVersions", new LongValue());
+      new ArrayProperty<>("knownVersions", LongValue::new);
 
   public VersionInfo() {
     declareProperty(highestVersionProp).declareProperty(knownVersions);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
@@ -21,7 +21,7 @@ public final class AwaitProcessInstanceResultMetadata extends UnpackedObject imp
   private final IntegerProperty requestStreamIdProperty =
       new IntegerProperty("requestStreamId", -1);
   private final ArrayProperty<StringValue> fetchVariablesProperty =
-      new ArrayProperty<>("fetchVariables", new StringValue());
+      new ArrayProperty<>("fetchVariables", StringValue::new);
 
   public AwaitProcessInstanceResultMetadata() {
     declareProperty(requestIdProperty)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
@@ -23,10 +23,10 @@ public final class EventScopeInstance extends UnpackedObject implements DbValue 
   private final BooleanProperty interruptedProp = new BooleanProperty("interrupted", false);
 
   private final ArrayProperty<StringValue> interruptingElementIdsProp =
-      new ArrayProperty<>("interrupting", new StringValue());
+      new ArrayProperty<>("interrupting", StringValue::new);
 
   private final ArrayProperty<StringValue> boundaryElementIdsProp =
-      new ArrayProperty<>("boundaryElementIds", new StringValue());
+      new ArrayProperty<>("boundaryElementIds", StringValue::new);
 
   public EventScopeInstance() {
     declareProperty(acceptingProp)

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -30,6 +30,16 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
     isSet = true;
   }
 
+  /**
+   * Please be aware that doing modifications whiles iterating over an {@link ArrayValue} is not
+   * thread-safe. Modification will modify the underlying buffer and will lead to exceptions when
+   * done multiple threads are accessing this buffer simultaneously.
+   *
+   * <p>When modifying during iteration make sure to {@link MutableArrayValueIterator#flush} when
+   * done.
+   *
+   * @return an iterator for this object
+   */
   @Override
   public MutableArrayValueIterator<T> iterator() {
     return resolveValue().iterator();

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -10,8 +10,9 @@ package io.camunda.zeebe.msgpack.property;
 import io.camunda.zeebe.msgpack.MsgpackPropertyException;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.BaseValue;
+import io.camunda.zeebe.msgpack.value.MutableArrayValueIterator;
 import io.camunda.zeebe.msgpack.value.ValueArray;
-import java.util.Iterator;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -22,6 +23,11 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
     isSet = true;
   }
 
+  public ArrayProperty(final String keyString, final Supplier<T> innerValueFactory) {
+    super(keyString, new ArrayValue<>(innerValueFactory));
+    isSet = true;
+  }
+
   @Override
   public void reset() {
     super.reset();
@@ -29,7 +35,7 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
   }
 
   @Override
-  public Iterator<T> iterator() {
+  public MutableArrayValueIterator<T> iterator() {
     return resolveValue().iterator();
   }
 

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -18,10 +18,6 @@ import java.util.stream.StreamSupport;
 
 public final class ArrayProperty<T extends BaseValue> extends BaseProperty<ArrayValue<T>>
     implements ValueArray<T> {
-  public ArrayProperty(final String keyString, final T innerValue) {
-    super(keyString, new ArrayValue<>(innerValue));
-    isSet = true;
-  }
 
   public ArrayProperty(final String keyString, final Supplier<T> innerValueFactory) {
     super(keyString, new ArrayValue<>(innerValueFactory));

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
@@ -156,38 +156,27 @@ public final class ArrayValue<T extends BaseValue> extends BaseValue implements 
       return true;
     }
 
-    if (!(o instanceof ArrayValue)) {
+    if (!(o instanceof final ArrayValue<?> that)) {
       return false;
     }
 
-    final ArrayValue<?> that = (ArrayValue<?>) o;
     return elementCount == that.elementCount
         && bufferLength == that.bufferLength
         && Objects.equals(buffer, that.buffer);
   }
 
   private int getInnerValueLength() {
-    switch (innerValueState) {
-      case Insert:
-      case Modify:
-        return innerValue.getEncodedLength();
-      case Uninitialized:
-      default:
-        return 0;
-    }
+    return switch (innerValueState) {
+      case Insert, Modify -> innerValue.getEncodedLength();
+      default -> 0;
+    };
   }
 
   private void flushAndResetInnerValue() {
     switch (innerValueState) {
-      case Insert:
-        insertInnerValue();
-        break;
-      case Modify:
-        updateInnerValue();
-        break;
-      case Uninitialized:
-      default:
-        break;
+      case Insert -> insertInnerValue();
+      case Modify -> updateInnerValue();
+      default -> {}
     }
 
     resetInnerValue();

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
@@ -30,12 +30,6 @@ public final class ArrayValue<T extends BaseValue> extends BaseValue implements 
   // iterator
   private int cursorOffset;
 
-  public ArrayValue(final T innerValue) {
-    this.innerValue = innerValue;
-    innerValueFactory = null;
-    reset();
-  }
-
   public ArrayValue(final Supplier<T> innerValueFactory) {
     this.innerValueFactory = innerValueFactory;
     innerValue = innerValueFactory.get();

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
@@ -108,9 +108,12 @@ public final class ArrayValue<T extends BaseValue> extends BaseValue implements 
   }
 
   /**
-   * Please be aware that iterating over an {@link ArrayValue} is not thread-safe. Iterating over
-   * this will modify the buffer. Multiple threads iterating over the same object will result in
-   * exceptions!
+   * Please be aware that doing modifications whiles iterating over an {@link ArrayValue} is not
+   * thread-safe. Modification will modify the underlying buffer and will lead to exceptions when
+   * done multiple threads are accessing this buffer simultaneously.
+   *
+   * <p>When modifying during iteration make sure to {@link MutableArrayValueIterator#flush} when
+   * done.
    *
    * @return an iterator for this object
    */

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
@@ -16,7 +16,6 @@ import org.agrona.ExpandableArrayBuffer;
 
 public final class ArrayValue<T extends BaseValue> extends BaseValue implements Iterable<T> {
   private final MsgPackWriter writer = new MsgPackWriter();
-  private final MsgPackReader reader = new MsgPackReader();
 
   // buffer
   private final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(10);

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/MutableArrayValueIterator.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/MutableArrayValueIterator.java
@@ -11,5 +11,9 @@ import java.util.Iterator;
 
 public interface MutableArrayValueIterator<T extends BaseValue> extends Iterator<T> {
 
+  /**
+   * Write any changes made to the value to the underlying buffer. This must be called when
+   * modifying a value during iteration. If not, the changes are not written to the buffer!
+   */
   void flush();
 }

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/MutableArrayValueIterator.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/MutableArrayValueIterator.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.msgpack.value;
+
+import java.util.Iterator;
+
+public interface MutableArrayValueIterator<T extends BaseValue> extends Iterator<T> {
+
+  void flush();
+}

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -17,8 +17,6 @@ import io.camunda.zeebe.msgpack.value.BaseValue;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -37,7 +35,7 @@ public final class ArrayValueTest {
   @Rule public final ExpectedException exception = ExpectedException.none();
   private final MsgPackWriter writer = new MsgPackWriter();
   private final MsgPackReader reader = new MsgPackReader();
-  private final ArrayValue<IntegerValue> array = new ArrayValue<>(new IntegerValue());
+  private final ArrayValue<IntegerValue> array = new ArrayValue<IntegerValue>(IntegerValue::new);
 
   @Test
   public void shouldAppendValues() {
@@ -213,7 +211,7 @@ public final class ArrayValueTest {
   @Test
   public void shouldUpdateWithSmallerValue() {
     // given
-    final ArrayValue<StringValue> array = new ArrayValue<>(new StringValue());
+    final ArrayValue<StringValue> array = new ArrayValue<StringValue>(StringValue::new);
     addStringValues(array, "foo", "bar", "baz");
 
     // when
@@ -233,7 +231,7 @@ public final class ArrayValueTest {
   @Test
   public void shouldUpdateWithBiggerValue() {
     // given
-    final ArrayValue<StringValue> array = new ArrayValue<>(new StringValue());
+    final ArrayValue<StringValue> array = new ArrayValue<StringValue>(StringValue::new);
     addStringValues(array, "foo", "bar", "baz");
 
     // when
@@ -298,12 +296,12 @@ public final class ArrayValueTest {
   @Test
   public void shouldSerializeUndeclaredProperties() {
     // given
-    final ArrayValue<Foo> fooArray = new ArrayValue<>(new Foo());
+    final ArrayValue<Foo> fooArray = new ArrayValue<Foo>(Foo::new);
     fooArray.add().setFoo("foo").setBar("bar");
 
     final DirectBuffer buffer = encode(fooArray);
 
-    final ArrayValue<Bar> barArray = new ArrayValue<>(new Bar());
+    final ArrayValue<Bar> barArray = new ArrayValue<Bar>(Bar::new);
 
     // when
     decode(barArray, buffer);
@@ -356,7 +354,7 @@ public final class ArrayValueTest {
   @Test
   public void shouldWriteJson() {
     // given
-    final ArrayValue<MinimalPOJO> array = new ArrayValue<>(new MinimalPOJO());
+    final ArrayValue<MinimalPOJO> array = new ArrayValue<MinimalPOJO>(MinimalPOJO::new);
     array.add().setLongProp(1);
     array.add().setLongProp(2);
     array.add().setLongProp(3);

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -70,10 +70,13 @@ public final class ArrayValueTest {
     addIntValues(array, 1, 2, 3);
 
     // when
-    final Iterator<IntegerValue> iterator = array.iterator();
+    final var iterator = array.iterator();
     iterator.next().setValue(4);
+    iterator.flush();
     iterator.next().setValue(5);
+    iterator.flush();
     iterator.next().setValue(6);
+    iterator.flush();
 
     // then
     encodeAndDecode(array);
@@ -185,13 +188,16 @@ public final class ArrayValueTest {
     addStringValues(array, "foo", "bar", "baz");
 
     // when
-    final Iterator<StringValue> iterator = array.iterator();
+    final var iterator = array.iterator();
     StringValue element = iterator.next();
     element.wrap(BufferUtil.wrapString("a"));
+    iterator.flush();
     element = iterator.next();
     element.wrap(BufferUtil.wrapString("b"));
+    iterator.flush();
     element = iterator.next();
     element.wrap(BufferUtil.wrapString("c"));
+    iterator.flush();
 
     // then
     encodeAndDecode(array);
@@ -205,13 +211,16 @@ public final class ArrayValueTest {
     addStringValues(array, "foo", "bar", "baz");
 
     // when
-    final Iterator<StringValue> iterator = array.iterator();
+    final var iterator = array.iterator();
     StringValue element = iterator.next();
     element.wrap(BufferUtil.wrapString("hello"));
+    iterator.flush();
     element = iterator.next();
     element.wrap(BufferUtil.wrapString("world"));
+    iterator.flush();
     element = iterator.next();
     element.wrap(BufferUtil.wrapString("friend"));
+    iterator.flush();
 
     // then
     encodeAndDecode(array);
@@ -250,7 +259,9 @@ public final class ArrayValueTest {
 
     // when
     decode(barArray, buffer);
-    barArray.iterator().next().setBar("barbar");
+    final var iterator = barArray.iterator();
+    iterator.next().setBar("barbar");
+    iterator.flush();
 
     // then
     encodeAndDecode(barArray);

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -48,36 +48,6 @@ public final class ArrayValueTest {
   }
 
   @Test
-  public void shouldAddValueAtBeginning() {
-    // given
-    addIntValues(array, 1, 2, 3);
-
-    // when
-    // reset iterator to append at beginning
-    array.iterator();
-    addIntValues(array, 4, 5, 6);
-
-    // then
-    encodeAndDecode(array);
-    assertIntValues(array, 4, 5, 6, 1, 2, 3);
-  }
-
-  @Test
-  public void shouldAddValueInBetween() {
-    // given
-    addIntValues(array, 1, 2, 3);
-
-    // when
-    final Iterator<IntegerValue> iterator = array.iterator();
-    iterator.next();
-    addIntValues(array, 4, 5, 6);
-
-    // then
-    encodeAndDecode(array);
-    assertIntValues(array, 1, 4, 5, 6, 2, 3);
-  }
-
-  @Test
   public void shouldAddValuesAtEndAfterRead() {
     // given
     addIntValues(array, 1, 2, 3);
@@ -266,31 +236,6 @@ public final class ArrayValueTest {
     // then
     encodeAndDecode(array);
     assertIntValues(array, values);
-  }
-
-  @Test
-  public void shouldIncreaseInternalBufferWhenAddingToBeginning() {
-    // given
-    final int valueCount = 10_000;
-    final List<Integer> generatedList =
-        IntStream.iterate(0, (i) -> ++i).limit(valueCount).boxed().collect(Collectors.toList());
-    final List<Integer> reverseList = new ArrayList<>(generatedList);
-    Collections.reverse(generatedList);
-
-    final Integer[] values = generatedList.toArray(new Integer[valueCount]);
-
-    // when
-    for (final Integer value : values) {
-      // reset cursor to first position
-      array.iterator();
-      array.add().setValue(value);
-    }
-
-    // then
-    encodeAndDecode(array);
-
-    final Integer[] resultValues = reverseList.toArray(new Integer[valueCount]);
-    assertIntValues(array, resultValues);
   }
 
   @Test

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArray.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArray.java
@@ -15,7 +15,7 @@ public final class POJOArray extends UnpackedObject {
   protected final ArrayProperty<MinimalPOJO> simpleArrayProp;
 
   public POJOArray() {
-    simpleArrayProp = new ArrayProperty<>("simpleArray", new MinimalPOJO());
+    simpleArrayProp = new ArrayProperty<>("simpleArray", MinimalPOJO::new);
 
     declareProperty(simpleArrayProp);
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -53,7 +53,7 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
 
   private final ArrayProperty<EvaluatedDecisionRecord> evaluatedDecisionsProp =
-      new ArrayProperty<>("evaluatedDecisions", new EvaluatedDecisionRecord());
+      new ArrayProperty<>("evaluatedDecisions", EvaluatedDecisionRecord::new);
 
   private final StringProperty evaluationFailureMessageProp =
       new StringProperty("evaluationFailureMessage", "");

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -38,10 +38,10 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
   private final BinaryProperty decisionOutputProp = new BinaryProperty("decisionOutput");
 
   private final ArrayProperty<EvaluatedInputRecord> evaluatedInputsProp =
-      new ArrayProperty<>("evaluatedInputs", new EvaluatedInputRecord());
+      new ArrayProperty<>("evaluatedInputs", EvaluatedInputRecord::new);
 
   private final ArrayProperty<MatchedRuleRecord> matchedRulesProp =
-      new ArrayProperty<>("matchedRules", new MatchedRuleRecord());
+      new ArrayProperty<>("matchedRules", MatchedRuleRecord::new);
 
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
@@ -28,7 +28,7 @@ public final class MatchedRuleRecord extends UnifiedRecordValue implements Match
   private final IntegerProperty ruleIndexProp = new IntegerProperty("ruleIndex");
 
   private final ArrayProperty<EvaluatedOutputRecord> evaluatedOutputsProp =
-      new ArrayProperty<>("evaluatedOutputs", new EvaluatedOutputRecord());
+      new ArrayProperty<>("evaluatedOutputs", EvaluatedOutputRecord::new);
 
   public MatchedRuleRecord() {
     declareProperty(ruleIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -29,19 +29,19 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
   public static final String PROCESSES = "processesMetadata";
 
   private final ArrayProperty<DeploymentResource> resourcesProp =
-      new ArrayProperty<>(RESOURCES, new DeploymentResource());
+      new ArrayProperty<>(RESOURCES, DeploymentResource::new);
 
   private final ArrayProperty<ProcessMetadata> processesMetadataProp =
-      new ArrayProperty<>(PROCESSES, new ProcessMetadata());
+      new ArrayProperty<>(PROCESSES, ProcessMetadata::new);
 
   private final ArrayProperty<DecisionRecord> decisionMetadataProp =
-      new ArrayProperty<>("decisionsMetadata", new DecisionRecord());
+      new ArrayProperty<>("decisionsMetadata", DecisionRecord::new);
 
   private final ArrayProperty<DecisionRequirementsMetadataRecord> decisionRequirementsMetadataProp =
-      new ArrayProperty<>("decisionRequirementsMetadata", new DecisionRequirementsMetadataRecord());
+      new ArrayProperty<>("decisionRequirementsMetadata", DecisionRequirementsMetadataRecord::new);
 
   private final ArrayProperty<FormMetadataRecord> formMetadataProp =
-      new ArrayProperty<>("formMetadata", new FormMetadataRecord());
+      new ArrayProperty<>("formMetadata", FormMetadataRecord::new);
 
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -34,12 +34,12 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final IntegerProperty maxJobsToActivateProp =
       new IntegerProperty("maxJobsToActivate", -1);
   private final ArrayProperty<LongValue> jobKeysProp =
-      new ArrayProperty<>("jobKeys", new LongValue());
-  private final ArrayProperty<JobRecord> jobsProp = new ArrayProperty<>("jobs", new JobRecord());
+      new ArrayProperty<>("jobKeys", LongValue::new);
+  private final ArrayProperty<JobRecord> jobsProp = new ArrayProperty<>("jobs", JobRecord::new);
   private final ArrayProperty<StringValue> tenantIdsProp =
-      new ArrayProperty<>("tenantIds", new StringValue());
+      new ArrayProperty<>("tenantIds", StringValue::new);
   private final ArrayProperty<StringValue> variablesProp =
-      new ArrayProperty<>("variables", new StringValue());
+      new ArrayProperty<>("variables", StringValue::new);
   private final BooleanProperty truncatedProp = new BooleanProperty("truncated", false);
 
   public JobBatchRecord() {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
@@ -20,7 +20,7 @@ public final class MessageBatchRecord extends UnifiedRecordValue
     implements MessageBatchRecordValue {
 
   private final ArrayProperty<LongValue> messageKeysProp =
-      new ArrayProperty<>("messageKeys", new LongValue());
+      new ArrayProperty<>("messageKeys", LongValue::new);
 
   public MessageBatchRecord() {
     declareProperty(messageKeysProp);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -39,10 +39,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private final LongProperty processInstanceKeyProperty =
       new LongProperty("processInstanceKey", -1);
   private final ArrayProperty<StringValue> fetchVariablesProperty =
-      new ArrayProperty<>("fetchVariables", new StringValue());
+      new ArrayProperty<>("fetchVariables", StringValue::new);
 
   private final ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructionsProperty =
-      new ArrayProperty<>("startInstructions", new ProcessInstanceCreationStartInstruction());
+      new ArrayProperty<>("startInstructions", ProcessInstanceCreationStartInstruction::new);
 
   public ProcessInstanceCreationRecord() {
     declareProperty(bpmnProcessIdProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
@@ -35,10 +35,10 @@ public final class ProcessInstanceModificationActivateInstruction extends Object
   private final ArrayProperty<ProcessInstanceModificationVariableInstruction>
       variableInstructionsProperty =
           new ArrayProperty<>(
-              "variableInstructions", new ProcessInstanceModificationVariableInstruction());
+              "variableInstructions", ProcessInstanceModificationVariableInstruction::new);
 
   private final ArrayProperty<LongValue> ancestorScopeKeysProperty =
-      new ArrayProperty<>("ancestorScopeKeys", new LongValue());
+      new ArrayProperty<>("ancestorScopeKeys", LongValue::new);
 
   public ProcessInstanceModificationActivateInstruction() {
     declareProperty(elementIdProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -26,15 +26,15 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   private final ArrayProperty<ProcessInstanceModificationTerminateInstruction>
       terminateInstructionsProperty =
           new ArrayProperty<>(
-              "terminateInstructions", new ProcessInstanceModificationTerminateInstruction());
+              "terminateInstructions", ProcessInstanceModificationTerminateInstruction::new);
   private final ArrayProperty<ProcessInstanceModificationActivateInstruction>
       activateInstructionsProperty =
           new ArrayProperty<>(
-              "activateInstructions", new ProcessInstanceModificationActivateInstruction());
+              "activateInstructions", ProcessInstanceModificationActivateInstruction::new);
 
   @Deprecated(since = "8.1.3")
   private final ArrayProperty<LongValue> activatedElementInstanceKeys =
-      new ArrayProperty<>("activatedElementInstanceKeys", new LongValue());
+      new ArrayProperty<>("activatedElementInstanceKeys", LongValue::new);
 
   public ProcessInstanceModificationRecord() {
     declareProperty(processInstanceKeyProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import java.util.List;
@@ -26,9 +25,9 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   private final StringProperty workerProp = new StringProperty("worker", "");
   private final LongProperty timeoutProp = new LongProperty("timeout", -1);
   private final ArrayProperty<StringValue> fetchVariablesProp =
-      new ArrayProperty<>("variables", new StringValue());
+      new ArrayProperty<>("variables", StringValue::new);
   private final ArrayProperty<StringValue> tenantIdsProp =
-      new ArrayProperty<>("tenantIds", new StringValue(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+      new ArrayProperty<StringValue>("tenantIds", StringValue::new);
 
   public JobActivationPropertiesImpl() {
     declareProperty(workerProp)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR makes iterating over the `ArrayValue` thread-safe. It does so by extracting the Iterator to a separate class, instead of being an iterator by itself. This allows us to read from the buffer from multiple threads at once.

One limitation is modifying values whilst iterating. This will still modify the underlying buffer, and as a result it **not** thread-safe. Another thing to note is that after modifying, `flush()` must be called explicitly.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14624 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
