### PR TITLE
test(qa): verify consecutive partition join and leave

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -61,13 +61,6 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     localMember =
         new DefaultRaftMember(localMemberId, RaftMember.Type.PASSIVE, time).setCluster(this);
     this.raft = checkNotNull(raft, "context cannot be null");
-
-    // If a configuration is stored, use the stored configuration, otherwise configure the server
-    // with the user provided configuration.
-    final var storedConfiguration = raft.getMetaStore().loadConfiguration();
-    if (storedConfiguration != null) {
-      updateConfiguration(storedConfiguration);
-    }
   }
 
   @Override
@@ -81,7 +74,13 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     raft.getThreadContext()
         .execute(
             () -> {
-              if (configuration == null) {
+              // If a configuration is stored, use the stored configuration, otherwise configure the
+              // server
+              // with the user provided configuration.
+              final var storedConfiguration = raft.getMetaStore().loadConfiguration();
+              if (storedConfiguration != null) {
+                updateConfiguration(storedConfiguration);
+              } else {
                 createInitialConfig(cluster);
               }
               raft.transition(localMember.getType());

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
 
 /** Manages the persistent state of the Raft cluster from the perspective of a single server. */
 public final class RaftClusterContext implements RaftCluster, AutoCloseable {
-
   private final RaftContext raft;
   private final DefaultRaftMember localMember;
   private final Map<MemberId, RaftMemberContext> remoteMemberContexts = new HashMap<>();
@@ -294,8 +293,10 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
       return;
     }
 
+    final var initialType = localMember.getType();
     updateConfiguration(configuration);
-    if (wasPromoted(currentConfig, configuration, localMember)) {
+    final var newType = localMember.getType();
+    if (initialType.ordinal() < newType.ordinal()) {
       raft.transition(localMember.getType());
     }
 
@@ -303,36 +304,6 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     if (raft.getCommitIndex() >= configuration.index()) {
       commitCurrentConfiguration();
     }
-  }
-
-  /**
-   * @return true if member exists in previous and update configuration and the member type changed
-   *     to a higher type
-   */
-  private boolean wasPromoted(
-      final Configuration previousConfig,
-      final Configuration updatedConfig,
-      final RaftMember member) {
-    if (previousConfig == null) {
-      // When a member receives its first configuration, i.e. when it's joining an existing
-      // partition, the member should immediately transition to the newly configured role.
-      // Without this, joining will fail when the newly joining member is required for quorum. The
-      // most simple case is starting with a single member cluster and adding one new member. The
-      // join request completes only when both old and new members have committed the configuration
-      // change. That means the new member must transition to follower before the join request
-      // completes, when it receives the first configure request from the current leader.
-      return true;
-    }
-
-    final var previousMembers = previousConfig.newMembers();
-    final var updatedMembers = updatedConfig.newMembers();
-
-    final var previousMember = previousMembers.stream().filter(m -> m.equals(member)).findFirst();
-    final var updatedMember = updatedMembers.stream().filter(m -> m.equals(member)).findFirst();
-
-    return previousMember.isPresent()
-        && updatedMember.isPresent()
-        && previousMember.get().getType().ordinal() < updatedMember.get().getType().ordinal();
   }
 
   private void updateConfiguration(final Configuration configuration) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -188,7 +188,20 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
       if (error instanceof StartupProcessShutdownException) {
         LOGGER.warn("Aborting startup of partition {}", partitionId, error);
       } else {
-        LOGGER.error("Failed to start partition {}", partitionId, error);
+        LOGGER.error(
+            "Failed to start partition {}, removing partition and shutting down already started steps",
+            partitionId,
+            error);
+        concurrencyControl.runOnCompletion(
+            partitions.remove(partitionId).stop(),
+            (stopped, stopError) -> {
+              if (stopError != null) {
+                LOGGER.error(
+                    "Partition {} already failed during startup, now shutdown failed too",
+                    partitionId,
+                    error);
+              }
+            });
       }
 
       topologyManager.onHealthChanged(partitionId, HealthStatus.DEAD);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
@@ -52,7 +52,8 @@ final class PartitionLeaveTest {
       assertChangeIsApplied(cluster, leave);
       try (final var client = cluster.newClientBuilder().build()) {
         Awaitility.await("All partition have a leader")
-            .pollDelay(Duration.ofSeconds(5))
+            .pollDelay(Duration.ofSeconds(10))
+            .timeout(Duration.ofMinutes(1))
             .untilAsserted(
                 () ->
                     TopologyAssert.assertThat(client.newTopologyRequest().send().join())

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
@@ -15,7 +15,6 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned
 import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
-import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import java.time.Duration;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
@@ -50,21 +49,12 @@ final class PartitionLeaveTest {
       Awaitility.await("Leaving is completed in time")
           .untilAsserted(() -> assertChangeIsCompleted(cluster, leave));
       assertChangeIsApplied(cluster, leave);
-      try (final var client = cluster.newClientBuilder().build()) {
-        Awaitility.await("All partition have a leader")
-            .pollDelay(Duration.ofSeconds(10))
-            .timeout(Duration.ofMinutes(1))
-            .untilAsserted(
-                () ->
-                    TopologyAssert.assertThat(client.newTopologyRequest().send().join())
-                        .hasLeaderForEachPartition(
-                            scenario.initialClusterState().partitionCount()));
-      }
       // when
       final var join = revertOperation(cluster, scenario.operation());
       // then
       assertChangeIsPlanned(join);
       Awaitility.await("Rejoining is completed in time")
+          .timeout(Duration.ofMinutes(1))
           .untilAsserted(() -> assertChangeIsCompleted(cluster, join));
       assertChangeIsApplied(cluster, join);
     }


### PR DESCRIPTION
Two new test scenarios:
1. After joining, a member can leave again
2. After leaving, a member can join again

This also fixes two bugs in the `RaftClusterContext` found while adding these tests.

Relates to #14905