### PR TITLE
[Backport stable/8.3] Fix empty checksum file/snapshot corruption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - name: Install strace tests
+        run: sudo apt-get -qq update && sudo apt-get install -y strace
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false

--- a/snapshot/pom.xml
+++ b/snapshot/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -531,8 +531,7 @@ public final class FileBasedSnapshotStore extends Actor
           checksumPath.resolveSibling(checksumPath.getFileName().toString() + TMP_CHECKSUM_SUFFIX);
       try {
         SnapshotChecksum.persist(tmpChecksumPath, immutableChecksumsSFV);
-        Files.move(tmpChecksumPath, checksumPath, StandardCopyOption.ATOMIC_MOVE);
-        FileUtil.flushDirectory(snapshotsDirectory);
+        FileUtil.moveDurably(tmpChecksumPath, checksumPath);
       } catch (final IOException e) {
         rollbackPartialSnapshot(destination);
         throw new UncheckedIOException(e);

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -28,6 +28,7 @@ import java.util.zip.Checksum;
 import org.agrona.IoUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
@@ -129,6 +130,7 @@ public final class SnapshotChecksumTest {
     assertThat(actual.getCombinedValue()).isEqualTo(expectedChecksum.getCombinedValue());
   }
 
+  @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true")
   @EnabledOnOs(OS.LINUX)
   @Test
   void shouldFlushOnPersist() throws Exception {

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -28,6 +28,8 @@ import java.util.zip.Checksum;
 import org.agrona.IoUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 public final class SnapshotChecksumTest {
@@ -127,6 +129,7 @@ public final class SnapshotChecksumTest {
     assertThat(actual.getCombinedValue()).isEqualTo(expectedChecksum.getCombinedValue());
   }
 
+  @EnabledOnOs(OS.LINUX)
   @Test
   void shouldFlushOnPersist() throws Exception {
     // given

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.test.util.STracer;
 import io.camunda.zeebe.test.util.STracer.Syscall;
 import io.camunda.zeebe.test.util.asserts.strace.FSyncTraceAssert;
 import io.camunda.zeebe.test.util.asserts.strace.STracerAssert;
+import io.camunda.zeebe.util.FileUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -25,24 +26,23 @@ import java.nio.file.StandardOpenOption;
 import java.util.zip.CRC32C;
 import java.util.zip.Checksum;
 import org.agrona.IoUtil;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class SnapshotChecksumTest {
+public final class SnapshotChecksumTest {
 
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private @TempDir Path temporaryFolder;
 
   private Path singleFileSnapshot;
   private Path multipleFileSnapshot;
   private Path corruptedSnapshot;
 
-  @Before
-  public void setup() throws Exception {
-    singleFileSnapshot = temporaryFolder.newFolder().toPath();
-    multipleFileSnapshot = temporaryFolder.newFolder().toPath();
-    corruptedSnapshot = temporaryFolder.newFolder().toPath();
+  @BeforeEach
+  void setup() throws Exception {
+    singleFileSnapshot = createTempDir("single");
+    multipleFileSnapshot = createTempDir("multi");
+    corruptedSnapshot = createTempDir("corrupted");
 
     createChunk(singleFileSnapshot, "file1.txt");
 
@@ -64,7 +64,7 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldGenerateTheSameChecksumForOneFile() throws Exception {
+  void shouldGenerateTheSameChecksumForOneFile() throws Exception {
     // given
     final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
 
@@ -76,7 +76,7 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldGenerateDifferentChecksumWhenFileNameIsDifferent() throws Exception {
+  void shouldGenerateDifferentChecksumWhenFileNameIsDifferent() throws Exception {
     // given
     final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
 
@@ -89,7 +89,7 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldGenerateTheSameChecksumForMultipleFiles() throws Exception {
+  void shouldGenerateTheSameChecksumForMultipleFiles() throws Exception {
     // given
     final var expectedChecksum =
         SnapshotChecksum.calculate(multipleFileSnapshot).getCombinedValue();
@@ -102,7 +102,7 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldGenerateDifferentChecksumForDifferentFiles() throws Exception {
+  void shouldGenerateDifferentChecksumForDifferentFiles() throws Exception {
     // given
     final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
 
@@ -114,7 +114,7 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldPersistChecksum() throws Exception {
+  void shouldPersistChecksum() throws Exception {
     // given
     final var expectedChecksum = SnapshotChecksum.calculate(multipleFileSnapshot);
     final var checksumPath = multipleFileSnapshot.resolveSibling("checksum");
@@ -128,9 +128,9 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldFlushOnPersist() throws Exception {
+  void shouldFlushOnPersist() throws Exception {
     // given
-    final var traceFile = temporaryFolder.newFile().toPath();
+    final var traceFile = temporaryFolder.resolve("traceFile");
     final var expectedChecksum = SnapshotChecksum.calculate(multipleFileSnapshot);
     final var checksumPath = multipleFileSnapshot.resolveSibling("checksum");
     final var tracer = STracer.traceFor(Syscall.FSYNC, traceFile);
@@ -150,7 +150,7 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldDetectCorruptedSnapshot() throws IOException {
+  void shouldDetectCorruptedSnapshot() throws IOException {
     // given
     final var expectedChecksum = SnapshotChecksum.calculate(corruptedSnapshot);
     final var checksumPath = corruptedSnapshot.resolveSibling("checksum");
@@ -165,9 +165,9 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldCalculateSameChecksumOfLargeFile() throws IOException {
+  void shouldCalculateSameChecksumOfLargeFile() throws IOException {
     // given
-    final var largeSnapshot = temporaryFolder.newFolder().toPath();
+    final var largeSnapshot = createTempDir("large");
     final Path file = largeSnapshot.resolve("file");
     final String largeData = "a".repeat(4 * IoUtil.BLOCK_SIZE + 100);
     Files.writeString(file, largeData, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
@@ -185,12 +185,12 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldReadFormerSimpleChecksumFile() throws IOException {
+  void shouldReadFormerSimpleChecksumFile() throws IOException {
     // given
-    final Path temp = temporaryFolder.newFolder().toPath();
+    final Path temp = createTempDir("temp");
     final File tempFile = new File(temp.toFile(), "checksum");
     final long expectedChecksum = 0xccaaffeeL;
-    try (final RandomAccessFile file = new RandomAccessFile(tempFile, "rw"); ) {
+    try (final RandomAccessFile file = new RandomAccessFile(tempFile, "rw")) {
       file.writeLong(expectedChecksum);
     }
 
@@ -203,9 +203,9 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldWriteTheNumberOfFiles() throws IOException {
+  void shouldWriteTheNumberOfFiles() throws IOException {
     // given
-    final var folder = temporaryFolder.newFolder().toPath();
+    final var folder = createTempDir("folder");
     createChunk(folder, "file1.txt");
     createChunk(folder, "file2.txt");
     createChunk(folder, "file3.txt");
@@ -221,9 +221,9 @@ public class SnapshotChecksumTest {
   }
 
   @Test
-  public void shouldAddChecksumOfMetadataAtTheEnd() throws IOException {
+  void shouldAddChecksumOfMetadataAtTheEnd() throws IOException {
     // given
-    final var folder = temporaryFolder.newFolder().toPath();
+    final var folder = createTempDir("folder");
     createChunk(folder, "file1.txt");
     createChunk(folder, "file2.txt");
     createChunk(folder, "file3.txt");
@@ -241,5 +241,11 @@ public class SnapshotChecksumTest {
     // then
     assertThat(checksumCalculatedInSteps.getCombinedValue())
         .isEqualTo(checksumCalculatedAtOnce.getCombinedValue());
+  }
+
+  private Path createTempDir(final String name) throws IOException {
+    final var path = temporaryFolder.resolve(name);
+    FileUtil.ensureDirectoryExists(path);
+    return path;
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/STracer.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/STracer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public final class STracer implements AutoCloseable {
+  private final Process process;
+  private final Path outputFile;
+
+  private STracer(final Process process, final Path outputFile) {
+    this.process = process;
+    this.outputFile = outputFile;
+  }
+
+  public static STracer traceFor(final Syscall syscall, final Path outputFile) throws IOException {
+    return traceFor(syscall, outputFile, false);
+  }
+
+  public static STracer traceFor(final Syscall syscall, final Path outputFile, final boolean debug)
+      throws IOException {
+    final var pid = ProcessHandle.current().pid();
+    final var output = outputFile.toAbsolutePath().toString();
+    final var builder =
+        new ProcessBuilder()
+            .command(
+                "strace",
+                "-y",
+                "-f",
+                "-e",
+                "trace=" + syscall.id,
+                "-o",
+                output,
+                "-p",
+                String.valueOf(pid));
+
+    if (debug) {
+      builder.inheritIO();
+    }
+
+    return new STracer(builder.start(), outputFile);
+  }
+
+  @Override
+  public void close() throws Exception {
+    process.destroy();
+    process.waitFor();
+  }
+
+  public List<FSyncTrace> fSyncTraces() throws IOException {
+    try (final var reader = Files.newBufferedReader(outputFile)) {
+      return reader.lines().filter(s -> s.contains("fsync")).map(FSyncTrace::of).toList();
+    }
+  }
+
+  public record FSyncTrace(int pid, int fd, Path path, int result) {
+    private static final Pattern FSYNC_CALL =
+        Pattern.compile(
+            "^(?<pid>[0-9]+)\\s+fsync\\((?<fd>[0-9]+)\\<(?<path>.+?)\\>\\)\\s+=\\s+(?<result>[0-9]+)$");
+
+    public static FSyncTrace of(final String straceLine) {
+      final var matcher = FSYNC_CALL.matcher(straceLine);
+      if (!matcher.find()) {
+        throw new IllegalArgumentException(
+            "Expected line to match format of 'PID fsync(FD<PATH>) = RESULT', but '%s' does not match"
+                .formatted(straceLine));
+      }
+
+      final var pid = Integer.parseInt(matcher.group("pid"));
+      final var fd = Integer.parseInt(matcher.group("fd"));
+      final var path = Path.of(matcher.group("path"));
+      final var result = Integer.parseInt(matcher.group("result"));
+
+      return new FSyncTrace(pid, fd, path, result);
+    }
+  }
+
+  public enum Syscall {
+    FSYNC("fsync");
+
+    private final String id;
+
+    Syscall(final String id) {
+      this.id = id;
+    }
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/strace/FSyncTraceAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/strace/FSyncTraceAssert.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.asserts.strace;
+
+import io.camunda.zeebe.test.util.STracer.FSyncTrace;
+import java.nio.file.Path;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.condition.VerboseCondition;
+
+/**
+ * Utility assertion class to verify `fsync` traces obtained via a {@link
+ * io.camunda.zeebe.test.util.STracer}.
+ *
+ * <p>Typical usage is via {@link STracerAssert}.
+ */
+@SuppressWarnings("UnusedReturnValue")
+public final class FSyncTraceAssert extends AbstractObjectAssert<FSyncTraceAssert, FSyncTrace> {
+
+  /**
+   * @param trace the actual trace to assert against
+   */
+  public FSyncTraceAssert(final FSyncTrace trace) {
+    super(trace, FSyncTraceAssert.class);
+  }
+
+  /**
+   * A convenience factory method that's consistent with AssertJ conventions.
+   *
+   * @param actual the actual trace to assert against
+   * @return an instance of {@link FSyncTraceAssert} to assert properties of the given trace
+   */
+  public static FSyncTraceAssert assertThat(final FSyncTrace actual) {
+    return new FSyncTraceAssert(actual);
+  }
+
+  /**
+   * @return a factory you can use with {@link
+   *     org.assertj.core.api.ListAssert#first(InstanceOfAssertFactory)} or {@link
+   *     org.assertj.core.api.ObjectAssert#asInstanceOf(InstanceOfAssertFactory)}
+   */
+  public static InstanceOfAssertFactory<FSyncTrace, FSyncTraceAssert> factory() {
+    return new InstanceOfAssertFactory<>(FSyncTrace.class, FSyncTraceAssert::assertThat);
+  }
+
+  /**
+   * Asserts that the given fsync was applied on the given path.
+   *
+   * @param path the expected path
+   * @return itself for chaining
+   */
+  public FSyncTraceAssert hasPath(final Path path) {
+    return has(Conditions.hasPath(path));
+  }
+
+  /**
+   * Asserts that the fsync call was successful, i.e. its result code was 0.
+   *
+   * @return itself for chaining
+   */
+  public FSyncTraceAssert isSuccessful() {
+    return has(Conditions.hasResult(0));
+  }
+
+  public static final class Conditions {
+    private Conditions() {}
+
+    /** Returns a condition which checks that a stream has the given stream type. */
+    public static Condition<FSyncTrace> hasPath(final Path path) {
+      return VerboseCondition.verboseCondition(
+          trace -> trace.path().equals(path),
+          "fsync call for the '%s'".formatted(path),
+          trace -> " but actual path is '%s'".formatted(trace.path()));
+    }
+
+    /** Returns a condition which checks that a trace has the given result code. */
+    public static Condition<FSyncTrace> hasResult(final int result) {
+      return VerboseCondition.verboseCondition(
+          trace -> trace.result() == result,
+          "a fsync call with the result '%d'".formatted(result),
+          trace -> " but result code was '%d'".formatted(trace.result()));
+    }
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/strace/STracerAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/strace/STracerAssert.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.asserts.strace;
+
+import io.camunda.zeebe.test.util.STracer;
+import io.camunda.zeebe.test.util.STracer.FSyncTrace;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
+
+/**
+ * Convenience class to assert values obtained through a {@link io.camunda.zeebe.test.util.STracer}.
+ */
+public final class STracerAssert extends AbstractObjectAssert<STracerAssert, STracer> {
+  /**
+   * @param tracer the actual tracer to assert against
+   */
+  public STracerAssert(final STracer tracer) {
+    super(tracer, STracerAssert.class);
+  }
+
+  /**
+   * A convenience factory method that's consistent with AssertJ conventions.
+   *
+   * @param actual the actual tracer to assert against
+   * @return an instance of {@link STracerAssert} to assert properties of the given tracer
+   */
+  public static STracerAssert assertThat(final STracer actual) {
+    return new STracerAssert(actual);
+  }
+
+  /** Returns collection assertions on the underlying `fsync` traces */
+  public ListAssert<FSyncTrace> fsyncTraces() {
+    isNotNull();
+
+    final List<FSyncTrace> traces;
+    try {
+      traces = actual.fSyncTraces();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    return Assertions.assertThat(traces);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #14778 to `stable/8.3`.

relates to #14699
original author: @npepinpe