### PR TITLE
Handle scale brokers request in broker

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/api/ScaleRequestTransformer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/ScaleRequestTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator.TopologyChangeRequest;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ScaleRequestTransformer implements TopologyChangeRequest {
+
+  private final Set<MemberId> members;
+  private final ArrayList<TopologyChangeOperation> generatedOperations = new ArrayList<>();
+
+  public ScaleRequestTransformer(final Set<MemberId> members) {
+    this.members = members;
+  }
+
+  @Override
+  public Either<Exception, List<TopologyChangeOperation>> operations(
+      final ClusterTopology currentTopology) {
+    generatedOperations.clear();
+
+    // First add new members
+    return new AddMembersTransformer(members)
+        .operations(currentTopology)
+        .map(this::addToOperations)
+        // then reassign partitions
+        .flatMap(
+            ignore -> new PartitionReassignRequestTransformer(members).operations(currentTopology))
+        .map(this::addToOperations)
+        // then remove members that are not part of the new topology
+        .flatMap(
+            ignore -> {
+              final var membersToRemove =
+                  currentTopology.members().keySet().stream()
+                      .filter(m -> !members.contains(m))
+                      .collect(Collectors.toSet());
+              return new RemoveMembersTransformer(membersToRemove).operations(currentTopology);
+            })
+        .map(this::addToOperations);
+  }
+
+  private ArrayList<TopologyChangeOperation> addToOperations(
+      final List<TopologyChangeOperation> reassignOperations) {
+    generatedOperations.addAll(reassignOperations);
+    return generatedOperations;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementApi.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementApi.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequ
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementRequest.ScaleRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementResponse.TopologyChangeStatus;
 
 /** Defines the API for the topology management requests. */
@@ -28,4 +29,6 @@ public interface TopologyManagementApi {
 
   ActorFuture<TopologyChangeStatus> reassignPartitions(
       ReassignPartitionsRequest reassignPartitionsRequest);
+
+  ActorFuture<TopologyChangeStatus> scaleMembers(ScaleRequest scaleRequest);
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequest.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequest.java
@@ -23,4 +23,6 @@ public sealed interface TopologyManagementRequest {
       implements TopologyManagementRequest {}
 
   record ReassignPartitionsRequest(Set<MemberId> members) implements TopologyManagementRequest {}
+
+  record ScaleRequest(Set<MemberId> members) implements TopologyManagementRequest {}
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequ
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementRequest.ScaleRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementResponse.TopologyChangeStatus;
 import io.camunda.zeebe.topology.serializer.TopologyRequestsSerializer;
 import java.time.Duration;
@@ -85,6 +86,16 @@ public final class TopologyManagementRequestSender {
         TopologyRequestTopics.REASSIGN_PARTITIONS.topic(),
         reassignPartitionsRequest,
         serializer::encodeReassignPartitionsRequest,
+        serializer::decodeTopologyChangeStatus,
+        coordinator,
+        TIMEOUT);
+  }
+
+  public CompletableFuture<TopologyChangeStatus> scaleMembers(final ScaleRequest scaleRequest) {
+    return communicationService.send(
+        TopologyRequestTopics.SCALE_MEMBERS.topic(),
+        scaleRequest,
+        serializer::encodeScaleRequest,
         serializer::decodeTopologyChangeStatus,
         coordinator,
         TIMEOUT);

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequ
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementRequest.ScaleRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementResponse.StatusCode;
 import io.camunda.zeebe.topology.api.TopologyManagementResponse.TopologyChangeStatus;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator;
@@ -82,6 +83,11 @@ public final class TopologyManagementRequestsHandler implements TopologyManageme
     final var transformer =
         new PartitionReassignRequestTransformer(reassignPartitionsRequest.members());
     return handleRequest(transformer);
+  }
+
+  @Override
+  public ActorFuture<TopologyChangeStatus> scaleMembers(final ScaleRequest scaleRequest) {
+    return handleRequest(new ScaleRequestTransformer(scaleRequest.members()));
   }
 
   private ActorFuture<TopologyChangeStatus> handleRequest(final TopologyChangeRequest transformer) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -40,6 +40,7 @@ public final class TopologyRequestServer implements AutoCloseable {
     registerJoinPartitionRequestsHandler();
     registerLeavePartitionRequestsHandler();
     registerReassignPartitionRequestHandler();
+    registerScaleRequestHandler();
   }
 
   @Override
@@ -86,6 +87,14 @@ public final class TopologyRequestServer implements AutoCloseable {
         TopologyRequestTopics.REASSIGN_PARTITIONS.topic(),
         serializer::decodeReassignPartitionsRequest,
         request -> toCompletableFuture(topologyManagementApi.reassignPartitions(request)),
+        serializer::encode);
+  }
+
+  private void registerScaleRequestHandler() {
+    communicationService.replyTo(
+        TopologyRequestTopics.SCALE_MEMBERS.topic(),
+        serializer::decodeScaleRequest,
+        request -> toCompletableFuture(topologyManagementApi.scaleMembers(request)),
         serializer::encode);
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestTopics.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestTopics.java
@@ -12,7 +12,8 @@ public enum TopologyRequestTopics {
   REMOVE_MEMBER("topology-member-remove"),
   JOIN_PARTITION("topology-partition-join"),
   LEAVE_PARTITION("topology-partition-leave"),
-  REASSIGN_PARTITIONS("topology-partition-reassign");
+  REASSIGN_PARTITIONS("topology-partition-reassign"),
+  SCALE_MEMBERS("topology-member-scale");
   private final String topic;
 
   TopologyRequestTopics(final String topic) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
@@ -23,6 +23,8 @@ public interface TopologyRequestsSerializer {
   byte[] encodeReassignPartitionsRequest(
       TopologyManagementRequest.ReassignPartitionsRequest reassignPartitionsRequest);
 
+  byte[] encodeScaleRequest(TopologyManagementRequest.ScaleRequest scaleRequest);
+
   TopologyManagementRequest.AddMembersRequest decodeAddMembersRequest(byte[] encodedState);
 
   TopologyManagementRequest.RemoveMembersRequest decodeRemoveMembersRequest(byte[] encodedState);
@@ -33,6 +35,8 @@ public interface TopologyRequestsSerializer {
 
   TopologyManagementRequest.ReassignPartitionsRequest decodeReassignPartitionsRequest(
       byte[] encodedState);
+
+  TopologyManagementRequest.ScaleRequest decodeScaleRequest(byte[] encodedState);
 
   byte[] encode(TopologyChangeStatus topologyChangeStatus);
 

--- a/topology/src/main/resources/proto/requests.proto
+++ b/topology/src/main/resources/proto/requests.proto
@@ -24,6 +24,10 @@ message LeavePartitionRequest {
   int32 partitionId = 2;
 }
 
+message ScaleRequest {
+  repeated string memberIds = 1;
+}
+
 message TopologyChangeStatus {
   int64 changeId = 1;
   ChangeStatus status = 2;

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
@@ -9,24 +9,18 @@ package io.camunda.zeebe.topology.api;
 
 import static java.lang.Math.max;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
-import io.camunda.zeebe.topology.changes.NoopPartitionChangeExecutor;
-import io.camunda.zeebe.topology.changes.NoopTopologyMembershipChangeExecutor;
-import io.camunda.zeebe.topology.changes.TopologyChangeAppliersImpl;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.topology.util.TopologyUtil;
-import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import net.jqwik.api.EdgeCasesMode;
@@ -151,24 +145,8 @@ class PartitionReassignRequestTransformerTest {
             .get();
 
     // apply operations to generate new topology
-    final var topologyChangeSimulator =
-        new TopologyChangeAppliersImpl(
-            new NoopPartitionChangeExecutor(), new NoopTopologyMembershipChangeExecutor());
-    ClusterTopology newTopology = oldClusterTopology;
-    if (!operations.isEmpty()) {
-      newTopology = oldClusterTopology.startTopologyChange(operations);
-    }
-    while (newTopology.hasPendingChanges()) {
-      final var operation = newTopology.nextPendingOperation();
-      final var applier = topologyChangeSimulator.getApplier(operation);
-      final Either<Exception, UnaryOperator<MemberState>> init = applier.init(newTopology);
-      if (init.isLeft()) {
-        fail("fail");
-      }
-      newTopology = newTopology.updateMember(operation.memberId(), init.get());
-      newTopology = newTopology.advanceTopologyChange(operation.memberId(), applier.apply().join());
-    }
-
+    final ClusterTopology newTopology =
+        TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
     // then
     final var newDistribution = TopologyUtil.getPartitionDistributionFrom(newTopology, "temp");
     assertThat(newDistribution).isEqualTo(expectedNewDistribution);

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/ScaleRequestTransformerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/ScaleRequestTransformerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.topology.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.topology.changes.NoopTopologyMembershipChangeExecutor;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliersImpl;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.util.RoundRobinPartitionDistributor;
+import io.camunda.zeebe.topology.util.TopologyUtil;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import net.jqwik.api.EdgeCasesMode;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.constraints.IntRange;
+
+class ScaleRequestTransformerTest {
+  @Property(tries = 10)
+  void shouldScaleAndReassignWithReplicationFactor1(
+      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
+      @ForAll @IntRange(min = 1, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 1, max = 100) final int newClusterSize) {
+    shouldScaleAndReassign(partitionCount, 1, oldClusterSize, newClusterSize);
+  }
+
+  @Property(tries = 10)
+  void shouldScaleAndReassignWithReplicationFactor2(
+      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
+      @ForAll @IntRange(min = 2, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 2, max = 100) final int newClusterSize) {
+    shouldScaleAndReassign(partitionCount, 2, oldClusterSize, newClusterSize);
+  }
+
+  @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+  void shouldScaleAndReassignWithReplicationFactor3(
+      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
+      @ForAll @IntRange(min = 3, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 3, max = 100) final int newClusterSize) {
+    shouldScaleAndReassign(partitionCount, 3, oldClusterSize, newClusterSize);
+  }
+
+  @Property(tries = 10)
+  void shouldScaleAndReassignWithReplicationFactor4(
+      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
+      @ForAll @IntRange(min = 4, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 4, max = 100) final int newClusterSize) {
+    shouldScaleAndReassign(partitionCount, 4, oldClusterSize, newClusterSize);
+  }
+
+  @Property
+  void shouldFailIfClusterSizeLessThanReplicationFactor3(
+      @ForAll @IntRange(min = 0, max = 2) final int newClusterSize) {
+    shouldFailIfClusterSizeLessThanReplicationFactor(3, 3, 3, newClusterSize);
+  }
+
+  @Property
+  void shouldFailIfClusterSizeLessThanReplicationFactor4(
+      @ForAll @IntRange(min = 0, max = 3) final int newClusterSize) {
+    shouldFailIfClusterSizeLessThanReplicationFactor(12, 4, 6, newClusterSize);
+  }
+
+  void shouldFailIfClusterSizeLessThanReplicationFactor(
+      final int partitionCount,
+      final int replicationFactor,
+      final int oldClusterSize,
+      final int newClusterSize) {
+    // given
+    final var oldDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(
+                getClusterMembers(oldClusterSize),
+                getSortedPartitionIds(partitionCount),
+                replicationFactor);
+    final var oldClusterTopology = TopologyUtil.getClusterTopologyFrom(oldDistribution);
+
+    //  when
+    final var operationsEither =
+        new ScaleRequestTransformer(getClusterMembers(newClusterSize))
+            .operations(oldClusterTopology);
+
+    // then
+    EitherAssert.assertThat(operationsEither)
+        .isLeft()
+        .left()
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  void shouldScaleAndReassign(
+      final int partitionCount,
+      final int replicationFactor,
+      final int oldClusterSize,
+      final int newClusterSize) {
+    // given
+    final var expectedNewDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(
+                getClusterMembers(newClusterSize),
+                getSortedPartitionIds(partitionCount),
+                replicationFactor);
+
+    final var oldDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(
+                getClusterMembers(oldClusterSize),
+                getSortedPartitionIds(partitionCount),
+                replicationFactor);
+    final var oldClusterTopology = TopologyUtil.getClusterTopologyFrom(oldDistribution);
+
+    // when
+    final var operations =
+        new ScaleRequestTransformer(getClusterMembers(newClusterSize))
+            .operations(oldClusterTopology)
+            .get();
+
+    // apply operations to generate new topology
+    final var topologyChangeSimulator =
+        new TopologyChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(), new NoopTopologyMembershipChangeExecutor());
+    ClusterTopology newTopology = oldClusterTopology;
+    if (!operations.isEmpty()) {
+      newTopology = oldClusterTopology.startTopologyChange(operations);
+    }
+    while (newTopology.hasPendingChanges()) {
+      final var operation = newTopology.changes().pendingOperations().get(0);
+      final var applier = topologyChangeSimulator.getApplier(operation);
+      final Either<Exception, UnaryOperator<MemberState>> init = applier.init(newTopology);
+      if (init.isLeft()) {
+        fail("fail");
+      }
+      newTopology = newTopology.updateMember(operation.memberId(), init.get());
+      newTopology = newTopology.advanceTopologyChange(operation.memberId(), applier.apply().join());
+    }
+
+    // then
+    final var newDistribution = TopologyUtil.getPartitionDistributionFrom(newTopology, "temp");
+    assertThat(newDistribution).isEqualTo(expectedNewDistribution);
+    assertThat(newTopology.members().keySet())
+        .containsExactlyInAnyOrderElementsOf(getClusterMembers(newClusterSize));
+  }
+
+  private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
+    return IntStream.rangeClosed(1, partitionCount)
+        .mapToObj(id -> PartitionId.from("temp", id))
+        .collect(Collectors.toList());
+  }
+
+  private Set<MemberId> getClusterMembers(final int newClusterSize) {
+    return IntStream.range(0, newClusterSize)
+        .mapToObj(Integer::toString)
+        .map(MemberId::from)
+        .collect(Collectors.toSet());
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TestTopologyChangeSimulator.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TestTopologyChangeSimulator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.zeebe.topology.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.topology.changes.NoopTopologyMembershipChangeExecutor;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliersImpl;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+final class TestTopologyChangeSimulator {
+
+  static ClusterTopology apply(
+      final ClusterTopology currentTopology, final List<TopologyChangeOperation> operations) {
+    final var topologyChangeSimulator =
+        new TopologyChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(), new NoopTopologyMembershipChangeExecutor());
+    ClusterTopology newTopology = currentTopology;
+    if (!operations.isEmpty()) {
+      newTopology = currentTopology.startTopologyChange(operations);
+    }
+    while (newTopology.hasPendingChanges()) {
+      final var operation = newTopology.nextPendingOperation();
+      final var applier = topologyChangeSimulator.getApplier(operation);
+      final Either<Exception, UnaryOperator<MemberState>> init = applier.init(newTopology);
+      if (init.isLeft()) {
+        fail("Failed to init operation ", init.getLeft());
+      }
+      newTopology = newTopology.updateMember(operation.memberId(), init.get());
+      newTopology = newTopology.advanceTopologyChange(operation.memberId(), applier.apply().join());
+    }
+    return newTopology;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for handling scale request in the broker. Later, this will be wired up to the `post actuator/cluster/brokers`  endpoint in the gateway. The coordinator broker can process the request, and apply the generated operations to add new brokers, reassign partitions, and remove brokers that are not part of the cluster anymore.

## Related issues

related #14462 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
