### PR TITLE
Fix incorrect aggregation of gateway streams

### DIFF
--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -28,6 +28,7 @@ import java.util.stream.StreamSupport;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -391,6 +392,38 @@ public final class ArrayValueTest {
 
     // then
     assertThat(isEmpty).isFalse();
+  }
+
+  @Test
+  public void shouldBeEqual() {
+    // given
+    final var other = new ArrayValue<>(new IntegerValue());
+    addIntValues(array, 1, 2, 3);
+    array.iterator(); // force flush
+
+    // when
+    other.add().setValue(1);
+    other.add().setValue(2);
+    other.add().setValue(3);
+
+    // then - fails because it's not flushed
+    Assertions.assertThat((Object) other).isEqualTo(array);
+  }
+
+  @Test
+  public void shouldHashLatestModification() {
+    // given
+    final var other = new ArrayValue<>(new IntegerValue());
+    addIntValues(array, 1, 2, 3);
+    array.iterator(); // force flush
+
+    // when
+    other.add().setValue(1);
+    other.add().setValue(2);
+    other.add().setValue(3);
+
+    // then - fails because it's not flushed
+    Assertions.assertThat((Object) other).hasSameHashCodeAs(array);
   }
 
   // Helpers

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/JobStreamEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/JobStreamEndpointIT.java
@@ -7,19 +7,18 @@
  */
 package io.camunda.zeebe.it.management;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert.RemoteJobStreamsAssert;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteJobStream;
