### PR TITLE
feat(dist): expose partition join and leave over cluster API

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -8,10 +8,28 @@
 package io.camunda.zeebe.shared.management;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.management.cluster.BrokerState;
+import io.camunda.zeebe.management.cluster.BrokerStateCode;
+import io.camunda.zeebe.management.cluster.Operation;
+import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
+import io.camunda.zeebe.management.cluster.PartitionState;
+import io.camunda.zeebe.management.cluster.PartitionStateCode;
+import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.topology.api.TopologyChangeResponse;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequestSender;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState.State;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
@@ -56,7 +74,7 @@ public class ClusterEndpoint {
   }
 
   @WriteOperation
-  public WebEndpointResponse<?> addSubResource(
+  public WebEndpointResponse<PostOperationResponse> addSubResource(
       @Selector final Resource resource,
       @Selector final String resourceId,
       @Selector final Resource subResource,
@@ -66,28 +84,30 @@ public class ClusterEndpoint {
       case BROKERS -> switch (subResource) {
         case PARTITIONS -> new WebEndpointResponse<>(
             // POST /cluster/brokers/1/partitions/2
-            requestSender
-                .joinPartition(
-                    new JoinPartitionRequest(
-                        MemberId.from(resourceId), Integer.parseInt(subResourceId), priority))
-                .join());
+            mapResponseType(
+                requestSender
+                    .joinPartition(
+                        new JoinPartitionRequest(
+                            MemberId.from(resourceId), Integer.parseInt(subResourceId), priority))
+                    .join()));
         case BROKERS -> new WebEndpointResponse<>(404);
       };
       case PARTITIONS -> switch (subResource) {
         case BROKERS -> new WebEndpointResponse<>(
             // POST /cluster/partitions/1/brokers/2
-            requestSender
-                .joinPartition(
-                    new JoinPartitionRequest(
-                        MemberId.from(subResourceId), Integer.parseInt(resourceId), priority))
-                .join());
+            mapResponseType(
+                requestSender
+                    .joinPartition(
+                        new JoinPartitionRequest(
+                            MemberId.from(subResourceId), Integer.parseInt(resourceId), priority))
+                    .join()));
         case PARTITIONS -> new WebEndpointResponse<>(404);
       };
     };
   }
 
   @DeleteOperation
