### PR TITLE
Store job activation properties immutably in broker stream registry

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -19,6 +19,9 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
+import java.util.Collection;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
 
 /**
  * Sets up the {@link JobStreamService}, which manages the lifecycle of the job specific stream API
@@ -40,7 +43,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
         new TransportFactory(scheduler)
             .createRemoteStreamServer(
                 clusterServices.getCommunicationService(),
-                JobActivationPropertiesImpl::new,
+                JobStreamServiceStep::readJobActivationProperties,
                 errorHandlerService,
                 new JobStreamMetrics());
     final var errorHandlerStarted = scheduler.submitActor(errorHandlerService);
@@ -112,8 +115,34 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     }
   }
 
+  private static JobActivationProperties readJobActivationProperties(final DirectBuffer buffer) {
+    final var mutable = new JobActivationPropertiesImpl();
+    mutable.wrap(buffer);
+
+    return new ImmutableJobActivationPropertiesImpl(
+        mutable.worker(), mutable.timeout(), mutable.fetchVariables(), mutable.tenantIds());
+  }
+
   @Override
   public String getName() {
     return "JobStreamService";
+  }
+
+  private record ImmutableJobActivationPropertiesImpl(
+      DirectBuffer worker,
+      long timeout,
+      Collection<DirectBuffer> fetchVariables,
+      Collection<String> tenantIds)
+      implements JobActivationProperties {
+
+    @Override
+    public int getLength() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Collection;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -115,7 +116,8 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     }
   }
 
-  private static JobActivationProperties readJobActivationProperties(final DirectBuffer buffer) {
+  @VisibleForTesting("https://github.com/camunda/zeebe/issues/14624")
+  static JobActivationProperties readJobActivationProperties(final DirectBuffer buffer) {
     final var mutable = new JobActivationPropertiesImpl();
     mutable.wrap(buffer);
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class JobStreamServiceStepTest {
+
+  @Nested
+  final class ImmutableJobActivationPropertiesTest {
+    @Test
+    void shouldDeserializeImmutableActivationProperties() {
+      // given
+      final var worker = BufferUtil.wrapString("worker");
+      final var properties =
+          new JobActivationPropertiesImpl()
+              .setTimeout(250)
+              .setFetchVariables(List.of(new StringValue("foo"), new StringValue("bar")))
+              .setWorker(worker, 0, worker.capacity())
+              .setTenantIds(List.of("tenant1", "tenant2"));
+      final var buffer = BufferUtil.createCopy(properties);
+
+      // when
+      final var immutable = JobStreamServiceStep.readJobActivationProperties(buffer);
+
+      // then
+      assertThat(immutable.worker()).isEqualTo(worker).isNotSameAs(worker);
+      assertThat(immutable.timeout()).isEqualTo(250L);
+      assertThat(immutable.fetchVariables())
+          .containsExactlyInAnyOrder(BufferUtil.wrapString("foo"), BufferUtil.wrapString("bar"));
+      assertThat(immutable.tenantIds()).containsExactlyInAnyOrder("tenant1", "tenant2");
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -67,7 +67,7 @@ public class BpmnJobActivationBehavior {
     final Optional<JobStream> optionalJobStream =
         jobStreamer.streamFor(
             wrappedJobRecord.getTypeBuffer(),
-            jobActivationProperties -> jobActivationProperties.getTenantIds().contains(tenantId));
+            jobActivationProperties -> jobActivationProperties.tenantIds().contains(tenantId));
 
     if (optionalJobStream.isPresent()) {
       final JobStream jobStream = optionalJobStream.get();

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
@@ -8,17 +8,15 @@
 package io.camunda.zeebe.protocol.impl.stream.job;
 
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
-import java.util.List;
 import org.agrona.DirectBuffer;
 
 /**
  * {@link JobActivationProperties} represents the minimum set of properties required to activate a
  * {@link JobRecordValue} in the engine.
  */
