### PR TITLE
Map internal errors thrown when applying topology changes to specific error codes

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -203,8 +203,7 @@ public class ClusterEndpoint {
   private ResponseEntity<?> mapOperationResponse(
       final Either<ErrorResponse, TopologyChangeResponse> response) {
     if (response.isRight()) {
-      return ResponseEntity.status(202)
-          .body(mapResponseType(response.get()));
+      return ResponseEntity.status(202).body(mapResponseType(response.get()));
     } else {
       final var errorCode =
           switch (response.getLeft().code()) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.management.cluster.TopologyChange;
 import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
 import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
+import io.camunda.zeebe.topology.api.ErrorResponse;
 import io.camunda.zeebe.topology.api.TopologyChangeResponse;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequest;
@@ -40,6 +41,7 @@ import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperat
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.util.Either;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
@@ -198,9 +200,22 @@ public class ClusterEndpoint {
     };
   }
 
-  private ResponseEntity<PostOperationResponse> mapOperationResponse(
-      final TopologyChangeResponse requestSender) {
-    return ResponseEntity.status(202).body(mapResponseType(requestSender));
+  private ResponseEntity<?> mapOperationResponse(
+      final Either<ErrorResponse, TopologyChangeResponse> response) {
+    if (response.isRight()) {
+      return ResponseEntity.status(202)
+          .body(mapResponseType(response.get()));
+    } else {
+      final var errorCode =
+          switch (response.getLeft().code()) {
+            case INVALID_REQUEST, OPERATION_NOT_ALLOWED -> 400;
+            case CONCURRENT_MODIFICATION -> 409;
+            case INTERNAL_ERROR -> 500;
+          };
+      final var error = new Error();
+      error.setMessage(response.getLeft().message());
+      return ResponseEntity.status(errorCode).body(error);
+    }
   }
 
   private static PostOperationResponse mapResponseType(final TopologyChangeResponse response) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/ErrorResponse.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/ErrorResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+public record ErrorResponse(ErrorCode code, String message) {
+
+  public enum ErrorCode {
+    INVALID_REQUEST,
+    OPERATION_NOT_ALLOWED,
+    CONCURRENT_MODIFICATION,
+    INTERNAL_ERROR;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformer.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.topology.PartitionDistributor;
+import io.camunda.zeebe.topology.api.TopologyRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator.TopologyChangeRequest;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
@@ -39,7 +40,9 @@ public class PartitionReassignRequestTransformer implements TopologyChangeReques
       final ClusterTopology currentTopology) {
     if (members.isEmpty()) {
       return Either.left(
-          new IllegalArgumentException("Cannot reassign partitions if no brokers are provided"));
+          new InvalidRequest(
+              new IllegalArgumentException(
+                  "Cannot reassign partitions if no brokers are provided")));
     }
 
     return generatePartitionDistributionOperations(currentTopology, members);

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformer.java
@@ -59,7 +59,7 @@ public class PartitionReassignRequestTransformer implements TopologyChangeReques
 
     if (brokers.size() < replicationFactor) {
       return Either.left(
-          new IllegalArgumentException(
+          new TopologyRequestFailedException.InvalidRequest(
               String.format(
                   "Number of brokers [%d] is less than the replication factor [%d]",
                   brokers.size(), replicationFactor)));

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.topology.api.TopologyManagementRequest.RemoveMembersRequ
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.ScaleRequest;
 import io.camunda.zeebe.topology.serializer.TopologyRequestsSerializer;
 import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -37,67 +38,68 @@ public final class TopologyManagementRequestSender {
     this.serializer = serializer;
   }
 
-  public CompletableFuture<TopologyChangeResponse> addMembers(
+  public CompletableFuture<Either<ErrorResponse, TopologyChangeResponse>> addMembers(
       final AddMembersRequest addMembersRequest) {
     return communicationService.send(
         TopologyRequestTopics.ADD_MEMBER.topic(),
         addMembersRequest,
         serializer::encodeAddMembersRequest,
-        serializer::decodeTopologyChangeResponse,
+        serializer::decodeResponse,
         coordinator,
         TIMEOUT);
   }
 
-  public CompletableFuture<TopologyChangeResponse> removeMembers(
+  public CompletableFuture<Either<ErrorResponse, TopologyChangeResponse>> removeMembers(
       final RemoveMembersRequest removeMembersRequest) {
     return communicationService.send(
         TopologyRequestTopics.REMOVE_MEMBER.topic(),
         removeMembersRequest,
         serializer::encodeRemoveMembersRequest,
-        serializer::decodeTopologyChangeResponse,
+        serializer::decodeResponse,
         coordinator,
         TIMEOUT);
   }
 
-  public CompletableFuture<TopologyChangeResponse> joinPartition(
+  public CompletableFuture<Either<ErrorResponse, TopologyChangeResponse>> joinPartition(
       final JoinPartitionRequest joinPartitionRequest) {
     return communicationService.send(
         TopologyRequestTopics.JOIN_PARTITION.topic(),
         joinPartitionRequest,
         serializer::encodeJoinPartitionRequest,
-        serializer::decodeTopologyChangeResponse,
+        serializer::decodeResponse,
         coordinator,
         TIMEOUT);
   }
 
-  public CompletableFuture<TopologyChangeResponse> leavePartition(
+  public CompletableFuture<Either<ErrorResponse, TopologyChangeResponse>> leavePartition(
       final LeavePartitionRequest leavePartitionRequest) {
     return communicationService.send(
         TopologyRequestTopics.LEAVE_PARTITION.topic(),
         leavePartitionRequest,
         serializer::encodeLeavePartitionRequest,
-        serializer::decodeTopologyChangeResponse,
+        serializer::decodeResponse,
         coordinator,
         TIMEOUT);
   }
 
-  public CompletableFuture<TopologyChangeResponse> reassignPartitions(
+  public CompletableFuture<Either<ErrorResponse, TopologyChangeResponse>> reassignPartitions(
       final ReassignPartitionsRequest reassignPartitionsRequest) {
     return communicationService.send(
         TopologyRequestTopics.REASSIGN_PARTITIONS.topic(),
         reassignPartitionsRequest,
         serializer::encodeReassignPartitionsRequest,
-        serializer::decodeTopologyChangeResponse,
+        serializer::decodeResponse,
         coordinator,
         TIMEOUT);
   }
 
-  public CompletableFuture<TopologyChangeResponse> scaleMembers(final ScaleRequest scaleRequest) {
+  public CompletableFuture<Either<ErrorResponse, TopologyChangeResponse>> scaleMembers(
+      final ScaleRequest scaleRequest) {
     return communicationService.send(
         TopologyRequestTopics.SCALE_MEMBERS.topic(),
         scaleRequest,
         serializer::encodeScaleRequest,
-        serializer::decodeTopologyChangeResponse,
+        serializer::decodeResponse,
         coordinator,
         TIMEOUT);
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestFailedException.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestFailedException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+public sealed interface TopologyRequestFailedException {
+
+  final class InvalidRequest extends RuntimeException implements TopologyRequestFailedException {
+    public InvalidRequest(final String message) {
+      super(message);
+    }
+
+    public InvalidRequest(final Throwable cause) {
+      super(cause);
+    }
+  }
+
+  final class OperationNotAllowed extends RuntimeException
+      implements TopologyRequestFailedException {
+    public OperationNotAllowed(final String message) {
+      super(message);
+    }
+  }
+
+  final class ConcurrentModificationException extends RuntimeException
+      implements TopologyRequestFailedException {
+    public ConcurrentModificationException(final String message) {
+      super(message);
+    }
+  }
+
+  final class InternalError extends RuntimeException implements TopologyRequestFailedException {
+    public InternalError(final String message) {
+      super(message);
+    }
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -127,7 +127,8 @@ public final class TopologyRequestServer implements AutoCloseable {
   }
 
   private Either<ErrorResponse, TopologyChangeResponse> mapError(final Throwable throwable) {
-    return switch (throwable) {
+    // throwable is always CompletionException
+    return switch (throwable.getCause()) {
       case final TopologyRequestFailedException.OperationNotAllowed operationNotAllowed -> Either
           .left(
               new ErrorResponse(ErrorCode.OPERATION_NOT_ALLOWED, operationNotAllowed.getMessage()));

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.topology.serializer;
 
+import io.camunda.zeebe.topology.api.ErrorResponse;
 import io.camunda.zeebe.topology.api.TopologyChangeResponse;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest;
 import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.util.Either;
 
 public interface TopologyRequestsSerializer {
 
@@ -39,9 +41,11 @@ public interface TopologyRequestsSerializer {
 
   TopologyManagementRequest.ScaleRequest decodeScaleRequest(byte[] encodedState);
 
-  byte[] encodeTopologyChangeResponse(TopologyChangeResponse topologyChangeResponse);
+  byte[] encodeResponse(TopologyChangeResponse response);
 
-  TopologyChangeResponse decodeTopologyChangeResponse(byte[] encodedTopologyChangeResponse);
+  byte[] encodeResponse(ErrorResponse response);
+
+  Either<ErrorResponse, TopologyChangeResponse> decodeResponse(byte[] encodedResponse);
 
   byte[] encode(ClusterTopology clusterTopology);
 

--- a/topology/src/main/resources/proto/requests.proto
+++ b/topology/src/main/resources/proto/requests.proto
@@ -39,3 +39,22 @@ message TopologyChangeResponse {
   map<string, topology_protocol.MemberState> expectedTopology = 3;
   repeated topology_protocol.TopologyChangeOperation plannedChanges = 4;
 }
+
+message Response {
+  oneof response {
+    TopologyChangeResponse topologyChangeResponse = 2;
+    ErrorResponse error = 3;
+  }
+}
+
+message ErrorResponse {
+  ErrorCode errorCode = 1;
+  string errorMessage = 2;
+}
+
+enum ErrorCode {
+  INVALID_REQUEST = 0;
+  OPERATION_NOT_ALLOWED = 1;
+  CONCURRENT_MODIFICATION = 2;
+  INTERNAL_ERROR = 3;
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
@@ -106,7 +106,7 @@ class PartitionReassignRequestTransformerTest {
     EitherAssert.assertThat(operationsEither)
         .isLeft()
         .left()
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(TopologyRequestFailedException.InvalidRequest.class);
   }
 
   void shouldReassignPartitionsRoundRobin(

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/ScaleRequestTransformerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/ScaleRequestTransformerTest.java
@@ -93,7 +93,7 @@ class ScaleRequestTransformerTest {
     EitherAssert.assertThat(operationsEither)
         .isLeft()
         .left()
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(TopologyRequestFailedException.InvalidRequest.class);
   }
 
   void shouldScaleAndReassign(

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
@@ -112,7 +112,7 @@ final class TopologyManagementApiTest {
     final var request = new TopologyManagementRequest.AddMembersRequest(Set.of(MemberId.from("1")));
 
     // when
-    final var changeStatus = clientApi.addMembers(request).join();
+    final var changeStatus = clientApi.addMembers(request).join().get();
 
     // then
     final var expected = new MemberJoinOperation(MemberId.from("1"));
@@ -131,7 +131,7 @@ final class TopologyManagementApiTest {
             Set.of(MemberId.from("1"), MemberId.from("2")));
 
     // when
-    final var changeStatus = clientApi.removeMembers(request).join();
+    final var changeStatus = clientApi.removeMembers(request).join().get();
 
     // then
     final List<TopologyChangeOperation> expected =
@@ -148,7 +148,7 @@ final class TopologyManagementApiTest {
         new TopologyManagementRequest.JoinPartitionRequest(MemberId.from("1"), 1, 3);
 
     // when
-    final var changeStatus = clientApi.joinPartition(request).join();
+    final var changeStatus = clientApi.joinPartition(request).join().get();
 
     // then
     assertThat(changeStatus.plannedChanges())
@@ -161,7 +161,7 @@ final class TopologyManagementApiTest {
     final var request = new TopologyManagementRequest.LeavePartitionRequest(MemberId.from("1"), 1);
 
     // when
-    final var changeStatus = clientApi.leavePartition(request).join();
+    final var changeStatus = clientApi.leavePartition(request).join().get();
 
     // then
     assertThat(changeStatus.plannedChanges())
@@ -184,7 +184,7 @@ final class TopologyManagementApiTest {
     recordingCoordinator.setCurrentTopology(currentTopology);
 
     // when
-    final var changeStatus = clientApi.reassignPartitions(request).join();
+    final var changeStatus = clientApi.reassignPartitions(request).join().get();
 
     // then
     assertThat(changeStatus.plannedChanges())
@@ -207,7 +207,7 @@ final class TopologyManagementApiTest {
     recordingCoordinator.setCurrentTopology(currentTopology);
 
     // when
-    final var changeStatus = clientApi.scaleMembers(request).join();
+    final var changeStatus = clientApi.scaleMembers(request).join().get();
 
     // then
     assertThat(changeStatus.plannedChanges())

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
@@ -15,9 +15,9 @@ import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.topology.ClusterTopologyAssert;
 import io.camunda.zeebe.topology.ClusterTopologyManager;
+import io.camunda.zeebe.topology.api.TopologyRequestFailedException;
+import io.camunda.zeebe.topology.api.TopologyRequestFailedException.OperationNotAllowed;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator.TopologyChangeRequest;
-import io.camunda.zeebe.topology.changes.TopologyChangeCoordinatorImpl.InvalidTopologyChangeException;
-import io.camunda.zeebe.topology.changes.TopologyChangeCoordinatorImpl.OperationNotAllowed;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.PartitionState;
@@ -53,7 +53,7 @@ final class TopologyChangeCoordinatorImplTest {
     assertThat(applyFuture)
         .failsWithin(Duration.ofMillis(100))
         .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(InvalidTopologyChangeException.class)
+        .withCauseInstanceOf(TopologyRequestFailedException.InvalidRequest.class)
         .withMessageContaining(
             "Expected to leave partition, but the local member does not exist in the topology");
   }
@@ -86,7 +86,7 @@ final class TopologyChangeCoordinatorImplTest {
     assertThat(applyFuture)
         .failsWithin(Duration.ofMillis(100))
         .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(InvalidTopologyChangeException.class)
+        .withCauseInstanceOf(TopologyRequestFailedException.InvalidRequest.class)
         .withMessageContaining(
             "Expected to leave partition, but the local member does not have the partition 1");
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -156,11 +156,10 @@ final class ProtoBufSerializerTest {
                 new PartitionJoinOperation(MemberId.from("2"), 1, 2)));
 
     // when
-    final var encodedResponse =
-        protoBufSerializer.encodeTopologyChangeResponse(topologyChangeResponse);
+    final var encodedResponse = protoBufSerializer.encodeResponse(topologyChangeResponse);
 
     // then
-    final var decodedResponse = protoBufSerializer.decodeTopologyChangeResponse(encodedResponse);
+    final var decodedResponse = protoBufSerializer.decodeResponse(encodedResponse).get();
     assertThat(decodedResponse).isEqualTo(topologyChangeResponse);
   }
 


### PR DESCRIPTION
## Description

Previously, the exception thrown the topology request handlers were handled by the transport layer. Transport layer swallows the exception type and only pass the error message back to the client. The error message also contains messages from the exceptions created by the transport. So it was not easy to find the actual failure reason. This PR address this by returning specific error response instead of failing the future with an exception. The error code in the response can be translated to proper httpstatus code to sent back to the client.

In this PR a few specific errors are added. We would have to add more specific errors to be able to give more useful information back to the client.

## Related issues

related #14462 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
