### PR TITLE
feat(dist): empty template implementation of the cluster api

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/TopologyServices.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/TopologyServices.java
@@ -9,9 +9,13 @@ package io.camunda.zeebe.broker;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.topology.api.TopologyManagementRequestSender;
+import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -21,11 +25,13 @@ public class TopologyServices {
   private final ActorScheduler scheduler;
 
   private final ClusterMembershipService clusterMembershipService;
+  private final ClusterCommunicationService clusterCommunicationService;
 
   @Autowired
   public TopologyServices(final ActorScheduler scheduler, final AtomixCluster atomixCluster) {
     this.scheduler = scheduler;
     clusterMembershipService = atomixCluster.getMembershipService();
+    clusterCommunicationService = atomixCluster.getCommunicationService();
   }
 
   @Bean
@@ -35,5 +41,11 @@ public class TopologyServices {
     scheduler.submitActor(brokerTopologyManager).join();
     clusterMembershipService.addListener(brokerTopologyManager);
     return brokerTopologyManager;
+  }
+
+  @Bean
+  TopologyManagementRequestSender topologyManagementRequestSender() {
+    return new TopologyManagementRequestSender(
+        clusterCommunicationService, MemberId.from("0"), new ProtoBufSerializer());
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/TopologyServices.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/TopologyServices.java
@@ -9,12 +9,15 @@ package io.camunda.zeebe.gateway;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.topology.GatewayClusterTopologyService;
+import io.camunda.zeebe.topology.api.TopologyManagementRequestSender;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
+import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -55,5 +58,11 @@ public class TopologyServices {
     gatewayClusterTopologyService.addUpdateListener(brokerTopologyManager);
 
     return brokerTopologyManager;
+  }
+
+  @Bean
+  TopologyManagementRequestSender topologyManagementRequestSender() {
+    return new TopologyManagementRequestSender(
+        clusterCommunicationService, MemberId.from("0"), new ProtoBufSerializer());
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.topology.api.TopologyManagementRequestSender;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@WebEndpoint(id = "cluster")
+public class ClusterEndpoint {
+  private final TopologyManagementRequestSender requestSender;
+
+  @Autowired
+  public ClusterEndpoint(final TopologyManagementRequestSender requestSender) {
+    this.requestSender = requestSender;
+  }
+
+  @WriteOperation
+  public WebEndpointResponse<?> scale(
+      @Selector final ClusterComponent clusterComponent, final List<String> ids) {
+    return switch (clusterComponent) {
+      case BROKERS -> new WebEndpointResponse<>("Scaling brokers is not supported", 400);
+    };
+  }
+
+  @WriteOperation
+  public WebEndpointResponse<?> addMember(
+      @Selector final ClusterComponent clusterComponent, @Selector final String id) {
+    return switch (clusterComponent) {
+      case ClusterComponent.BROKERS -> new WebEndpointResponse<>(
+          "Adding brokers is not supported", 400);
+    };
+  }
+
+  public enum ClusterComponent {
+    BROKERS,
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /** Forwards all requests to the coordinator. */
-final class TopologyManagementRequestSender {
+public final class TopologyManagementRequestSender {
   private static final Duration TIMEOUT = Duration.ofSeconds(10);
   private final ClusterCommunicationService communicationService;
   private final MemberId coordinator;

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Handles the requests for the topology management. This is expected be running on the coordinator
  * node.
  */
-final class TopologyManagementRequestsHandler implements TopologyManagementApi {
+public final class TopologyManagementRequestsHandler implements TopologyManagementApi {
 
   private final TopologyChangeCoordinator coordinator;
   private final ConcurrencyControl executor;

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -23,7 +23,7 @@ public final class TopologyRequestServer implements AutoCloseable {
   private final ConcurrencyControl executor;
   private final TopologyRequestsSerializer serializer;
 
-  TopologyRequestServer(
+  public TopologyRequestServer(
       final ClusterCommunicationService communicationService,
       final TopologyRequestsSerializer serializer,
       final TopologyManagementApi topologyManagementApi,
@@ -34,7 +34,7 @@ public final class TopologyRequestServer implements AutoCloseable {
     this.executor = executor;
   }
 
-  void start() {
+  public void start() {
     registerAddMemberRequestsHandler();
     registerRemoveMemberRequestsHandler();
     registerJoinPartitionRequestsHandler();
@@ -92,15 +92,17 @@ public final class TopologyRequestServer implements AutoCloseable {
   private CompletableFuture<TopologyChangeStatus> toCompletableFuture(
       final ActorFuture<TopologyChangeStatus> resultFuture) {
     final var future = new CompletableFuture<TopologyChangeStatus>();
-    executor.runOnCompletion(
-        resultFuture,
-        (status, error) -> {
-          if (error == null) {
-            future.complete(status);
-          } else {
-            future.completeExceptionally(error);
-          }
-        });
+    executor.run(
+        () ->
+            executor.runOnCompletion(
+                resultFuture,
+                (status, error) -> {
+                  if (error == null) {
+                    future.complete(status);
+                  } else {
+                    future.completeExceptionally(error);
+                  }
+                }));
     return future;
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 // Test to verify that server handles requests from the clients. This test uses the actual
 // communicationService to ensure that request subscription and handling is done correctly.
 final class TopologyManagementApiTest {
-  private TopologyManagementApi clientApi;
+  private TopologyManagementRequestSender clientApi;
 
   private final RecordingChangeCoordinator recordingCoordinator = new RecordingChangeCoordinator();
   private TopologyRequestServer requestServer;
@@ -62,8 +62,7 @@ final class TopologyManagementApiTest {
         new TopologyManagementRequestSender(
             gateway.getCommunicationService(),
             coordinator.getMembershipService().getLocalMember().id(),
-            new ProtoBufSerializer(),
-            new TestConcurrencyControl());
+            new ProtoBufSerializer());
 
     requestServer =
         new TopologyRequestServer(


### PR DESCRIPTION
Adds a template for the cluster API. Actual methods are not yet implemented.
This also touches some related code to make sure that the coordinator starts the request handler.

Related to https://github.com/camunda/zeebe/issues/14462