### PR TITLE
refactor: broker client doesn't start topology gossip server

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -69,6 +69,7 @@ public final class Broker implements AutoCloseable {
             healthCheckService,
             buildExporterRepository(getConfig()),
             new ClusterServicesImpl(systemContext.getCluster()),
+            systemContext.getBrokerClient(),
             additionalPartitionListeners);
 
     brokerStartupActor = new BrokerStartupActor(startupContext);

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -103,4 +104,6 @@ public interface BrokerStartupContext {
   ClusterTopologyService getClusterTopology();
 
   void setClusterTopology(ClusterTopologyService clusterTopologyService);
+
+  BrokerClient getBrokerClient();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -43,6 +44,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final BrokerHealthCheckService healthCheckService;
   private final ExporterRepository exporterRepository;
   private final ClusterServicesImpl clusterServices;
+  private final BrokerClient brokerClient;
   private final List<PartitionListener> partitionListeners = new ArrayList<>();
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
 
@@ -66,6 +68,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final BrokerHealthCheckService healthCheckService,
       final ExporterRepository exporterRepository,
       final ClusterServicesImpl clusterServices,
+      final BrokerClient brokerClient,
       final List<PartitionListener> additionalPartitionListeners) {
 
     this.brokerInfo = requireNonNull(brokerInfo);
@@ -75,6 +78,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.healthCheckService = requireNonNull(healthCheckService);
     this.exporterRepository = requireNonNull(exporterRepository);
     this.clusterServices = requireNonNull(clusterServices);
+    this.brokerClient = brokerClient;
     partitionListeners.addAll(additionalPartitionListeners);
   }
 
