### PR TITLE
[Backport stable/8.3] Get Identity version during runtime

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -158,7 +158,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>identity-sdk</artifactId>
-      <version>${version.identity}</version>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1089,6 +1089,12 @@
         <version>${version.jetbrains-annotations}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>identity-sdk</artifactId>
+        <version>${version.identity}</version>
+      </dependency>
+
       <!-- Dependencies present for convergence only -->
       <!-- between log4j2 and commons-compress (from testcontainers) -->
       <dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -437,6 +437,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>identity-sdk</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.it.multitenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.identity.sdk.Identity;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
@@ -130,9 +131,12 @@ public class MultiTenancyOverIdentityIT {
   private static final GenericContainer<?> IDENTITY =
       new GenericContainer<>(
               DockerImageName.parse("camunda/identity")
-                  .withTag(System.getProperty("identity.docker.image.version", "8.3.0")))
+                  .withTag(
+                      System.getProperty(
+                          "identity.docker.image.version",
+                          Identity.class.getPackage().getImplementationVersion())))
           .withImagePullPolicy(
-              System.getProperty("identity.docker.image.version", "8.3.0").equals("8.3.0")
+              System.getProperty("identity.docker.image.version", "SNAPSHOT").equals("SNAPSHOT")
                   ? PullPolicy.alwaysPull()
                   : PullPolicy.defaultPolicy())
           .dependsOn(POSTGRES, KEYCLOAK)


### PR DESCRIPTION
# Description
Backport of #14813 to `stable/8.3`.

relates to #14812
original author: @remcowesterhoud