### PR TITLE
Detailed appender and processing metrics

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControl.java
@@ -24,9 +24,9 @@ public final class AppenderFlowControl {
   private final Limiter<Void> limiter;
   private final AppenderMetrics metrics;
 
-  public AppenderFlowControl(final AppendErrorHandler errorHandler, final int partitionId) {
+  public AppenderFlowControl(final AppendErrorHandler errorHandler, final AppenderMetrics metrics) {
     this.errorHandler = errorHandler;
-    metrics = new AppenderMetrics(partitionId);
+    this.metrics = metrics;
     limiter = configureLimiter();
   }
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControlTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControlTest.java
@@ -21,7 +21,7 @@ final class AppenderFlowControlTest {
   void callsErrorHandlerOnWriteError() {
     // given
     final var errorHandler = Mockito.mock(AppendErrorHandler.class);
-    final var flow = new AppenderFlowControl(errorHandler, 1);
+    final var flow = new AppenderFlowControl(errorHandler, new AppenderMetrics(1));
     final var error = new RuntimeException();
     // when
     final var inFlight = flow.tryAcquire().orElseThrow();
@@ -34,7 +34,7 @@ final class AppenderFlowControlTest {
   void callsErrorHandlerOnCommitError() {
     // given
     final var errorHandler = Mockito.mock(AppendErrorHandler.class);
-    final var flow = new AppenderFlowControl(errorHandler, 1);
+    final var flow = new AppenderFlowControl(errorHandler, new AppenderMetrics(1));
     final var error = new RuntimeException();
     // when
     final var inFlight = flow.tryAcquire().orElseThrow();
@@ -47,7 +47,7 @@ final class AppenderFlowControlTest {
   void eventuallyRejects() {
     // given
     final var errorHandler = Mockito.mock(AppendErrorHandler.class);
-    final var flow = new AppenderFlowControl(errorHandler, 1);
+    final var flow = new AppenderFlowControl(errorHandler, new AppenderMetrics(1));
 
     // when - then
     Awaitility.await("Rejects new appends")
@@ -60,7 +60,7 @@ final class AppenderFlowControlTest {
   void recoversWhenCompletingAppends() {
     // given
     final var errorHandler = Mockito.mock(AppendErrorHandler.class);
-    final var flow = new AppenderFlowControl(errorHandler, 1);
+    final var flow = new AppenderFlowControl(errorHandler, new AppenderMetrics(1));
     // when
     boolean rejecting = false;
     final var inFlight = new LinkedList<InFlightAppend>();

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -42,6 +42,12 @@
       "version": ""
     },
     {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
@@ -2877,7 +2883,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2978,7 +2984,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -3081,7 +3087,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -3175,7 +3181,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -3270,7 +3276,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -3359,7 +3365,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3446,7 +3452,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3513,7 +3519,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 53
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 288,
@@ -3533,7 +3539,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3600,7 +3606,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 53
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 289,
@@ -3620,7 +3626,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4646,33 +4652,7 @@
               },
               "unit": "bytes"
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "np-metrics-zeebe-gateway-648d886fdb-4gkc5",
-                      "np-metrics-zeebe-gateway-648d886fdb-r74d5"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -4762,33 +4742,7 @@
               },
               "unit": "bytes"
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "np-metrics-zeebe-gateway-648d886fdb-4gkc5",
-                      "np-metrics-zeebe-gateway-648d886fdb-r74d5"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -7080,7 +7034,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 9
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7127,7 +7081,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7180,7 +7134,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 222,
@@ -7201,7 +7155,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7299,7 +7253,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 17
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7346,7 +7300,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7410,7 +7364,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 17
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7457,7 +7411,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7522,7 +7476,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 50
+            "y": 25
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7569,7 +7523,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7601,6 +7555,131 @@
             "show": true
           },
           "yBucketBound": "auto"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Time taken to process a record",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
+          "id": 593,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le, valueType, intent))",
+              "format": "time_series",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "p50 {{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le, valueType, intent))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "p90 {{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le, valueType, intent))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "p99 {{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Record Processing Duration",
+          "type": "timeseries"
         },
         {
           "cards": {},
@@ -7636,7 +7715,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 42
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7683,7 +7762,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7749,7 +7828,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 42
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7796,7 +7875,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7852,7 +7931,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 49
           },
           "id": 420,
           "options": {
@@ -7889,7 +7968,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -7933,7 +8012,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 49
           },
           "id": 419,
           "options": {
@@ -7970,7 +8049,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -8004,7 +8083,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 71
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 310,
@@ -8025,7 +8104,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -8121,7 +8200,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 71
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 311,
@@ -8142,7 +8221,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -8256,7 +8335,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 63
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8303,7 +8382,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -8367,7 +8446,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 63
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -8414,7 +8493,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -12380,7 +12459,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -12392,7 +12472,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 173
+            "y": 14
           },
           "id": 356,
           "links": [],
@@ -12462,7 +12542,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 179
+            "y": 20
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -12508,7 +12588,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -12575,7 +12655,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 179
+            "y": 20
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -12622,7 +12702,7 @@
               "unit": "kbytes"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "9.5.2",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -12654,6 +12734,508 @@
             "show": true
           },
           "yBucketBound": "auto"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Rate of commands written per second by the log storage appender on the leader",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 28
+          },
+          "id": 586,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND\"}[$__rate_interval])) by (valueType, intent)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Written commands",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Rate of events written per second by the log storage appender on the leader",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 28
+          },
+          "id": 589,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"EVENT\"}[$__rate_interval])) by (valueType, intent)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Written events",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Rate of written rejections per second by the log storage appender on the leader",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 28
+          },
+          "id": 590,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND_REJECTION\"}[$__rate_interval])) by (valueType, intent)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Written rejections",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Distribution of written commands by the leading log storage appender",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 37
+          },
+          "id": 588,
+          "links": [],
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND\"}[$__rate_interval])) by (recordType, valueType, intent)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Written commands",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Distribution of written events by the leading log storage appender",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 37
+          },
+          "id": 591,
+          "links": [],
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"EVENT\"}[$__rate_interval])) by (valueType, intent)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Written events",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Distribution of written rejections by the leading log storage appender",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 37
+          },
+          "id": 592,
+          "links": [],
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND_REJECTION\"}[$__rate_interval])) by (valueType, intent)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{valueType}}.{{intent}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Written rejections",
+          "type": "piechart"
         }
       ],
       "title": "Logstream",

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -261,8 +261,7 @@ public final class ProcessingStateMachine {
       final var processingStartTime = ActorClock.currentTimeMillis();
       metrics.processingLatency(loggedEvent.getTimestamp(), processingStartTime);
       processingTimer =
-          metrics.startProcessingDurationTimer(
-              metadata.getRecordType(), metadata.getValueType(), metadata.getIntent());
+          metrics.startProcessingDurationTimer(metadata.getValueType(), metadata.getIntent());
 
       final var value = recordValues.readRecordValue(loggedEvent, metadata.getValueType());
       typedCommand.wrap(loggedEvent, metadata, value);

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -260,7 +260,9 @@ public final class ProcessingStateMachine {
       // In all other cases we should prefer to use the Prometheus Timer API.
       final var processingStartTime = ActorClock.currentTimeMillis();
       metrics.processingLatency(loggedEvent.getTimestamp(), processingStartTime);
-      processingTimer = metrics.startProcessingDurationTimer(metadata.getRecordType());
+      processingTimer =
+          metrics.startProcessingDurationTimer(
+              metadata.getRecordType(), metadata.getValueType(), metadata.getIntent());
 
       final var value = recordValues.readRecordValue(loggedEvent, metadata.getValueType());
       typedCommand.wrap(loggedEvent, metadata, value);

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.stream.impl.metrics;
 
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
@@ -47,12 +49,18 @@ public final class StreamProcessorMetrics {
               "Time between a command is written until it is picked up for processing (in seconds)")
           .labelNames(LABEL_NAME_PARTITION)
           .register();
+  private static final String LABEL_NAME_VALUE_TYPE = "valueType";
+  private static final String LABEL_NAME_INTENT = "intent";
   private static final Histogram PROCESSING_DURATION =
       Histogram.build()
           .namespace(NAMESPACE)
           .name("stream_processor_processing_duration")
           .help("Time for processing a record (in seconds)")
-          .labelNames(LABEL_NAME_RECORD_TYPE, LABEL_NAME_PARTITION)
+          .labelNames(
+              LABEL_NAME_RECORD_TYPE,
+              LABEL_NAME_PARTITION,
+              LABEL_NAME_VALUE_TYPE,
+              LABEL_NAME_INTENT)
           .register();
 
   private static final Gauge STARTUP_RECOVERY_TIME =
@@ -76,8 +84,11 @@ public final class StreamProcessorMetrics {
     PROCESSING_LATENCY.labels(partitionIdLabel).observe((processed - written) / 1000f);
   }
 
-  public Histogram.Timer startProcessingDurationTimer(final RecordType recordType) {
-    return PROCESSING_DURATION.labels(recordType.name(), partitionIdLabel).startTimer();
+  public Histogram.Timer startProcessingDurationTimer(
+      final RecordType recordType, final ValueType valueType, final Intent intent) {
+    return PROCESSING_DURATION
+        .labels(recordType.name(), partitionIdLabel, valueType.name(), intent.name())
+        .startTimer();
   }
 
   /** We only process commands. */

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.stream.impl.metrics;
 
-import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.prometheus.client.Counter;
@@ -17,7 +16,6 @@ import io.prometheus.client.Histogram;
 public final class StreamProcessorMetrics {
 
   private static final String LABEL_NAME_PARTITION = "partition";
-  private static final String LABEL_NAME_RECORD_TYPE = "recordType";
   private static final String LABEL_NAME_ACTION = "action";
 
   private static final String LABEL_WRITTEN = "written";
@@ -56,11 +54,7 @@ public final class StreamProcessorMetrics {
           .namespace(NAMESPACE)
           .name("stream_processor_processing_duration")
           .help("Time for processing a record (in seconds)")
-          .labelNames(
-              LABEL_NAME_RECORD_TYPE,
-              LABEL_NAME_PARTITION,
-              LABEL_NAME_VALUE_TYPE,
-              LABEL_NAME_INTENT)
+          .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_VALUE_TYPE, LABEL_NAME_INTENT)
           .register();
 
   private static final Gauge STARTUP_RECOVERY_TIME =
@@ -85,9 +79,9 @@ public final class StreamProcessorMetrics {
   }
 
   public Histogram.Timer startProcessingDurationTimer(
-      final RecordType recordType, final ValueType valueType, final Intent intent) {
+      final ValueType valueType, final Intent intent) {
     return PROCESSING_DURATION
-        .labels(recordType.name(), partitionIdLabel, valueType.name(), intent.name())
+        .labels(partitionIdLabel, valueType.name(), intent.name())
         .startTimer();
   }
 


### PR DESCRIPTION
## Description

This PR adds a new log appender metric to track how many log entries of each type are being written by the leader, grouped by record type, value type, and intent. The idea is to allow us to more quickly diagnose issues such as internal load creating too many of a specific command, etc.

The added `valueType` and `intent` labels on the processing latency metric will also help us diagnose where the processor is spending most of its time.

Context: this came out of a recent incident, and it's a fairly simple issue.

### Processing latency metric

![image](https://github.com/camunda/zeebe/assets/43373/7acbfba3-e8d4-4d97-a793-682052587ad0)

### Log appender metrics

![image](https://github.com/camunda/zeebe/assets/43373/1660ebeb-3921-47ad-b6e9-dd63ff8fe965)


## Related issues

closes #14925 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
