### PR TITLE
Add gateway endpoint to query current cluster topology

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -10,15 +10,24 @@ package io.camunda.zeebe.shared.management;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.BrokerStateCode;
+import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.PartitionState;
 import io.camunda.zeebe.management.cluster.PartitionStateCode;
 import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.management.cluster.TopologyChange;
+import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
+import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
 import io.camunda.zeebe.topology.api.TopologyChangeResponse;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequestSender;
+import io.camunda.zeebe.topology.state.ClusterChangePlan;
+import io.camunda.zeebe.topology.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.topology.state.ClusterChangePlan.Status;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.CompletedChange;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.PartitionState.State;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
@@ -32,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
@@ -46,6 +56,11 @@ public class ClusterEndpoint {
   @Autowired
   public ClusterEndpoint(final TopologyManagementRequestSender requestSender) {
     this.requestSender = requestSender;
+  }
+
+  @ReadOperation
+  public WebEndpointResponse<?> clusterTopology() {
+    return new WebEndpointResponse<>(mapClusterTopology(requestSender.getTopology().join()));
   }
 
   @WriteOperation
@@ -217,6 +232,85 @@ public class ClusterEndpoint {
       case LEAVING -> PartitionStateCode.LEAVING;
       case UNKNOWN -> PartitionStateCode.UNKNOWN;
     };
+  }
+
+  private static GetTopologyResponse mapClusterTopology(final ClusterTopology topology) {
+    final var response = new GetTopologyResponse();
+    final List<BrokerState> brokers = mapBrokerStates(topology.members());
+    final TopologyChange change;
+
+    if (topology.pendingChanges().isPresent()) {
+      change = mapOngoingChange(topology.pendingChanges().get());
+    } else if (topology.lastChange().isPresent()) {
+      change = mapCompletedChange(topology.lastChange().get());
+    } else {
+      change = new TopologyChange();
+    }
+
+    response.version(topology.version()).brokers(brokers).change(change);
+
+    return response;
+  }
+
+  private static TopologyChange mapCompletedChange(final CompletedChange completedChange) {
+    return new TopologyChange()
+        .id(completedChange.id())
+        .status(mapChangeStatus(completedChange.status()))
+        .startedAt(completedChange.startedAt().atOffset(ZoneOffset.UTC))
+        .completedAt(completedChange.completedAt().atOffset(ZoneOffset.UTC));
+  }
+
+  private static TopologyChange mapOngoingChange(final ClusterChangePlan clusterChangePlan) {
+    return new TopologyChange()
+        .id(clusterChangePlan.id())
+        .status(mapChangeStatus(clusterChangePlan.status()))
+        .pending(mapOperations(clusterChangePlan.pendingOperations()))
+        .completed(mapCompletedOperations(clusterChangePlan.completedOperations()));
+  }
+
+  private static StatusEnum mapChangeStatus(final Status status) {
+    return switch (status) {
+      case IN_PROGRESS -> StatusEnum.IN_PROGRESS;
+      case COMPLETED -> StatusEnum.COMPLETED;
+      case FAILED -> StatusEnum.FAILED;
+    };
+  }
+
+  private static List<TopologyChangeCompletedInner> mapCompletedOperations(
+      final List<CompletedOperation> completedOperations) {
+    return completedOperations.stream().map(ClusterEndpoint::mapCompletedOperation).toList();
+  }
+
+  private static TopologyChangeCompletedInner mapCompletedOperation(
+      final CompletedOperation operation) {
+    final var mappedOperation =
+        switch (operation.operation()) {
+          case final MemberJoinOperation join -> new TopologyChangeCompletedInner()
+              .operation(TopologyChangeCompletedInner.OperationEnum.BROKER_ADD)
+              .brokerId(Integer.parseInt(join.memberId().id()));
+          case final MemberLeaveOperation leave -> new TopologyChangeCompletedInner()
+              .operation(TopologyChangeCompletedInner.OperationEnum.BROKER_REMOVE)
+              .brokerId(Integer.parseInt(leave.memberId().id()));
+          case final PartitionJoinOperation join -> new TopologyChangeCompletedInner()
+              .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_JOIN)
+              .brokerId(Integer.parseInt(join.memberId().id()))
+              .partitionId(join.partitionId())
+              .priority(join.priority());
+          case final PartitionLeaveOperation leave -> new TopologyChangeCompletedInner()
+              .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_LEAVE)
+              .brokerId(Integer.parseInt(leave.memberId().id()))
+              .partitionId(leave.partitionId());
+          case final PartitionReconfigurePriorityOperation
+          reconfigure -> new TopologyChangeCompletedInner()
+              .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
+              .brokerId(Integer.parseInt(reconfigure.memberId().id()))
+              .partitionId(reconfigure.partitionId())
+              .priority(reconfigure.priority());
+        };
+
+    mappedOperation.completedAt(operation.completedAt().atOffset(ZoneOffset.UTC));
+
+    return mappedOperation;
   }
 
   public enum Resource {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -7,12 +7,13 @@
  */
 package io.camunda.zeebe.it.management;
 
+import static org.assertj.core.api.Assertions.*;
+
 import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -22,6 +23,32 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 @Execution(ExecutionMode.CONCURRENT)
 final class ClusterEndpointIT {
   private static final int BROKER_COUNT = 2;
+  private static final int PARTITION_COUNT = 2;
+
+  @Test
+  void shouldQueryCurrentClusterTopology() {
+    final ClusterActuator actuator;
+    try (final var cluster = createCluster(2)) {
+      // given
+      cluster.awaitCompleteTopology();
+      actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when
+      final var response = actuator.getTopology();
+
+      // then - topology is as expected
+      assertThat(response.getBrokers())
+          .hasSize(BROKER_COUNT)
+          .allSatisfy(
+              b ->
+                  assertThat(b.getPartitions())
+                      .describedAs("All brokers have two partitions each")
+                      .hasSize(PARTITION_COUNT));
+      assertThat(response.getChange().getId())
+          .describedAs("Initial topology has no completed or pending changes")
+          .isNull();
+    }
+  }
 
   @Test
   void shouldRequestPartitionLeave() {
@@ -34,7 +61,7 @@ final class ClusterEndpointIT {
       // when -- request a leave
       final var response = actuator.leavePartition(1, 2);
       // then
-      Assertions.assertThat(response.getPlannedChanges())
+      assertThat(response.getPlannedChanges())
           .singleElement()
           .asInstanceOf(InstanceOfAssertFactories.type(Operation.class))
           .returns(OperationEnum.PARTITION_LEAVE, Operation::getOperation)
@@ -52,7 +79,7 @@ final class ClusterEndpointIT {
       // when -- request a join
       final var response = actuator.joinPartition(0, 2, 3);
       // then
-      Assertions.assertThat(response.getPlannedChanges())
+      assertThat(response.getPlannedChanges())
           .singleElement()
           .asInstanceOf(InstanceOfAssertFactories.type(Operation.class))
           .returns(OperationEnum.PARTITION_JOIN, Operation::getOperation)
@@ -66,7 +93,7 @@ final class ClusterEndpointIT {
     return TestCluster.builder()
         .withEmbeddedGateway(true)
         .withBrokersCount(BROKER_COUNT)
-        .withPartitionsCount(2)
+        .withPartitionsCount(PARTITION_COUNT)
         .withReplicationFactor(replicationFactor)
         .withBrokerConfig(
             broker ->

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -18,6 +18,7 @@ import feign.Retryer;
 import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.zeebe.containers.ZeebeNode;
@@ -90,4 +91,13 @@ public interface ClusterActuator {
   @RequestLine("DELETE /brokers/{brokerId}/partitions/{partitionId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   PostOperationResponse leavePartition(@Param final int brokerId, @Param final int partitionId);
+
+  /**
+   * Queries the current cluster topology
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("GET")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  GetTopologyResponse getTopology();
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -39,6 +39,7 @@ public record ClusterTopology(
     Optional<CompletedChange> lastChange,
     Optional<ClusterChangePlan> pendingChanges) {
 
+  public static final int INITIAL_VERSION = 1;
   private static final int UNINITIALIZED_VERSION = -1;
 
   public static ClusterTopology uninitialized() {
@@ -50,7 +51,7 @@ public record ClusterTopology(
   }
 
   public static ClusterTopology init() {
-    return new ClusterTopology(0, Map.of(), Optional.empty(), Optional.empty());
+    return new ClusterTopology(INITIAL_VERSION, Map.of(), Optional.empty(), Optional.empty());
   }
 
   public ClusterTopology addMember(final MemberId memberId, final MemberState state) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
@@ -41,8 +41,11 @@ public final class TopologyUtil {
       memberStates.put(e.getKey(), MemberState.initializeAsActive(e.getValue()));
     }
 
-    return new io.camunda.zeebe.topology.state.ClusterTopology(
-        0, Map.copyOf(memberStates), Optional.empty(), Optional.empty());
+    return new ClusterTopology(
+        ClusterTopology.INITIAL_VERSION,
+        Map.copyOf(memberStates),
+        Optional.empty(),
+        Optional.empty());
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(


### PR DESCRIPTION
## Description

Add endpoint for `GET actuator/cluster`. This returns the current cluster topology with a list of brokers and their partitions. It also includes information about any ongoing changes to the topology such as a new broker is being added to the cluster.

Note that this is not the same result returned by `grpc GetTopologyRequest`. Both returns same brokers and partitions. But the grpc response also returns dynamically changing information such as who is leader/follower. 

## Related issues

related to #14462 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