-public interface JobActivationProperties extends BufferReader, BufferWriter {
+public interface JobActivationProperties extends BufferWriter {
 
   /**
    * Returns the name of the worker. This is mostly used for debugging purposes.
@@ -49,5 +47,5 @@ public interface JobActivationProperties extends BufferReader, BufferWriter {
    *
    * @return the identifiers of the tenants for which to activate jobs
    */
-  List<String> getTenantIds();
+  Collection<String> tenantIds();
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
-import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
@@ -72,7 +71,7 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   }
 
   @Override
-  public List<String> getTenantIds() {
+  public Collection<String> tenantIds() {
     return StreamSupport.stream(tenantIdsProp.spliterator(), false)
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
@@ -83,9 +82,5 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
     tenantIdsProp.reset();
     tenantIds.forEach(tenantId -> tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId)));
     return this;
-  }
-
-  public ValueArray<StringValue> tenantIds() {
-    return tenantIdsProp;
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -23,9 +23,9 @@ import io.camunda.zeebe.transport.stream.impl.RemoteStreamRegistry;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamServiceImpl;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamTransport;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamerImpl;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.util.function.Supplier;
+import java.util.function.Function;
+import org.agrona.DirectBuffer;
 
 public final class TransportFactory {
 
@@ -48,12 +48,11 @@ public final class TransportFactory {
     return atomixClientTransportAdapter;
   }
 
-  public <M extends BufferReader, P extends BufferWriter>
-      RemoteStreamService<M, P> createRemoteStreamServer(
-          final ClusterCommunicationService clusterCommunicationService,
-          final Supplier<M> metadataFactory,
-          final RemoteStreamErrorHandler<P> errorHandler,
-          final RemoteStreamMetrics metrics) {
+  public <M, P extends BufferWriter> RemoteStreamService<M, P> createRemoteStreamServer(
+      final ClusterCommunicationService clusterCommunicationService,
+      final Function<DirectBuffer, M> metadataFactory,
+      final RemoteStreamErrorHandler<P> errorHandler,
+      final RemoteStreamMetrics metrics) {
     final RemoteStreamRegistry<M> registry = new RemoteStreamRegistry<>(metrics);
     return new RemoteStreamServiceImpl<>(
         new RemoteStreamerImpl<>(clusterCommunicationService, registry, errorHandler, metrics),

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStream.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStream.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 
 /**
@@ -23,7 +22,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
  * @param <M> associated metadata with the stream
  * @param <P> the payload type that can be pushed to the stream
  */
-public interface RemoteStream<M extends BufferReader, P extends BufferWriter> {
+public interface RemoteStream<M, P extends BufferWriter> {
   /** Returns the stream's metadata */
   M metadata();
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamService.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamService.java
@@ -11,7 +11,6 @@ import io.atomix.cluster.ClusterMembershipEventListener;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 
@@ -21,7 +20,7 @@ import java.util.Collection;
  * @param <M> associated metadata with a stream
  * @param <P> the payload type that can be pushed to the streams
  */
-public interface RemoteStreamService<M extends BufferReader, P extends BufferWriter>
+public interface RemoteStreamService<M, P extends BufferWriter>
     extends ClusterMembershipEventListener {
   ActorFuture<RemoteStreamer<M, P>> start(
       ActorSchedulingService actorSchedulingService, ConcurrencyControl concurrencyControl);

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamer.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -22,7 +21,7 @@ import org.agrona.DirectBuffer;
  * @param <P> the payload type that can be pushed to the stream
  */
 @FunctionalInterface
-public interface RemoteStreamer<M extends BufferReader, P extends BufferWriter> {
+public interface RemoteStreamer<M, P extends BufferWriter> {
   /**
    * Returns a valid stream for the given streamType, or {@link Optional#empty()} if there is none.
    *

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImpl.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.transport.stream.api.RemoteStream;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
 import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
 import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamConsumer;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,8 +19,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class RemoteStreamImpl<M extends BufferReader, P extends BufferWriter>
-    implements RemoteStream<M, P> {
+public final class RemoteStreamImpl<M, P extends BufferWriter> implements RemoteStream<M, P> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RemoteStreamImpl.class);
   private final AggregatedRemoteStream<M> stream;

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
@@ -17,13 +17,12 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamInfo;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.stream.Stream;
 
-public class RemoteStreamServiceImpl<M extends BufferReader, P extends BufferWriter>
+public class RemoteStreamServiceImpl<M, P extends BufferWriter>
     implements RemoteStreamService<M, P> {
   private final RemoteStreamerImpl<M, P> streamer;
   private final RemoteStreamTransport<M> apiServer;

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -14,14 +14,13 @@ import io.camunda.zeebe.transport.stream.impl.messages.AddStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.MessageUtil;
 import io.camunda.zeebe.transport.stream.impl.messages.RemoveStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class RemoteStreamTransport<M extends BufferReader> extends Actor {
+public final class RemoteStreamTransport<M> extends Actor {
   private static final byte[] EMPTY_PAYLOAD = new byte[0];
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private static final Logger LOG = LoggerFactory.getLogger(RemoteStreamTransport.class);

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
-import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.time.Duration;
@@ -39,7 +38,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  * asynchronous, so the payload should be immutable, and the errors reported to the given {@link
  * RemoteStreamErrorHandler} may be reported on different threads.
  */
-public final class RemoteStreamerImpl<M extends BufferReader, P extends BufferWriter> extends Actor
+public final class RemoteStreamerImpl<M, P extends BufferWriter> extends Actor
     implements RemoteStreamer<M, P> {
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamApiHandlerTest.java
@@ -31,7 +31,13 @@ final class RemoteStreamApiHandlerTest {
   private final RemoteStreamRegistry<TestMetadata> registry =
       new RemoteStreamRegistry<>(RemoteStreamMetrics.noop());
   private final RemoteStreamApiHandler<TestMetadata> server =
-      new RemoteStreamApiHandler<>(registry, TestMetadata::new);
+      new RemoteStreamApiHandler<>(
+          registry,
+          buffer -> {
+            final var data = new TestMetadata();
+            data.wrap(buffer, 0, buffer.capacity());
+            return data;
+          });
 
   @Test
   void shouldNotAddOnMetadataReadError() {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -395,7 +395,11 @@ final class StreamIntegrationTest {
       streamService =
           factory.createRemoteStreamServer(
               cluster.getCommunicationService(),
-              TestSerializableData::new,
+              buffer -> {
+                final var data = new TestSerializableData();
+                data.wrap(buffer, 0, buffer.capacity());
+                return data;
+              },
               dynamicErrorHandler,
               RemoteStreamMetrics.noop());
     }


### PR DESCRIPTION
## Description

This PR fixes the issue surrounding mutable iteration of the array properties in `JobActivationPropertiesImpl`. It does so by introducing a new type, `ImmutableJobActivationProperties`, which is created from a copy of `JobActivationPropertiesImpl` once during registration and stored in the global stream registry.

This unfortunately does not solve the more general problem of immutable iteration of the array values, or accurate comparisons. A follow up PR will take care of that.

## Related issues

closes #14624 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