-  public WebEndpointResponse<?> removeSubResource(
+  public WebEndpointResponse<PostOperationResponse> removeSubResource(
       @Selector final Resource resource,
       @Selector final String resourceId,
       @Selector final Resource subResource,
@@ -96,23 +116,106 @@ public class ClusterEndpoint {
       case BROKERS -> switch (subResource) {
         case PARTITIONS -> new WebEndpointResponse<>(
             // DELETE /cluster/brokers/1/partitions/2
-            requestSender
-                .leavePartition(
-                    new LeavePartitionRequest(
-                        MemberId.from(resourceId), Integer.parseInt(subResourceId)))
-                .join());
+            mapResponseType(
+                requestSender
+                    .leavePartition(
+                        new LeavePartitionRequest(
+                            MemberId.from(resourceId), Integer.parseInt(subResourceId)))
+                    .join()));
         case BROKERS -> new WebEndpointResponse<>(404);
       };
       case PARTITIONS -> switch (subResource) {
         case BROKERS -> new WebEndpointResponse<>(
             // DELETE /cluster/partitions/1/brokers/2
-            requestSender
-                .leavePartition(
-                    new LeavePartitionRequest(
-                        MemberId.from(subResourceId), Integer.parseInt(resourceId)))
-                .join());
+            mapResponseType(
+                requestSender
+                    .leavePartition(
+                        new LeavePartitionRequest(
+                            MemberId.from(subResourceId), Integer.parseInt(resourceId)))
+                    .join()));
         case PARTITIONS -> new WebEndpointResponse<>(404);
       };
+    };
+  }
+
+  private static PostOperationResponse mapResponseType(final TopologyChangeResponse response) {
+    return new PostOperationResponse()
+        .changeId((int) response.changeId())
+        .currentTopology(mapBrokerStates(response.currentTopology()))
+        .expectedTopology(mapBrokerStates(response.expectedTopology()))
+        .plannedChanges(mapOperations(response.plannedChanges()));
+  }
+
+  private static List<Operation> mapOperations(final List<TopologyChangeOperation> operations) {
+    return operations.stream().map(ClusterEndpoint::mapOperation).toList();
+  }
+
+  private static Operation mapOperation(final TopologyChangeOperation operation) {
+    return switch (operation) {
+      case final MemberJoinOperation join -> new Operation()
+          .operation(OperationEnum.BROKER_ADD)
+          .brokerId(Integer.parseInt(join.memberId().id()));
+      case final MemberLeaveOperation leave -> new Operation()
+          .operation(OperationEnum.BROKER_REMOVE)
+          .brokerId(Integer.parseInt(leave.memberId().id()));
+      case final PartitionJoinOperation join -> new Operation()
+          .operation(OperationEnum.PARTITION_JOIN)
+          .brokerId(Integer.parseInt(join.memberId().id()))
+          .partitionId(join.partitionId())
+          .priority(join.priority());
+      case final PartitionLeaveOperation leave -> new Operation()
+          .operation(OperationEnum.PARTITION_LEAVE)
+          .brokerId(Integer.parseInt(leave.memberId().id()))
+          .partitionId(leave.partitionId());
+      case final PartitionReconfigurePriorityOperation reconfigure -> new Operation()
+          .operation(OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
+          .brokerId(Integer.parseInt(reconfigure.memberId().id()))
+          .partitionId(reconfigure.partitionId())
+          .priority(reconfigure.priority());
+    };
+  }
+
+  private static List<BrokerState> mapBrokerStates(final Map<MemberId, MemberState> topology) {
+    return topology.entrySet().stream()
+        .map(
+            entry ->
+                new BrokerState()
+                    .id(Integer.parseInt(entry.getKey().id()))
+                    .state(mapBrokerState(entry.getValue().state()))
+                    .lastUpdatedAt(entry.getValue().lastUpdated().atOffset(ZoneOffset.UTC))
+                    .version((int) entry.getValue().version())
+                    .partitions(mapPartitionStates(entry.getValue().partitions())))
+        .toList();
+  }
+
+  private static BrokerStateCode mapBrokerState(final MemberState.State state) {
+    return switch (state) {
+      case ACTIVE -> BrokerStateCode.ACTIVE;
+      case JOINING -> BrokerStateCode.JOINING;
+      case LEAVING -> BrokerStateCode.LEAVING;
+      case LEFT -> BrokerStateCode.LEFT;
+      case UNINITIALIZED -> BrokerStateCode.UNKNOWN;
+    };
+  }
+
+  private static List<PartitionState> mapPartitionStates(
+      final Map<Integer, io.camunda.zeebe.topology.state.PartitionState> partitions) {
+    return partitions.entrySet().stream()
+        .map(
+            entry ->
+                new PartitionState()
+                    .id(entry.getKey())
+                    .priority(entry.getValue().priority())
+                    .state(mapPartitionState(entry.getValue().state())))
+        .toList();
+  }
+
+  private static PartitionStateCode mapPartitionState(final State state) {
+    return switch (state) {
+      case JOINING -> PartitionStateCode.JOINING;
+      case ACTIVE -> PartitionStateCode.ACTIVE;
+      case LEAVING -> PartitionStateCode.LEAVING;
+      case UNKNOWN -> PartitionStateCode.UNKNOWN;
     };
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -140,7 +140,7 @@ public class ClusterEndpoint {
 
   private static PostOperationResponse mapResponseType(final TopologyChangeResponse response) {
     return new PostOperationResponse()
-        .changeId((int) response.changeId())
+        .changeId(response.changeId())
         .currentTopology(mapBrokerStates(response.currentTopology()))
         .expectedTopology(mapBrokerStates(response.expectedTopology()))
         .plannedChanges(mapOperations(response.plannedChanges()));
@@ -183,7 +183,7 @@ public class ClusterEndpoint {
                     .id(Integer.parseInt(entry.getKey().id()))
                     .state(mapBrokerState(entry.getValue().state()))
                     .lastUpdatedAt(entry.getValue().lastUpdated().atOffset(ZoneOffset.UTC))
-                    .version((int) entry.getValue().version())
+                    .version(entry.getValue().version())
                     .partitions(mapPartitionStates(entry.getValue().partitions())))
         .toList();
   }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -109,9 +109,9 @@ public class ClusterEndpoint {
   @DeleteOperation
   public WebEndpointResponse<PostOperationResponse> removeSubResource(
       @Selector final Resource resource,
-      @Selector final String resourceId,
+      @Selector final int resourceId,
       @Selector final Resource subResource,
-      @Selector final String subResourceId) {
+      @Selector final int subResourceId) {
     return switch (resource) {
       case BROKERS -> switch (subResource) {
         case PARTITIONS -> new WebEndpointResponse<>(
@@ -120,7 +120,7 @@ public class ClusterEndpoint {
                 requestSender
                     .leavePartition(
                         new LeavePartitionRequest(
-                            MemberId.from(resourceId), Integer.parseInt(subResourceId)))
+                            MemberId.from(String.valueOf(resourceId)), subResourceId))
                     .join()));
         case BROKERS -> new WebEndpointResponse<>(404);
       };
@@ -131,7 +131,7 @@ public class ClusterEndpoint {
                 requestSender
                     .leavePartition(
                         new LeavePartitionRequest(
-                            MemberId.from(subResourceId), Integer.parseInt(resourceId)))
+                            MemberId.from(String.valueOf(subResourceId)), resourceId))
                     .join()));
         case PARTITIONS -> new WebEndpointResponse<>(404);
       };

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -349,21 +349,21 @@ components:
 
     ChangeId:
       title: ChangeId
