### PR TITLE
QA : Verify Cluster can scale up by adding one broker

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertBrokerDoesNotHavePartition;
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertBrokerHasPartition;
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsApplied;
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+class ScaleUpBrokersTest {
+
+  @TestZeebe
+  private static final TestCluster CLUSTER =
+      TestCluster.builder()
+          .useRecordingExporter(true)
+          .withEmbeddedGateway(true)
+          .withBrokersCount(2)
+          .withPartitionsCount(3)
+          .withReplicationFactor(1)
+          .withBrokerConfig(
+              b ->
+                  b.brokerConfig()
+                      .getExperimental()
+                      .getFeatures()
+                      .setEnableDynamicClusterTopology(true))
+          .build();
+
+  @Test
+  void shouldScaleClusterByAddingOneBroker() {
+    // given
+    final int currentClusterSize = CLUSTER.brokers().size();
+    final int newClusterSize = currentClusterSize + 1;
+    final int newBrokerId = newClusterSize - 1;
+    try (final var newBroker = createNewBroker(newClusterSize, newBrokerId).start()) {
+
+      final var actuator = ClusterActuator.of(CLUSTER.availableGateway());
+      final var newBrokerSet = IntStream.range(0, currentClusterSize + 1).boxed().toList();
+
+      // when
+      final var response = actuator.scaleBrokers(newBrokerSet);
+      assertChangeIsPlanned(response);
+
+      // then
+      Awaitility.await()
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(() -> assertChangeIsApplied(CLUSTER, response));
+
+      // verify partition 3 is moved from broker 0 to 2
+      assertBrokerHasPartition(CLUSTER, newBrokerId, 3);
+      assertBrokerDoesNotHavePartition(CLUSTER, 0, 3);
+      // verify partition 2 remains in broker 1
+      assertBrokerHasPartition(CLUSTER, 1, 2);
+
+      // Changes are reflected in the topology returned by grpc query
+      CLUSTER.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(10));
+    }
+  }
+
+  private static TestStandaloneBroker createNewBroker(
+      final int newClusterSize, final int newBrokerId) {
+    return new TestStandaloneBroker()
+        .withBrokerConfig(
+            b -> {
+              b.getExperimental().getFeatures().setEnableDynamicClusterTopology(true);
+              b.getCluster().setClusterSize(newClusterSize);
+              b.getCluster().setNodeId(newBrokerId);
+              b.getCluster()
+                  .setInitialContactPoints(
+                      List.of(
+                          CLUSTER
+                              .brokers()
+                              .get(MemberId.from("0"))
+                              .address(TestZeebePort.CLUSTER)));
+            });
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -228,6 +228,12 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
           "Operation {} applied. Updated local topology to {}",
           operation,
           persistedClusterTopology.getTopology());
+
+      executor.run(
+          () -> {
+            // Continue applying topology change, if the next operation is for the local member
+            applyTopologyChangeOperation(persistedClusterTopology.getTopology());
+          });
     } else {
       // TODO: Retry after a fixed delay. The failure is most likely due to timeouts such
       // as when joining a raft partition.


### PR DESCRIPTION
## Description

- Test to add a new broker to an existing cluster. Verify that scale request adds the broker to the cluster and redistribute partitions.
- Fix a bug where two consecutive operations on same broker was not applied

## Related issues

related to #14953 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

