### PR TITLE
Replace incremental requestId in AtomixServerTransport with unique SnowflakeId

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
@@ -44,7 +44,8 @@ final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
     final var schedulingService = brokerStartupContext.getActorSchedulingService();
     final var messagingService = brokerStartupContext.getApiMessagingService();
 
-    final var atomixServerTransport = new AtomixServerTransport(messagingService);
+    final var atomixServerTransport =
+        new AtomixServerTransport(messagingService, brokerInfo.getNodeId());
 
     concurrencyControl.runOnCompletion(
         schedulingService.submitActor(atomixServerTransport),

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
@@ -80,7 +80,7 @@ public final class StubBrokerRule extends ExternalResource {
             .build();
     cluster.start().join();
     final var transportFactory = new TransportFactory(scheduler);
-    serverTransport = transportFactory.createServerTransport(0, cluster.getMessagingService());
+    serverTransport = transportFactory.createServerTransport(nodeId, cluster.getMessagingService());
 
     channelHandler = new StubRequestHandler(msgPackHelper);
     serverTransport.subscribe(1, RequestType.COMMAND, channelHandler);

--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -37,7 +37,7 @@ public final class TransportFactory {
 
   public ServerTransport createServerTransport(
       final int nodeId, final MessagingService messagingService) {
-    final var atomixServerTransport = new AtomixServerTransport(messagingService);
+    final var atomixServerTransport = new AtomixServerTransport(messagingService, nodeId);
     actorSchedulingService.submitActor(atomixServerTransport);
     return atomixServerTransport;
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -42,12 +42,13 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   public AtomixServerTransport(final MessagingService messagingService, final int nodeId) {
     this.messagingService = messagingService;
     partitionsRequestMap = new Int2ObjectHashMap<>();
-    this.idGenerator = new SnowflakeIdGenerator(
-        SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
-        SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
-        nodeId,
-        TIMESTAMP_OFFSET_2023,
-        SystemEpochClock.INSTANCE);
+    this.idGenerator =
+        new SnowflakeIdGenerator(
+            SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
+            SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
+            nodeId,
+            TIMESTAMP_OFFSET_2023,
+            SystemEpochClock.INSTANCE);
   }
 
   @Override

--- a/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -369,25 +369,23 @@ public class AtomixTransportTest {
   }
 
   @Test
-  public void shouldCreateUniqueRequestsIds(){
+  public void shouldCreateUniqueRequestsIds() {
     final DirectlyResponder directlyResponder = new DirectlyResponder();
 
-    serverTransport
-        .subscribe(0, RequestType.COMMAND, directlyResponder)
-        .join();
+    serverTransport.subscribe(0, RequestType.COMMAND, directlyResponder).join();
 
     // when
     final var requestFuture1 =
         clientTransport.sendRequestWithRetry(
             nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT);
     requestFuture1.join();
-    long requestId1 = directlyResponder.serverResponse.getRequestId();
+    final long requestId1 = directlyResponder.serverResponse.getRequestId();
 
     final var requestFuture2 =
         clientTransport.sendRequestWithRetry(
             nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT);
     requestFuture2.join();
-    long requestId2 = directlyResponder.serverResponse.getRequestId();
+    final long requestId2 = directlyResponder.serverResponse.getRequestId();
 
     // then
     assertThat(requestId1).isNotEqualByComparingTo(requestId2);
@@ -430,6 +428,7 @@ public class AtomixTransportTest {
     DirectlyResponder() {
       this.requestConsumer = (bytes -> {});
     }
+
     DirectlyResponder(final Consumer<byte[]> requestConsumer) {
       this.requestConsumer = requestConsumer;
     }


### PR DESCRIPTION
## Description

In the issue "Unexpected value type in command response" the problem is likely being cause by:

> Request X was sent to leader A, leader A assigns it a requestId R.
> New leader B before record X is processed
> New Request Y was sent to leader B, it got same requestId R.
> leader B process X first, and respond using the requestId R which will be sent to the response future waiting for request Y
> Why would this happen? RequestId is kept in memory per broker, and can restart at 0 after a broker restart.

https://github.com/camunda/zeebe/blob/a6803100c462387705716cfa1c90f17cd8fc6703/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java#L106

https://github.com/camunda/zeebe/issues/5624#issuecomment-1746328756

The solution chosen was to use SnowflakeIdGenerator which provides us with a unique request ID generated that uses the node ID and time as seed. It is also capable of generating up to 4096 unique IDs per millisecond per node.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/5624

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
