### PR TITLE
[Backport stable/8.3] Replace incremental requestId in AtomixServerTransport with unique SnowflakeId

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
@@ -44,7 +44,8 @@ final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
     final var schedulingService = brokerStartupContext.getActorSchedulingService();
     final var messagingService = brokerStartupContext.getApiMessagingService();
 
-    final var atomixServerTransport = new AtomixServerTransport(messagingService);
+    final var atomixServerTransport =
+        new AtomixServerTransport(messagingService, brokerInfo.getNodeId());
 
     concurrencyControl.runOnCompletion(
         schedulingService.submitActor(atomixServerTransport),

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
@@ -80,7 +80,7 @@ public final class StubBrokerRule extends ExternalResource {
             .build();
     cluster.start().join();
     final var transportFactory = new TransportFactory(scheduler);
-    serverTransport = transportFactory.createServerTransport(0, cluster.getMessagingService());
+    serverTransport = transportFactory.createServerTransport(nodeId, cluster.getMessagingService());
 
     channelHandler = new StubRequestHandler(msgPackHelper);
     serverTransport.subscribe(1, RequestType.COMMAND, channelHandler);

--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -37,7 +37,7 @@ public final class TransportFactory {
 
   public ServerTransport createServerTransport(
       final int nodeId, final MessagingService messagingService) {
-    final var atomixServerTransport = new AtomixServerTransport(messagingService);
+    final var atomixServerTransport = new AtomixServerTransport(messagingService, nodeId);
     actorSchedulingService.submitActor(atomixServerTransport);
     return atomixServerTransport;
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -42,12 +42,13 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   public AtomixServerTransport(final MessagingService messagingService, final int nodeId) {
     this.messagingService = messagingService;
     partitionsRequestMap = new Int2ObjectHashMap<>();
-    this.idGenerator = new SnowflakeIdGenerator(
-        SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
-        SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
-        nodeId,
-        TIMESTAMP_OFFSET_2023,
-        SystemEpochClock.INSTANCE);
+    this.idGenerator =
+        new SnowflakeIdGenerator(
+            SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
+            SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
+            nodeId,
+            TIMESTAMP_OFFSET_2023,
+            SystemEpochClock.INSTANCE);
   }
 
   @Override

--- a/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -369,25 +369,23 @@ public class AtomixTransportTest {
   }
 
   @Test
-  public void shouldCreateUniqueRequestsIds(){
+  public void shouldCreateUniqueRequestsIds() {
     final DirectlyResponder directlyResponder = new DirectlyResponder();
 
-    serverTransport
-        .subscribe(0, RequestType.COMMAND, directlyResponder)
-        .join();
+    serverTransport.subscribe(0, RequestType.COMMAND, directlyResponder).join();
 
     // when
     final var requestFuture1 =
         clientTransport.sendRequestWithRetry(
             nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT);
     requestFuture1.join();
-    long requestId1 = directlyResponder.serverResponse.getRequestId();
+    final long requestId1 = directlyResponder.serverResponse.getRequestId();
 
     final var requestFuture2 =
         clientTransport.sendRequestWithRetry(
             nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT);
     requestFuture2.join();
-    long requestId2 = directlyResponder.serverResponse.getRequestId();
+    final long requestId2 = directlyResponder.serverResponse.getRequestId();
 
     // then
     assertThat(requestId1).isNotEqualByComparingTo(requestId2);
@@ -430,6 +428,7 @@ public class AtomixTransportTest {
     DirectlyResponder() {
       this.requestConsumer = (bytes -> {});
     }
+
     DirectlyResponder(final Consumer<byte[]> requestConsumer) {
       this.requestConsumer = requestConsumer;
     }


### PR DESCRIPTION
# Description
Backport of #14857 to `stable/8.3`.

relates to camunda/zeebe#5624
original author: @rodrigo-lourenco-lopes