### PR TITLE
[Backport stable/8.2] Capture async stack traces of scheduler jobs

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1014,14 +1014,13 @@
         <scope>import</scope>
       </dependency>
 
-      <!-- Dependencies present for convergence only -->
-      <!-- between duct-tape (from testcontainers) and kotlin-stdlib (from identity-sdk) -->
       <dependency>
         <groupId>org.jetbrains</groupId>
         <artifactId>annotations</artifactId>
         <version>${version.jetbrains-annotations}</version>
       </dependency>
 
+      <!-- Dependencies present for convergence only -->
       <!-- between log4j2 and commons-compress (from testcontainers) -->
       <dependency>
         <groupId>org.osgi</groupId>

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -74,6 +74,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
 
   </dependencies>
   <build>

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Loggers;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.util.concurrent.Callable;
+import org.jetbrains.annotations.Async;
 import org.slf4j.Logger;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
@@ -38,6 +39,7 @@ public final class ActorJob {
     schedulingState = TaskSchedulingState.QUEUED;
   }
 
+  @Async.Execute
   void execute(final ActorThread runner) {
     actorThread = runner;
     observeSchedulingLatency(runner.getActorMetrics());

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
@@ -68,11 +68,11 @@ public final class ActorJob {
   private void observeSchedulingLatency(final ActorMetrics metrics) {
     if (metrics.isEnabled()) {
       final var now = System.nanoTime();
-      if (subscription instanceof ActorFutureSubscription s
-          && s.getFuture() instanceof CompletableActorFuture<?> f) {
+      if (subscription instanceof final ActorFutureSubscription s
+          && s.getFuture() instanceof final CompletableActorFuture<?> f) {
         final var subscriptionCompleted = f.getCompletedAt();
         metrics.observeJobSchedulingLatency(now - subscriptionCompleted, "Future");
-      } else if (subscription instanceof TimerSubscription s) {
+      } else if (subscription instanceof final TimerSubscription s) {
         final var timerExpired = s.getTimerExpiredAt();
         metrics.observeJobSchedulingLatency(now - timerExpired, "Timer");
       } else if (subscription == null && scheduledAt != -1) {

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.jetbrains.annotations.Async;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +92,7 @@ public class ActorTask {
   }
 
   /** Used to externally submit a job. */
-  public void submit(final ActorJob job) {
+  public void submit(@Async.Schedule final ActorJob job) {
     // get reference to jobs queue
     final Queue<ActorJob> submittedJobs = this.submittedJobs;
 
@@ -500,7 +501,7 @@ public class ActorTask {
     actorThreadGroup.submit(this);
   }
 
-  public void insertJob(final ActorJob job) {
+  public void insertJob(@Async.Schedule final ActorJob job) {
     fastLaneJobs.addFirst(job);
   }
 


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/14747