-      description: The ID of broker
+      description: The ID of a topology change operation
       type: integer
       format: int64
       example: 8
 
     BrokerId:
       title: BrokerId
-      description: The ID of broker
+      description: The ID of a broker, starting from 0
       type: integer
       format: int32
       example: 0
 
     PartitionId:
       title: PartitionId
-      description: The ID of broker
+      description: The ID of a partition, starting from 1
       type: integer
       format: int32
       example: 1

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -188,8 +188,7 @@ components:
       type: object
       properties:
         changeId:
-          description: The id to track topology change.
-          type: integer
+          $ref: "#/components/schemas/ChangeId"
         currentTopology:
           description: Current topology of the cluster
           type: array
@@ -214,6 +213,7 @@ components:
       properties:
         version:
           type: integer
+          format: int64
           description: The version of the topology
           example: 1
         brokers:
@@ -227,10 +227,7 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          format: int64
-          description: The id of the current ongoing or last completed change.
-          example: 3
+          $ref: "#/components/schemas/ChangeId"
         status:
           type: string
           enum:
@@ -303,6 +300,7 @@ components:
           $ref: "#/components/schemas/BrokerStateCode"
         version:
           type: integer
+          format: int64
           description: The version of the broker state
           example: 1
         lastUpdatedAt:
@@ -353,7 +351,7 @@ components:
       title: ChangeId
       description: The ID of broker
       type: integer
-      format: int32
+      format: int64
       example: 8
 
     BrokerId:
@@ -361,11 +359,11 @@ components:
       description: The ID of broker
       type: integer
       format: int32
-      example: 8
+      example: 0
 
     PartitionId:
       title: PartitionId
       description: The ID of broker
       type: integer
       format: int32
