### PR TITLE
Get Identity version during runtime

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -158,7 +158,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>identity-sdk</artifactId>
-      <version>${version.identity}</version>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1089,6 +1089,12 @@
         <version>${version.jetbrains-annotations}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>identity-sdk</artifactId>
+        <version>${version.identity}</version>
+      </dependency>
+
       <!-- Dependencies present for convergence only -->
       <!-- between log4j2 and commons-compress (from testcontainers) -->
       <dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -413,6 +413,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>identity-sdk</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.it.multitenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.identity.sdk.Identity;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
@@ -130,9 +131,12 @@ public class MultiTenancyOverIdentityIT {
   private static final GenericContainer<?> IDENTITY =
       new GenericContainer<>(
               DockerImageName.parse("camunda/identity")
-                  .withTag(System.getProperty("identity.docker.image.version", "8.3.0")))
+                  .withTag(
+                      System.getProperty(
+                          "identity.docker.image.version",
+                          Identity.class.getPackage().getImplementationVersion())))
           .withImagePullPolicy(
-              System.getProperty("identity.docker.image.version", "8.3.0").equals("8.3.0")
+              System.getProperty("identity.docker.image.version", "SNAPSHOT").equals("SNAPSHOT")
                   ? PullPolicy.alwaysPull()
                   : PullPolicy.defaultPolicy())
           .dependsOn(POSTGRES, KEYCLOAK)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The Identity version was hardcoded. This means it would get out of sync soon, unless we manually update the version everytime.

We can retrieve this version during runtime through one of the classes in the Identity SDK. As a result we'll always run these tests with the tag that's defined in our pom file.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14812 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
