### PR TITLE
Support ISM (data retention) in OpenSearch Exporter

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -782,6 +782,12 @@
         #     size: 1000
         #     memoryLimit: 10485760
         #
+        #   retention:
+        #     enabled: false
+        #     minimumAge: 30d
+        #     policyName: zeebe-record-retention-policy
+        #     policyDecsription: Zeebe record retention policy
+        #
         #   authentication:
         #     username: opensearch
         #     password: changeme

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -674,6 +674,12 @@
         #     size: 1000
         #     memoryLimit: 10485760
         #
+        #   retention:
+        #     enabled: false
+        #     minimumAge: 30d
+        #     policyName: zeebe-record-retention-policy
+        #     policyDecsription: Zeebe record retention policy
+        #
         #   authentication:
         #     username: opensearch
         #     password: changeme

--- a/exporters/opensearch-exporter/docker-compose.yml
+++ b/exporters/opensearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.6.0
+    image: opensearchproject/opensearch:2.5.0
     ports:
       - "9200:9200"
       - "9600:9600"
@@ -14,7 +14,7 @@ services:
       - opensearch-net
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:2.6.0
+    image: opensearchproject/opensearch-dashboards:2.5.0
     ports:
       - "5601:5601"
     expose:

--- a/exporters/opensearch-exporter/docker-compose.yml
+++ b/exporters/opensearch-exporter/docker-compose.yml
@@ -3,26 +3,20 @@ version: '3'
 services:
   opensearch:
     image: opensearchproject/opensearch:2.5.0
+    container_name: opensearch
+    environment:
+      - "discovery.type=single-node"
+      - "plugins.security.disabled=true"
     ports:
       - "9200:9200"
-      - "9600:9600"
-    environment:
-      - discovery.type=single-node
-      - cluster.name=test
-      - OPENSEARCH_JAVA_OPTS=-Xmx750m -Xms750m
-    networks:
-      - opensearch-net
 
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards:2.5.0
+    container_name: opensearch-dashboards
     ports:
       - "5601:5601"
-    expose:
-      - "5601"
     environment:
-      OPENSEARCH_HOSTS: '["https://opensearch:9200"]'
-    networks:
-      - opensearch-net
-
-networks:
-  opensearch-net:
+      - "OPENSEARCH_HOSTS=http://opensearch:9200"
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
+    depends_on:
+      - opensearch

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.http.entity.EntityTemplate;
@@ -222,12 +223,26 @@ public class OpensearchClient implements AutoCloseable {
     }
   }
 
