### PR TITLE
Allow tracing system calls in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Install strace tests
-        run: sudo apt-get -qq update && sudo apt-get install -y strace
+      - name: Install and allow strace tests
+        run: |
+          sudo apt-get -qq update && sudo apt-get install -y strace
+          sudo sysctl -w kernel.yama.ptrace_scope=0
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,7 +105,6 @@
     <version.json-smart>2.4.8</version.json-smart>
     <version.byte-buddy>1.14.9</version.byte-buddy>
     <version.revapi>0.28.1</version.revapi>
-    <version.commons-io>2.11.0</version.commons-io>
     <version.immutables>2.10.0</version.immutables>
     <version.jsr305>3.0.2</version.jsr305>
     <version.classgraph>4.8.163</version.classgraph>

--- a/snapshot/pom.xml
+++ b/snapshot/pom.xml
@@ -57,6 +57,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-scheduler</artifactId>
       <classifier>tests</classifier>

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -28,7 +28,6 @@ import java.util.zip.Checksum;
 import org.agrona.IoUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
@@ -130,7 +129,6 @@ public final class SnapshotChecksumTest {
     assertThat(actual.getCombinedValue()).isEqualTo(expectedChecksum.getCombinedValue());
   }
 
-  @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true")
   @EnabledOnOs(OS.LINUX)
   @Test
   void shouldFlushOnPersist() throws Exception {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/STracer.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/STracer.java
@@ -7,65 +7,138 @@
  */
 package io.camunda.zeebe.test.util;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
+import java.time.Duration;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.agrona.LangUtil;
 
+/**
+ * A utility class to manage <a
+ * href="https://man7.org/linux/man-pages/man1/strace.1.html">strace</a> runs.
+ *
+ * <p>It allows tracing system calls during its run, which can be used to test that `fsync` or
+ * `mysnc` are actually called.
+ *
+ * <p>NOTE: all methods to read back traces block up to 1 second. This is because communication
+ * between this process (i.e. Java) and strace happens over a file, meaning it's asynchronous and
+ * there may be some delay. As such, calling {@link #fSyncTraces()}, for example, will block up to 1
+ * second
+ *
+ * <p>This is only usable iff:
+ *
+ * <ul>
+ *   <li>strace is installed on your machine
+ *   <li>Running {@code sysctl kernel.yama.ptace_scope} returns 0
+ *   <li>If running on Docker, CAP_SYS_PTRACE is added to the capabilities
+ *   <li>If running in Kubernetes, SYS_PTRACE is added to the container's security context
+ *       capabilities
+ * </ul>
+ */
 public final class STracer implements AutoCloseable {
   private final Process process;
   private final Path outputFile;
+
+  private boolean isClosed;
 
   private STracer(final Process process, final Path outputFile) {
     this.process = process;
     this.outputFile = outputFile;
   }
 
-  public static STracer traceFor(final Syscall syscall, final Path outputFile) throws IOException {
-    return traceFor(syscall, outputFile, false);
-  }
-
-  public static STracer traceFor(final Syscall syscall, final Path outputFile, final boolean debug)
-      throws IOException {
+  /**
+   * Returns a tracer for the given system call which will output its result in the given output
+   * file.
+   *
+   * <p>Make sure to close the tracer instance when you're finished.
+   *
+   * @param syscall the call to trace
+   * @param outputFile the file to write to
+   * @return a closeable tracer
+   * @throws IOException if the output file cannot be created/accessed, or strace does not launch
+   */
+  public static STracer tracerFor(final Syscall syscall, final Path outputFile) throws IOException {
     final var pid = ProcessHandle.current().pid();
     final var output = outputFile.toAbsolutePath().toString();
-    final var builder =
+    final var process =
         new ProcessBuilder()
             .command(
-                "strace",
-                "-y",
-                "-f",
-                "-e",
-                "trace=" + syscall.id,
-                "-o",
-                output,
-                "-p",
-                String.valueOf(pid));
+                "strace", "-fye", "trace=" + syscall.id, "-o", output, "-p", String.valueOf(pid))
+            .redirectErrorStream(true)
+            .start();
 
-    if (debug) {
-      builder.inheritIO();
+    if (!Files.exists(outputFile)) {
+      try {
+        Files.createFile(outputFile);
+      } catch (final FileAlreadyExistsException ignored) {
+        // ignored
+      }
     }
 
-    return new STracer(builder.start(), outputFile);
+    // wait until strace is attached, otherwise we risk a race condition where our system call was
+    // called before and we'll never observe it
+    try {
+      Thread.startVirtualThread(() -> waitUntilAttached(process.getInputStream(), pid))
+          .join(Duration.ofSeconds(5));
+    } catch (final InterruptedException e) {
+      LangUtil.rethrowUnchecked(e);
+    }
+
+    return new STracer(process, outputFile);
+  }
+
+  private static void waitUntilAttached(final InputStream input, final long pid) {
+    String line;
+    try (final var reader = new BufferedReader(new InputStreamReader(input))) {
+      while ((line = reader.readLine()) != null) {
+        if (line.startsWith("strace: Process %d attached with".formatted(pid))) {
+          break;
+        }
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   @Override
   public void close() throws Exception {
+    if (isClosed) {
+      return;
+    }
+
+    isClosed = true;
     process.destroy();
     process.waitFor();
   }
 
-  public List<FSyncTrace> fSyncTraces() throws IOException {
-    try (final var reader = Files.newBufferedReader(outputFile)) {
-      return reader.lines().filter(s -> s.contains("fsync")).map(FSyncTrace::of).toList();
+  /**
+   * Returns the list of observed fsync traces.
+   *
+   * <p>NOTE: this method blocks up to 1 second for an incoming trace.
+   *
+   * @return the list of fsync calls observed
+   */
+  public Stream<FSyncTrace> fSyncTraces() {
+    try {
+      return Files.readAllLines(outputFile).stream()
+          .filter(s -> s.contains("fsync"))
+          .map(FSyncTrace::of);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 
   public record FSyncTrace(int pid, int fd, Path path, int result) {
     private static final Pattern FSYNC_CALL =
         Pattern.compile(
-            "^(?<pid>[0-9]+)\\s+fsync\\((?<fd>[0-9]+)\\<(?<path>.+?)\\>\\)\\s+=\\s+(?<result>[0-9]+)$");
+            "^(?<pid>[0-9]+)\\s+fsync\\((?<fd>[0-9]+)<(?<path>.+?)>\\)\\s+=\\s+(?<result>[0-9]+)$");
 
     public static FSyncTrace of(final String straceLine) {
       final var matcher = FSYNC_CALL.matcher(straceLine);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/strace/STracerAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/strace/STracerAssert.java
@@ -9,15 +9,14 @@ package io.camunda.zeebe.test.util.asserts.strace;
 
 import io.camunda.zeebe.test.util.STracer;
 import io.camunda.zeebe.test.util.STracer.FSyncTrace;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.List;
 import org.assertj.core.api.AbstractObjectAssert;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 
 /**
  * Convenience class to assert values obtained through a {@link io.camunda.zeebe.test.util.STracer}.
+ *
+ * <p>NOTE: since strace and the Java program interact asynchronously over file I/O, you will likely
+ * need to wrap your assertion in an {@link org.awaitility.Awaitility} block.
  */
 public final class STracerAssert extends AbstractObjectAssert<STracerAssert, STracer> {
   /**
@@ -40,14 +39,6 @@ public final class STracerAssert extends AbstractObjectAssert<STracerAssert, STr
   /** Returns collection assertions on the underlying `fsync` traces */
   public ListAssert<FSyncTrace> fsyncTraces() {
     isNotNull();
-
-    final List<FSyncTrace> traces;
-    try {
-      traces = actual.fSyncTraces();
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
-
-    return Assertions.assertThat(traces);
+    return ListAssert.assertThatStream(actual.fSyncTraces());
   }
 }


### PR DESCRIPTION
## Description

This PR allows running `strace` in CI. Right now it's enabled only for unit tests, as I don't expect we will use it elsewhere since it will become complicated to trace all system calls as the scope of the test grows.

It also re-enables the snapshot checksum flush test. We could look into reusing this with `msync` for the journal, for Raft, etc., to guarantee we do flush at the expected moments.

## Related issues

related to #14699 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
