### PR TITLE
[Backport stable/8.3] fix(transport): handle MEMBER_ADDED events as well

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
@@ -83,13 +83,16 @@ public class RemoteStreamServiceImpl<M, P extends BufferWriter>
 
   @Override
   public boolean isRelevant(final ClusterMembershipEvent event) {
-    return event.type() == Type.MEMBER_REMOVED;
+    return event.type() == Type.MEMBER_REMOVED || event.type() == Type.MEMBER_ADDED;
   }
 
   @Override
   public void event(final ClusterMembershipEvent event) {
-    apiServer.removeAll(event.subject().id());
-    if (event.type() == Type.MEMBER_ADDED) {
+    final var type = event.type();
+
+    if (type == Type.MEMBER_REMOVED) {
+      apiServer.removeAll(event.subject().id());
+    } else if (type == Type.MEMBER_ADDED) {
       apiServer.recreateStreams(event.subject().id());
     }
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -84,10 +84,18 @@ public final class RemoteStreamTransport<M> extends Actor {
 
   public void recreateStreams(final MemberId receiver) {
     try {
-      sendRestartStreamsCommand(receiver);
-      LOG.debug("Tried to restart streams with member: {}", receiver);
+      LOG.debug("Restarting streams with for newly added member '{}'", receiver);
+      sendRestartStreamsCommand(receiver)
+          .whenComplete(
+              (ok, error) -> {
+                if (error != null) {
+                  LOG.warn("Failed to restart streams for member '{}'", receiver, error);
+                } else {
+                  LOG.debug("Restarted streams for member '{}'", receiver);
+                }
+              });
     } catch (final Exception e) {
-      LOG.warn("Failed to restart streams with member: {}", receiver, e);
+      LOG.warn("Failed to restart streams for member '{}'", receiver, e);
     }
   }
 


### PR DESCRIPTION
# Description
Backport of #14772 to `stable/8.3`.

relates to #14771
original author: @npepinpe