### PR TITLE
fix(atomix): fix DNS/UDP resource leaks

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -138,6 +138,11 @@
       <artifactId>simpleclient</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-dns</artifactId>
+    </dependency>
+
     <!-- test dependencies -->
 
     <dependency>

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyDnsMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyDnsMetrics.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsResponseCode;
+import io.netty.resolver.dns.DnsQueryLifecycleObserver;
+import io.prometheus.client.Counter;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+final class NettyDnsMetrics implements DnsQueryLifecycleObserver {
+  private static final Counter ERROR =
+      Counter.build()
+          .help("Counts how often DNS queries fail with an error")
+          .namespace("zeebe")
+          .subsystem("dns")
+          .name("error")
+          .register();
+  private static final Counter FAILED =
+      Counter.build()
+          .help("Counts how often DNS queries return an unsuccessful answer")
+          .namespace("zeebe")
+          .subsystem("dns")
+          .name("failed")
+          .labelNames("code")
+          .register();
+  private static final Counter WRITTEN =
+      Counter.build()
+          .help("Counts how often DNS queries are written")
+          .namespace("zeebe")
+          .subsystem("dns")
+          .name("written")
+          .register();
+  private static final Counter SUCCESS =
+      Counter.build()
+          .help("Counts how often DNS queries are successful")
+          .namespace("zeebe")
+          .subsystem("dns")
+          .name("success")
+          .register();
+
+  @Override
+  public void queryWritten(final InetSocketAddress dnsServerAddress, final ChannelFuture future) {
+    WRITTEN.inc();
+  }
+
+  @Override
+  public void queryCancelled(final int queriesRemaining) {}
+
+  @Override
+  public DnsQueryLifecycleObserver queryRedirected(final List<InetSocketAddress> nameServers) {
+    return this;
+  }
+
+  @Override
+  public DnsQueryLifecycleObserver queryCNAMEd(final DnsQuestion cnameQuestion) {
+    return this;
+  }
+
+  @Override
+  public DnsQueryLifecycleObserver queryNoAnswer(final DnsResponseCode code) {
+    FAILED.labels(code.toString()).inc();
+    return this;
+  }
+
+  @Override
+  public void queryFailed(final Throwable cause) {
+    ERROR.inc();
+  }
+
+  @Override
+  public void querySucceed() {
+    SUCCESS.inc();
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -62,6 +62,7 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
+import io.netty.resolver.dns.BiDnsQueryLifecycleObserverFactory;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.LoggingDnsQueryLifeCycleObserverFactory;
@@ -377,11 +378,14 @@ public final class NettyMessagingService implements ManagedMessagingService {
         .thenCompose(ok -> bootstrapServer())
         .thenRun(
             () -> {
+              final var metrics = new NettyDnsMetrics();
               dnsResolverGroup =
                   new DnsAddressResolverGroup(
                       new DnsNameResolverBuilder(clientGroup.next())
                           .dnsQueryLifecycleObserverFactory(
-                              new LoggingDnsQueryLifeCycleObserverFactory())
+                              new BiDnsQueryLifecycleObserverFactory(
+                                  ignored -> metrics,
+                                  new LoggingDnsQueryLifeCycleObserverFactory()))
                           .channelType(clientDataGramChannelClass));
               timeoutExecutor =
                   Executors.newSingleThreadScheduledExecutor(

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -91,6 +91,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,6 +126,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private volatile LocalClientConnection localConnection;
   private SslContext serverSslContext;
   private SslContext clientSslContext;
+  private DnsAddressResolverGroup dnsResolverGroup;
   private final MessagingMetrics messagingMetrics = new MessagingMetricsImpl();
 
   public NettyMessagingService(
@@ -375,6 +377,12 @@ public final class NettyMessagingService implements ManagedMessagingService {
         .thenCompose(ok -> bootstrapServer())
         .thenRun(
             () -> {
+              dnsResolverGroup =
+                  new DnsAddressResolverGroup(
+                      new DnsNameResolverBuilder(clientGroup.next())
+                          .dnsQueryLifecycleObserverFactory(
+                              new LoggingDnsQueryLifeCycleObserverFactory())
+                          .channelType(clientDataGramChannelClass));
               timeoutExecutor =
                   Executors.newSingleThreadScheduledExecutor(
                       new DefaultThreadFactory("netty-messaging-timeout-"));
@@ -397,6 +405,11 @@ public final class NettyMessagingService implements ManagedMessagingService {
           () -> {
             boolean interrupted = false;
             try {
+              if (dnsResolverGroup != null) {
+                CloseHelper.close(
+                    error -> log.warn("Failed to close DNS resolvers", error), dnsResolverGroup);
+              }
+
               try {
                 serverChannel.close().sync();
               } catch (final InterruptedException e) {
@@ -721,11 +734,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000);
     bootstrap.group(clientGroup);
     bootstrap.channel(clientChannelClass);
-    bootstrap.resolver(
-        new DnsAddressResolverGroup(
-            new DnsNameResolverBuilder(clientGroup.next())
-                .dnsQueryLifecycleObserverFactory(new LoggingDnsQueryLifeCycleObserverFactory())
-                .channelType(clientDataGramChannelClass)));
+    bootstrap.resolver(dnsResolverGroup);
     bootstrap.remoteAddress(socketAddress);
     bootstrap.handler(new BasicClientChannelInitializer(future));
 

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.condition.OS;
 final class NettyMessagingServiceTest {
 
   private static final String IP_STRING = "127.0.0.1";
+  private static final int UID_COLUMN = 7;
 
   @AutoCloseResource private NettyMessagingService netty1;
   private Address address1;
@@ -747,12 +748,13 @@ final class NettyMessagingServiceTest {
     final var uid = new UnixSystem().getUid();
     lines.remove(0);
 
-    // then filter out any sockets not opened by the current user
+    // the UDP file is a table, where each row is whitespace separated and here we're only
+    // interested in the lines where the UID column happens to match our user ID
     return lines.stream()
         .filter(
             line -> {
               final String[] columns = line.trim().split("\\s+");
-              return Long.parseLong(columns[7]) == uid;
+              return Long.parseLong(columns[UID_COLUMN]) == uid;
             })
         .count();
   }

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -17,13 +17,6 @@
 package io.atomix.cluster.messaging.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -31,12 +24,13 @@ import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.utils.net.Address;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.net.ConnectException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -49,72 +43,69 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
-import java.util.stream.Stream;
 import org.agrona.collections.MutableReference;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.slf4j.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /** Netty messaging service test. */
-public class NettyMessagingServiceTest {
+@AutoCloseResources
+final class NettyMessagingServiceTest {
 
-  private static final Logger LOGGER = getLogger(NettyMessagingServiceTest.class);
   private static final String IP_STRING = "127.0.0.1";
-  ManagedMessagingService netty1;
-  ManagedMessagingService netty2;
-  ManagedMessagingService nettyv11;
-  ManagedMessagingService nettyv12;
-  ManagedMessagingService nettyv21;
-  ManagedMessagingService nettyv22;
-  Address address1;
-  Address address2;
-  Address addressv11;
-  Address addressv12;
-  Address addressv21;
-  Address addressv22;
-  Address invalidAddress;
-  private ManagedMessagingService messagingService;
 
-  @Before
-  public void setUp() throws Exception {
+  @AutoCloseResource private NettyMessagingService netty1;
+  private Address address1;
+  @AutoCloseResource private NettyMessagingService netty2;
+  private Address address2;
+  @AutoCloseResource private NettyMessagingService nettyv11;
+  private Address addressv11;
+  @AutoCloseResource private NettyMessagingService nettyv12;
+  private Address addressv12;
+  @AutoCloseResource private NettyMessagingService nettyv21;
+  private Address addressv21;
+  @AutoCloseResource private NettyMessagingService nettyv22;
+  private Address addressv22;
+  private Address invalidAddress;
+
+  @SuppressWarnings("resource")
+  @BeforeEach
+  void beforeEach() {
     address1 = Address.from(SocketUtil.getNextAddress().getPort());
     final var config = new MessagingConfig().setShutdownQuietPeriod(Duration.ofMillis(50));
 
     netty1 =
-        (ManagedMessagingService)
-            new NettyMessagingService("test", address1, config).start().join();
+        (NettyMessagingService) new NettyMessagingService("test", address1, config).start().join();
 
     address2 = Address.from(SocketUtil.getNextAddress().getPort());
     netty2 =
-        (ManagedMessagingService)
-            new NettyMessagingService("test", address2, config).start().join();
+        (NettyMessagingService) new NettyMessagingService("test", address2, config).start().join();
 
     addressv11 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv11 =
-        (ManagedMessagingService)
+        (NettyMessagingService)
             new NettyMessagingService("test", addressv11, config, ProtocolVersion.V1)
                 .start()
                 .join();
 
     addressv12 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv12 =
-        (ManagedMessagingService)
+        (NettyMessagingService)
             new NettyMessagingService("test", addressv12, config, ProtocolVersion.V1)
                 .start()
                 .join();
 
     addressv21 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv21 =
-        (ManagedMessagingService)
+        (NettyMessagingService)
             new NettyMessagingService("test", addressv21, config, ProtocolVersion.V2)
                 .start()
                 .join();
 
     addressv22 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv22 =
-        (ManagedMessagingService)
+        (NettyMessagingService)
             new NettyMessagingService("test", addressv22, config, ProtocolVersion.V2)
                 .start()
                 .join();
@@ -131,23 +122,8 @@ public class NettyMessagingServiceTest {
     return UUID.randomUUID().toString();
   }
 
-  @After
-  public void tearDown() throws Exception {
-    Stream.of(netty1, netty2, nettyv11, nettyv12, nettyv21, nettyv22, messagingService)
-        .parallel()
-        .filter(Objects::nonNull)
-        .forEach(
-            service -> {
-              try {
-                service.stop().join();
-              } catch (final Exception e) {
-                LOGGER.warn("Failed stopping NettyMessagingService {}", service, e);
-              }
-            });
-  }
-
   @Test
-  public void testSendAsyncToUnresolvable() {
+  void testSendAsyncToUnresolvable() {
     final Address unresolvable = Address.from("unknown.local", address1.port());
     final String subject = nextSubject();
     final CompletableFuture<Void> response =
@@ -157,14 +133,14 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testSendAsync() {
+  void testSendAsync() {
     final String subject = nextSubject();
     final CountDownLatch latch1 = new CountDownLatch(1);
     CompletableFuture<Void> response =
         netty1.sendAsync(address2, subject, "hello world".getBytes());
     response.whenComplete(
         (r, e) -> {
-          assertNull(e);
+          assertThat(e).isNull();
           latch1.countDown();
         });
     Uninterruptibles.awaitUninterruptibly(latch1);
@@ -173,15 +149,14 @@ public class NettyMessagingServiceTest {
     response = netty1.sendAsync(invalidAddress, subject, "hello world".getBytes());
     response.whenComplete(
         (r, e) -> {
-          assertNotNull(e);
-          assertTrue(e instanceof ConnectException);
+          assertThat(e).isInstanceOf(ConnectException.class);
           latch2.countDown();
         });
     Uninterruptibles.awaitUninterruptibly(latch2);
   }
 
   @Test
-  public void testSendAndReceive() {
+  void testSendAndReceive() {
     final String subject = nextSubject();
     final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
     final AtomicReference<byte[]> request = new AtomicReference<>();
@@ -198,14 +173,15 @@ public class NettyMessagingServiceTest {
 
     final CompletableFuture<byte[]> response =
         netty1.sendAndReceive(address2, subject, "hello world".getBytes());
-    assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
-    assertTrue(handlerInvoked.get());
-    assertTrue(Arrays.equals(request.get(), "hello world".getBytes()));
-    assertEquals(address1.tryResolveAddress(), sender.get().tryResolveAddress());
+    assertThat("hello there".getBytes()).isEqualTo(response.join());
+    assertThat(handlerInvoked.get()).isTrue();
+    assertThat(request.get()).asString().isEqualTo("hello world");
+    assertThat(Arrays.equals(request.get(), "hello world".getBytes())).isTrue();
+    assertThat(sender.get().tryResolveAddress()).isEqualTo(address1.tryResolveAddress());
   }
 
   @Test
-  public void shouldCompleteExistingRequestFutureExceptionallyWhenMessagingServiceIsClosed() {
+  void shouldCompleteExistingRequestFutureExceptionallyWhenMessagingServiceIsClosed() {
     final String subject = nextSubject();
     final CompletableFuture<byte[]> response =
         netty1.sendAndReceive(
@@ -234,7 +210,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void shouldCompleteFutureExceptionallyIfMessagingServiceIsClosedInBetween() {
+  void shouldCompleteFutureExceptionallyIfMessagingServiceIsClosedInBetween() {
     final String subject = nextSubject();
 
     // when
@@ -250,7 +226,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void shouldCompleteRequestWithKeepAliveExceptionallyIfMessagingServiceIsClosedInBetween() {
+  void shouldCompleteRequestWithKeepAliveExceptionallyIfMessagingServiceIsClosedInBetween() {
     final String subject = nextSubject();
 
     // when
@@ -266,7 +242,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void shouldCompleteFutureExceptionallyIfMessagingServiceHasAlreadyClosed() {
+  void shouldCompleteFutureExceptionallyIfMessagingServiceHasAlreadyClosed() {
     final String subject = nextSubject();
     netty1.stop().join();
 
@@ -280,7 +256,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void shouldCompleteRequestWithKeepAliveExceptionallyIfMessagingServiceHasAlreadyClosed() {
+  void shouldCompleteRequestWithKeepAliveExceptionallyIfMessagingServiceHasAlreadyClosed() {
     final String subject = nextSubject();
     netty1.stop().join();
 
@@ -294,7 +270,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testTransientSendAndReceive() {
+  void testTransientSendAndReceive() {
     final String subject = nextSubject();
     final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
     final AtomicReference<byte[]> request = new AtomicReference<>();
@@ -311,14 +287,14 @@ public class NettyMessagingServiceTest {
 
     final CompletableFuture<byte[]> response =
         netty1.sendAndReceive(address2, subject, "hello world".getBytes(), false);
-    assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
-    assertTrue(handlerInvoked.get());
-    assertTrue(Arrays.equals(request.get(), "hello world".getBytes()));
-    assertEquals(address1.tryResolveAddress(), sender.get().tryResolveAddress());
+    assertThat("hello there".getBytes()).isEqualTo(response.join());
+    assertThat(handlerInvoked.get()).isTrue();
+    assertThat(request.get()).asString().isEqualTo("hello world");
+    assertThat(sender.get().tryResolveAddress()).isEqualTo(address1.tryResolveAddress());
   }
 
   @Test
-  public void testSendAndReceiveWithFixedTimeout() {
+  void testSendAndReceiveWithFixedTimeout() {
     final String subject = nextSubject();
     final BiFunction<Address, byte[], CompletableFuture<byte[]>> handler =
         (ep, payload) -> new CompletableFuture<>();
@@ -328,15 +304,15 @@ public class NettyMessagingServiceTest {
       netty1
           .sendAndReceive(address2, subject, "hello world".getBytes(), Duration.ofSeconds(1))
           .join();
-      fail();
+      Assertions.fail();
     } catch (final CompletionException e) {
-      assertTrue(e.getCause() instanceof TimeoutException);
+      assertThat(e.getCause()).isInstanceOf(TimeoutException.class);
     }
   }
 
   @Test
-  @Ignore
-  public void testSendAndReceiveWithExecutor() {
+  @Disabled
+  void testSendAndReceiveWithExecutor() {
     final String subject = nextSubject();
     final ExecutorService completionExecutor =
         Executors.newSingleThreadExecutor(r -> new Thread(r, "completion-thread"));
@@ -354,7 +330,7 @@ public class NettyMessagingServiceTest {
             latch.await();
           } catch (final InterruptedException e1) {
             Thread.currentThread().interrupt();
-            fail("InterruptedException");
+            Assertions.fail("InterruptedException");
           }
           return "hello there".getBytes();
         };
@@ -370,13 +346,13 @@ public class NettyMessagingServiceTest {
 
     // Verify that the message was request handling and response completion happens on the correct
     // thread.
-    assertTrue(Arrays.equals("hello there".getBytes(), response.join()));
-    assertEquals("completion-thread", completionThreadName.get());
-    assertEquals("handler-thread", handlerThreadName.get());
+    assertThat("hello there".getBytes()).isEqualTo(response.join());
+    assertThat(completionThreadName.get()).isEqualTo("completion-thread");
+    assertThat(handlerThreadName.get()).isEqualTo("handler-thread");
   }
 
   @Test
-  public void testV1() throws Exception {
+  void testV1() throws Exception {
     final String subject;
     final byte[] payload = "Hello world!".getBytes();
     final byte[] response;
@@ -384,11 +360,11 @@ public class NettyMessagingServiceTest {
     subject = nextSubject();
     nettyv11.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
     response = nettyv12.sendAndReceive(addressv11, subject, payload).get(10, TimeUnit.SECONDS);
-    assertArrayEquals(payload, response);
+    assertThat(response).isEqualTo(payload);
   }
 
   @Test
-  public void testV2() throws Exception {
+  void testV2() throws Exception {
     final String subject;
     final byte[] payload = "Hello world!".getBytes();
     final byte[] response;
@@ -396,11 +372,11 @@ public class NettyMessagingServiceTest {
     subject = nextSubject();
     nettyv21.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
     response = nettyv22.sendAndReceive(addressv21, subject, payload).get(10, TimeUnit.SECONDS);
-    assertArrayEquals(payload, response);
+    assertThat(response).isEqualTo(payload);
   }
 
   @Test
-  public void testVersionNegotiation() throws Exception {
+  void testVersionNegotiation() throws Exception {
     String subject;
     final byte[] payload = "Hello world!".getBytes();
     byte[] response;
@@ -408,16 +384,16 @@ public class NettyMessagingServiceTest {
     subject = nextSubject();
     nettyv11.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
     response = nettyv21.sendAndReceive(addressv11, subject, payload).get(10, TimeUnit.SECONDS);
-    assertArrayEquals(payload, response);
+    assertThat(response).isEqualTo(payload);
 
     subject = nextSubject();
     nettyv22.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
     response = nettyv12.sendAndReceive(addressv22, subject, payload).get(10, TimeUnit.SECONDS);
-    assertArrayEquals(payload, response);
+    assertThat(response).isEqualTo(payload);
   }
 
   @Test
-  public void shouldNotBindToAdvertisedAddress() {
+  void shouldNotBindToAdvertisedAddress() throws Exception {
     // given
     final var bindingAddress = Address.from(SocketUtil.getNextAddress().getPort());
     final MessagingConfig config = new MessagingConfig();
@@ -426,16 +402,16 @@ public class NettyMessagingServiceTest {
 
     // when
     final Address nonBindableAddress = new Address("invalid.host", 1);
-    final var startFuture = new NettyMessagingService("test", nonBindableAddress, config).start();
-
-    // then - should not fail by using advertisedAddress for binding
-    messagingService = (ManagedMessagingService) startFuture.join();
-    assertThat(messagingService.bindingAddresses()).contains(bindingAddress);
-    assertThat(messagingService.address()).isEqualTo(nonBindableAddress);
+    try (final var service = new NettyMessagingService("test", nonBindableAddress, config)) {
+      // then - should not fail by using advertisedAddress for binding
+      assertThat(service.start()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(service.bindingAddresses()).contains(bindingAddress);
+      assertThat(service.address()).isEqualTo(nonBindableAddress);
+    }
   }
 
   @Test
-  public void testRemoteHandlerFailure() {
+  void testRemoteHandlerFailure() {
     // given
     final var exceptionMessage = "foo bar";
     final var expectedException = new MessagingException.RemoteHandlerFailure(exceptionMessage);
@@ -462,7 +438,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testRemoteHandlerFailureNullValue() {
+  void testRemoteHandlerFailureNullValue() {
     // given
     final var expectedException = new MessagingException.RemoteHandlerFailure(null);
 
@@ -488,7 +464,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testRemoteHandlerFailureEmptyStringValue() {
+  void testRemoteHandlerFailureEmptyStringValue() {
     // given
     final var exceptionMessage = "";
     final var expectedException = new MessagingException.RemoteHandlerFailure(null);
@@ -515,7 +491,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testCompletableRemoteHandlerFailure() {
+  void testCompletableRemoteHandlerFailure() {
     // given
     final var exceptionMessage = "foo bar";
     final var expectedException = new MessagingException.RemoteHandlerFailure(exceptionMessage);
@@ -539,7 +515,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testCompletableRemoteHandlerFailureNullValue() {
+  void testCompletableRemoteHandlerFailureNullValue() {
     // given
     final var expectedException = new MessagingException.RemoteHandlerFailure(null);
 
@@ -561,7 +537,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testCompletableRemoteHandlerFailureEmptyStringValue() {
+  void testCompletableRemoteHandlerFailureEmptyStringValue() {
     // given
     final var exceptionMessage = "";
     final var expectedException = new MessagingException.RemoteHandlerFailure(null);
@@ -585,7 +561,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void shouldCloseChannelAfterTimeout() {
+  void shouldCloseChannelAfterTimeout() {
     // given
     final var subject = nextSubject();
     final MutableReference<ChannelPool> poolRef = new MutableReference<>();
@@ -626,7 +602,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void shouldCreateNewChannelOnNewRequestAfterTimeout() {
+  void shouldCreateNewChannelOnNewRequestAfterTimeout() {
     // given
     final var subject = nextSubject();
     final MutableReference<ChannelPool> poolRef = new MutableReference<>();
@@ -693,7 +669,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testNoRemoteHandlerException() {
+  void testNoRemoteHandlerException() {
     // given
     final var subject = nextSubject();
     final var expectedException = new MessagingException.NoRemoteHandler(subject);
@@ -712,7 +688,7 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
-  public void testNoRemoteHandlerExceptionEmptyStringValue() {
+  void testNoRemoteHandlerExceptionEmptyStringValue() {
     // given
     final var subject = "";
     final var expectedException = new MessagingException.NoRemoteHandler(null);

--- a/atomix/utils/src/main/java/io/atomix/utils/Managed.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/Managed.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @param <T> managed type
  */
-public interface Managed<T> {
+public interface Managed<T> extends AutoCloseable {
 
   /**
    * Starts the managed object.
@@ -45,4 +45,9 @@ public interface Managed<T> {
    * @return A completable future to be completed once the object has been stopped.
    */
   CompletableFuture<Void> stop();
+
+  @Override
+  default void close() throws Exception {
+    stop().join();
+  }
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -17860,6 +17860,292 @@
       ],
       "title": "Job stream",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 581,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of successful DNS requests per second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 9
+          },
+          "id": 582,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_dns_success_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+              "legendFormat": "{{pod}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Successful DNS requests",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of failed DNS requests per second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 9
+          },
+          "id": 583,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_dns_failed_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod, code)",
+              "hide": false,
+              "legendFormat": "{{pod}} {{code}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Failed DNS Requests",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of DNS errors per second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 9
+          },
+          "id": 584,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_dns_error_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+              "hide": false,
+              "legendFormat": "{{pod}} errors",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "DNS Error",
+          "type": "timeseries"
+        }
+      ],
+      "title": "DNS",
+      "type": "row"
     }
   ],
   "refresh": "10s",


### PR DESCRIPTION
## Description

Fixes a UDP resource leak associated with the `DnsAddressResolverGroup` usage. The group is meant to be reused and shared, as the channels will not close any associated resolvers/groups. By creating a new group for every channel, especially with transient channels, we end up with a new group that is created and garbage collected, but the underlying socket is never closed (since as far as the channel is concerned, it doesn't "own" the group).

While we could create one group per channel and ensure it's closed along with the channel via a promise, the group is thread safe and seems perfectly reusable, so let's do that and make full use of the underlying cache.

## Related issues

closes camunda/zeebe#14837

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
