### PR TITLE
Reduce NettyMessagingServiceTest duration by 3x

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -48,10 +48,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 import org.agrona.collections.MutableReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -59,613 +61,23 @@ import org.junit.jupiter.api.condition.OS;
 /** Netty messaging service test. */
 @AutoCloseResources
 final class NettyMessagingServiceTest {
-
-  private static final String IP_STRING = "127.0.0.1";
+  private static final String CLUSTER_NAME = "zeebe";
   private static final int UID_COLUMN = 7;
 
-  @AutoCloseResource private NettyMessagingService netty1;
-  private Address address1;
-  @AutoCloseResource private NettyMessagingService netty2;
-  private Address address2;
-  @AutoCloseResource private NettyMessagingService nettyv11;
-  private Address addressv11;
-  @AutoCloseResource private NettyMessagingService nettyv12;
-  private Address addressv12;
-  @AutoCloseResource private NettyMessagingService nettyv21;
-  private Address addressv21;
-  @AutoCloseResource private NettyMessagingService nettyv22;
-  private Address addressv22;
-  private Address invalidAddress;
-
-  @SuppressWarnings("resource")
-  @BeforeEach
-  void beforeEach() {
-    address1 = Address.from(SocketUtil.getNextAddress().getPort());
-    final var config = new MessagingConfig().setShutdownQuietPeriod(Duration.ofMillis(50));
-
-    netty1 =
-        (NettyMessagingService) new NettyMessagingService("test", address1, config).start().join();
-
-    address2 = Address.from(SocketUtil.getNextAddress().getPort());
-    netty2 =
-        (NettyMessagingService) new NettyMessagingService("test", address2, config).start().join();
-
-    addressv11 = Address.from(SocketUtil.getNextAddress().getPort());
-    nettyv11 =
-        (NettyMessagingService)
-            new NettyMessagingService("test", addressv11, config, ProtocolVersion.V1)
-                .start()
-                .join();
-
-    addressv12 = Address.from(SocketUtil.getNextAddress().getPort());
-    nettyv12 =
-        (NettyMessagingService)
-            new NettyMessagingService("test", addressv12, config, ProtocolVersion.V1)
-                .start()
-                .join();
-
-    addressv21 = Address.from(SocketUtil.getNextAddress().getPort());
-    nettyv21 =
-        (NettyMessagingService)
-            new NettyMessagingService("test", addressv21, config, ProtocolVersion.V2)
-                .start()
-                .join();
-
-    addressv22 = Address.from(SocketUtil.getNextAddress().getPort());
-    nettyv22 =
-        (NettyMessagingService)
-            new NettyMessagingService("test", addressv22, config, ProtocolVersion.V2)
-                .start()
-                .join();
-
-    invalidAddress = Address.from(IP_STRING, 5007);
+  private MessagingConfig defaultConfig() {
+    return new MessagingConfig().setShutdownQuietPeriod(Duration.ofMillis(50));
   }
 
-  /**
-   * Returns a random String to be used as a test subject.
-   *
-   * @return string
-   */
   private String nextSubject() {
     return UUID.randomUUID().toString();
   }
 
-  @Test
-  void testSendAsyncToUnresolvable() {
-    final Address unresolvable = Address.from("unknown.local", address1.port());
-    final String subject = nextSubject();
-    final CompletableFuture<Void> response =
-        netty1.sendAsync(unresolvable, subject, "hello world".getBytes());
-
-    assertThat(response).failsWithin(Duration.ofSeconds(10));
-  }
-
-  @Test
-  void testSendAsync() {
-    final String subject = nextSubject();
-    final CountDownLatch latch1 = new CountDownLatch(1);
-    CompletableFuture<Void> response =
-        netty1.sendAsync(address2, subject, "hello world".getBytes());
-    response.whenComplete(
-        (r, e) -> {
-          assertThat(e).isNull();
-          latch1.countDown();
-        });
-    Uninterruptibles.awaitUninterruptibly(latch1);
-
-    final CountDownLatch latch2 = new CountDownLatch(1);
-    response = netty1.sendAsync(invalidAddress, subject, "hello world".getBytes());
-    response.whenComplete(
-        (r, e) -> {
-          assertThat(e).isInstanceOf(ConnectException.class);
-          latch2.countDown();
-        });
-    Uninterruptibles.awaitUninterruptibly(latch2);
-  }
-
-  @Test
-  void testSendAndReceive() {
-    final String subject = nextSubject();
-    final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
-    final AtomicReference<byte[]> request = new AtomicReference<>();
-    final AtomicReference<Address> sender = new AtomicReference<>();
-
-    final BiFunction<Address, byte[], byte[]> handler =
-        (ep, data) -> {
-          handlerInvoked.set(true);
-          sender.set(ep);
-          request.set(data);
-          return "hello there".getBytes();
-        };
-    netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
-
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "hello world".getBytes());
-    assertThat("hello there".getBytes()).isEqualTo(response.join());
-    assertThat(handlerInvoked.get()).isTrue();
-    assertThat(request.get()).asString().isEqualTo("hello world");
-    assertThat(Arrays.equals(request.get(), "hello world".getBytes())).isTrue();
-    assertThat(sender.get().tryResolveAddress()).isEqualTo(address1.tryResolveAddress());
-  }
-
-  @Test
-  void shouldCompleteExistingRequestFutureExceptionallyWhenMessagingServiceIsClosed() {
-    final String subject = nextSubject();
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(
-            address2, subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
-
-    // when
-    netty1.stop().join();
-
-    // then
-    assertThat(response).isCompletedExceptionally();
-  }
-
-  @Test
-  public void
-      shouldCompleteExistingRequestWithKeepAliveExceptionallyWhenMessagingServiceIsClosed() {
-    final String subject = nextSubject();
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(
-            address2, subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
-
-    // when
-    netty1.stop().join();
-
-    // then
-    assertThat(response).isCompletedExceptionally();
-  }
-
-  @Test
-  void shouldCompleteFutureExceptionallyIfMessagingServiceIsClosedInBetween() {
-    final String subject = nextSubject();
-
-    // when
-    final var stopFuture = netty1.stop();
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(
-            address2, subject, "hello world".getBytes(), false, Duration.ofSeconds(5));
-
-    stopFuture.join();
-
-    // then
-    assertThat(response).isCompletedExceptionally();
-  }
-
-  @Test
-  void shouldCompleteRequestWithKeepAliveExceptionallyIfMessagingServiceIsClosedInBetween() {
-    final String subject = nextSubject();
-
-    // when
-    final var stopFuture = netty1.stop();
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(
-            address2, subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
-
-    stopFuture.join();
-
-    // then
-    assertThat(response).isCompletedExceptionally();
-  }
-
-  @Test
-  void shouldCompleteFutureExceptionallyIfMessagingServiceHasAlreadyClosed() {
-    final String subject = nextSubject();
-    netty1.stop().join();
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(
-            address2, subject, "hello world".getBytes(), false, Duration.ofSeconds(5));
-
-    // then
-    assertThat(response).isCompletedExceptionally();
-  }
-
-  @Test
-  void shouldCompleteRequestWithKeepAliveExceptionallyIfMessagingServiceHasAlreadyClosed() {
-    final String subject = nextSubject();
-    netty1.stop().join();
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(
-            address2, subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
-
-    // then
-    assertThat(response).isCompletedExceptionally();
-  }
-
-  @Test
-  void testTransientSendAndReceive() {
-    final String subject = nextSubject();
-    final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
-    final AtomicReference<byte[]> request = new AtomicReference<>();
-    final AtomicReference<Address> sender = new AtomicReference<>();
-
-    final BiFunction<Address, byte[], byte[]> handler =
-        (ep, data) -> {
-          handlerInvoked.set(true);
-          sender.set(ep);
-          request.set(data);
-          return "hello there".getBytes();
-        };
-    netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
-
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "hello world".getBytes(), false);
-    assertThat("hello there".getBytes()).isEqualTo(response.join());
-    assertThat(handlerInvoked.get()).isTrue();
-    assertThat(request.get()).asString().isEqualTo("hello world");
-    assertThat(sender.get().tryResolveAddress()).isEqualTo(address1.tryResolveAddress());
-  }
-
-  @Test
-  void testSendAndReceiveWithFixedTimeout() {
-    final String subject = nextSubject();
-    final BiFunction<Address, byte[], CompletableFuture<byte[]>> handler =
-        (ep, payload) -> new CompletableFuture<>();
-    netty2.registerHandler(subject, handler);
-
-    try {
-      netty1
-          .sendAndReceive(address2, subject, "hello world".getBytes(), Duration.ofSeconds(1))
-          .join();
-      Assertions.fail();
-    } catch (final CompletionException e) {
-      assertThat(e.getCause()).isInstanceOf(TimeoutException.class);
-    }
-  }
-
-  @Test
-  @Disabled
-  void testSendAndReceiveWithExecutor() {
-    final String subject = nextSubject();
-    final ExecutorService completionExecutor =
-        Executors.newSingleThreadExecutor(r -> new Thread(r, "completion-thread"));
-    final ExecutorService handlerExecutor =
-        Executors.newSingleThreadExecutor(r -> new Thread(r, "handler-thread"));
-    final AtomicReference<String> handlerThreadName = new AtomicReference<>();
-    final AtomicReference<String> completionThreadName = new AtomicReference<>();
-
-    final CountDownLatch latch = new CountDownLatch(1);
-
-    final BiFunction<Address, byte[], byte[]> handler =
-        (ep, data) -> {
-          handlerThreadName.set(Thread.currentThread().getName());
-          try {
-            latch.await();
-          } catch (final InterruptedException e1) {
-            Thread.currentThread().interrupt();
-            Assertions.fail("InterruptedException");
-          }
-          return "hello there".getBytes();
-        };
-    netty2.registerHandler(subject, handler, handlerExecutor);
-
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "hello world".getBytes(), completionExecutor);
-    response.whenComplete(
-        (r, e) -> {
-          completionThreadName.set(Thread.currentThread().getName());
-        });
-    latch.countDown();
-
-    // Verify that the message was request handling and response completion happens on the correct
-    // thread.
-    assertThat("hello there".getBytes()).isEqualTo(response.join());
-    assertThat(completionThreadName.get()).isEqualTo("completion-thread");
-    assertThat(handlerThreadName.get()).isEqualTo("handler-thread");
-  }
-
-  @Test
-  void testV1() throws Exception {
-    final String subject;
-    final byte[] payload = "Hello world!".getBytes();
-    final byte[] response;
-
-    subject = nextSubject();
-    nettyv11.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
-    response = nettyv12.sendAndReceive(addressv11, subject, payload).get(10, TimeUnit.SECONDS);
-    assertThat(response).isEqualTo(payload);
-  }
-
-  @Test
-  void testV2() throws Exception {
-    final String subject;
-    final byte[] payload = "Hello world!".getBytes();
-    final byte[] response;
-
-    subject = nextSubject();
-    nettyv21.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
-    response = nettyv22.sendAndReceive(addressv21, subject, payload).get(10, TimeUnit.SECONDS);
-    assertThat(response).isEqualTo(payload);
-  }
-
-  @Test
-  void testVersionNegotiation() throws Exception {
-    String subject;
-    final byte[] payload = "Hello world!".getBytes();
-    byte[] response;
-
-    subject = nextSubject();
-    nettyv11.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
-    response = nettyv21.sendAndReceive(addressv11, subject, payload).get(10, TimeUnit.SECONDS);
-    assertThat(response).isEqualTo(payload);
-
-    subject = nextSubject();
-    nettyv22.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
-    response = nettyv12.sendAndReceive(addressv22, subject, payload).get(10, TimeUnit.SECONDS);
-    assertThat(response).isEqualTo(payload);
-  }
-
-  @Test
-  void shouldNotBindToAdvertisedAddress() throws Exception {
-    // given
-    final var bindingAddress = Address.from(SocketUtil.getNextAddress().getPort());
-    final MessagingConfig config = new MessagingConfig();
-    config.setInterfaces(List.of(bindingAddress.host()));
-    config.setPort(bindingAddress.port());
-
-    // when
-    final Address nonBindableAddress = new Address("invalid.host", 1);
-    try (final var service = new NettyMessagingService("test", nonBindableAddress, config)) {
-      // then - should not fail by using advertisedAddress for binding
-      assertThat(service.start()).succeedsWithin(Duration.ofSeconds(5));
-      assertThat(service.bindingAddresses()).contains(bindingAddress);
-      assertThat(service.address()).isEqualTo(nonBindableAddress);
-    }
-  }
-
-  @Test
-  void testRemoteHandlerFailure() {
-    // given
-    final var exceptionMessage = "foo bar";
-    final var expectedException = new MessagingException.RemoteHandlerFailure(exceptionMessage);
-
-    final BiFunction<Address, byte[], byte[]> handler =
-        (ep, data) -> {
-          throw new RuntimeException(exceptionMessage);
-        };
-
-    final var subject = nextSubject();
-    netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "fail".getBytes());
-
-    // then
-    assertThat(response)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .havingRootCause()
-        .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
-        .withMessage(expectedException.getMessage());
-  }
-
-  @Test
-  void testRemoteHandlerFailureNullValue() {
-    // given
-    final var expectedException = new MessagingException.RemoteHandlerFailure(null);
-
-    final BiFunction<Address, byte[], byte[]> handler =
-        (ep, data) -> {
-          throw new RuntimeException();
-        };
-
-    final var subject = nextSubject();
-    netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "fail".getBytes());
-
-    // then
-    assertThat(response)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .havingRootCause()
-        .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
-        .withMessage(expectedException.getMessage());
-  }
-
-  @Test
-  void testRemoteHandlerFailureEmptyStringValue() {
-    // given
-    final var exceptionMessage = "";
-    final var expectedException = new MessagingException.RemoteHandlerFailure(null);
-
-    final BiFunction<Address, byte[], byte[]> handler =
-        (ep, data) -> {
-          throw new RuntimeException(exceptionMessage);
-        };
-
-    final var subject = nextSubject();
-    netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "fail".getBytes());
-
-    // then
-    assertThat(response)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .havingRootCause()
-        .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
-        .withMessage(expectedException.getMessage());
-  }
-
-  @Test
-  void testCompletableRemoteHandlerFailure() {
-    // given
-    final var exceptionMessage = "foo bar";
-    final var expectedException = new MessagingException.RemoteHandlerFailure(exceptionMessage);
-
-    final var subject = nextSubject();
-    netty2.registerHandler(
-        subject,
-        (address, bytes) -> CompletableFuture.failedFuture(new RuntimeException(exceptionMessage)));
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "fail".getBytes());
-
-    // then
-    assertThat(response)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .havingRootCause()
-        .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
-        .withMessage(expectedException.getMessage());
-  }
-
-  @Test
-  void testCompletableRemoteHandlerFailureNullValue() {
-    // given
-    final var expectedException = new MessagingException.RemoteHandlerFailure(null);
-
-    final var subject = nextSubject();
-    netty2.registerHandler(
-        subject, (address, bytes) -> CompletableFuture.failedFuture(new RuntimeException()));
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "fail".getBytes());
-
-    // then
-    assertThat(response)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .havingRootCause()
-        .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
-        .withMessage(expectedException.getMessage());
-  }
-
-  @Test
-  void testCompletableRemoteHandlerFailureEmptyStringValue() {
-    // given
-    final var exceptionMessage = "";
-    final var expectedException = new MessagingException.RemoteHandlerFailure(null);
-
-    final var subject = nextSubject();
-    netty2.registerHandler(
-        subject,
-        (address, bytes) -> CompletableFuture.failedFuture(new RuntimeException(exceptionMessage)));
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "fail".getBytes());
-
-    // then
-    assertThat(response)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .havingRootCause()
-        .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
-        .withMessage(expectedException.getMessage());
-  }
-
-  @Test
-  void shouldCloseChannelAfterTimeout() {
-    // given
-    final var subject = nextSubject();
-    final MutableReference<ChannelPool> poolRef = new MutableReference<>();
-    final var timeoutOnCreate = Duration.ofSeconds(10);
-    final var nettyWithOwnPool = createMessagingServiceWithPool(poolRef);
-    final var channelPool = poolRef.get();
-
-    try {
-      nettyWithOwnPool.start().join();
-
-      // grab the original channel, so we can assert it was closed
-      // it's also useful to send a successful request once, so we can ensure the channel exists and
-      // set a lower timeout on the request we want specifically to time out
-      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-      nettyWithOwnPool
-          .sendAndReceive(address2, subject, "get channel".getBytes(), true, timeoutOnCreate)
-          .join();
-      final var originalChannel = channelPool.getChannel(address2, subject).join();
-
-      // when - set up handler which will always cause timeouts
-      netty2.unregisterHandler(subject);
-      netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
-      final CompletableFuture<byte[]> response =
-          nettyWithOwnPool.sendAndReceive(
-              address2, subject, "fail".getBytes(), true, Duration.ofSeconds(1));
-
-      // then
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(15))
-          .withThrowableThat()
-          .havingRootCause()
-          .isInstanceOf(TimeoutException.class)
-          .withMessageContaining("timed out in");
-      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
-    } finally {
-      nettyWithOwnPool.stop().join();
-    }
-  }
-
-  @Test
-  void shouldCreateNewChannelOnNewRequestAfterTimeout() {
-    // given
-    final var subject = nextSubject();
-    final MutableReference<ChannelPool> poolRef = new MutableReference<>();
-    final var timeoutOnCreate = Duration.ofSeconds(10);
-    final var nettyWithOwnPool = createMessagingServiceWithPool(poolRef);
-    final var channelPool = poolRef.get();
-
-    try {
-      nettyWithOwnPool.start().join();
-
-      // grab the original channel, so we can assert it was closed
-      // it's also useful to send a successful request once, so we can ensure the channel exists and
-      // set a lower timeout on the request we want specifically to time out
-      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-      nettyWithOwnPool
-          .sendAndReceive(address2, subject, "get channel".getBytes(), true, timeoutOnCreate)
-          .join();
-      final var originalChannel = channelPool.getChannel(address2, subject).join();
-
-      // set up handler which will always cause timeouts
-      netty2.unregisterHandler(subject);
-      netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
-      final CompletableFuture<byte[]> response =
-          nettyWithOwnPool.sendAndReceive(
-              address2, subject, "fail".getBytes(), true, Duration.ofSeconds(1));
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(15))
-          .withThrowableThat()
-          .havingRootCause()
-          .isInstanceOf(TimeoutException.class);
-      // wait until the channel is closed before grabbing the next one
-      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
-
-      // when - remote connection finally succeeds
-      // give a generous time out on the second request, as creating a new channel can be slow at
-      // times
-      netty2.unregisterHandler(subject);
-      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-      nettyWithOwnPool.sendAndReceive(
-          address2, subject, "success".getBytes(), true, timeoutOnCreate);
-
-      // then
-      final var newChannel = channelPool.getChannel(address2, subject).join();
-      assertThat(newChannel).isNotEqualTo(originalChannel);
-    } finally {
-      nettyWithOwnPool.stop().join();
-    }
-  }
-
   private ManagedMessagingService createMessagingServiceWithPool(
       final MutableReference<ChannelPool> poolRef) {
-    final var otherAddress = Address.from(SocketUtil.getNextAddress().getPort());
-    final var config = new MessagingConfig();
+    final var otherAddress = newAddress();
+    final var config = defaultConfig();
     return new NettyMessagingService(
-        "test",
+        CLUSTER_NAME,
         otherAddress,
         config,
         ProtocolVersion.V2,
@@ -676,63 +88,21 @@ final class NettyMessagingServiceTest {
         });
   }
 
