### PR TITLE
Allow changing raft partition's priority for priority election

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -323,6 +323,16 @@ public interface RaftServer {
   CompletableFuture<RaftServer> promote();
 
   /**
+   * Update priority of this server used for priority election. If priority election is not enabled,
+   * this method has no effect. To get the desired result, priority of all replicas must be updated
+   * accordingly. This method only updates the local server's priority.
+   *
+   * @param newPriority the priority to be set
+   * @return a future to be completed when the new priority is applied
+   */
+  CompletableFuture<Void> reconfigurePriority(int newPriority);
+
+  /**
    * Ensures that all records written to the log are flushed to disk
    *
    * @return a future which will be completed after the log is flushed to disk

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -99,6 +99,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public CompletableFuture<RaftServer> join(final Collection<MemberId> cluster) {
+    return start(() -> cluster().join(cluster));
+  }
+
+  @Override
   public CompletableFuture<RaftServer> leave() {
     return context.leave().thenApply(v -> this);
   }
@@ -106,6 +111,11 @@ public class DefaultRaftServer implements RaftServer {
   @Override
   public CompletableFuture<RaftServer> promote() {
     return context.anoint().thenApply(v -> this);
+  }
+
+  @Override
+  public CompletableFuture<Void> reconfigurePriority(final int newPriority) {
+    return context.reconfigurePriority(newPriority);
   }
 
   @Override
@@ -167,11 +177,6 @@ public class DefaultRaftServer implements RaftServer {
   public CompletableFuture<Void> stepDown() {
     return CompletableFuture.runAsync(
         () -> context.transition(Role.FOLLOWER), context.getThreadContext());
-  }
-
-  @Override
-  public CompletableFuture<RaftServer> join(final Collection<MemberId> cluster) {
-    return start(() -> cluster().join(cluster));
   }
 
   /** Starts the server. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/PriorityElectionTimer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/PriorityElectionTimer.java
@@ -29,7 +29,7 @@ public class PriorityElectionTimer implements ElectionTimer {
   private final Runnable triggerElection;
   private final Logger log;
   private final int initialTargetPriority;
-  private final int nodePriority;
+  private int nodePriority;
   private int targetPriority;
 
   public PriorityElectionTimer(
@@ -60,6 +60,10 @@ public class PriorityElectionTimer implements ElectionTimer {
     if (electionTimer != null) {
       electionTimer.cancel();
     }
+  }
+
+  public void setNodePriority(final int newPriority) {
+    nodePriority = newPriority;
   }
 
   private void onElectionTimeout() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1306,6 +1306,21 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     partitionConfig.setPreferSnapshotReplicationThreshold(snapshotReplicationThreshold);
   }
 
+  public CompletableFuture<Void> reconfigurePriority(final int newPriority) {
+    final CompletableFuture<Void> configureFuture = new CompletableFuture<>();
+    threadContext.execute(
+        () -> {
+          electionConfig.setNodePriority(newPriority);
+          if (role instanceof final FollowerRole followerRole
+              && followerRole.getElectionTimer()
+                  instanceof final PriorityElectionTimer priorityElectionTimer) {
+            priorityElectionTimer.setNodePriority(newPriority);
+          }
+          configureFuture.complete(null);
+        });
+    return configureFuture;
+  }
+
   public int getPartitionId() {
     return partitionId;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftElectionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftElectionConfig.java
@@ -19,7 +19,7 @@ public final class RaftElectionConfig {
 
   private final boolean priorityElectionEnabled;
   private final int initialTargetPriority;
-  private final int nodePriority;
+  private int nodePriority;
 
   private RaftElectionConfig(
       final boolean priorityElectionEnabled,
@@ -49,5 +49,9 @@ public final class RaftElectionConfig {
 
   public int getNodePriority() {
     return nodePriority;
+  }
+
+  public void setNodePriority(final int nodePriority) {
+    this.nodePriority = nodePriority;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -143,6 +143,10 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server != null ? server.shutdown() : CompletableFuture.completedFuture(null);
   }
 
+  public CompletableFuture<Void> reconfigurePriority(final int newPriority) {
+    return server.reconfigurePriority(newPriority);
+  }
+
   private RaftServer buildServer() {
     final var partitionId = partition.id().id();
     final var electionConfig =

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -52,6 +52,10 @@ public final class FollowerRole extends ActiveRole {
     electionTimer = electionTimerFactory.create(this::schedulePollRequests, log);
   }
 
+  public ElectionTimer getElectionTimer() {
+    return electionTimer;
+  }
+
   @Override
   public synchronized CompletableFuture<RaftRole> start() {
     raft.getMembershipService().addListener(clusterListener);

--- a/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
@@ -29,7 +29,7 @@ public final class DeterministicSingleThreadContext implements ThreadContext {
 
   private final DeterministicScheduler deterministicScheduler;
 
-  private DeterministicSingleThreadContext(final DeterministicScheduler executor) {
+  public DeterministicSingleThreadContext(final DeterministicScheduler executor) {
     deterministicScheduler = executor;
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopPartitionChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopPartitionChangeExecutor.java
@@ -24,4 +24,9 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
   public ActorFuture<Void> leave(final int partitionId) {
     return CompletableActorFuture.completed(null);
   }
+
+  @Override
+  public ActorFuture<Void> reconfigurePriority(final int partitionId, final int newPriority) {
+    return CompletableActorFuture.completed(null);
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionChangeExecutor.java
@@ -40,4 +40,13 @@ public interface PartitionChangeExecutor {
    * @return a future that completes when the partition is stopped and removed from the replication.
    */
   ActorFuture<Void> leave(int partitionId);
+
+  /**
+   * Updates the priority of the member used for raft priority election for the given partition.
+   *
+   * @param partitionId id of hte partition
+   * @param newPriority new priority value
+   * @return a future that completes when the priority is updated
+   */
+  ActorFuture<Void> reconfigurePriority(int partitionId, int newPriority);
 }


### PR DESCRIPTION
## Description

To support partition re-assignment for scaling brokers, we have to change priority of partition replicas. This PR adds support for it in raft and the PartitionManager.
- RaftContext exposes methods for changing priority used for priority election. When changing this the current timer as well as the election config is updated.
- PartitionManagerImpl allows changing the priority which can be triggered by the topology change.

## Related issues

related #14745 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