-import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteStreamId;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.time.Duration;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -27,11 +26,12 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 @AutoCloseResources
 final class JobStreamEndpointIT {
-  @TestZeebe private static final TestStandaloneBroker BROKER = new TestStandaloneBroker();
+  @TestZeebe
+  private static final TestCluster CLUSTER =
+      TestCluster.builder().withGatewaysCount(2).withEmbeddedGateway(false).build();
 
-  @AutoCloseResource private final ZeebeClient client = BROKER.newClientBuilder().build();
-
-  private final JobStreamActuator actuator = JobStreamActuator.of(BROKER);
+  private final TestGateway<?> gateway = CLUSTER.availableGateway();
+  @AutoCloseResource private final ZeebeClient client = gateway.newClientBuilder().build();
 
   @AfterEach
   void afterEach() {
@@ -39,12 +39,12 @@ final class JobStreamEndpointIT {
     client.close();
 
     // avoid flakiness between tests by waiting until the registries are empty
+    final var actuator = JobStreamActuator.of(gateway);
     Awaitility.await("until no streams are registered")
         .untilAsserted(
             () -> {
-              final var streams = actuator.list();
-              assertThat(streams.remote()).isEmpty();
-              assertThat(streams.client()).isEmpty();
+              JobStreamActuatorAssert.assertThat(actuator).remoteStreams().isEmpty();
+              JobStreamActuatorAssert.assertThat(actuator).clientStreams().isEmpty();
             });
   }
 
@@ -68,66 +68,69 @@ final class JobStreamEndpointIT {
         .fetchVariables("bar", "barz")
         .send();
 
-    // when
-    final var streams =
-        Awaitility.await("until all streams are registered")
-            .until(actuator::listRemote, list -> list.size() == 2);
-
     // then
-    assertThat(streams)
-        .anySatisfy(
-            stream -> {
-              assertThat(stream.jobType()).isEqualTo("foo");
-              assertThat(stream.metadata().worker()).isEqualTo("foo");
-              assertThat(stream.metadata().timeout()).isEqualTo(Duration.ofMillis(100L));
-              assertThat(stream.metadata().fetchVariables())
-                  .containsExactlyInAnyOrder("foo", "fooz");
-            })
-        .anySatisfy(
-            stream -> {
-              assertThat(stream.jobType()).isEqualTo("bar");
-              assertThat(stream.metadata().worker()).isEqualTo("bar");
-              assertThat(stream.metadata().timeout()).isEqualTo(Duration.ofMillis(250));
-              assertThat(stream.metadata().fetchVariables())
-                  .containsExactlyInAnyOrder("bar", "barz");
-            });
+    final var brokerActuator = JobStreamActuator.of(CLUSTER.brokers().get(MemberId.from("0")));
+    Awaitility.await("until foo stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(brokerActuator)
+                    .remoteStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType("foo"),
+                        RemoteJobStreamsAssert.hasWorker("foo"),
+                        RemoteJobStreamsAssert.hasTimeout(100L),
+                        RemoteJobStreamsAssert.hasFetchVariables("foo", "fooz")));
+    Awaitility.await("until bar stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(brokerActuator)
+                    .remoteStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType("bar"),
+                        RemoteJobStreamsAssert.hasWorker("bar"),
+                        RemoteJobStreamsAssert.hasTimeout(250L),
+                        RemoteJobStreamsAssert.hasFetchVariables("bar", "barz")));
   }
 
   @Test
   void shouldListMultipleRemoteConsumers() {
     // given
-    client
-        .newStreamJobsCommand()
-        .jobType("foo")
-        .consumer(ignored -> {})
-        .workerName("foo")
-        .timeout(Duration.ofMillis(100))
-        .fetchVariables("foo", "fooz")
-        .send();
-    client
-        .newStreamJobsCommand()
-        .jobType("foo")
-        .consumer(ignored -> {})
-        .workerName("foo")
-        .timeout(Duration.ofMillis(100))
-        .fetchVariables("foo", "fooz")
-        .send();
+    //noinspection resource
+    final var otherGateway =
+        CLUSTER.gateways().values().stream()
+            .filter(g -> !g.nodeId().equals(gateway.nodeId()))
+            .findAny()
+            .orElseThrow();
+    try (final var otherClient = otherGateway.newClientBuilder().build()) {
+      client
+          .newStreamJobsCommand()
+          .jobType("foo")
+          .consumer(ignored -> {})
+          .workerName("foo")
+          .timeout(Duration.ofMillis(100))
+          .fetchVariables("foo", "fooz")
+          .send();
+      otherClient
+          .newStreamJobsCommand()
+          .jobType("foo")
+          .consumer(ignored -> {})
+          .workerName("foo")
+          .timeout(Duration.ofMillis(100))
+          .fetchVariables("foo", "fooz")
+          .send();
 
-    // when
-    final var streams =
-        Awaitility.await("until all streams are registered")
-            .atMost(Duration.ofSeconds(60))
-            .until(
-                actuator::listRemote,
-                list -> list.size() == 1 && list.get(0).consumers().size() == 2);
-
-    // then
-    assertThat(streams)
-        .first(InstanceOfAssertFactories.type(RemoteJobStream.class))
-        .extracting(RemoteJobStream::consumers)
-        .asInstanceOf(InstanceOfAssertFactories.list(RemoteStreamId.class))
-        .extracting(RemoteStreamId::receiver)
-        .containsExactly("0", "0");
+      // then
+      final var brokerActuator = JobStreamActuator.of(CLUSTER.brokers().get(MemberId.from("0")));
+      Awaitility.await("until all streams are registered")
+          .untilAsserted(
+              () ->
+                  JobStreamActuatorAssert.assertThat(brokerActuator)
+                      .remoteStreams()
+                      .haveConsumerReceiver(
+                          1, "foo", gateway.nodeId().id(), otherGateway.nodeId().id()));
+    }
   }
 
   @Test
