### PR TITLE
Add details about completed operations in ClusterTopology

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -92,9 +92,14 @@ final class TopologyManagementRequestsHandler implements TopologyManagementApi {
             (result, error) -> {
               if (error == null) {
                 // TODO: This must be return result directly
-                responseFuture.complete(
-                    new TopologyChangeStatus(
-                        result.finalTopology().changes().version(), StatusCode.IN_PROGRESS));
+                final var changeStatus =
+                    result.finalTopology().pendingChanges().isPresent()
+                        ? new TopologyChangeStatus(
+                            result.finalTopology().pendingChanges().get().id(),
+                            StatusCode.IN_PROGRESS)
+                        : new TopologyChangeStatus(
+                            result.finalTopology().version(), StatusCode.COMPLETED);
+                responseFuture.complete(changeStatus);
               } else {
                 responseFuture.completeExceptionally(error);
               }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -150,12 +150,12 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
       final ClusterTopology updatedTopology,
       final TopologyChangeAppliersImpl topologyChangeSimulator,
       final ActorFuture<ClusterTopology> simulationCompleted) {
-    if (!updatedTopology.changes().hasPendingChanges()) {
+    if (!updatedTopology.hasPendingChanges()) {
       simulationCompleted.complete(updatedTopology);
       return;
     }
 
-    final var operation = updatedTopology.changes().nextPendingOperation();
+    final var operation = updatedTopology.nextPendingOperation();
     final OperationApplier applier = topologyChangeSimulator.getApplier(operation);
     final var result = applier.init(updatedTopology);
     if (result.isLeft()) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -150,12 +150,12 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
       final ClusterTopology updatedTopology,
       final TopologyChangeAppliersImpl topologyChangeSimulator,
       final ActorFuture<ClusterTopology> simulationCompleted) {
-    if (updatedTopology.changes().pendingOperations().isEmpty()) {
+    if (!updatedTopology.changes().hasPendingChanges()) {
       simulationCompleted.complete(updatedTopology);
       return;
     }
 
-    final var operation = updatedTopology.changes().pendingOperations().get(0);
+    final var operation = updatedTopology.changes().nextPendingOperation();
     final OperationApplier applier = topologyChangeSimulator.getApplier(operation);
     final var result = applier.init(updatedTopology);
     if (result.isLeft()) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -125,7 +125,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
         .lastChange()
         .ifPresent(lastChange -> builder.setLastChange(encodeCompletedChange(lastChange)));
     clusterTopology
-        .changes()
+        .pendingChanges()
         .ifPresent(changePlan -> builder.setCurrentChange(encodeChangePlan(changePlan)));
 
     return builder.build();

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
@@ -7,7 +7,11 @@
  */
 package io.camunda.zeebe.topology.state;
 
+import io.atomix.cluster.MemberId;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents the ongoing cluster topology changes. The pendingOperations are executed sequentially.
@@ -18,21 +22,51 @@ import java.util.List;
  * pending operations. This helps to choose the latest state of the topology change when receiving
  * gossip update out of order.
  */
-public record ClusterChangePlan(int version, List<TopologyChangeOperation> pendingOperations) {
+public record ClusterChangePlan(
+    int version, Optional<CompletedChange> lastChange, Optional<PendingChange> ongoingChange) {
   public static ClusterChangePlan empty() {
-    return new ClusterChangePlan(0, List.of());
+    return new ClusterChangePlan(0, Optional.empty(), Optional.empty());
   }
 
-  public static ClusterChangePlan init(final List<TopologyChangeOperation> operations) {
-    return new ClusterChangePlan(1, List.copyOf(operations));
+  public static ClusterChangePlan init(
+      final long id, final List<TopologyChangeOperation> operations) {
+    return new ClusterChangePlan(
+        1,
+        Optional.empty(),
+        Optional.of(
+            new PendingChange(
+                id, Status.IN_PROGRESS, Instant.now(), List.of(), List.copyOf(operations))));
   }
 
   /** To be called when the first operation is completed. */
   ClusterChangePlan advance() {
     // List#subList hold on to the original list. Make a copy to prevent a potential memory leak.
+    final PendingChange pendingChange = ongoingChange.orElseThrow();
+    final List<TopologyChangeOperation> pendingOperations = pendingChange.pendingOperations();
     final var nextPendingOperations =
         List.copyOf(pendingOperations.subList(1, pendingOperations.size()));
-    return new ClusterChangePlan(version + 1, nextPendingOperations);
+    final var newCompletedOperations = new ArrayList<>(pendingChange.completedOperations());
+    newCompletedOperations.add(new CompletedOperation(pendingOperations.get(0), Instant.now()));
+    return new ClusterChangePlan(
+        version + 1,
+        lastChange,
+        Optional.of(
+            new PendingChange(
+                pendingChange.id(),
+                pendingChange.status(),
+                pendingChange.startedAt(),
+                newCompletedOperations,
+                nextPendingOperations)));
+  }
+
+  ClusterChangePlan completed() {
+    final var pendingChange = ongoingChange.orElseThrow();
+    return new ClusterChangePlan(
+        0, // reset version
+        Optional.of(
+            new CompletedChange(
+                pendingChange.id(), Status.COMPLETED, pendingChange.startedAt(), Instant.now())),
+        Optional.empty());
   }
 
   public ClusterChangePlan merge(final ClusterChangePlan other) {
@@ -44,5 +78,38 @@ public record ClusterChangePlan(int version, List<TopologyChangeOperation> pendi
       return other;
     }
     return this;
+  }
+
+  public boolean hasPendingChangesFor(final MemberId memberId) {
+    if (ongoingChange.isEmpty()) {
+      return false;
+    }
+    final var pendingOperations = ongoingChange.get().pendingOperations();
+    return !pendingOperations.isEmpty() && pendingOperations.get(0).memberId().equals(memberId);
+  }
+
+  public TopologyChangeOperation nextPendingOperation() {
+    return ongoingChange.orElseThrow().pendingOperations().get(0);
+  }
+
+  public boolean hasPendingChanges() {
+    return ongoingChange.isPresent() && !ongoingChange.get().pendingOperations().isEmpty();
+  }
+
+  public record CompletedChange(long id, Status status, Instant startedAt, Instant completedAt) {}
+
+  public record PendingChange(
+      long id,
+      Status status,
+      Instant startedAt,
+      List<CompletedOperation> completedOperations,
+      List<TopologyChangeOperation> pendingOperations) {}
+
+  public record CompletedOperation(TopologyChangeOperation operation, Instant completedAt) {}
+
+  public enum Status {
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -12,6 +12,8 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.state.MemberState.State;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
@@ -32,12 +34,15 @@ import java.util.stream.Stream;
  * <p>This class is immutable. Each mutable methods returns a new instance with the updated state.
  */
 public record ClusterTopology(
-    long version, Map<MemberId, MemberState> members, ClusterChangePlan changes) {
+    long version,
+    Map<MemberId, MemberState> members,
+    Optional<CompletedChange> lastChange,
+    Optional<ClusterChangePlan> changes) {
 
   private static final int UNINITIALIZED_VERSION = -1;
 
   public static ClusterTopology uninitialized() {
-    return new ClusterTopology(UNINITIALIZED_VERSION, Map.of(), ClusterChangePlan.empty());
+    return new ClusterTopology(UNINITIALIZED_VERSION, Map.of(), Optional.empty(), Optional.empty());
   }
 
   public boolean isUninitialized() {
@@ -45,7 +50,7 @@ public record ClusterTopology(
   }
 
   public static ClusterTopology init() {
-    return new ClusterTopology(0, Map.of(), ClusterChangePlan.empty());
+    return new ClusterTopology(0, Map.of(), Optional.empty(), Optional.empty());
   }
 
   public ClusterTopology addMember(final MemberId memberId, final MemberState state) {
@@ -58,7 +63,7 @@ public record ClusterTopology(
 
     final var newMembers =
         ImmutableMap.<MemberId, MemberState>builder().putAll(members).put(memberId, state).build();
-    return new ClusterTopology(version, newMembers, changes);
+    return new ClusterTopology(version, newMembers, lastChange, changes);
   }
 
   /**
@@ -96,7 +101,7 @@ public record ClusterTopology(
     }
 
     final var newMembers = mapBuilder.buildKeepingLast();
-    return new ClusterTopology(version, newMembers, changes);
+    return new ClusterTopology(version, newMembers, lastChange, changes);
   }
 
   public ClusterTopology startTopologyChange(final List<TopologyChangeOperation> operations) {
@@ -110,7 +115,10 @@ public record ClusterTopology(
     } else {
       final long newVersion = version + 1;
       return new ClusterTopology(
-          newVersion, members, ClusterChangePlan.init(newVersion, operations));
+          newVersion,
+          members,
+          lastChange,
+          Optional.of(ClusterChangePlan.init(newVersion, operations)));
     }
   }
 
@@ -130,12 +138,20 @@ public record ClusterTopology(
     } else {
       final var mergedMembers =
           Stream.concat(members.entrySet().stream(), other.members().entrySet().stream())
-              .collect(
-                  Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, MemberState::merge));
+              .collect(Collectors.toMap(Entry::getKey, Entry::getValue, MemberState::merge));
 
-      final var mergedChanges = changes.merge(other.changes);
-      return new ClusterTopology(version, ImmutableMap.copyOf(mergedMembers), mergedChanges);
+      final Optional<ClusterChangePlan> mergedChanges =
+          Stream.of(changes, other.changes)
+              .flatMap(Optional::stream)
+              .reduce(ClusterChangePlan::merge);
+
+      return new ClusterTopology(
+          version, ImmutableMap.copyOf(mergedMembers), lastChange, mergedChanges);
     }
+  }
+
+  public boolean hasPendingChanges() {
+    return changes.isPresent() && changes.orElseThrow().hasPendingChanges();
   }
 
   /**
@@ -143,7 +159,7 @@ public record ClusterTopology(
    *     otherwise returns false.
    */
   private boolean hasPendingChangesFor(final MemberId memberId) {
-    return changes.hasPendingChangesFor(memberId);
+    return changes.isPresent() && changes.get().hasPendingChangesFor(memberId);
   }
 
   /**
@@ -157,7 +173,7 @@ public record ClusterTopology(
     if (!hasPendingChangesFor(memberId)) {
       return Optional.empty();
     }
-    return Optional.of(changes.nextPendingOperation());
+    return Optional.of(changes.orElseThrow().nextPendingOperation());
   }
 
   /**
@@ -179,7 +195,9 @@ public record ClusterTopology(
       throw new IllegalStateException(
           "Expected to advance the topology change, but there is no pending change");
     }
-    final ClusterTopology result = new ClusterTopology(version, members, changes.advance());
+    final ClusterTopology result =
+        new ClusterTopology(
+            version, members, lastChange, Optional.of(changes.orElseThrow().advance()));
 
     if (!result.hasPendingChanges()) {
       // The last change has been applied. Clean up the members that are marked as LEFT in the
@@ -194,7 +212,9 @@ public record ClusterTopology(
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
       // Increment the version so that other members can merge by overwriting their local topology.
-      return new ClusterTopology(result.version() + 1, currentMembers, changes.completed());
+      final var completedChange = changes.orElseThrow().completed();
+      return new ClusterTopology(
+          result.version() + 1, currentMembers, Optional.of(completedChange), Optional.empty());
     }
 
     return result;
@@ -206,10 +226,6 @@ public record ClusterTopology(
 
   public MemberState getMember(final MemberId memberId) {
     return members().get(memberId);
-  }
-
-  public boolean hasPendingChanges() {
-    return changes.hasPendingChanges();
   }
 
   public int clusterSize() {
@@ -225,5 +241,12 @@ public record ClusterTopology(
   public int partitionCount() {
     return (int)
         members.values().stream().flatMap(m -> m.partitions().keySet().stream()).distinct().count();
+  }
+
+  public TopologyChangeOperation nextPendingOperation() {
+    if (!hasPendingChanges()) {
+      throw new NoSuchElementException();
+    }
+    return changes.orElseThrow().nextPendingOperation();
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/CompletedChange.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/CompletedChange.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.state;
+
+import io.camunda.zeebe.topology.state.ClusterChangePlan.Status;
+import java.time.Instant;
+
+public record CompletedChange(long id, Status status, Instant startedAt, Instant completedAt) {}

--- a/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
@@ -10,13 +10,13 @@ package io.camunda.zeebe.topology.util;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
-import io.camunda.zeebe.topology.state.ClusterChangePlan;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.PartitionState;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -42,7 +42,7 @@ public final class TopologyUtil {
     }
 
     return new io.camunda.zeebe.topology.state.ClusterTopology(
-        0, Map.copyOf(memberStates), ClusterChangePlan.empty());
+        0, Map.copyOf(memberStates), Optional.empty(), Optional.empty());
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -12,7 +12,8 @@ message GossipState {
 message ClusterTopology {
   int64 version = 1;
   map<string, MemberState> members = 2;
-  ClusterChangePlan changes = 3;
+  CompletedChange lastChange = 3;
+  ClusterChangePlan currentChange = 4;
 }
 
 message MemberState {
@@ -28,11 +29,13 @@ message PartitionState {
 }
 
 message ClusterChangePlan {
-  int32 version = 1;
-  oneof change {
-    CompletedChange completedChange = 2;
-    PendingChange pendingChange = 3;
-  }
+  int64 id = 1;
+  int32 version = 2;
+  ChangeStatus status = 3;
+  google.protobuf.Timestamp startedAt = 4;
+  repeated CompletedTopologyChangeOperation completedOperations = 5;
+  repeated TopologyChangeOperation pendingOperations = 6;
+
 }
 
 message CompletedChange {
@@ -40,14 +43,6 @@ message CompletedChange {
   ChangeStatus status = 2;
   google.protobuf.Timestamp startedAt = 3;
   google.protobuf.Timestamp completedAt = 4;
-}
-
-message PendingChange {
-  int64 id = 1;
-  ChangeStatus status = 2;
-  google.protobuf.Timestamp startedAt = 3;
-  repeated CompletedTopologyChangeOperation completedOperations = 4;
-  repeated TopologyChangeOperation pendingOperations = 5;
 }
 
 message TopologyChangeOperation {

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -29,7 +29,25 @@ message PartitionState {
 
 message ClusterChangePlan {
   int32 version = 1;
-  repeated TopologyChangeOperation operation = 2;
+  oneof change {
+    CompletedChange completedChange = 2;
+    PendingChange pendingChange = 3;
+  }
+}
+
+message CompletedChange {
+  int64 id = 1;
+  ChangeStatus status = 2;
+  google.protobuf.Timestamp startedAt = 3;
+  google.protobuf.Timestamp completedAt = 4;
+}
+
+message PendingChange {
+  int64 id = 1;
+  ChangeStatus status = 2;
+  google.protobuf.Timestamp startedAt = 3;
+  repeated CompletedTopologyChangeOperation completedOperations = 4;
+  repeated TopologyChangeOperation pendingOperations = 5;
 }
 
 message TopologyChangeOperation {
@@ -41,6 +59,11 @@ message TopologyChangeOperation {
     MemberLeaveOperation memberLeave = 5;
     PartitionReconfigurePriorityOperation partitionReconfigurePriority = 6;
   }
+}
+
+message CompletedTopologyChangeOperation {
+  TopologyChangeOperation operation = 1;
+  google.protobuf.Timestamp completedAt = 2;
 }
 
 message PartitionJoinOperation {
@@ -66,6 +89,13 @@ enum State {
   ACTIVE = 2;
   LEAVING = 3;
   LEFT = 4;
+}
+
+enum ChangeStatus {
+  CHANGE_STATUS_UNKNOWN = 0;
+  IN_PROGRESS = 1;
+  COMPLETED = 2;
+  FAILED = 3;
 }
 
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -72,7 +72,13 @@ public final class ClusterTopologyAssert
   }
 
   public ClusterTopologyAssert hasPendingOperationsWithSize(final int expectedSize) {
-    assertThat(actual.changes().pendingOperations()).hasSize(expectedSize);
+    if (expectedSize > 0) {
+      assertThat(actual.hasPendingChanges()).isTrue();
+      assertThat(actual.changes().ongoingChange().orElseThrow().pendingOperations())
+          .hasSize(expectedSize);
+    } else {
+      assertThat(actual.hasPendingChanges()).isFalse();
+    }
     return this;
   }
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -74,7 +74,7 @@ public final class ClusterTopologyAssert
   public ClusterTopologyAssert hasPendingOperationsWithSize(final int expectedSize) {
     if (expectedSize > 0) {
       assertThat(actual.hasPendingChanges()).isTrue();
-      assertThat(actual.changes().orElseThrow().pendingOperations()).hasSize(expectedSize);
+      assertThat(actual.pendingChanges().orElseThrow().pendingOperations()).hasSize(expectedSize);
     } else {
       assertThat(actual.hasPendingChanges()).isFalse();
     }
@@ -115,8 +115,8 @@ public final class ClusterTopologyAssert
         .isEqualTo(optionalExpectedCompletedChange);
 
     // compare ongoing change without timestamps
-    final var optionalActualOngoingChange = actual.changes();
-    final var optionalExpectedOngoingChange = expected.changes();
+    final var optionalActualOngoingChange = actual.pendingChanges();
+    final var optionalExpectedOngoingChange = expected.pendingChanges();
     assertThat(optionalActualOngoingChange)
         .usingRecursiveComparison()
         .ignoringFieldsMatchingRegexes(".*startedAt", ".*version")

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyAssert.java
@@ -74,8 +74,7 @@ public final class ClusterTopologyAssert
   public ClusterTopologyAssert hasPendingOperationsWithSize(final int expectedSize) {
     if (expectedSize > 0) {
       assertThat(actual.hasPendingChanges()).isTrue();
-      assertThat(actual.changes().ongoingChange().orElseThrow().pendingOperations())
-          .hasSize(expectedSize);
+      assertThat(actual.changes().orElseThrow().pendingOperations()).hasSize(expectedSize);
     } else {
       assertThat(actual.hasPendingChanges()).isFalse();
     }
@@ -108,16 +107,16 @@ public final class ClusterTopologyAssert
         .isEqualTo(expected.members());
 
     // compare last change without timestamps
-    final var optionalActualCompletedChange = actual.changes().lastChange();
-    final var optionalExpectedCompletedChange = expected.changes().lastChange();
+    final var optionalActualCompletedChange = actual.lastChange();
+    final var optionalExpectedCompletedChange = expected.lastChange();
     assertThat(optionalActualCompletedChange)
         .usingRecursiveComparison()
         .ignoringFieldsMatchingRegexes(".*startedAt", ".*completedAt")
         .isEqualTo(optionalExpectedCompletedChange);
 
     // compare ongoing change without timestamps
-    final var optionalActualOngoingChange = actual.changes().ongoingChange();
-    final var optionalExpectedOngoingChange = expected.changes().ongoingChange();
+    final var optionalActualOngoingChange = actual.changes();
+    final var optionalExpectedOngoingChange = expected.changes();
     assertThat(optionalActualOngoingChange)
         .usingRecursiveComparison()
         .ignoringFieldsMatchingRegexes(".*startedAt", ".*version")

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
@@ -159,7 +159,7 @@ class PartitionReassignRequestTransformerTest {
       newTopology = oldClusterTopology.startTopologyChange(operations);
     }
     while (newTopology.hasPendingChanges()) {
-      final var operation = newTopology.changes().nextPendingOperation();
+      final var operation = newTopology.nextPendingOperation();
       final var applier = topologyChangeSimulator.getApplier(operation);
       final Either<Exception, UnaryOperator<MemberState>> init = applier.init(newTopology);
       if (init.isLeft()) {

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
@@ -159,7 +159,7 @@ class PartitionReassignRequestTransformerTest {
       newTopology = oldClusterTopology.startTopologyChange(operations);
     }
     while (newTopology.hasPendingChanges()) {
-      final var operation = newTopology.changes().pendingOperations().get(0);
+      final var operation = newTopology.changes().nextPendingOperation();
       final var applier = topologyChangeSimulator.getApplier(operation);
       final Either<Exception, UnaryOperator<MemberState>> init = applier.init(newTopology);
       if (init.isLeft()) {

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -150,6 +150,7 @@ final class ProtoBufSerializerTest {
         topologyWithOneMemberTwoPartitions(),
         topologyWithTwoMembers(),
         topologyWithClusterChangePlan(),
+        topologyWithCompletedClusterChangePlan(),
         topologyWithClusterChangePlanWithMemberOperations());
   }
 
@@ -220,6 +221,15 @@ final class ProtoBufSerializerTest {
     return ClusterTopology.init()
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
         .startTopologyChange(changes);
+  }
+
+  private static ClusterTopology topologyWithCompletedClusterChangePlan() {
+    final List<TopologyChangeOperation> changes =
+        List.of(new PartitionLeaveOperation(MemberId.from("1"), 1));
+    return ClusterTopology.init()
+        .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
+        .startTopologyChange(changes)
+        .advanceTopologyChange(MemberId.from("1"), m -> m);
   }
 
   private static ClusterTopology topologyWithClusterChangePlanWithMemberOperations() {

--- a/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.ClusterTopologyAssert;
-import io.camunda.zeebe.topology.state.ClusterChangePlan.CompletedChange;
 import io.camunda.zeebe.topology.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.topology.state.MemberState.State;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
@@ -182,7 +181,7 @@ class ClusterTopologyTest {
         ClusterTopology.init()
             .addMember(member(1), MemberState.initializeAsActive(Map.of()))
             .startTopologyChange(List.of(new PartitionJoinOperation(member(1), 1, 1)));
-    final var changeId = initialTopology.changes().ongoingChange().orElseThrow().id();
+    final var changeId = initialTopology.changes().orElseThrow().id();
 
     // when
     final var finalTopology =
@@ -194,11 +193,9 @@ class ClusterTopologyTest {
         new ClusterTopology(
             2,
             Map.of(member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.active(1)))),
-            new ClusterChangePlan(
-                0,
-                Optional.of(
-                    new CompletedChange(changeId, Status.COMPLETED, Instant.now(), Instant.now())),
-                Optional.empty()));
+            Optional.of(
+                new CompletedChange(changeId, Status.COMPLETED, Instant.now(), Instant.now())),
+            Optional.empty());
 
     ClusterTopologyAssert.assertThatClusterTopology(finalTopology).hasSameTopologyAs(expected);
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
@@ -181,7 +181,7 @@ class ClusterTopologyTest {
         ClusterTopology.init()
             .addMember(member(1), MemberState.initializeAsActive(Map.of()))
             .startTopologyChange(List.of(new PartitionJoinOperation(member(1), 1, 1)));
-    final var changeId = initialTopology.changes().orElseThrow().id();
+    final var changeId = initialTopology.pendingChanges().orElseThrow().id();
 
     // when
     final var finalTopology =


### PR DESCRIPTION
## Description

Restructured `ClusterChangePlan`  to add an optional completed change and optional pending change. PendingChange is updated while the change is in progress. Once the change is completed pending change is cleared and completed change will be updated with the id, started and completed timestamps.

## Related issues

closes #14835 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