-  public boolean putIndexStateManagementPolicy() {
+  public boolean createIndexStateManagementPolicy() {
+    return putIndexStateManagementPolicy(Collections.emptyMap());
+  }
+
+  public boolean updateIndexStateManagementPolicy(final Integer seqNo, final Integer primaryTerm) {
+    final var queryParameters =
+        Map.of("if_seq_no", seqNo.toString(), "if_primary_term", primaryTerm.toString());
+    return putIndexStateManagementPolicy(queryParameters);
+  }
+
+  private boolean putIndexStateManagementPolicy(final Map<String, String> queryParameters) {
     try {
       final var request =
           new Request("PUT", "_plugins/_ism/policies/" + configuration.retention.getPolicyName());
+
+      queryParameters.forEach(request::addParameter);
+
       final var requestEntity = createPutIndexManagementPolicyRequest();
       request.setJsonEntity(MAPPER.writeValueAsString(requestEntity));
+
       final var response = sendRequest(request, PutIndexStateManagementPolicyResponse.class);
       return response.policy() != null;
     } catch (final IOException e) {

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -296,17 +296,18 @@ public class OpensearchExporter implements Exporter {
 
     // Create the policy if it doesn't exist yet
     if (policyOptional.isEmpty()) {
-      if (!client.putIndexStateManagementPolicy()) {
-        log.warn(
-            "Failed to acknowledge the creation or update of the Index State Management Policy");
-        return;
+      if (!client.createIndexStateManagementPolicy()) {
+        log.warn("Failed to acknowledge the creation of the Index State Management Policy");
       }
+      return;
     }
 
     // Update the policy if it exists and is different from the configuration
     final var policy = policyOptional.get();
     if (!policy.equalsConfiguration(configuration)) {
-      // TODO
+      if (!client.updateIndexStateManagementPolicy(policy.seqNo(), policy.primaryTerm())) {
+        log.warn("Failed to acknowledge the update of the Index State Management Policy");
+      }
     }
   }
 

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -187,6 +187,10 @@ public class OpensearchExporter implements Exporter {
   }
 
   private void createIndexTemplates() {
+    if (configuration.retention.isEnabled()) {
+      createIndexStateManagementPolicy();
+    }
+
     final IndexConfiguration index = configuration.index;
 
     if (index.createTemplate) {
@@ -285,6 +289,15 @@ public class OpensearchExporter implements Exporter {
     }
 
     indexTemplatesCreated = true;
+  }
+
+  private void createIndexStateManagementPolicy() {
+    // TODO get policy
+    //  POST if not exists
+    //  Compare if exists, PUT if different
+    if (!client.putIndexStateManagementPolicy()) {
+      log.warn("Failed to acknowledge the creation or update of the Index State Management Policy");
+    }
   }
 
   private void createComponentTemplate() {

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -292,11 +292,21 @@ public class OpensearchExporter implements Exporter {
   }
 
   private void createIndexStateManagementPolicy() {
-    // TODO get policy
-    //  POST if not exists
-    //  Compare if exists, PUT if different
-    if (!client.putIndexStateManagementPolicy()) {
-      log.warn("Failed to acknowledge the creation or update of the Index State Management Policy");
+    final var policyOptional = client.getIndexStateManagementPolicy();
+
+    // Create the policy if it doesn't exist yet
+    if (policyOptional.isEmpty()) {
+      if (!client.putIndexStateManagementPolicy()) {
+        log.warn(
+            "Failed to acknowledge the creation or update of the Index State Management Policy");
+        return;
+      }
+    }
+
+    // Update the policy if it exists and is different from the configuration
+    final var policy = policyOptional.get();
+    if (!policy.equalsConfiguration(configuration)) {
+      // TODO
     }
   }
 

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -24,6 +24,7 @@ public class OpensearchExporterConfiguration {
   public final IndexConfiguration index = new IndexConfiguration();
   public final BulkConfiguration bulk = new BulkConfiguration();
   public final AwsConfiguration aws = new AwsConfiguration();
+  public final RetentionConfiguration retention = new RetentionConfiguration();
   private final AuthenticationConfiguration authentication = new AuthenticationConfiguration();
 
   public boolean hasAuthenticationPresent() {
@@ -46,6 +47,8 @@ public class OpensearchExporterConfiguration {
         + bulk
         + ", aws="
         + aws
+        + ", retention="
+        + retention
         + '}';
   }
 
@@ -348,6 +351,60 @@ public class OpensearchExporterConfiguration {
       } else {
         return "AwsConfiguration{Disabled}";
       }
+    }
+  }
+
+  public static class RetentionConfiguration {
+    private boolean enabled = false;
+    private String minimumAge = "30d";
+    private String policyName = "zeebe-record-retention-policy";
+    private String policyDescription = "Zeebe record retention policy";
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public String getMinimumAge() {
+      return minimumAge;
+    }
+
+    public void setMinimumAge(final String minimumAge) {
+      this.minimumAge = minimumAge;
+    }
+
+    public String getPolicyName() {
+      return policyName;
+    }
+
+    public void setPolicyName(final String policyName) {
+      this.policyName = policyName;
+    }
+
+    public String getPolicyDescription() {
+      return policyDescription;
+    }
+
+    public void setPolicyDescription(final String policyDescription) {
+      this.policyDescription = policyDescription;
+    }
+
+    @Override
+    public String toString() {
+      return "RetentionConfiguration{"
+          + "isEnabled="
+          + enabled
+          + ", minimumAge='"
+          + minimumAge
+          + ", policyName='"
+          + policyName
+          + ", policyDescription='"
+          + policyDescription
+          + '\''
+          + '}';
     }
   }
 }

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponse.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponse.java
@@ -17,7 +17,10 @@ import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record GetIndexStateManagementPolicyResponse(Policy policy) {
+public record GetIndexStateManagementPolicyResponse(
+    Policy policy,
+    @JsonProperty("_seq_no") Integer seqNo,
+    @JsonProperty("_primary_term") Integer primaryTerm) {
 
   @JsonIgnore
   public boolean equalsConfiguration(final OpensearchExporterConfiguration configuration) {

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponse.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponse.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration;
+import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse.Policy.IsmTemplate;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -46,7 +47,20 @@ public record GetIndexStateManagementPolicyResponse(
     final var minIndexAgeEqual =
         deleteTransition.conditions.minIndexAge.equals(configuration.retention.getMinimumAge());
 
-    return nameEqual && descriptionEqual && minIndexAgeEqual;
+    final var ismTemplateOptional = policy.ismTemplate.stream().findFirst();
+    if (ismTemplateOptional.isEmpty()) {
+      return false;
+    }
+
+    final var indexPatternOptional = ismTemplateOptional.get().indexPatterns.stream().findFirst();
+    if (indexPatternOptional.isEmpty()) {
+      return false;
+    }
+
+    final var indexPatternEqual =
+        indexPatternOptional.get().equals(configuration.index.prefix + "*");
+
+    return nameEqual && descriptionEqual && minIndexAgeEqual && indexPatternEqual;
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponse.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GetIndexStateManagementPolicyResponse(Policy policy) {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Policy(
+      String description,
+      @JsonProperty("default_state") String defaultState,
+      List<State> states,
+      @JsonProperty("ism_template") List<IsmTemplate> ismTemplate) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record State(String name, List<Action> actions, List<Transition> transitions) {
+
+      @JsonIgnoreProperties(ignoreUnknown = true)
+      public record Action(Object delete) {}
+
+      @JsonIgnoreProperties(ignoreUnknown = true)
+      public record Transition(
+          @JsonProperty("state_name") String stateName, Conditions conditions) {
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public record Conditions(@JsonProperty("min_index_age") String minIndexAge) {}
+      }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record IsmTemplate(
+        @JsonProperty("index_patterns") List<String> indexPatterns, Integer priority) {}
+  }
+}

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/PutIndexStateManagementPolicyRequest.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/PutIndexStateManagementPolicyRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record PutIndexStateManagementPolicyRequest(Policy policy) {
+
+  public record Policy(
+      String description,
+      @JsonProperty("default_state") String defaultState,
+      List<State> states,
+      @JsonProperty("ism_template") IsmTemplate ismTemplate) {
+
+    public record State(String name, List<Action> actions, List<Transition> transitions) {
+
+      public record Action(Object delete) {}
+
+      public record Transition(
+          @JsonProperty("state_name") String stateName, Conditions conditions) {
+
+        public record Conditions(@JsonProperty("min_index_age") String minIndexAge) {}
+      }
+    }
+
+    public record IsmTemplate(
+        @JsonProperty("index_patterns") List<String> indexPatterns, Integer priority) {}
+  }
+}

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/PutIndexStateManagementPolicyResponse.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/PutIndexStateManagementPolicyResponse.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PutIndexStateManagementPolicyResponse(Policy policy) {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record Policy() {}
+}

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -7,14 +7,13 @@
  */
 package io.camunda.zeebe.exporter.opensearch;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.TestClient.ComponentTemplatesDto.ComponentTemplateWrapper;
 import io.camunda.zeebe.exporter.opensearch.TestClient.IndexTemplatesDto.IndexTemplateWrapper;
-import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy;
+import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse;
 import io.camunda.zeebe.exporter.opensearch.dto.Template;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
@@ -92,13 +91,13 @@ final class TestClient implements CloseableSilently {
     }
   }
 
-  IndexStateManagementPolicyDto getIndexStateManagementPolicy() {
+  GetIndexStateManagementPolicyResponse getIndexStateManagementPolicy() {
     try {
       final var request =
           new Request("GET", "_plugins/_ism/policies/" + config.retention.getPolicyName());
       final var response = restClient.performRequest(request);
       return MAPPER.readValue(
-          response.getEntity().getContent(), IndexStateManagementPolicyDto.class);
+          response.getEntity().getContent(), GetIndexStateManagementPolicyResponse.class);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -132,37 +131,6 @@ final class TestClient implements CloseableSilently {
       @JsonProperty("component_templates") List<ComponentTemplateWrapper> wrappers) {
     record ComponentTemplateWrapper(
         String name, @JsonProperty("component_template") Template template) {}
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  record IndexStateManagementPolicyDto(Policy policy) {
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Policy(
-        String description,
-        @JsonProperty("default_state") String defaultState,
-        List<State> states,
-        @JsonProperty("ism_template") List<IsmTemplate> ismTemplate) {
-
-      @JsonIgnoreProperties(ignoreUnknown = true)
-      public record State(String name, List<Action> actions, List<Transition> transitions) {
-
-        @JsonIgnoreProperties(ignoreUnknown = true)
-        public record Action(Object delete) {}
-
-        @JsonIgnoreProperties(ignoreUnknown = true)
-        public record Transition(
-            @JsonProperty("state_name") String stateName, Conditions conditions) {
-
-          @JsonIgnoreProperties(ignoreUnknown = true)
-          public record Conditions(@JsonProperty("min_index_age") String minIndexAge) {}
-        }
-      }
-
-      @JsonIgnoreProperties(ignoreUnknown = true)
-      public record IsmTemplate(
-          @JsonProperty("index_patterns") List<String> indexPatterns, Integer priority) {}
-    }
   }
 
   @JsonInclude(Include.NON_EMPTY)

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponseTest.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponseTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.dto;
+
+import static io.camunda.zeebe.exporter.opensearch.OpensearchClient.ISM_INITIAL_STATE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration;
+import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse.Policy;
+import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse.Policy.IsmTemplate;
+import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse.Policy.State;
+import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse.Policy.State.Transition;
+import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse.Policy.State.Transition.Conditions;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class GetIndexStateManagementPolicyResponseTest {
+
+  private final OpensearchExporterConfiguration config = new OpensearchExporterConfiguration();
+
+  @Test
+  void shouldEqualConfiguration() {
+    // given
+    final var response =
+        createResponse(
+            config.retention.getPolicyName(),
+            config.retention.getPolicyDescription(),
+            config.retention.getMinimumAge(),
+            config.index.prefix + "*");
+
+    // when
+    final var equal = response.equalsConfiguration(config);
+
+    // then
+    assertThat(equal).as("Response equals configuration").isTrue();
+  }
+
+  @Test
+  void shouldNotEqualConfigurationWhenDifferentName() {
+    // given
+    final var response =
+        createResponse(
+            "name",
+            config.retention.getPolicyDescription(),
+            config.retention.getMinimumAge(),
+            config.index.prefix + "*");
+
+    // when
+    final var equal = response.equalsConfiguration(config);
+
+    // then
+    assertThat(equal).as("Response does not equal configuration").isFalse();
+  }
+
+  @Test
+  void shouldNotEqualConfigurationWhenDifferentDescription() {
+    // given
+    final var response =
+        createResponse(
+            config.retention.getPolicyName(),
+            "description",
+            config.retention.getMinimumAge(),
+            config.index.prefix + "*");
+
+    // when
+    final var equal = response.equalsConfiguration(config);
+
+    // then
+    assertThat(equal).as("Response does not equal configuration").isFalse();
+  }
+
+  @Test
+  void shouldNotEqualConfigurationWhenDifferentMinimumAge() {
+    // given
+    final var response =
+        createResponse(
+            config.retention.getPolicyName(),
+            config.retention.getPolicyDescription(),
+            "100d",
+            config.index.prefix + "*");
+
+    // when
+    final var equal = response.equalsConfiguration(config);
+
+    // then
+    assertThat(equal).as("Response does not equal configuration").isFalse();
+  }
+
+  @Test
+  void shouldNotEqualConfigurationWhenDifferentIndexPattern() {
+    // given
+    final var response =
+        createResponse(
+            config.retention.getPolicyName(),
+            config.retention.getPolicyDescription(),
+            config.retention.getMinimumAge(),
+            "foo*");
+
+    // when
+    final var equal = response.equalsConfiguration(config);
+
+    // then
+    assertThat(equal).as("Response does not equal configuration").isFalse();
+  }
+
+  private static GetIndexStateManagementPolicyResponse createResponse(
+      final String name,
+      final String description,
+      final String minimumAge,
+      final String indexPattern) {
+    final Policy policy =
+        new Policy(
+            name,
+            description,
+            ISM_INITIAL_STATE,
+            List.of(
+                new State(
+                    ISM_INITIAL_STATE,
+                    Collections.emptyList(),
+                    List.of(new Transition("delete", new Conditions(minimumAge))))),
+            List.of(new IsmTemplate(List.of(indexPattern), 1)));
+    return new GetIndexStateManagementPolicyResponse(policy, 1, 1);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds ISM support to the OpenSearch Exporter. Users can configure 4 options:
1. They can enable/disable data retention
2. They can configure a name for the ISM policy
3. They can configure a description for the ISM policy
4. They can configure a minimumAge (retention period) for the ISM policy

The exporter will create the policy once upon exporting. After this it won't do it again until the broker is restarted. If the policy already exists it will update the existing policy instead. If nothing has changed in the configuration we won't do anything.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13203 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
