### PR TITLE
Add endpoint for scaling broker

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -134,6 +134,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-transport</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.shared.management;
 
-import com.google.api.client.http.HttpStatusCodes;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.BrokerStateCode;
@@ -71,7 +70,7 @@ public class ClusterEndpoint {
   public ResponseEntity<?> clusterTopology() {
     try {
       final GetTopologyResponse response = mapClusterTopology(requestSender.getTopology().join());
-      return new ResponseEntity<>(response, HttpStatusCode.valueOf(HttpStatusCodes.STATUS_CODE_OK));
+      return new ResponseEntity<>(response, HttpStatusCode.valueOf(200));
     } catch (final Exception error) {
       return mapError(error);
     }
@@ -81,7 +80,7 @@ public class ClusterEndpoint {
     // TODO: Map error to proper HTTP status code as defined in spec
     final var errorResponse = new Error();
     errorResponse.setMessage(error.getMessage());
-    return ResponseEntity.status(HttpStatusCodes.STATUS_CODE_SERVER_ERROR).body(errorResponse);
+    return ResponseEntity.status(500).body(errorResponse);
   }
 
   @PostMapping(path = "/{resource}/{id}")
@@ -201,8 +200,7 @@ public class ClusterEndpoint {
 
   private ResponseEntity<PostOperationResponse> mapOperationResponse(
       final TopologyChangeResponse requestSender) {
-    return ResponseEntity.status(HttpStatusCodes.STATUS_CODE_ACCEPTED)
-        .body(mapResponseType(requestSender));
+    return ResponseEntity.status(202).body(mapResponseType(requestSender));
   }
 
   private static PostOperationResponse mapResponseType(final TopologyChangeResponse response) {
@@ -366,8 +364,6 @@ public class ClusterEndpoint {
   }
 
   public record PartitionAddRequest(int priority) {}
-
-  public record ResourceScaleRequest(List<Integer> ids) {}
 
   public enum Resource {
     brokers,

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -140,9 +140,9 @@ public class ClusterEndpoint {
       consumes = "application/json")
   public ResponseEntity<?> addSubResource(
       @PathVariable("resource") final Resource resource,
-      @PathVariable final String resourceId,
+      @PathVariable final int resourceId,
       @PathVariable("subResource") final Resource subResource,
-      @PathVariable final String subResourceId,
+      @PathVariable final int subResourceId,
       @RequestBody final PartitionAddRequest request) {
     final int priority = request.priority();
     return switch (resource) {
@@ -152,7 +152,7 @@ public class ClusterEndpoint {
             requestSender
                 .joinPartition(
                     new JoinPartitionRequest(
-                        MemberId.from(resourceId), Integer.parseInt(subResourceId), priority))
+                        MemberId.from(String.valueOf(resourceId)), subResourceId, priority))
                 .join());
         case brokers -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
       };
@@ -162,7 +162,7 @@ public class ClusterEndpoint {
             requestSender
                 .joinPartition(
                     new JoinPartitionRequest(
-                        MemberId.from(subResourceId), Integer.parseInt(resourceId), priority))
+                        MemberId.from(String.valueOf(subResourceId)), resourceId, priority))
                 .join());
         case partitions -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
       };

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import java.util.List;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -86,6 +87,21 @@ final class ClusterEndpointIT {
           .returns(0, Operation::getBrokerId)
           .returns(2, Operation::getPartitionId)
           .returns(3, Operation::getPriority);
+    }
+  }
+
+  @Test
+  void shouldRequestScaleBrokers() {
+    try (final var cluster = createCluster(1)) {
+      // given
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when
+      final var response = actuator.scaleBrokers(List.of(0, 1, 2));
+
+      // then
+      assertThat(response.getExpectedTopology()).hasSize(3);
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -18,10 +18,10 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import java.util.List;
 import java.util.function.Predicate;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 @ZeebeIntegration
 @Execution(ExecutionMode.CONCURRENT)

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -163,5 +163,10 @@
       <artifactId>junit-platform-commons</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -102,7 +102,31 @@ public interface ClusterActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   GetTopologyResponse getTopology();
 
+  /**
+   * Scales the given brokers up or down and reassigns partitions to the new brokers.
+   *
+   * @param ids
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
   @RequestLine("POST /brokers")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   PostOperationResponse scaleBrokers(@RequestBody List<Integer> ids);
+
+  /**
+   * Request that the broker is added to the cluster.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /brokers/{brokerId}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PostOperationResponse addBroker(@Param final int brokerId);
+
+  /**
+   * Request that the broker is removed from the cluster
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("DELETE /brokers/{brokerId}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PostOperationResponse removeBroker(@Param final int brokerId);
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -21,6 +21,7 @@ import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.zeebe.containers.ZeebeNode;
 import java.util.List;
 
@@ -100,4 +101,8 @@ public interface ClusterActuator {
   @RequestLine("GET")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   GetTopologyResponse getTopology();
+
+  @RequestLine("POST /brokers")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PostOperationResponse scaleBrokers(@RequestBody List<Integer> ids);
 }


### PR DESCRIPTION
## Description

- Adedd endpoint for scaling brokers `POST actuator/cluster/broker` 
- Added endpoint for adding a new broker `POST actuator/cluster/broker/{brokerId}`
- Added endpoint for deleting a broker `DELETE actuator/cluster/broker/{brokerId}`

Had to replace use of `WebEndpoint` with `RestControllerEndpoint`. WebEndpoint do not allow to parse complex json body. For scale request we have to accept a list of broker ids. This was not possible with the `@WriteOperation`. The difference is that this new endpoint is only available over rest, while `WebEndpoint` is also available over jmx. But we don't have to expose it over jmx.

## Related issues

related #14462 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