-  @Test
-  void testNoRemoteHandlerException() {
-    // given
-    final var subject = nextSubject();
-    final var expectedException = new MessagingException.NoRemoteHandler(subject);
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "fail".getBytes());
-
-    // then
-    assertThat(response)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .havingRootCause()
-        .isInstanceOf(MessagingException.NoRemoteHandler.class)
-        .withMessage(expectedException.getMessage());
+  private NettyMessagingService newMessagingService() {
+    return new NettyMessagingService(CLUSTER_NAME, newAddress(), defaultConfig());
   }
 
-  @Test
-  void testNoRemoteHandlerExceptionEmptyStringValue() {
-    // given
-    final var subject = "";
-    final var expectedException = new MessagingException.NoRemoteHandler(null);
-
-    // when
-    final CompletableFuture<byte[]> response =
-        netty1.sendAndReceive(address2, subject, "fail".getBytes());
-
-    // then
-    assertThat(response)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .havingRootCause()
-        .isInstanceOf(MessagingException.NoRemoteHandler.class)
-        .withMessage(expectedException.getMessage());
+  private Address newAddress() {
+    return Address.from(SocketUtil.getNextAddress().getPort());
   }
 
-  @EnabledOnOs(OS.LINUX)
-  @RegressionTest("https://github.com/camunda/zeebe/issues/14837")
-  void shouldNotLeakUdpSockets() throws IOException {
-    // given
-    // the configured amount of threads for Netty's epoll transport
-    final var maxConnections = Runtime.getRuntime().availableProcessors() * 2;
-    final var subject = nextSubject();
-    netty2.registerHandler(
-        subject, (address, bytes) -> new byte[0], MoreExecutors.directExecutor());
-
-    // when
-    for (int i = 0; i < maxConnections * 4; i++) {
-      netty1.sendAndReceive(netty2.address(), subject, "hello world".getBytes(), false).join();
-    }
-
-    // then - there seems to be a slight amount more than maxConnections normally, but without the
-    // fix this was way, way, way more, so it should be fine to allow a little bit more than the
-    // expected max number of connections
-    assertThat(udpSocketCount()).isLessThanOrEqualTo(maxConnections * 2L);
+  private void startMessagingServices(final NettyMessagingService... services) {
+    CompletableFuture.allOf(
+            Stream.of(services)
+                .parallel()
+                .map(ManagedMessagingService::start)
+                .toArray(CompletableFuture[]::new))
+        .join();
   }
 
   private long udpSocketCount() throws IOException {
@@ -757,5 +127,633 @@ final class NettyMessagingServiceTest {
               return Long.parseLong(columns[UID_COLUMN]) == uid;
             })
         .count();
+  }
+
+  @Nested
+  final class VersionTest {
+    @AutoCloseResource private final NettyMessagingService nettyv11 = newMessagingService();
+    @AutoCloseResource private final NettyMessagingService nettyv12 = newMessagingService();
+    @AutoCloseResource private final NettyMessagingService nettyv21 = newMessagingService();
+    @AutoCloseResource private final NettyMessagingService nettyv22 = newMessagingService();
+
+    @BeforeEach
+    void beforeEach() {
+      startMessagingServices(nettyv11, nettyv12, nettyv21, nettyv22);
+    }
+
+    @Test
+    void testV1() throws Exception {
+      final String subject;
+      final byte[] payload = "Hello world!".getBytes();
+      final byte[] response;
+
+      subject = nextSubject();
+      nettyv11.registerHandler(
+          subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
+      response =
+          nettyv12.sendAndReceive(nettyv11.address(), subject, payload).get(10, TimeUnit.SECONDS);
+      assertThat(response).isEqualTo(payload);
+    }
+
+    @Test
+    void testV2() throws Exception {
+      final String subject;
+      final byte[] payload = "Hello world!".getBytes();
+      final byte[] response;
+
+      subject = nextSubject();
+      nettyv21.registerHandler(
+          subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
+      response =
+          nettyv22.sendAndReceive(nettyv21.address(), subject, payload).get(10, TimeUnit.SECONDS);
+      assertThat(response).isEqualTo(payload);
+    }
+
+    @Test
+    void testVersionNegotiation() throws Exception {
+      String subject;
+      final byte[] payload = "Hello world!".getBytes();
+      byte[] response;
+
+      subject = nextSubject();
+      nettyv11.registerHandler(
+          subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
+      response =
+          nettyv21.sendAndReceive(nettyv11.address(), subject, payload).get(10, TimeUnit.SECONDS);
+      assertThat(response).isEqualTo(payload);
+
+      subject = nextSubject();
+      nettyv22.registerHandler(
+          subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
+      response =
+          nettyv12.sendAndReceive(nettyv22.address(), subject, payload).get(10, TimeUnit.SECONDS);
+      assertThat(response).isEqualTo(payload);
+    }
+  }
+
+  @Nested
+  final class SingleInstanceTest {
+    @Test
+    void testSendAsyncToUnresolvable() throws Exception {
+      // given
+      final var subject = nextSubject();
+      try (final var service = newMessagingService()) {
+        final var unresolvable = Address.from("unknown.local", service.address().port());
+
+        // when
+        assertThat(service.start()).succeedsWithin(Duration.ofSeconds(5));
+        final var response = service.sendAsync(unresolvable, subject, "hello world".getBytes());
+
+        // then
+        assertThat(response).failsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldNotBindToAdvertisedAddress() throws Exception {
+      // given
+      final var bindingAddress = newAddress();
+      final MessagingConfig config = defaultConfig();
+      config.setInterfaces(List.of(bindingAddress.host()));
+      config.setPort(bindingAddress.port());
+
+      // when
+      final var nonBindableAddress = new Address("invalid.host", 1);
+      try (final var service = new NettyMessagingService("test", nonBindableAddress, config)) {
+        // then - should not fail by using advertisedAddress for binding
+        assertThat(service.start()).succeedsWithin(Duration.ofSeconds(5));
+        assertThat(service.bindingAddresses()).contains(bindingAddress);
+        assertThat(service.address()).isEqualTo(nonBindableAddress);
+      }
+    }
+  }
+
+  @Nested
+  final class DualInstanceTest {
+    @AutoCloseResource private final NettyMessagingService netty1 = newMessagingService();
+    @AutoCloseResource private final NettyMessagingService netty2 = newMessagingService();
+
+    @BeforeEach
+    void beforeEach() {
+      startMessagingServices(netty1, netty2);
+    }
+
+    @Test
+    void testSendAndReceive() {
+      final String subject = nextSubject();
+      final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+      final AtomicReference<byte[]> request = new AtomicReference<>();
+      final AtomicReference<Address> sender = new AtomicReference<>();
+
+      final BiFunction<Address, byte[], byte[]> handler =
+          (ep, data) -> {
+            handlerInvoked.set(true);
+            sender.set(ep);
+            request.set(data);
+            return "hello there".getBytes();
+          };
+      netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
+
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "hello world".getBytes());
+      assertThat("hello there".getBytes()).isEqualTo(response.join());
+      assertThat(handlerInvoked.get()).isTrue();
+      assertThat(request.get()).asString().isEqualTo("hello world");
+      assertThat(Arrays.equals(request.get(), "hello world".getBytes())).isTrue();
+      assertThat(sender.get().tryResolveAddress()).isEqualTo(netty1.address().tryResolveAddress());
+    }
+
+    @Test
+    void testSendAsync() {
+      final var invalidAddress = Address.from("127.0.0.1", 5007);
+      final var subject = nextSubject();
+      final var latch1 = new CountDownLatch(1);
+      CompletableFuture<Void> response =
+          netty1.sendAsync(netty2.address(), subject, "hello world".getBytes());
+      response.whenComplete(
+          (r, e) -> {
+            assertThat(e).isNull();
+            latch1.countDown();
+          });
+      Uninterruptibles.awaitUninterruptibly(latch1);
+
+      final CountDownLatch latch2 = new CountDownLatch(1);
+      response = netty1.sendAsync(invalidAddress, subject, "hello world".getBytes());
+      response.whenComplete(
+          (r, e) -> {
+            assertThat(e).isInstanceOf(ConnectException.class);
+            latch2.countDown();
+          });
+      Uninterruptibles.awaitUninterruptibly(latch2);
+    }
+
+    @Test
+    void shouldCompleteExistingRequestFutureExceptionallyWhenMessagingServiceIsClosed() {
+      final String subject = nextSubject();
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
+
+      // when
+      netty1.stop().join();
+
+      // then
+      assertThat(response).isCompletedExceptionally();
+    }
+
+    @Test
+    public void
+        shouldCompleteExistingRequestWithKeepAliveExceptionallyWhenMessagingServiceIsClosed() {
+      final String subject = nextSubject();
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
+
+      // when
+      netty1.stop().join();
+
+      // then
+      assertThat(response).isCompletedExceptionally();
+    }
+
+    @Test
+    void shouldCompleteFutureExceptionallyIfMessagingServiceIsClosedInBetween() {
+      final String subject = nextSubject();
+
+      // when
+      final var stopFuture = netty1.stop();
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "hello world".getBytes(), false, Duration.ofSeconds(5));
+
+      stopFuture.join();
+
+      // then
+      assertThat(response).isCompletedExceptionally();
+    }
+
+    @Test
+    void shouldCompleteRequestWithKeepAliveExceptionallyIfMessagingServiceIsClosedInBetween() {
+      final String subject = nextSubject();
+
+      // when
+      final var stopFuture = netty1.stop();
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
+
+      stopFuture.join();
+
+      // then
+      assertThat(response).isCompletedExceptionally();
+    }
+
+    @Test
+    void shouldCompleteFutureExceptionallyIfMessagingServiceHasAlreadyClosed() {
+      final String subject = nextSubject();
+      netty1.stop().join();
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "hello world".getBytes(), false, Duration.ofSeconds(5));
+
+      // then
+      assertThat(response).isCompletedExceptionally();
+    }
+
+    @Test
+    void shouldCompleteRequestWithKeepAliveExceptionallyIfMessagingServiceHasAlreadyClosed() {
+      final String subject = nextSubject();
+      netty1.stop().join();
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
+
+      // then
+      assertThat(response).isCompletedExceptionally();
+    }
+
+    @Test
+    void testTransientSendAndReceive() {
+      final String subject = nextSubject();
+      final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+      final AtomicReference<byte[]> request = new AtomicReference<>();
+      final AtomicReference<Address> sender = new AtomicReference<>();
+
+      final BiFunction<Address, byte[], byte[]> handler =
+          (ep, data) -> {
+            handlerInvoked.set(true);
+            sender.set(ep);
+            request.set(data);
+            return "hello there".getBytes();
+          };
+      netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
+
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "hello world".getBytes(), false);
+      assertThat("hello there".getBytes()).isEqualTo(response.join());
+      assertThat(handlerInvoked.get()).isTrue();
+      assertThat(request.get()).asString().isEqualTo("hello world");
+      assertThat(sender.get().tryResolveAddress()).isEqualTo(netty1.address().tryResolveAddress());
+    }
+
+    @Test
+    void testSendAndReceiveWithFixedTimeout() {
+      final String subject = nextSubject();
+      final BiFunction<Address, byte[], CompletableFuture<byte[]>> handler =
+          (ep, payload) -> new CompletableFuture<>();
+      netty2.registerHandler(subject, handler);
+
+      try {
+        netty1
+            .sendAndReceive(
+                netty2.address(), subject, "hello world".getBytes(), Duration.ofSeconds(1))
+            .join();
+        Assertions.fail();
+      } catch (final CompletionException e) {
+        assertThat(e.getCause()).isInstanceOf(TimeoutException.class);
+      }
+    }
+
+    @Test
+    @Disabled
+    void testSendAndReceiveWithExecutor() {
+      final String subject = nextSubject();
+      final ExecutorService completionExecutor =
+          Executors.newSingleThreadExecutor(r -> new Thread(r, "completion-thread"));
+      final ExecutorService handlerExecutor =
+          Executors.newSingleThreadExecutor(r -> new Thread(r, "handler-thread"));
+      final AtomicReference<String> handlerThreadName = new AtomicReference<>();
+      final AtomicReference<String> completionThreadName = new AtomicReference<>();
+
+      final CountDownLatch latch = new CountDownLatch(1);
+
+      final BiFunction<Address, byte[], byte[]> handler =
+          (ep, data) -> {
+            handlerThreadName.set(Thread.currentThread().getName());
+            try {
+              latch.await();
+            } catch (final InterruptedException e1) {
+              Thread.currentThread().interrupt();
+              Assertions.fail("InterruptedException");
+            }
+            return "hello there".getBytes();
+          };
+      netty2.registerHandler(subject, handler, handlerExecutor);
+
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "hello world".getBytes(), completionExecutor);
+      response.whenComplete((r, e) -> completionThreadName.set(Thread.currentThread().getName()));
+      latch.countDown();
+
+      // Verify that the message was request handling and response completion happens on the correct
+      // thread.
+      assertThat("hello there".getBytes()).isEqualTo(response.join());
+      assertThat(completionThreadName.get()).isEqualTo("completion-thread");
+      assertThat(handlerThreadName.get()).isEqualTo("handler-thread");
+    }
+
+    @Test
+    void testNoRemoteHandlerException() {
+      // given
+      final var subject = nextSubject();
+      final var expectedException = new MessagingException.NoRemoteHandler(subject);
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "fail".getBytes());
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(MessagingException.NoRemoteHandler.class)
+          .withMessage(expectedException.getMessage());
+    }
+
+    @Test
+    void testNoRemoteHandlerExceptionEmptyStringValue() {
+      // given
+      final var subject = "";
+      final var expectedException = new MessagingException.NoRemoteHandler(null);
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "fail".getBytes());
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(MessagingException.NoRemoteHandler.class)
+          .withMessage(expectedException.getMessage());
+    }
+
+    @Test
+    void testRemoteHandlerFailure() {
+      // given
+      final var exceptionMessage = "foo bar";
+      final var expectedException = new MessagingException.RemoteHandlerFailure(exceptionMessage);
+
+      final BiFunction<Address, byte[], byte[]> handler =
+          (ep, data) -> {
+            throw new RuntimeException(exceptionMessage);
+          };
+
+      final var subject = nextSubject();
+      netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "fail".getBytes());
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
+          .withMessage(expectedException.getMessage());
+    }
+
+    @Test
+    void testRemoteHandlerFailureNullValue() {
+      // given
+      final var expectedException = new MessagingException.RemoteHandlerFailure(null);
+
+      final BiFunction<Address, byte[], byte[]> handler =
+          (ep, data) -> {
+            throw new RuntimeException();
+          };
+
+      final var subject = nextSubject();
+      netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "fail".getBytes());
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
+          .withMessage(expectedException.getMessage());
+    }
+
+    @Test
+    void testRemoteHandlerFailureEmptyStringValue() {
+      // given
+      final var exceptionMessage = "";
+      final var expectedException = new MessagingException.RemoteHandlerFailure(null);
+
+      final BiFunction<Address, byte[], byte[]> handler =
+          (ep, data) -> {
+            throw new RuntimeException(exceptionMessage);
+          };
+
+      final var subject = nextSubject();
+      netty2.registerHandler(subject, handler, MoreExecutors.directExecutor());
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "fail".getBytes());
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
+          .withMessage(expectedException.getMessage());
+    }
+
+    @Test
+    void testCompletableRemoteHandlerFailure() {
+      // given
+      final var exceptionMessage = "foo bar";
+      final var expectedException = new MessagingException.RemoteHandlerFailure(exceptionMessage);
+
+      final var subject = nextSubject();
+      netty2.registerHandler(
+          subject,
+          (address, bytes) ->
+              CompletableFuture.failedFuture(new RuntimeException(exceptionMessage)));
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "fail".getBytes());
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
+          .withMessage(expectedException.getMessage());
+    }
+
+    @Test
+    void testCompletableRemoteHandlerFailureNullValue() {
+      // given
+      final var expectedException = new MessagingException.RemoteHandlerFailure(null);
+
+      final var subject = nextSubject();
+      netty2.registerHandler(
+          subject, (address, bytes) -> CompletableFuture.failedFuture(new RuntimeException()));
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "fail".getBytes());
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
+          .withMessage(expectedException.getMessage());
+    }
+
+    @Test
+    void testCompletableRemoteHandlerFailureEmptyStringValue() {
+      // given
+      final var exceptionMessage = "";
+      final var expectedException = new MessagingException.RemoteHandlerFailure(null);
+
+      final var subject = nextSubject();
+      netty2.registerHandler(
+          subject,
+          (address, bytes) ->
+              CompletableFuture.failedFuture(new RuntimeException(exceptionMessage)));
+
+      // when
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(netty2.address(), subject, "fail".getBytes());
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(MessagingException.RemoteHandlerFailure.class)
+          .withMessage(expectedException.getMessage());
+    }
+
+    @Test
+    void shouldCloseChannelAfterTimeout() throws Exception {
+      // given
+      final var subject = nextSubject();
+      final MutableReference<ChannelPool> poolRef = new MutableReference<>();
+      final var timeoutOnCreate = Duration.ofSeconds(10);
+
+      try (final var nettyWithOwnPool = createMessagingServiceWithPool(poolRef)) {
+        final var channelPool = poolRef.get();
+        nettyWithOwnPool.start().join();
+
+        // grab the original channel, so we can assert it was closed
+        // it's also useful to send a successful request once, so we can ensure the channel exists
+        // and set a lower timeout on the request we want specifically to time out
+        netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+        nettyWithOwnPool
+            .sendAndReceive(
+                netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
+            .join();
+        final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
+
+        // when - set up handler which will always cause timeouts
+        netty2.unregisterHandler(subject);
+        netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
+        final CompletableFuture<byte[]> response =
+            nettyWithOwnPool.sendAndReceive(
+                netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
+
+        // then
+        assertThat(response)
+            .failsWithin(Duration.ofSeconds(15))
+            .withThrowableThat()
+            .havingRootCause()
+            .isInstanceOf(TimeoutException.class)
+            .withMessageContaining("timed out in");
+        assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
+      }
+    }
+
+    @Test
+    void shouldCreateNewChannelOnNewRequestAfterTimeout() throws Exception {
+      // given
+      final var subject = nextSubject();
+      final MutableReference<ChannelPool> poolRef = new MutableReference<>();
+      final var timeoutOnCreate = Duration.ofSeconds(10);
+
+      try (final var nettyWithOwnPool = createMessagingServiceWithPool(poolRef)) {
+        final var channelPool = poolRef.get();
+        nettyWithOwnPool.start().join();
+
+        // grab the original channel, so we can assert it was closed
+        // it's also useful to send a successful request once, so we can ensure the channel exists
+        // and set a lower timeout on the request we want specifically to time out
+        netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+        nettyWithOwnPool
+            .sendAndReceive(
+                netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
+            .join();
+        final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
+
+        // set up handler which will always cause timeouts
+        netty2.unregisterHandler(subject);
+        netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
+        final CompletableFuture<byte[]> response =
+            nettyWithOwnPool.sendAndReceive(
+                netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
+        assertThat(response)
+            .failsWithin(Duration.ofSeconds(15))
+            .withThrowableThat()
+            .havingRootCause()
+            .isInstanceOf(TimeoutException.class);
+        // wait until the channel is closed before grabbing the next one
+        assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
+
+        // when - remote connection finally succeeds
+        // give a generous time out on the second request, as creating a new channel can be slow at
+        // times
+        netty2.unregisterHandler(subject);
+        netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+        nettyWithOwnPool.sendAndReceive(
+            netty2.address(), subject, "success".getBytes(), true, timeoutOnCreate);
+
+        // then
+        final var newChannel = channelPool.getChannel(netty2.address(), subject).join();
+        assertThat(newChannel).isNotEqualTo(originalChannel);
+      }
+    }
+
+    @EnabledOnOs(OS.LINUX)
+    @RegressionTest("https://github.com/camunda/zeebe/issues/14837")
+    void shouldNotLeakUdpSockets() throws IOException {
+      // given
+      // the configured amount of threads for Netty's epoll transport
+      final var maxConnections = Runtime.getRuntime().availableProcessors() * 2;
+      final var subject = nextSubject();
+      netty2.registerHandler(
+          subject, (address, bytes) -> new byte[0], MoreExecutors.directExecutor());
+
+      // when
+      for (int i = 0; i < maxConnections * 4; i++) {
+        netty1.sendAndReceive(netty2.address(), subject, "hello world".getBytes(), false).join();
+      }
+
+      // then - there seems to be a slight amount more than maxConnections normally, but without the
+      // fix this was way, way, way more, so it should be fine to allow a little bit more than the
+      // expected max number of connections
+      assertThat(udpSocketCount()).isLessThanOrEqualTo(maxConnections * 2L);
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR reduces the total time of the `NettyMessagingServiceTest` class from (locally) ~30s down to ~10s. It does so by grouping the tests in nested classes, which avoids having to start 5 or more service instances for every test when most tests use one or two service instances.

Based on/blocked by #14839.

## Related issues

related to #14837 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
