### PR TITLE
fix(transport): handle MEMBER_ADDED events as well

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
@@ -84,13 +84,16 @@ public class RemoteStreamServiceImpl<M extends BufferReader, P extends BufferWri
 
   @Override
   public boolean isRelevant(final ClusterMembershipEvent event) {
-    return event.type() == Type.MEMBER_REMOVED;
+    return event.type() == Type.MEMBER_REMOVED || event.type() == Type.MEMBER_ADDED;
   }
 
   @Override
   public void event(final ClusterMembershipEvent event) {
-    apiServer.removeAll(event.subject().id());
-    if (event.type() == Type.MEMBER_ADDED) {
+    final var type = event.type();
+
+    if (type == Type.MEMBER_REMOVED) {
+      apiServer.removeAll(event.subject().id());
+    } else if (type == Type.MEMBER_ADDED) {
       apiServer.recreateStreams(event.subject().id());
     }
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -85,10 +85,18 @@ public final class RemoteStreamTransport<M extends BufferReader> extends Actor {
 
   public void recreateStreams(final MemberId receiver) {
     try {
-      sendRestartStreamsCommand(receiver);
-      LOG.debug("Tried to restart streams with member: {}", receiver);
+      LOG.debug("Restarting streams with for newly added member '{}'", receiver);
+      sendRestartStreamsCommand(receiver)
+          .whenComplete(
+              (ok, error) -> {
+                if (error != null) {
+                  LOG.warn("Failed to restart streams for member '{}'", receiver, error);
+                } else {
+                  LOG.debug("Restarted streams for member '{}'", receiver);
+                }
+              });
     } catch (final Exception e) {
-      LOG.warn("Failed to restart streams with member: {}", receiver, e);
+      LOG.warn("Failed to restart streams for member '{}'", receiver, e);
     }
   }
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the remote stream service was ignoring `MEMBER_ADDED` events, meaning streams would never get restarted since these events did not reach the broker.

## Related issues

closes #14771 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
