### PR TITLE
[Backport stable/8.0] Capture async stack traces of scheduler jobs

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -102,6 +102,7 @@
     <version.kryo>5.3.0</version.kryo>
     <version.awaitility>4.0.3</version.awaitility>
     <version.failsafe>2.4.4</version.failsafe>
+    <version.jetbrains-annotations>24.0.1</version.jetbrains-annotations>
     <version.jqwik>1.6.5</version.jqwik>
     <version.jmock>2.12.0</version.jmock>
     <version.json-smart>2.4.11</version.json-smart>
@@ -1018,6 +1019,12 @@
         <artifactId>annotations</artifactId>
         <version>${version.findbugs-annotations}</version>
         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${version.jetbrains-annotations}</version>
       </dependency>
 
       <dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -62,6 +62,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorJob.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorJob.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.util.sched.ActorTask.TaskSchedulingState;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.concurrent.Callable;
+import org.jetbrains.annotations.Async;
 import org.slf4j.Logger;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
@@ -36,6 +37,7 @@ public final class ActorJob {
     schedulingState = TaskSchedulingState.QUEUED;
   }
 
+  @Async.Execute
   void execute(final ActorThread runner) {
     actorThread = runner;
     try {

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.jetbrains.annotations.Async;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +98,7 @@ public class ActorTask {
   }
 
   /** Used to externally submit a job. */
-  public void submit(final ActorJob job) {
+  public void submit(@Async.Schedule final ActorJob job) {
     // get reference to jobs queue
     final Queue<ActorJob> submittedJobs = this.submittedJobs;
 
@@ -531,7 +532,7 @@ public class ActorTask {
     actorThreadGroup.submit(this);
   }
 
-  public void insertJob(final ActorJob job) {
+  public void insertJob(@Async.Schedule final ActorJob job) {
     fastLaneJobs.addFirst(job);
   }
 


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/14747