### PR TITLE
Make resource deletion tenant-aware

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -307,8 +307,13 @@ public class ResourceDeletionProcessor
   }
 
   private List<String> getAuthorizedTenants(final TypedRecord<ResourceDeletionRecord> command) {
-    return (List)
-        command.getAuthorizations().getOrDefault(Authorization.AUTHORIZED_TENANTS, List.of());
+    final String tenantId = command.getValue().getTenantId();
+    if (tenantId.isEmpty()) {
+      return (List)
+          command.getAuthorizations().getOrDefault(Authorization.AUTHORIZED_TENANTS, List.of());
+    }
+
+    return List.of(tenantId);
   }
 
   private void setTenantId(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionProcessor.java
@@ -144,6 +144,7 @@ public class ResourceDeletionProcessor
           Optional.ofNullable(
               processState.getProcessByKeyAndTenant(value.getResourceKey(), tenantId));
       if (processOptional.isPresent()) {
+        setTenantId(command, tenantId);
         deleteProcess(processOptional.get());
         return;
       }
@@ -151,12 +152,14 @@ public class ResourceDeletionProcessor
       final var drgOptional =
           decisionState.findDecisionRequirementsByTenantAndKey(tenantId, value.getResourceKey());
       if (drgOptional.isPresent()) {
+        setTenantId(command, tenantId);
         deleteDecisionRequirements(drgOptional.get());
         return;
       }
 
       final var formOptional = formState.findFormByKey(value.getResourceKey(), tenantId);
       if (formOptional.isPresent()) {
+        setTenantId(command, tenantId);
         deleteForm(formOptional.get());
         return;
       }
@@ -306,6 +309,11 @@ public class ResourceDeletionProcessor
   private List<String> getAuthorizedTenants(final TypedRecord<ResourceDeletionRecord> command) {
     return (List)
         command.getAuthorizations().getOrDefault(Authorization.AUTHORIZED_TENANTS, List.of());
+  }
+
+  private void setTenantId(
+      final TypedRecord<ResourceDeletionRecord> command, final String tenantId) {
+    command.getValue().setTenantId(tenantId);
   }
 
   private static final class NoSuchResourceException extends IllegalStateException {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordAssert;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TenantAwareResourceDeletionTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String DRG_SINGLE_DECISION = "/dmn/decision-table.dmn";
+  private static final String TEST_FORM_1 = "/form/test-form-1.form";
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("test").startEvent().endEvent().done();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  private final String tenantIdA = "tenant-a";
+  private final String tenantIdB = "tenant-b";
+
+  @Test
+  public void shouldDeleteProcessForAuthorizedTenant() {
+    // given
+    final var deployment =
+        ENGINE.deployment().withXmlResource(PROCESS).withTenantId(tenantIdA).deploy();
+    final var resourceKey =
+        deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey();
+
+    // when
+    final var deleted =
+        ENGINE
+            .resourceDeletion()
+            .withResourceKey(resourceKey)
+            .withAuthorizedTenantIds(tenantIdA)
+            .delete();
+
+    // then
+    Assertions.assertThat(deleted.getValue()).hasTenantId(tenantIdA);
+    verifyResourceIsDeleted(resourceKey);
+  }
+
+  @Test
+  public void shouldDeleteDecisionForAuthorizedTenant() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlClasspathResource(DRG_SINGLE_DECISION)
+            .withTenantId(tenantIdA)
+            .deploy();
+    final var resourceKey =
+        deployment.getValue().getDecisionRequirementsMetadata().get(0).getDecisionRequirementsKey();
+
+    // when
+    final var deleted =
+        ENGINE
+            .resourceDeletion()
+            .withResourceKey(resourceKey)
+            .withAuthorizedTenantIds(tenantIdA)
+            .delete();
+
+    // then
+    Assertions.assertThat(deleted.getValue()).hasTenantId(tenantIdA);
+    verifyResourceIsDeleted(resourceKey);
+  }
+
+  @Test
+  public void shouldDeleteFormForAuthorizedTenant() {
+    // given
+    final var deployment =
+        ENGINE.deployment().withXmlClasspathResource(TEST_FORM_1).withTenantId(tenantIdA).deploy();
+    final var resourceKey = deployment.getValue().getFormMetadata().get(0).getFormKey();
+
+    // when
+    final var deleted =
+        ENGINE
+            .resourceDeletion()
+            .withResourceKey(resourceKey)
+            .withAuthorizedTenantIds(tenantIdA)
+            .delete();
+
+    // then
+    Assertions.assertThat(deleted.getValue()).hasTenantId(tenantIdA);
+    verifyResourceIsDeleted(resourceKey);
+  }
+
+  @Test
+  public void shouldNotDeleteResourceForUnauthorizedTenant() {
+    // given
+    final var deployment =
+        ENGINE.deployment().withXmlResource(PROCESS).withTenantId(tenantIdA).deploy();
+    final var resourceKey =
+        deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey();
+
+    // when
+    final var rejection =
+        ENGINE
+            .resourceDeletion()
+            .withResourceKey(resourceKey)
+            .withAuthorizedTenantIds(tenantIdB)
+            .expectRejection()
+            .delete();
+
+    // then
+    RecordAssert.assertThat(rejection)
+        .describedAs("Expect resource is not found")
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to delete resource but no resource found with key `%d`"
+                .formatted(resourceKey));
+    assertThat(
+            RecordingExporter.resourceDeletionRecords()
+                .withIntent(ResourceDeletionIntent.DELETED)
+                .exists())
+        .isFalse();
+  }
+
+  private void verifyResourceIsDeleted(final long key) {
+    assertThat(
+            RecordingExporter.resourceDeletionRecords()
+                .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED)))
+        .describedAs("Expect resource to be deleted")
+        .extracting(Record::getIntent, r -> r.getValue().getResourceKey())
+        .containsOnly(
+            tuple(ResourceDeletionIntent.DELETE, key),
+            tuple(ResourceDeletionIntent.DELETING, key),
+            tuple(ResourceDeletionIntent.DELETED, key));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.function.Consumer;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -167,7 +166,6 @@ public class TenantAwareTimerStartEventTest {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/zeebe/issues/14279")
   public void shouldCancelTimerWhenDeletingProcessDefinition() {
     // given
     assertThat(
@@ -177,7 +175,11 @@ public class TenantAwareTimerStartEventTest {
         .isTrue();
 
     // when
-    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    engine
+        .resourceDeletion()
+        .withResourceKey(processDefinitionKey)
+        .withAuthorizedTenantIds(TENANT)
+        .delete();
 
     // then
     final var canceledEvent =
@@ -188,7 +190,6 @@ public class TenantAwareTimerStartEventTest {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/zeebe/issues/14279")
   public void shouldRecreateTimerWhenDeletingLatestProcessDefinition() {
     // given
     assertThat(
@@ -204,7 +205,11 @@ public class TenantAwareTimerStartEventTest {
         deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey();
 
     // when
-    engine.resourceDeletion().withResourceKey(latestProcessDefinitionKey).delete();
+    engine
+        .resourceDeletion()
+        .withResourceKey(latestProcessDefinitionKey)
+        .withAuthorizedTenantIds(TENANT)
+        .delete();
 
     // then
     final var canceledEvent =

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
@@ -11,7 +11,9 @@ import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionReco
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
 import java.util.function.Function;
 
 public class ResourceDeletionClient {
@@ -32,6 +34,7 @@ public class ResourceDeletionClient {
   private final CommandWriter writer;
   private final ResourceDeletionRecord resourceDeletionRecord = new ResourceDeletionRecord();
   private Function<Long, Record<ResourceDeletionRecordValue>> expectation = SUCCESS_EXPECTATION;
+  private List<String> authorizedTenantIds = List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ResourceDeletionClient(final CommandWriter writer) {
     this.writer = writer;
@@ -42,9 +45,17 @@ public class ResourceDeletionClient {
     return this;
   }
 
+  public ResourceDeletionClient withAuthorizedTenantIds(final String... tenantIds) {
+    authorizedTenantIds = List.of(tenantIds);
+    return this;
+  }
+
   public Record<ResourceDeletionRecordValue> delete() {
     final long position =
-        writer.writeCommand(ResourceDeletionIntent.DELETE, resourceDeletionRecord);
+        writer.writeCommand(
+            ResourceDeletionIntent.DELETE,
+            resourceDeletionRecord,
+            authorizedTenantIds.toArray(new String[0]));
     return expectation.apply(position);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
@@ -8,17 +8,19 @@
 package io.camunda.zeebe.protocol.impl.record.value.resource;
 
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class ResourceDeletionRecord extends UnifiedRecordValue
     implements ResourceDeletionRecordValue {
 
   private final LongProperty resourceKeyProp = new LongProperty("resourceKey");
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
 
   public ResourceDeletionRecord() {
-    declareProperty(resourceKeyProp);
+    declareProperty(resourceKeyProp).declareProperty(tenantIdProp);
   }
 
   public void wrap(final ResourceDeletionRecord record) {
@@ -37,7 +39,11 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
 
   @Override
   public String getTenantId() {
-    // todo(#13238): replace dummy implementation
-    return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public ResourceDeletionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.camunda.zeebe.test.util.JsonUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -1930,7 +1931,9 @@ final class JsonSerializableToJsonTest {
             () -> {
               final var resourceKey = 1L;
 
-              return new ResourceDeletionRecord().setResourceKey(resourceKey);
+              return new ResourceDeletionRecord()
+                  .setResourceKey(resourceKey)
+                  .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
             },
         """
         {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.CompleteJobResponse;
+import io.camunda.zeebe.client.api.response.DeleteResourceResponse;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
 import io.camunda.zeebe.client.api.response.ModifyProcessInstanceResponse;
@@ -47,6 +48,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 import org.awaitility.Awaitility;
@@ -320,6 +322,63 @@ public class MultiTenancyOverIdentityIT {
           .withMessageContaining(
               "Expected to handle gRPC request DeployResource with tenant identifier 'tenant-b'")
           .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @Test
+  void shouldAuthorizeDeleteResource() throws ExecutionException, InterruptedException {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      final Future<DeploymentEvent> deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send();
+      assertThat(deploymentResponse)
+          .describedAs("Expect that process was deployed for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+      final long resourceKey =
+          deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
+
+      // when
+      final Future<DeleteResourceResponse> response =
+          client.newDeleteResourceCommand(resourceKey).send();
+
+      // then
+      assertThat(response)
+          .describedAs("Expect that process can be deleted for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldDenyDeleteResourceWhenUnauthorized() throws ExecutionException, InterruptedException {
+    // given
+    final long resourceKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      final Future<DeploymentEvent> deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send();
+      assertThat(deploymentResponse)
+          .describedAs("Expect that process was deployed for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+      resourceKey = deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
+    }
+
+    // when
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      final Future<DeleteResourceResponse> response =
+          client.newDeleteResourceCommand(resourceKey).send();
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND");
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Ensure that resources are only deleted for authorized tenants.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14279 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [x] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