@@ -150,30 +153,29 @@ final class JobStreamEndpointIT {
         .fetchVariables("bar", "barz")
         .send();
 
-    // when
-    final var streams =
-        Awaitility.await("until all streams are registered")
-            .until(actuator::listClient, list -> list.size() == 2);
-
     // then
-    assertThat(streams)
-        .anySatisfy(
-            stream -> {
-              assertThat(stream.jobType()).isEqualTo("foo");
-              assertThat(stream.metadata().worker()).isEqualTo("foo");
-              assertThat(stream.metadata().timeout()).isEqualTo(Duration.ofMillis(100));
-              assertThat(stream.metadata().fetchVariables())
-                  .containsExactlyInAnyOrder("foo", "fooz");
-              assertThat(stream.id()).isNotNull();
-            })
-        .anySatisfy(
-            stream -> {
-              assertThat(stream.jobType()).isEqualTo("bar");
-              assertThat(stream.metadata().worker()).isEqualTo("bar");
-              assertThat(stream.metadata().timeout()).isEqualTo(Duration.ofMillis(250));
-              assertThat(stream.metadata().fetchVariables())
-                  .containsExactlyInAnyOrder("bar", "barz");
-              assertThat(stream.id()).isNotNull();
-            });
+    final var actuator = JobStreamActuator.of(gateway);
+    Awaitility.await("until foo stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(actuator)
+                    .clientStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType("foo"),
+                        RemoteJobStreamsAssert.hasWorker("foo"),
+                        RemoteJobStreamsAssert.hasTimeout(100L),
+                        RemoteJobStreamsAssert.hasFetchVariables("foo", "fooz")));
+    Awaitility.await("until bar stream is registered")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(actuator)
+                    .clientStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType("bar"),
+                        RemoteJobStreamsAssert.hasWorker("bar"),
+                        RemoteJobStreamsAssert.hasTimeout(250L),
+                        RemoteJobStreamsAssert.hasFetchVariables("bar", "barz")));
   }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/AbstractJobStreamsAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/AbstractJobStreamsAssert.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.qa.util.jobstream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.ClientJobStream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.JobStream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteJobStream;
+import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteStreamId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -141,6 +142,23 @@ public abstract class AbstractJobStreamsAssert<
     return VerboseCondition.verboseCondition(
         stream -> stream.consumers().size() == count,
         "a stream with '%d' consumers".formatted(count),
+        stream -> " but actual consumers are '%s'".formatted(stream.consumers()));
+  }
+
+  /**
+   * Returns a condition which checks that a stream consumers contains exactly the given receivers,
+   * in any order.
+   */
+  public static Condition<RemoteJobStream> hasConsumerReceivers(
+      final Collection<String> receivers) {
+    return VerboseCondition.verboseCondition(
+        stream ->
+            stream.consumers().size() == receivers.size()
+                && stream.consumers().stream()
+                    .map(RemoteStreamId::receiver)
+                    .collect(Collectors.toSet())
+                    .containsAll(receivers),
+        "a stream with consumer receivers '%s'".formatted(receivers),
         stream -> " but actual consumers are '%s'".formatted(stream.consumers()));
   }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/JobStreamActuatorAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/JobStreamActuatorAssert.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.qa.util.jobstream;
 import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.ClientJobStream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteJobStream;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -104,6 +105,22 @@ public final class JobStreamActuatorAssert
         final int expectedCount, final String jobType, final int consumerCount) {
       return haveExactly(
           expectedCount, AllOf.allOf(hasJobType(jobType), hasConsumerCount(consumerCount)));
+    }
+
+    /**
+     * Asserts that the given service contains exactly {@code expectedCount} streams with the given
+     * job type and the expected consumer receivers (in any order).
+     *
+     * @param expectedCount the exact count of streams to find
+     * @param jobType the expected type of the streams
+     * @param receivers the expected consumer receivers
+     * @return itself for chaining
+     */
+    public RemoteJobStreamsAssert haveConsumerReceiver(
+        final int expectedCount, final String jobType, final String... receivers) {
+      final var collection = Arrays.asList(receivers);
+      return haveExactly(
+          expectedCount, AllOf.allOf(hasJobType(jobType), hasConsumerReceivers(collection)));
     }
 
     @Override


### PR DESCRIPTION
## Description

Since `ArrayProperty` and `ArrayValue` `equals` and `hashCode` methods depend on the latest modification having been flushed to the backing buffer, using these methods is error prone and inaccurate. Case in point, in the gateway, we don't always manage to aggregate job streams properly because we consider the metadata different (since we rely on the `equals` and `hashCode` methods), even if they are.

This PR ensures that if the current inner value has been modified, we first flush it before computing `equals` or `hashCode`. If that value is unmodified then nothing new happens.

## Related issues

related to #14624 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