@@ -255,5 +259,10 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public void setClusterTopology(final ClusterTopologyService clusterTopologyService) {
     this.clusterTopologyService = clusterTopologyService;
+  }
+
+  @Override
+  public BrokerClient getBrokerClient() {
+    return brokerClient;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -28,6 +28,7 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
 
     final var clusterServices = brokerStartupContext.getClusterServices();
     final var scheduler = brokerStartupContext.getActorSchedulingService();
+    final var brokerClient = brokerStartupContext.getBrokerClient();
     final var jobStreamClient =
         new JobStreamClientImpl(scheduler, clusterServices.getCommunicationService());
 
@@ -35,9 +36,9 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
         new EmbeddedGatewayService(
             brokerStartupContext.getBrokerConfiguration(),
             scheduler,
-            clusterServices,
             concurrencyControl,
-            jobStreamClient);
+            jobStreamClient,
+            brokerClient);
 
     final var embeddedGatewayServiceFuture = embeddedGatewayService.start();
     concurrencyControl.runOnCompletion(

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
@@ -61,6 +61,8 @@ public class DynamicClusterTopologyService implements ClusterTopologyService {
           if (topologyManagerFailed != null) {
             started.completeExceptionally(topologyManagerFailed);
           } else {
+            clusterTopologyManagerService.addUpdateListener(
+                brokerStartupContext.getBrokerClient().getTopologyManager());
             clusterTopologyManagerService
                 .getClusterTopology()
                 .onComplete(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -7,11 +7,10 @@
  */
 package io.camunda.zeebe.broker.system;
 
-import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.Gateway;
 import io.camunda.zeebe.gateway.Loggers;
-import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -22,25 +21,18 @@ import org.agrona.CloseHelper;
 
 public final class EmbeddedGatewayService implements AutoCloseable {
   private final Gateway gateway;
-  private final BrokerClientImpl brokerClient;
+  private final BrokerClient brokerClient;
   private final JobStreamClient jobStreamClient;
   private final ConcurrencyControl concurrencyControl;
 
   public EmbeddedGatewayService(
       final BrokerCfg configuration,
       final ActorSchedulingService actorScheduler,
-      final ClusterServices clusterServices,
       final ConcurrencyControl concurrencyControl,
-      final JobStreamClient jobStreamClient) {
+      final JobStreamClient jobStreamClient,
+      final BrokerClient brokerClient) {
     this.concurrencyControl = concurrencyControl;
-    brokerClient =
-        new BrokerClientImpl(
-            configuration.getGateway().getCluster().getRequestTimeout(),
-            clusterServices.getMessagingService(),
-            clusterServices.getMembershipService(),
-            clusterServices.getEventService(),
-            clusterServices.getCommunicationService(),
-            actorScheduler);
+    this.brokerClient = brokerClient;
     this.jobStreamClient = jobStreamClient;
     gateway =
         new Gateway(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -51,7 +51,9 @@ public final class SystemContext {
   private final BrokerClient brokerClient;
 
   public SystemContext(
-      final BrokerCfg brokerCfg, final ActorScheduler scheduler, final AtomixCluster cluster,
+      final BrokerCfg brokerCfg,
+      final ActorScheduler scheduler,
+      final AtomixCluster cluster,
       final BrokerClient brokerClient) {
     this.brokerCfg = brokerCfg;
     this.scheduler = scheduler;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,12 +48,15 @@ public final class SystemContext {
   private Map<String, String> diagnosticContext;
   private final ActorScheduler scheduler;
   private final AtomixCluster cluster;
+  private final BrokerClient brokerClient;
 
   public SystemContext(
-      final BrokerCfg brokerCfg, final ActorScheduler scheduler, final AtomixCluster cluster) {
+      final BrokerCfg brokerCfg, final ActorScheduler scheduler, final AtomixCluster cluster,
+      final BrokerClient brokerClient) {
     this.brokerCfg = brokerCfg;
     this.scheduler = scheduler;
     this.cluster = cluster;
+    this.brokerClient = brokerClient;
     initSystemContext();
   }
 
@@ -248,5 +252,9 @@ public final class SystemContext {
 
   public Map<String, String> getDiagnosticContext() {
     return diagnosticContext;
+  }
+
+  public BrokerClient getBrokerClient() {
+    return brokerClient;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -64,6 +65,7 @@ class ApiMessagingServiceStepTest {
             mock(BrokerHealthCheckService.class),
             mock(ExporterRepository.class),
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
+            mock(BrokerClient.class),
             Collections.emptyList());
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitorActor;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -66,6 +67,7 @@ class CommandApiServiceStepTest {
             mock(BrokerHealthCheckService.class),
             mock(ExporterRepository.class),
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
+            mock(BrokerClient.class),
             Collections.emptyList());
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
     testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitorActor.class));

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -76,6 +77,7 @@ class EmbeddedGatewayServiceStepTest {
               mock(BrokerHealthCheckService.class),
               mock(ExporterRepository.class),
               mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
+              mock(BrokerClient.class),
               Collections.emptyList());
 
       final var port = SocketUtil.getNextAddress().getPort();
@@ -143,6 +145,7 @@ class EmbeddedGatewayServiceStepTest {
               mock(BrokerHealthCheckService.class),
               mock(ExporterRepository.class),
               mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
+              mock(BrokerClient.class),
               Collections.emptyList());
 
       testBrokerStartupContext.setEmbeddedGatewayService(mockEmbeddedGatewayService);

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -57,6 +58,7 @@ class GatewayBrokerTransportStepTest {
             mock(BrokerHealthCheckService.class),
             mock(ExporterRepository.class),
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
+            mock(BrokerClient.class),
             Collections.emptyList());
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -88,6 +89,7 @@ class PartitionManagerStepTest {
               mock(BrokerHealthCheckService.class),
               mock(ExporterRepository.class),
               mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
+              mock(BrokerClient.class),
               Collections.emptyList());
       testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
@@ -183,6 +185,7 @@ class PartitionManagerStepTest {
               mock(BrokerHealthCheckService.class),
               mock(ExporterRepository.class),
               mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
+              mock(BrokerClient.class),
               Collections.emptyList());
 
       testBrokerStartupContext.setPartitionManager(mockPartitionManager);

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
+import io.camunda.zeebe.broker.test.TestBrokerClientFactory;
 import io.camunda.zeebe.broker.test.TestClusterFactory;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -94,12 +95,12 @@ final class PartitionJoinTest {
     assignSocketAddresses(brokerCfg);
     brokerCfg.init(tmp.toAbsolutePath().toString());
     configure.accept(brokerCfg);
+    final var atomixCluster = TestClusterFactory.createAtomixCluster(brokerCfg);
+    final var actorScheduler = TestActorSchedulerFactory.ofBrokerConfig(brokerCfg);
+    final var brokerClient =
+        TestBrokerClientFactory.createBrokerClient(atomixCluster, actorScheduler);
     final var systemContext =
-        new SystemContext(
-            brokerCfg,
-            TestActorSchedulerFactory.ofBrokerConfig(brokerCfg),
-            TestClusterFactory.createAtomixCluster(brokerCfg));
-    systemContext.getScheduler().start();
+        new SystemContext(brokerCfg, actorScheduler, atomixCluster, brokerClient);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
+import io.camunda.zeebe.broker.test.TestBrokerClientFactory;
 import io.camunda.zeebe.broker.test.TestClusterFactory;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
@@ -85,12 +86,12 @@ final class PartitionLeaveTest {
     assignSocketAddresses(brokerCfg);
     brokerCfg.init(tmp.toAbsolutePath().toString());
     configure.accept(brokerCfg);
+    final var actorScheduler = TestActorSchedulerFactory.ofBrokerConfig(brokerCfg);
+    final var atomixCluster = TestClusterFactory.createAtomixCluster(brokerCfg);
+    final var brokerClient =
+        TestBrokerClientFactory.createBrokerClient(atomixCluster, actorScheduler);
     final var systemContext =
-        new SystemContext(
-            brokerCfg,
-            TestActorSchedulerFactory.ofBrokerConfig(brokerCfg),
-            TestClusterFactory.createAtomixCluster(brokerCfg));
-    systemContext.getScheduler().start();
+        new SystemContext(brokerCfg, actorScheduler, atomixCluster, brokerClient);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.Backup
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
@@ -327,6 +328,7 @@ final class SystemContextTest {
   }
 
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {
-    return new SystemContext(brokerCfg, mock(ActorScheduler.class), mock(AtomixCluster.class));
+    return new SystemContext(
+        brokerCfg, mock(ActorScheduler.class), mock(AtomixCluster.class), mock(BrokerClient.class));
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -232,8 +232,12 @@ public final class EmbeddedBrokerRule extends ExternalResource {
 
     final var scheduler = TestActorSchedulerFactory.ofBrokerConfig(brokerCfg, controlledActorClock);
     atomixCluster = TestClusterFactory.createAtomixCluster(brokerCfg);
-    systemContext = new SystemContext(brokerCfg, scheduler, atomixCluster);
-    scheduler.start();
+    systemContext =
+        new SystemContext(
+            brokerCfg,
+            scheduler,
+            atomixCluster,
+            TestBrokerClientFactory.createBrokerClient(atomixCluster, scheduler));
 
     final var additionalListeners = new ArrayList<>(Arrays.asList(listeners));
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/TestActorSchedulerFactory.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/TestActorSchedulerFactory.java
@@ -23,11 +23,14 @@ public final class TestActorSchedulerFactory {
     final var threads = config.getThreads();
     final var features = config.getExperimental().getFeatures();
 
-    return ActorScheduler.newActorScheduler()
-        .setCpuBoundActorThreadCount(threads.getCpuThreadCount())
-        .setIoBoundActorThreadCount(threads.getIoThreadCount())
-        .setMetricsEnabled(features.isEnableActorMetrics())
-        .setActorClock(clock)
-        .build();
+    final var scheduler =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(threads.getCpuThreadCount())
+            .setIoBoundActorThreadCount(threads.getIoThreadCount())
+            .setMetricsEnabled(features.isEnableActorMetrics())
+            .setActorClock(clock)
+            .build();
+    scheduler.start();
+    return scheduler;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/TestBrokerClientFactory.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/TestBrokerClientFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.test;
+
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_REQUEST_TIMEOUT;
+
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+
+public final class TestBrokerClientFactory {
+  public static BrokerClient createBrokerClient(
+      final AtomixCluster atomixCluster, final ActorScheduler actorScheduler) {
+    final var topologyManager =
+        new BrokerTopologyManagerImpl(() -> atomixCluster.getMembershipService().getMembers());
+    actorScheduler.submitActor(topologyManager).join();
+    atomixCluster.getMembershipService().addListener(topologyManager);
+
+    return new BrokerClientImpl(
+        DEFAULT_REQUEST_TIMEOUT,
+        atomixCluster.getMessagingService(),
+        atomixCluster.getEventService(),
+        actorScheduler,
+        topologyManager);
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/TestBrokerClientFactory.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/TestBrokerClientFactory.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 
 public final class TestBrokerClientFactory {
   public static BrokerClient createBrokerClient(
@@ -23,11 +24,14 @@ public final class TestBrokerClientFactory {
     actorScheduler.submitActor(topologyManager).join();
     atomixCluster.getMembershipService().addListener(topologyManager);
 
-    return new BrokerClientImpl(
-        DEFAULT_REQUEST_TIMEOUT,
-        atomixCluster.getMessagingService(),
-        atomixCluster.getEventService(),
-        actorScheduler,
-        topologyManager);
+    final var client =
+        new BrokerClientImpl(
+            DEFAULT_REQUEST_TIMEOUT,
+            atomixCluster.getMessagingService(),
+            atomixCluster.getEventService(),
+            actorScheduler,
+            topologyManager);
+    client.start().forEach(ActorFuture::join);
+    return client;
   }
 }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -94,6 +94,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-topology</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/zeebe/broker/ActorSchedulerConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/ActorSchedulerConfiguration.java
@@ -36,13 +36,16 @@ public final class ActorSchedulerConfiguration {
     final var ioThreads = cfg.getIoThreadCount();
     final var metricsEnabled = brokerCfg.getExperimental().getFeatures().isEnableActorMetrics();
 
-    return ActorScheduler.newActorScheduler()
-        .setActorClock(actorClockConfiguration.getClock().orElse(null))
-        .setCpuBoundActorThreadCount(cpuThreads)
-        .setIoBoundActorThreadCount(ioThreads)
-        .setMetricsEnabled(metricsEnabled)
-        .setSchedulerName(String.format("Broker-%d", brokerCfg.getCluster().getNodeId()))
-        .setIdleStrategySupplier(idleStrategySupplier)
-        .build();
+    final var scheduler =
+        ActorScheduler.newActorScheduler()
+            .setActorClock(actorClockConfiguration.getClock().orElse(null))
+            .setCpuBoundActorThreadCount(cpuThreads)
+            .setIoBoundActorThreadCount(ioThreads)
+            .setMetricsEnabled(metricsEnabled)
+            .setSchedulerName(String.format("Broker-%d", brokerCfg.getCluster().getNodeId()))
+            .setIdleStrategySupplier(idleStrategySupplier)
+            .build();
+    scheduler.start();
+    return scheduler;
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerClientConfiguration.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -21,23 +22,27 @@ final class BrokerClientConfiguration {
   private final BrokerCfg config;
   private final AtomixCluster cluster;
   private final ActorScheduler scheduler;
+  private final BrokerTopologyManager topologyManager;
 
   @Autowired
   BrokerClientConfiguration(
-      final BrokerCfg config, final AtomixCluster cluster, final ActorScheduler scheduler) {
+      final BrokerCfg config,
+      final AtomixCluster cluster,
+      final ActorScheduler scheduler,
+      final BrokerTopologyManager topologyManager) {
     this.config = config;
     this.cluster = cluster;
     this.scheduler = scheduler;
+    this.topologyManager = topologyManager;
   }
 
   @Bean(destroyMethod = "close")
   BrokerClient brokerClient() {
-    return new BrokerClientImpl(
-        config.getGateway().getCluster().getRequestTimeout(),
-        cluster.getMessagingService(),
-        cluster.getMembershipService(),
-        cluster.getEventService(),
-        cluster.getCommunicationService(),
-        scheduler);
+    return
+        new BrokerClientImpl(
+            config.getGateway().getCluster().getRequestTimeout(),
+            cluster.getMessagingService(),
+            scheduler,
+            topologyManager);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerClientConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,11 +39,14 @@ final class BrokerClientConfiguration {
 
   @Bean(destroyMethod = "close")
   BrokerClient brokerClient() {
-    return
+    final var brokerClient =
         new BrokerClientImpl(
             config.getGateway().getCluster().getRequestTimeout(),
             cluster.getMessagingService(),
+            cluster.getEventService(),
             scheduler,
             topologyManager);
+    brokerClient.start().forEach(ActorFuture::join);
+    return brokerClient;
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -83,8 +83,6 @@ public class StandaloneBroker
     final SystemContext systemContext =
         new SystemContext(configuration, actorScheduler, cluster, brokerClient);
 
-    actorScheduler.start();
-    brokerClient.start();
     broker = new Broker(systemContext, springBrokerBridge);
     broker.start();
   }

--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -80,7 +80,8 @@ public class StandaloneBroker
 
   @Override
   public void run(final String... args) throws IOException {
-    final SystemContext systemContext = new SystemContext(configuration, actorScheduler, cluster);
+    final SystemContext systemContext =
+        new SystemContext(configuration, actorScheduler, cluster, brokerClient);
 
     actorScheduler.start();
     brokerClient.start();

--- a/dist/src/main/java/io/camunda/zeebe/broker/TopologyServices.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/TopologyServices.java
@@ -34,7 +34,6 @@ public class TopologyServices {
         new BrokerTopologyManagerImpl(clusterMembershipService::getMembers);
     scheduler.submitActor(brokerTopologyManager).join();
     clusterMembershipService.addListener(brokerTopologyManager);
-    // TODO: register with gossip
     return brokerTopologyManager;
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/TopologyServices.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/TopologyServices.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.ClusterMembershipService;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TopologyServices {
+  private final ActorScheduler scheduler;
+
+  private final ClusterMembershipService clusterMembershipService;
+
+  @Autowired
+  public TopologyServices(final ActorScheduler scheduler, final AtomixCluster atomixCluster) {
+    this.scheduler = scheduler;
+    clusterMembershipService = atomixCluster.getMembershipService();
+  }
+
+  @Bean
+  BrokerTopologyManager brokerTopologyManager() {
+    final var brokerTopologyManager =
+        new BrokerTopologyManagerImpl(clusterMembershipService::getMembers);
+    scheduler.submitActor(brokerTopologyManager).join();
+    clusterMembershipService.addListener(brokerTopologyManager);
+    // TODO: register with gossip
+    return brokerTopologyManager;
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerConfiguration.java
@@ -32,12 +32,15 @@ public final class ActorSchedulerConfiguration {
 
   @Bean(destroyMethod = "close")
   public ActorScheduler actorScheduler(final IdleStrategySupplier idleStrategySupplier) {
-    return ActorScheduler.newActorScheduler()
-        .setCpuBoundActorThreadCount(config.getThreads().getManagementThreads())
-        .setIoBoundActorThreadCount(0)
-        .setSchedulerName("Gateway-%s".formatted(config.getCluster().getMemberId()))
-        .setActorClock(clockConfiguration.getClock().orElse(null))
-        .setIdleStrategySupplier(idleStrategySupplier)
-        .build();
+    final var scheduler =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(config.getThreads().getManagementThreads())
+            .setIoBoundActorThreadCount(0)
+            .setSchedulerName("Gateway-%s".formatted(config.getCluster().getMemberId()))
+            .setActorClock(clockConfiguration.getClock().orElse(null))
+            .setIdleStrategySupplier(idleStrategySupplier)
+            .build();
+    scheduler.start();
+    return scheduler;
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
@@ -40,11 +40,14 @@ public final class BrokerClientComponent {
 
   @Bean(destroyMethod = "close")
   public BrokerClient brokerClient() {
-    return new BrokerClientImpl(
-        config.getCluster().getRequestTimeout(),
-        atomixCluster.getMessagingService(),
-        atomixCluster.getEventService(),
-        actorScheduler,
-        topologyManager);
+    final var brokerClient =
+        new BrokerClientImpl(
+            config.getCluster().getRequestTimeout(),
+            atomixCluster.getMessagingService(),
+            atomixCluster.getEventService(),
+            actorScheduler,
+            topologyManager);
+    brokerClient.start();
+    return brokerClient;
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -23,15 +24,18 @@ public final class BrokerClientComponent {
   final GatewayCfg config;
   final AtomixCluster atomixCluster;
   final ActorScheduler actorScheduler;
+  private final BrokerTopologyManager topologyManager;
 
   @Autowired
   public BrokerClientComponent(
       final GatewayCfg config,
       final AtomixCluster atomixCluster,
-      final ActorScheduler actorScheduler) {
+      final ActorScheduler actorScheduler,
+      final BrokerTopologyManager topologyManager) {
     this.config = config;
     this.atomixCluster = atomixCluster;
     this.actorScheduler = actorScheduler;
+    this.topologyManager = topologyManager;
   }
 
   @Bean(destroyMethod = "close")
@@ -39,9 +43,8 @@ public final class BrokerClientComponent {
     return new BrokerClientImpl(
         config.getCluster().getRequestTimeout(),
         atomixCluster.getMessagingService(),
-        atomixCluster.getMembershipService(),
         atomixCluster.getEventService(),
-        atomixCluster.getCommunicationService(),
-        actorScheduler);
+        actorScheduler,
+        topologyManager);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.VisibleForTesting;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -47,7 +48,7 @@ public final class BrokerClientComponent {
             atomixCluster.getEventService(),
             actorScheduler,
             topologyManager);
-    brokerClient.start();
+    brokerClient.start().forEach(ActorFuture::join);
     return brokerClient;
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import io.camunda.zeebe.scheduler.ActorScheduler;
-import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.shared.MainSupport;
 import io.camunda.zeebe.shared.Profile;
 import io.camunda.zeebe.util.CloseableSilently;
@@ -95,13 +94,11 @@ public class StandaloneGateway
       LOG.info("Starting standalone gateway with configuration {}", configuration.toJson());
     }
 
-    actorScheduler.start();
     atomixCluster.start();
     jobStreamClient.start().join();
 
     // before we can add the job stream client as a topology listener, we need to wait for the
     // topology to be set up, otherwise the callback may be lost
-    brokerClient.start().forEach(ActorFuture::join);
     brokerClient.getTopologyManager().addTopologyListener(jobStreamClient);
 
     gateway = new Gateway(configuration, brokerClient, actorScheduler, jobStreamClient.streamer());

--- a/dist/src/main/java/io/camunda/zeebe/gateway/TopologyServices.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/TopologyServices.java
@@ -52,7 +52,7 @@ public class TopologyServices {
         new BrokerTopologyManagerImpl(clusterMembershipService::getMembers);
     scheduler.submitActor(brokerTopologyManager).join();
     clusterMembershipService.addListener(brokerTopologyManager);
-    gatewayClusterTopologyService.registerClusterTopologyChangeListener(brokerTopologyManager);
+    gatewayClusterTopologyService.addUpdateListener(brokerTopologyManager);
 
     return brokerTopologyManager;
   }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/TopologyServices.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/TopologyServices.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.topology.GatewayClusterTopologyService;
+import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TopologyServices {
+  private final ActorScheduler scheduler;
+  private final ClusterMembershipService clusterMembershipService;
+  private final ClusterCommunicationService clusterCommunicationService;
+
+  @Autowired
+  public TopologyServices(final ActorScheduler scheduler, final AtomixCluster atomixCluster) {
+    this.scheduler = scheduler;
+    clusterMembershipService = atomixCluster.getMembershipService();
+    clusterCommunicationService = atomixCluster.getCommunicationService();
+  }
+
+  @Bean
+  GatewayClusterTopologyService gatewayClusterTopologyService() {
+    final var service =
+        new GatewayClusterTopologyService(
+            clusterCommunicationService,
+            clusterMembershipService,
+            new ClusterTopologyGossiperConfig(
+                false, Duration.ofSeconds(10), Duration.ofSeconds(1), 2));
+    scheduler.submitActor(service).join();
+    return service;
+  }
+
+  @Bean
+  BrokerTopologyManager brokerTopologyManager(
+      @Autowired final GatewayClusterTopologyService gatewayClusterTopologyService) {
+    final var brokerTopologyManager =
+        new BrokerTopologyManagerImpl(clusterMembershipService::getMembers);
+    scheduler.submitActor(brokerTopologyManager).join();
+    clusterMembershipService.addListener(brokerTopologyManager);
+    gatewayClusterTopologyService.registerClusterTopologyChangeListener(brokerTopologyManager);
+
+    return brokerTopologyManager;
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -140,8 +140,12 @@ final class StandaloneGatewaySecurityTest {
     final ActorSchedulerConfiguration actorSchedulerConfiguration =
         new ActorSchedulerConfiguration(gatewayCfg, new ActorClockConfiguration(false));
     actorScheduler = actorSchedulerConfiguration.actorScheduler(IdleStrategySupplier.ofDefault());
+    final var topologyServices = new TopologyServices(actorScheduler, atomixCluster);
+    final var clusterTopologyService = topologyServices.gatewayClusterTopologyService();
+    final var topologyManager = topologyServices.brokerTopologyManager(clusterTopologyService);
+
     final BrokerClientComponent brokerClientComponent =
-        new BrokerClientComponent(gatewayCfg, atomixCluster, actorScheduler);
+        new BrokerClientComponent(gatewayCfg, atomixCluster, actorScheduler, topologyManager);
     brokerClient = brokerClientComponent.brokerClient();
     jobStreamClient = new JobStreamComponent().jobStreamClient(actorScheduler, atomixCluster);
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerRequestManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerRequestManager.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.gateway.cmd.NoTopologyAvailableException;
 import io.camunda.zeebe.gateway.cmd.PartitionNotFoundException;
 import io.camunda.zeebe.gateway.impl.ErrorResponseHandler;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
-import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
@@ -44,12 +44,12 @@ final class BrokerRequestManager extends Actor {
   private static final TransportRequestSender SENDER_WITHOUT_RETRY = ClientTransport::sendRequest;
   private final ClientTransport clientTransport;
   private final RequestDispatchStrategy dispatchStrategy;
-  private final BrokerTopologyManagerImpl topologyManager;
+  private final BrokerTopologyManager topologyManager;
   private final Duration requestTimeout;
 
   BrokerRequestManager(
       final ClientTransport clientTransport,
-      final BrokerTopologyManagerImpl topologyManager,
+      final BrokerTopologyManager topologyManager,
       final RequestDispatchStrategy dispatchStrategy,
       final Duration requestTimeout) {
     this.clientTransport = clientTransport;
@@ -216,7 +216,7 @@ final class BrokerRequestManager extends Actor {
       // already know partition id
       return new BrokerAddressProvider(request.getPartitionId());
     } else if (request.requiresPartitionId()) {
-      if (request instanceof BrokerPublishMessageRequest publishMessageRequest) {
+      if (request instanceof final BrokerPublishMessageRequest publishMessageRequest) {
         determinePartitionIdForPublishMessageRequest(publishMessageRequest);
       } else {
         // select next partition id for request

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManager.java
@@ -8,8 +8,9 @@
 package io.camunda.zeebe.gateway.impl.broker.cluster;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.TopologyUpdateNotifier.TopologyUpdateListener;
 
-public interface BrokerTopologyManager {
+public interface BrokerTopologyManager extends TopologyUpdateListener {
 
   BrokerClusterState getTopology();
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -17,7 +17,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
-import io.camunda.zeebe.topology.GatewayClusterTopologyService;
+import io.camunda.zeebe.topology.TopologyUpdateNotifier.TopologyUpdateListener;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import java.util.HashSet;
 import java.util.Set;
@@ -26,9 +26,7 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 public final class BrokerTopologyManagerImpl extends Actor
-    implements BrokerTopologyManager,
-        ClusterMembershipEventListener,
-        GatewayClusterTopologyService.Listener {
+    implements BrokerTopologyManager, ClusterMembershipEventListener, TopologyUpdateListener {
 
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;
   private volatile BrokerClusterStateImpl topology = new BrokerClusterStateImpl();
@@ -200,7 +198,7 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   @Override
-  public void onClusterTopologyChanged(final ClusterTopology clusterTopology) {
+  public void onTopologyUpdated(final ClusterTopology clusterTopology) {
     if (clusterTopology.isUninitialized()) {
       return;
     }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterStateImpl;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyListener;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.camunda.zeebe.topology.state.ClusterTopology;
 
 public final class StubbedTopologyManager implements BrokerTopologyManager {
 
@@ -45,6 +46,11 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
 
   @Override
   public void removeTopologyListener(final BrokerTopologyListener listener) {
+    throw new UnsupportedOperationException("Not yet implemented; implement if need be");
+  }
+
+  @Override
+  public void onTopologyUpdated(final ClusterTopology clusterTopology) {
     throw new UnsupportedOperationException("Not yet implemented; implement if need be");
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/topology/TopologyUpdateTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/topology/TopologyUpdateTest.java
@@ -397,7 +397,7 @@ final class TopologyUpdateTest {
         ClusterTopology.init()
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
             .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()));
-    topologyManager.onClusterTopologyChanged(clusterTopologyWithTwoBrokers);
+    topologyManager.onTopologyUpdated(clusterTopologyWithTwoBrokers);
     actorSchedulerRule.workUntilDone();
 
     // then
@@ -413,7 +413,7 @@ final class TopologyUpdateTest {
         ClusterTopology.init()
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
             .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()));
-    topologyManager.onClusterTopologyChanged(clusterTopologyWithTwoBrokers);
+    topologyManager.onTopologyUpdated(clusterTopologyWithTwoBrokers);
     actorSchedulerRule.workUntilDone();
 
     // when

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -349,8 +349,6 @@ public class ClusteringRule extends ExternalResource {
 
     final var systemContext = new SystemContext(brokerCfg, scheduler, atomixCluster, brokerClient);
     systemContexts.put(nodeId, systemContext);
-
-    scheduler.start();
     scheduler.submitActor(topologyManager).join();
 
     atomixCluster.getMembershipService().addListener(topologyManager);
@@ -456,8 +454,6 @@ public class ClusteringRule extends ExternalResource {
     final ActorScheduler actorScheduler =
         new ActorSchedulerConfiguration(gatewayCfg, actorClockConfiguration)
             .actorScheduler(IdleStrategySupplier.ofDefault());
-    actorScheduler.start();
-
     final var topologyManager =
         new BrokerTopologyManagerImpl(() -> atomixCluster.getMembershipService().getMembers());
     actorScheduler.submitActor(topologyManager).join();

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -33,7 +33,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
-public final class ClusterTopologyManagerService extends Actor {
+public final class ClusterTopologyManagerService extends Actor implements TopologyUpdateNotifier {
   // Use a node 0 as always the coordinator. Later we can make it configurable or allow changing it
   // dynamically.
   private static final String COORDINATOR_ID = "0";
@@ -168,5 +168,15 @@ public final class ClusterTopologyManagerService extends Actor {
 
   public void removePartitionChangeExecutor() {
     clusterTopologyManager.removeTopologyChangeAppliers();
+  }
+
+  @Override
+  public void addUpdateListener(final TopologyUpdateListener listener) {
+    clusterTopologyGossiper.addUpdateListener(listener);
+  }
+
+  @Override
+  public void removeUpdateListener(final TopologyUpdateListener listener) {
+    clusterTopologyGossiper.removeUpdateListener(listener);
   }
 }


### PR DESCRIPTION
`BrokerClient` is supposed to be an isolated component that can be started multiple times. This fixes an issue where the `BrokerClient` would start a `ClusterTopologyGossiper` (indirectly, by starting `GatewayClusterTopologyService` in order to connect it to a new `BrokerTopologyManager`). This is not allowed because the `ClusterTopologyGossiper` can only run once.
To fix this, the `GatewayClusterTopologyService`, `ClusterTopologyManagerService` and `BrokerTopologyManager` are now managed by Spring and a `BrokerClient` is created with a given `BrokerTopologyManager` instead of building a new one for every client.