### PR TITLE
refactor: enable TCC using official GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,24 +38,22 @@ jobs:
             maven-build-threads: 2
             maven-test-fork-count: 7
             tcc-enabled: 'false'
+            tcc-concurrency: 1
           - group: qa-integration
             name: "QA Integration Tests"
             maven-modules: "qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
-            tcc-enabled: 'false'
-            tcc-concurrency: 4
+            tcc-enabled: 'true'
+            tcc-concurrency: 1
           - group: qa-update
             name: "QA Update Tests"
             maven-modules: "qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
-            tcc-enabled: 'false'
-            tcc-concurrency: 3
+            tcc-enabled: 'true'
+            tcc-concurrency: 2
     env:
-      TC_CLOUD_LOGS_VERBOSE: true
-      TC_CLOUD_TOKEN: ${{ matrix.tcc-enabled == 'true' && secrets.TC_CLOUD_TOKEN || '' }}
-      TC_CLOUD_CONCURRENCY: ${{ matrix.tcc-concurrency }}
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
       registry:
@@ -80,13 +78,19 @@ jobs:
           version: current-test
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
-      - name: Prepare Testcontainers Cloud agent
-        if: env.TC_CLOUD_TOKEN != ''
-        run: |
-          curl -L -o agent https://app.testcontainers.cloud/download/testcontainers-cloud-agent_linux_x86-64
-          chmod +x agent
-          ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' --terminate > .testcontainers-agent.log 2>&1 &
-          ./agent wait
+      - name: Setup TCC
+        if: matrix.tcc-enabled == 'true'
+        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        env:
+          TC_CLOUD_LOGS_VERBOSE: true
+          TC_CLOUD_CONCURRENCY: ${{ matrix.tcc-concurrency }}
+        with:
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
+          logfile: .testcontainers-agent.log
+          wait: true
+          args: >
+            --private-registry-url=http://localhost:5000
+            --private-registry-allowed-image-name-globs=camunda/zeebe
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build
@@ -100,9 +104,11 @@ jobs:
           -pl ${{ matrix.maven-modules }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Terminate TCC session
-        if: env.TC_CLOUD_TOKEN != ''
-        run: ./agent terminate
+      - name: Terminate TCC
+        if: matrix.tcc-enabled == 'true'
+        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        with:
+          action: terminate
       - name: Duplicate Test Check
         uses: ./.github/actions/check-duplicate-tests
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         with:
           name: "[IT] ${{ matrix.name }}"
   unit-tests:
@@ -158,7 +158,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         with:
           name: "unit tests"
   smoke-tests:
@@ -216,7 +216,7 @@ jobs:
           verify
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         with:
           name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
   property-tests:
@@ -251,7 +251,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         with:
           name: Property Tests
   performance-tests:
@@ -300,7 +300,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         with:
           name: Performance Tests
   go-client:

--- a/exporters/elasticsearch-exporter/src/test/resources/elasticsearch-fast-startup.options
+++ b/exporters/elasticsearch-exporter/src/test/resources/elasticsearch-fast-startup.options
@@ -1,0 +1,2 @@
+-Xlog:disable
+-XX:TieredStopAtLevel=1

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1122,6 +1122,7 @@
         <artifactId>jmh-core</artifactId>
         <version>${version.jmh}</version>
       </dependency>
+
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-generator-annprocess</artifactId>
@@ -1198,19 +1199,6 @@
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-core</artifactId>
         <version>3.6.0</version>
-      </dependency>
-
-      <!--      JMH Tests   -->
-      <dependency>
-        <groupId>org.openjdk.jmh</groupId>
-        <artifactId>jmh-core</artifactId>
-        <version>${version.jmh}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.openjdk.jmh</groupId>
-        <artifactId>jmh-generator-annprocess</artifactId>
-        <version>${version.jmh}</version>
       </dependency>
 
       <!-- between com.github.dasniko:testcontainers-keycloak and its own dependencies -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -131,6 +131,8 @@
     <version.postgresql>42.6.0</version.postgresql>
     <version.aws-signing>2.3.1</version.aws-signing>
     <version.reactor-netty>1.1.13</version.reactor-netty>
+    <version.tc-keycloak>3.1.0</version.tc-keycloak>
+    <version.jakarta-activation>2.1.0</version.jakarta-activation>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.1.0</plugin.version.antrun>
@@ -881,6 +883,18 @@
       </dependency>
 
       <dependency>
+        <groupId>com.github.dasniko</groupId>
+        <artifactId>testcontainers-keycloak</artifactId>
+        <version>${version.tc-keycloak}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java-api</artifactId>
         <version>${version.docker-java-api}</version>
@@ -1184,6 +1198,26 @@
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-core</artifactId>
         <version>3.6.0</version>
+      </dependency>
+
+      <!--      JMH Tests   -->
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${version.jmh}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>${version.jmh}</version>
+      </dependency>
+
+      <!-- between com.github.dasniko:testcontainers-keycloak and its own dependencies -->
+      <dependency>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
+        <version>${version.jakarta-activation}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -234,6 +234,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.dasniko</groupId>
+      <artifactId>testcontainers-keycloak</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.gateway;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.testcontainers.DefaultTestContainers;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
@@ -60,23 +62,14 @@ public class GatewayAuthenticationIdentityIT {
   private static final String ZEEBE_CLIENT_SECRET = "zecret";
   private static final Network NETWORK = Network.newNetwork();
 
-  @SuppressWarnings("resource")
   @Container
-  private static final GenericContainer<?> KEYCLOAK =
-      new GenericContainer<>("bitnami/keycloak:22.0.1")
-          .withEnv("KC_HEALTH_ENABLED", "true")
+  private static final KeycloakContainer KEYCLOAK =
+      DefaultTestContainers.createDefaultKeycloak()
           .withEnv("KEYCLOAK_ADMIN_USER", KEYCLOAK_USER)
           .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)
           .withEnv("KEYCLOAK_DATABASE_VENDOR", "dev-mem")
           .withNetwork(NETWORK)
-          .withNetworkAliases("keycloak")
-          .withExposedPorts(8080)
-          .waitingFor(
-              new HttpWaitStrategy()
-                  .forPort(8080)
-                  .forPath("/health/ready")
-                  .allowInsecure()
-                  .forStatusCode(200));
+          .withNetworkAliases("keycloak");
 
   @SuppressWarnings("resource")
   @Container

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.it.multitenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.testcontainers.DefaultTestContainers;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
@@ -107,27 +109,14 @@ public class MultiTenancyOverIdentityIT {
           .withNetworkAliases(DATABASE_HOST);
 
   @Container
-  @SuppressWarnings("resource")
-  private static final GenericContainer<?> KEYCLOAK =
-      new GenericContainer<>("bitnami/keycloak:22.0.1")
-          .dependsOn(POSTGRES)
-          .withEnv("KC_HEALTH_ENABLED", "true")
+  private static final KeycloakContainer KEYCLOAK =
+      DefaultTestContainers.createDefaultKeycloak()
           .withEnv("KEYCLOAK_ADMIN_USER", KEYCLOAK_USER)
           .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)
-          .withEnv("KEYCLOAK_DATABASE_HOST", DATABASE_HOST)
-          .withEnv("KEYCLOAK_DATABASE_PORT", String.valueOf(DATABASE_PORT))
-          .withEnv("KEYCLOAK_DATABASE_USER", DATABASE_USER)
-          .withEnv("KEYCLOAK_DATABASE_PASSWORD", DATABASE_PASSWORD)
-          .withEnv("KEYCLOAK_DATABASE_NAME", DATABASE_NAME)
+          .withEnv("KEYCLOAK_DATABASE_VENDOR", "dev-mem")
           .withNetwork(NETWORK)
           .withNetworkAliases("keycloak")
-          .withExposedPorts(8080)
-          .waitingFor(
-              new HttpWaitStrategy()
-                  .forPort(8080)
-                  .forPath("/health/ready")
-                  .allowInsecure()
-                  .forStatusCode(200));
+          .withExposedPorts(8080);
 
   @Container
   @SuppressWarnings("resource")

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -27,6 +27,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.dasniko</groupId>
+      <artifactId>testcontainers-keycloak</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/DefaultTestContainers.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/DefaultTestContainers.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.testcontainers;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import java.time.Duration;
+import org.testcontainers.utility.DockerImageName;
+
+public final class DefaultTestContainers {
+  private static final DockerImageName KEYCLOAK_IMAGE =
+      DockerImageName.parse("quay.io/keycloak/keycloak:22.0.1");
+
+  private DefaultTestContainers() {}
+
+  /** Returns a Keycloak container with defaults for CI. */
+  public static KeycloakContainer createDefaultKeycloak() {
+    final var container =
+        new KeycloakContainer(KEYCLOAK_IMAGE.asCanonicalNameString())
+            // Keycloak can take quite a while to start in CI
+            .withStartupTimeout(Duration.ofMinutes(5))
+            // speed up startup time at the expense of slower runtime, acceptable in CI
+            .withEnv("JAVA_TOOL_OPTIONS", "-Xlog:disable -XX:TieredStopAtLevel=1");
+
+    // remove the default log consumer
+    container.getLogConsumers().clear();
+
+    return container;
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
@@ -43,7 +43,7 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
    * this.
    */
   public MinioContainer() {
-    this("RELEASE.2022-09-17T00-09-45Z");
+    this("RELEASE.2023-11-20T22-40-07Z");
   }
 
   /**
@@ -57,8 +57,8 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
 
     withCommand("server /data")
         .withExposedPorts(PORT)
-        .withEnv("MINIO_ACCESS_KEY", DEFAULT_ACCESS_KEY)
-        .withEnv("MINIO_SECRET_KEY", DEFAULT_SECRET_KEY)
+        .withEnv("MINIO_ROOT_USER", DEFAULT_ACCESS_KEY)
+        .withEnv("MINIO_ROOT_PASSWORD", DEFAULT_SECRET_KEY)
         .withEnv("MINIO_REGION", DEFAULT_REGION)
         .waitingFor(defaultWaitStrategy());
   }


### PR DESCRIPTION
## Description

This PR re-enables TCC now that we've reduced container load _and_ a load balancing bug was fixed on their side.

I took the liberty of speeding up Keycloak and ES containers as well. As they both just need to spin up fast but not really do much, disabling GC logging and other system (note: not application, but system) logs is fine, and disabling JIT optimizations as well. This results in faster startup (ES by half, Keycloak a little less). At the same, I've switched Keycloak to use the official Testcontainers module as they suggested, which has a slightly different wait strategy. At the same time, I increased their startup time, as it's quite rare these will simply fail (and if they do crash, we would know immediately).

## Related issues

supersedes #13519

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