-      example: 8
+      example: 1

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.management;
+
+import io.camunda.zeebe.management.cluster.Operation;
+import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@ZeebeIntegration
+@Execution(ExecutionMode.CONCURRENT)
+final class ClusterEndpointIT {
+
+  @Test
+  void shouldRequestPartitionLeave() {
+    final ClusterActuator actuator;
+    try (final var cluster =
+        TestCluster.builder()
+            .withEmbeddedGateway(true)
+            .withBrokersCount(2)
+            .withPartitionsCount(2)
+            .withReplicationFactor(2)
+            .withBrokerConfig(
+                broker ->
+                    broker
+                        .brokerConfig()
+                        .getExperimental()
+                        .getFeatures()
+                        .setEnableDynamicClusterTopology(true))
+            .build()
+            .start()) {
+      // given - a process instance
+      cluster.awaitCompleteTopology();
+
+      actuator = ClusterActuator.of(cluster.availableGateway());
+      // when -- request a leave
+      final var response = actuator.leavePartition(1, 2);
+      // then
+      Assertions.assertThat(response.getPlannedChanges())
+          .singleElement()
+          .asInstanceOf(InstanceOfAssertFactories.type(Operation.class))
+          .returns(OperationEnum.PARTITION_LEAVE, Operation::getOperation)
+          .returns(1, Operation::getBrokerId)
+          .returns(2, Operation::getPartitionId);
+    }
+  }
+
+  @Test
+  void shouldRequestPartitionJoin() {
+    try (final var cluster =
+        TestCluster.builder()
+            .withEmbeddedGateway(true)
+            .withBrokersCount(2)
+            .withPartitionsCount(2)
+            .withReplicationFactor(1)
+            .withBrokerConfig(
+                broker ->
+                    broker
+                        .brokerConfig()
+                        .getExperimental()
+                        .getFeatures()
+                        .setEnableDynamicClusterTopology(true))
+            .build()
+            .start()) {
+      // given - a process instance
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+      // when -- request a leave
+      final var response = actuator.joinPartition(0, 2, 3);
+      // then
+      Assertions.assertThat(response.getPlannedChanges())
+          .singleElement()
+          .asInstanceOf(InstanceOfAssertFactories.type(Operation.class))
+          .returns(OperationEnum.PARTITION_JOIN, Operation::getOperation)
+          .returns(0, Operation::getBrokerId)
+          .returns(2, Operation::getPartitionId)
+          .returns(3, Operation::getPriority);
+    }
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.actuator;
+
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import feign.Body;
+import feign.Feign;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import io.zeebe.containers.ZeebeNode;
+import java.util.List;
+
+public interface ClusterActuator {
+
+  /**
+   * Returns a {@link ClusterActuator} instance using the given node as upstream.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link ClusterActuator}
+   */
+  static ClusterActuator of(final ZeebeNode<?> node) {
+    return ofAddress(node.getExternalMonitoringAddress());
+  }
+
+  /**
+   * Returns a {@link ClusterActuator} instance using the given node as upstream.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link ClusterActuator}
+   */
+  static ClusterActuator of(final TestApplication<?> node) {
+    return ofAddress(node.monitoringAddress());
+  }
+
+  /**
+   * Returns a {@link ClusterActuator} instance using the given address as upstream.
+   *
+   * @param address the monitoring address
+   * @return a new instance of {@link ClusterActuator}
+   */
+  static ClusterActuator ofAddress(final String address) {
+    final var endpoint = String.format("http://%s/actuator/cluster", address);
+    return of(endpoint);
+  }
+
+  /**
+   * Returns a {@link ClusterActuator} instance using the given endpoint as upstream.
+   *
+   * @param endpoint the endpoint to connect to
+   * @return a new instance of {@link ClusterActuator}
+   */
+  static ClusterActuator of(final String endpoint) {
+    final var target = new HardCodedTarget<>(ClusterActuator.class, endpoint);
+    return Feign.builder()
+        .encoder(new JacksonEncoder(List.of(new Jdk8Module(), new JavaTimeModule())))
+        .decoder(new JacksonDecoder(List.of(new Jdk8Module(), new JavaTimeModule())))
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+
+  /**
+   * Request that the broker joins the partition with the given priority.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /brokers/{brokerId}/partitions/{partitionId}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Body("%7B\"priority\": \"{priority}\"%7D")
+  PostOperationResponse joinPartition(
+      @Param final int brokerId, @Param final int partitionId, @Param final int priority);
+
+  /**
+   * Request that the broker leaves the partition.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("DELETE /brokers/{brokerId}/partitions/{partitionId}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PostOperationResponse leavePartition(@Param final int brokerId, @Param final int partitionId);
+}


### PR DESCRIPTION
This adds new endpoints for requesting partition join or leave from a specific broker:
- POST /cluster/brokers/$brokerId/partitions/$partitionId
- POST /cluster/partitions/$partitionId/brokers/$brokerId
- DELETE /cluster/brokers/$brokerId/partitions/$partitionId
- DELETE /cluster/partitions/$partitionId/brokers/$brokerId

This is mainly useful for testing, normally users will interact with the more ergonomic `scale` API.

I've added an actuator client so that the new cluster API can be tested easily.

Related to https://github.com/camunda/zeebe/issues/14462
Closes https://github.com/camunda/zeebe/issues/14746