### PR TITLE
fix: remove subscription when correlation is rejected

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -9,15 +9,12 @@ package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
@@ -28,8 +25,6 @@ public final class MessageSubscriptionRejectProcessor
   private final MessageSubscriptionState subscriptionState;
   private final SubscriptionCommandSender commandSender;
   private final StateWriter stateWriter;
-  private final TypedRejectionWriter rejectionWriter;
-  private final SideEffectWriter sideEffectWriter;
 
   public MessageSubscriptionRejectProcessor(
       final MessageState messageState,
@@ -40,22 +35,12 @@ public final class MessageSubscriptionRejectProcessor
     this.subscriptionState = subscriptionState;
     this.commandSender = commandSender;
     stateWriter = writers.state();
-    rejectionWriter = writers.rejection();
-    sideEffectWriter = writers.sideEffect();
   }
 
   @Override
   public void processRecord(final TypedRecord<MessageSubscriptionRecord> record) {
 
     final MessageSubscriptionRecord subscriptionRecord = record.getValue();
-
-    if (!messageState.existMessageCorrelation(
-        subscriptionRecord.getMessageKey(), subscriptionRecord.getBpmnProcessIdBuffer())) {
-
-      rejectCommand(record);
-      return;
-    }
-
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageSubscriptionIntent.REJECTED, subscriptionRecord);
 
@@ -100,8 +85,8 @@ public final class MessageSubscriptionRejectProcessor
         });
   }
 
