### PR TITLE
Check for banned instances during Process Definition Deletion

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
+import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.FormState;
@@ -62,6 +63,7 @@ public class ResourceDeletionProcessor
   private final ProcessState processState;
   private final ElementInstanceState elementInstanceState;
   private final TimerInstanceState timerInstanceState;
+  private final BannedInstanceState bannedInstanceState;
   private final CatchEventBehavior catchEventBehavior;
   private final ExpressionProcessor expressionProcessor;
   private final StartEventSubscriptionManager startEventSubscriptionManager;
@@ -82,6 +84,7 @@ public class ResourceDeletionProcessor
     processState = processingState.getProcessState();
     elementInstanceState = processingState.getElementInstanceState();
     timerInstanceState = processingState.getTimerState();
+    bannedInstanceState = processingState.getBannedInstanceState();
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     expressionProcessor = bpmnBehaviors.expressionBehavior();
     startEventSubscriptionManager =
@@ -226,8 +229,9 @@ public class ResourceDeletionProcessor
       }
     }
 
+    final var bannedInstances = bannedInstanceState.getBannedProcessInstanceKeys();
     final var hasRunningInstances =
-        elementInstanceState.hasActiveProcessInstances(process.getKey());
+        elementInstanceState.hasActiveProcessInstances(process.getKey(), bannedInstances);
 
     if (!hasRunningInstances) {
       stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETED, processRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BannedInstanceState.java
@@ -9,8 +9,12 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.List;
 
 public interface BannedInstanceState extends StreamProcessorLifecycleAware {
 
   boolean isBanned(final TypedRecord record);
+
+  /** Returns a list of keys of all banned process instances */
+  List<Long> getBannedProcessInstanceKeys();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -63,7 +63,8 @@ public interface ElementInstanceState {
    * Verifies if there are active process instances for a given process definition
    *
    * @param processDefinitionKey the key of the process definition
+   * @param bannedInstances a list of banned process instance keys
    * @return a boolean indicating if there are running instances
    */
-  boolean hasActiveProcessInstances(long processDefinitionKey);
+  boolean hasActiveProcessInstances(long processDefinitionKey, final List<Long> bannedInstances);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -358,13 +358,19 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public boolean hasActiveProcessInstances(final long processDefinitionKey) {
+  public boolean hasActiveProcessInstances(
+      final long processDefinitionKey, final List<Long> bannedInstances) {
     this.processDefinitionKey.wrapLong(processDefinitionKey);
     final AtomicBoolean hasActiveInstances = new AtomicBoolean(false);
 
     processInstanceKeyByProcessDefinitionKeyColumnFamily.whileEqualPrefix(
         this.processDefinitionKey,
         (key, value) -> {
+          // A banned instance should not be considered as active
+          if (bannedInstances.contains(key.second().getValue())) {
+            return true;
+          }
+
           hasActiveInstances.set(true);
           return false;
         });

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -83,6 +85,13 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
       }
     }
     return false;
+  }
+
+  @Override
+  public List<Long> getBannedProcessInstanceKeys() {
+    final List<Long> bannedInstanceKeys = new ArrayList<>();
+    bannedInstanceColumnFamily.forEach((key, nil) -> bannedInstanceKeys.add(key.getValue()));
+    return bannedInstanceKeys;
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.zeebe.engine.state.mutable.MutableBannedInstanceState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
@@ -226,6 +227,36 @@ public class ResourceDeletionTest {
     // given
     final var processId = helper.getBpmnProcessId();
     final var processDefinitionKey = deployProcess(processId);
+
+    // when
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+
+    // then
+    verifyProcessIdWithVersionIsDeleted(processId, 1);
+    verifyResourceIsDeleted(processDefinitionKey);
+  }
+
+  @Test
+  public void shouldWriteEventsForDeletedProcessWithBannedInstances() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var processDefinitionKey =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId).startEvent().userTask().endEvent().done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    // Note! We don't register the banned instance using an event. You won't see the Error Event in
+    // the log!
+    final var bannedInstanceState =
+        (MutableBannedInstanceState) engine.getProcessingState().getBannedInstanceState();
+    bannedInstanceState.banProcessInstance(processInstanceKey);
 
     // when
     engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
@@ -397,7 +398,7 @@ public final class ElementInstanceStateTest {
     Assertions.assertThat(processInstanceKeys).isEmpty();
     final var hasRunningInstances =
         elementInstanceState.hasActiveProcessInstances(
-            processInstanceRecord.getProcessDefinitionKey());
+            processInstanceRecord.getProcessDefinitionKey(), Collections.emptyList());
     assertThat(hasRunningInstances).isFalse();
   }
 
@@ -451,7 +452,7 @@ public final class ElementInstanceStateTest {
     // when
     final var hasRunningInstances =
         elementInstanceState.hasActiveProcessInstances(
-            processInstanceRecord.getProcessDefinitionKey());
+            processInstanceRecord.getProcessDefinitionKey(), Collections.emptyList());
 
     // then
     Assertions.assertThat(hasRunningInstances).isTrue();
@@ -466,7 +467,7 @@ public final class ElementInstanceStateTest {
     // when
     final var hasRunningInstances =
         elementInstanceState.hasActiveProcessInstances(
-            processInstanceRecord.getProcessDefinitionKey());
+            processInstanceRecord.getProcessDefinitionKey(), Collections.emptyList());
 
     // then
     Assertions.assertThat(hasRunningInstances).isFalse();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -474,6 +474,25 @@ public final class ElementInstanceStateTest {
   }
 
   @Test
+  public void shouldNotFindRunningInstanceForBannedInstance() {
+    // given
+    final var processInstanceKey = 123L;
+    final var processInstanceRecord =
+        createProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setProcessInstanceKey(processInstanceKey);
+
+    // when
+    final var hasRunningInstances =
+        elementInstanceState.hasActiveProcessInstances(
+            processInstanceRecord.getProcessDefinitionKey(),
+            Collections.singletonList(processInstanceKey));
+
+    // then
+    Assertions.assertThat(hasRunningInstances).isFalse();
+  }
+
+  @Test
   public void shouldUpdateAwaitResultMetadata() {
     final long key = 10L;
     final int streamId = 2;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The `ResourceDeletionProcessor` has a check when deleting a process definition. It checks if there is any active process instances in the state. If there is the delete command gets rejected, as we don't support waiting for completion/termination yet.

This is a problem in case of banned instances. These will always remain in the state and are wrongfully considered active. We should filter out these instances and allow the deletion of the definition even if there are still banned instances. This is fine to do as these instances are unrecoverable anyway.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14465

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