-  private boolean sendCorrelateCommand(final MessageSubscriptionRecord subscription) {
-    return commandSender.correlateProcessMessageSubscription(
+  private void sendCorrelateCommand(final MessageSubscriptionRecord subscription) {
+    commandSender.correlateProcessMessageSubscription(
         subscription.getProcessInstanceKey(),
         subscription.getElementInstanceKey(),
         subscription.getBpmnProcessIdBuffer(),
@@ -110,15 +95,5 @@ public final class MessageSubscriptionRejectProcessor
         subscription.getVariablesBuffer(),
         subscription.getCorrelationKeyBuffer(),
         subscription.getTenantId());
-  }
-
-  private void rejectCommand(final TypedRecord<MessageSubscriptionRecord> record) {
-    final var subscription = record.getValue();
-    final var reason =
-        String.format(
-            "Expected message '%d' to be correlated for process with BPMN process id '%s' but no correlation was found",
-            subscription.getMessageKey(), subscription.getBpmnProcessId());
-
-    rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -161,6 +161,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   private void sendRejectionCommand(final ProcessMessageSubscriptionRecord subscription) {
     subscriptionCommandSender.rejectCorrelateMessageSubscription(
         subscription.getProcessInstanceKey(),
+        subscription.getElementInstanceKey(),
         subscription.getBpmnProcessIdBuffer(),
         subscription.getMessageKey(),
         subscription.getMessageNameBuffer(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -160,6 +160,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
   private void sendRejectionCommand(final ProcessMessageSubscriptionRecord subscription) {
     subscriptionCommandSender.rejectCorrelateMessageSubscription(
+        subscription.getSubscriptionPartitionId(),
         subscription.getProcessInstanceKey(),
         subscription.getElementInstanceKey(),
         subscription.getBpmnProcessIdBuffer(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -284,6 +284,7 @@ public class SubscriptionCommandSender {
 
   public boolean rejectCorrelateMessageSubscription(
       final long processInstanceKey,
+      final long elementInstanceKey,
       final DirectBuffer bpmnProcessId,
       final long messageKey,
       final DirectBuffer messageName,
@@ -295,7 +296,7 @@ public class SubscriptionCommandSender {
         MessageSubscriptionIntent.REJECT,
         new MessageSubscriptionRecord()
             .setProcessInstanceKey(processInstanceKey)
-            .setElementInstanceKey(-1L)
+            .setElementInstanceKey(elementInstanceKey)
             .setBpmnProcessId(bpmnProcessId)
             .setMessageName(messageName)
             .setCorrelationKey(correlationKey)

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -283,6 +283,7 @@ public class SubscriptionCommandSender {
   }
 
   public boolean rejectCorrelateMessageSubscription(
+      final int subscriptionPartitionId,
       final long processInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer bpmnProcessId,
@@ -291,7 +292,7 @@ public class SubscriptionCommandSender {
       final DirectBuffer correlationKey,
       final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
-        Protocol.decodePartitionId(processInstanceKey),
+        subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
         MessageSubscriptionIntent.REJECT,
         new MessageSubscriptionRecord()

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -202,7 +202,8 @@ public final class EventAppliers implements EventApplier {
         new MessageSubscriptionCorrelatedApplier(state.getMessageSubscriptionState()));
     register(
         MessageSubscriptionIntent.REJECTED,
-        new MessageSubscriptionRejectedApplier(state.getMessageState()));
+        new MessageSubscriptionRejectedApplier(
+            state.getMessageState(), state.getMessageSubscriptionState()));
     register(
         MessageSubscriptionIntent.DELETED,
         new MessageSubscriptionDeletedApplier(state.getMessageSubscriptionState()));

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageSubscriptionRejectedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageSubscriptionRejectedApplier.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 
@@ -16,14 +17,18 @@ public final class MessageSubscriptionRejectedApplier
     implements TypedEventApplier<MessageSubscriptionIntent, MessageSubscriptionRecord> {
 
   private final MutableMessageState messageState;
+  private final MutableMessageSubscriptionState subscriptionState;
 
-  public MessageSubscriptionRejectedApplier(final MutableMessageState messageState) {
+  public MessageSubscriptionRejectedApplier(
+      final MutableMessageState messageState,
+      final MutableMessageSubscriptionState subscriptionState) {
     this.messageState = messageState;
+    this.subscriptionState = subscriptionState;
   }
 
   @Override
   public void applyState(final long key, final MessageSubscriptionRecord value) {
-
+    subscriptionState.remove(value.getElementInstanceKey(), value.getMessageNameBuffer());
     messageState.removeMessageCorrelation(value.getMessageKey(), value.getBpmnProcessIdBuffer());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -265,7 +265,7 @@ public final class DbMessageState implements MutableMessageState {
     this.messageKey.wrapLong(messageKey);
     bpmnProcessIdKey.wrapBuffer(bpmnProcessId);
 
-    correlatedMessageColumnFamily.deleteExisting(messageBpmnProcessIdKey);
+    correlatedMessageColumnFamily.deleteIfExists(messageBpmnProcessIdKey);
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationReliabilityTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationReliabilityTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class MessageCorrelationReliabilityTest {
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(2);
+
+  @Test
+  public void shouldCleanupSubscriptionAfterRejection() throws InterruptedException {
+    // given - a process instance on partition 1 that waits for a message published on 2
+    final var processInstancePartitionId = 1;
+    final var messageSubscriptionPartitionId = 2;
+    final var correlationKey = "test-2";
+    assertThat(
+            SubscriptionUtil.getSubscriptionPartitionId(
+                new UnsafeBuffer(correlationKey.getBytes(StandardCharsets.UTF_8)),
+                engine.getPartitionIds().size()))
+        .isEqualTo(messageSubscriptionPartitionId);
+
+    final var messageName = "message-" + UUID.randomUUID();
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent("receive-message")
+            .message(m -> m.name(messageName).zeebeCorrelationKeyExpression("key"))
+            .endEvent("end")
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withVariable("key", correlationKey)
+            .create();
+
+    assertThat(Protocol.decodePartitionId(processInstanceKey))
+        .isEqualTo(processInstancePartitionId);
+
+    engine.deployment().withXmlResource(process).deploy();
+
+    // given - MESSAGE_SUBSCRIPTION/CORRELATE messages from partition 2 to partition 1 are dropped
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) ->
+            !(receiverPartitionId == messageSubscriptionPartitionId
+                && intent == MessageSubscriptionIntent.CORRELATE));
+
+    // when - A message is published and some time passes
+    engine.message().withName(messageName).withCorrelationKey(correlationKey).publish();
+    engine.increaseTime(Duration.ofMinutes(10));
+
+    // then - the message correlation is not acknowledged and at least once rejected
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATE)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName(messageName)
+                .withPartitionId(messageSubscriptionPartitionId)
+                .limit(1)
+                .count())
+        .isZero();
+    // then - the message is correlated once to the process instance on partition 1
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CORRELATED)
+                .withPartitionId(processInstancePartitionId)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName(messageName)
+                .limit(10)
+                .count())
+        .isOne();
+
+    // then - the correlation is not acknowledged on partition 2
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATE)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName(messageName)
+                .withPartitionId(messageSubscriptionPartitionId)
+                .limit(1)
+                .count())
+        .isZero();
+
+    // then - Partition 1 gets another correlation after partition 2 retries
+    engine.increaseTime(Duration.ofMinutes(10));
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CORRELATE)
+                .withRecordType(RecordType.COMMAND)
+                .withProcessInstanceKey(processInstanceKey)
+                .withPartitionId(processInstancePartitionId)
+                .withMessageName(messageName)
+                .limit(10)
+                .count())
+        .isEqualTo(messageSubscriptionPartitionId);
+
+    // then - The correlation is rejected once on partition 1
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.REJECT)
+                .withProcessInstanceKey(processInstanceKey)
+                .withPartitionId(messageSubscriptionPartitionId)
+                .withMessageName(messageName)
+                .limit(10)
+                .count())
+        .isOne();
+  }
+
+  private int getPartitionId(final String correlationKey) {
+    final List<Integer> partitionIds = engine.getPartitionIds();
+    return SubscriptionUtil.getSubscriptionPartitionId(
+        BufferUtil.wrapString(correlationKey), partitionIds.size());
+  }
+
+  private ProcessInstanceWaitingForMessage waitingProcessInstance(
+      final int processInstancePartitionId, final int messageSubscriptionPartitionId) {
+    final var processId = "process-" + UUID.randomUUID();
+    final var correlationKey = correlationKeyWithSubscriptionOn(messageSubscriptionPartitionId);
+
+    final var messageName = "message-" + UUID.randomUUID();
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .id(processId)
+            .startEvent()
+            .intermediateCatchEvent("receive-message")
+            .message(m -> m.name(messageName).zeebeCorrelationKeyExpression("key"))
+            .endEvent("end")
+            .done();
+
+    engine.deployment().withXmlResource(process).deploy();
+    long processInstance = -1;
+    do {
+      if (processInstance != -1) {
+        engine.processInstance().withInstanceKey(processInstance).cancel();
+      }
+
+      processInstance =
+          engine
+              .processInstance()
+              .ofBpmnProcessId(processId)
+              .withVariable("key", correlationKey)
+              .create();
+    } while (Protocol.decodePartitionId(processInstance) != processInstancePartitionId);
+
+    return new ProcessInstanceWaitingForMessage(processInstance, messageName, correlationKey);
+  }
+
+  private String correlationKeyWithSubscriptionOn(final int partitionId) {
+    String correlationKey;
+    do {
+      correlationKey = "test-" + ThreadLocalRandom.current().nextInt();
+    } while (getPartitionId(correlationKey) != partitionId);
+    return correlationKey;
+  }
+
+  record ProcessInstanceWaitingForMessage(
+      long processInstanceKey, String messagename, String correlationKey) {}
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -322,6 +322,7 @@ public class SubscriptionCommandSenderTest {
     // when
     subscriptionCommandSender.rejectCorrelateMessageSubscription(
         DIFFERENT_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_KEY,
         DEFAULT_MESSAGE_NAME,
@@ -340,6 +341,7 @@ public class SubscriptionCommandSenderTest {
     // when
     subscriptionCommandSender.rejectCorrelateMessageSubscription(
         SAME_RECEIVER_PARTITION_KEY,
+        DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_KEY,
         DEFAULT_MESSAGE_NAME,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -321,6 +321,7 @@ public class SubscriptionCommandSenderTest {
 
     // when
     subscriptionCommandSender.rejectCorrelateMessageSubscription(
+        DIFFERENT_PARTITION,
         DIFFERENT_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_ID,
@@ -340,6 +341,7 @@ public class SubscriptionCommandSenderTest {
 
     // when
     subscriptionCommandSender.rejectCorrelateMessageSubscription(
+        (int) SAME_RECEIVER_PARTITION_KEY,
         SAME_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_ID,


### PR DESCRIPTION
This fixes two issues with rejecting message correlation.

First, there appears to be a long-standing bug where `MESSAGE_SUBSCRIPTION/REJECT` was written on the process instance partition, not the message partition. I couldn't find a state in the git history where this has not been the case but best I can tell, `MESSAGE_SUBSCRIPTION` records are always supposed to be written on the message partition.

:warning: While it makes perfect sense to me that this was a bug and my fix is correct, I'm also very surprised that this was not caught before and that message correlation appeared to work. A double check by someone more familiar with message correlation is required.

Second is the bug reported in #13814 where a missed acknowledgement (via `MESSAGE_SUBSCRIPTION/CORRELATE`) would result in an endless loop of correlation attempts and rejections. To fix this, a `MESSAGE_SUBSCRIPTION/REJECT` is now treated as a definitive signal that the subscription is not supposed to exist anymore. As a result, the message partition now removes the subscription when correlation is rejected and stops trying to correlate.

:warning: While I've discussed the bug fix for #13814 with @saig0, I'm still not entirely sure if the new behavior for `MESSAGE_SUBSCRIPTION/REJECT` is always safe. The risk I see is that we might accidentally remove a subscription that was not supposed to be removed. I'm not familiar enough with BPMN and the engine implementation to figure that out.


:sos: I've tried adding a test to verify the behavior when acknowledgments are lost (the root cause for #13814). Overall I'm not happy with this test, mainly because I'm not sure if it is verifying enough and also because it is very slow. Some help to improve this test would be greatly appreciated <3.


Closes #14814 
