### PR TITLE
fix(engine): treat static assignee values as string

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExpressionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExpressionTransformer.java
@@ -64,7 +64,13 @@ public final class ExpressionTransformer {
         .collect(Collectors.joining(",", "[", "]"));
   }
 
-  private static String asStringLiteral(final String value) {
+  /**
+   * Transforms a string value to a string literal, e.g. {@code "a" => "\"a\""}.
+   *
+   * @param value the string value to transform
+   * @return a string representation of the string literal
+   */
+  public static String asStringLiteral(final String value) {
     return String.format("\"%s\"", value);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -71,18 +71,32 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     if (assignmentDefinition == null) {
       return;
     }
+    transformAssignee(jobWorkerProperties, assignmentDefinition);
+    transformCandidateGroups(jobWorkerProperties, assignmentDefinition);
+    transformCandidateUsers(jobWorkerProperties, assignmentDefinition);
+  }
+
+  private void transformAssignee(
+      final JobWorkerProperties jobWorkerProperties,
+      final ZeebeAssignmentDefinition assignmentDefinition) {
     final var assignee = assignmentDefinition.getAssignee();
     if (assignee != null && !assignee.isBlank()) {
-      var assigneeExpression = expressionLanguage.parseExpression(assignee);
+      final var assigneeExpression = expressionLanguage.parseExpression(assignee);
       if (assigneeExpression.isStatic()) {
         // static assignee values are always treated as string literals
-        assigneeExpression =
+        jobWorkerProperties.setAssignee(
             expressionLanguage.parseExpression(
                 ExpressionTransformer.asFeelExpressionString(
-                    ExpressionTransformer.asStringLiteral(assignee)));
+                    ExpressionTransformer.asStringLiteral(assignee))));
+      } else {
+        jobWorkerProperties.setAssignee(assigneeExpression);
       }
-      jobWorkerProperties.setAssignee(assigneeExpression);
     }
+  }
+
+  private void transformCandidateGroups(
+      final JobWorkerProperties jobWorkerProperties,
+      final ZeebeAssignmentDefinition assignmentDefinition) {
     final var candidateGroups = assignmentDefinition.getCandidateGroups();
     if (candidateGroups != null && !candidateGroups.isBlank()) {
       final var candidateGroupsExpression = expressionLanguage.parseExpression(candidateGroups);
@@ -98,6 +112,11 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
         jobWorkerProperties.setCandidateGroups(candidateGroupsExpression);
       }
     }
+  }
+
+  private void transformCandidateUsers(
+      final JobWorkerProperties jobWorkerProperties,
+      final ZeebeAssignmentDefinition assignmentDefinition) {
     final var candidateUsers = assignmentDefinition.getCandidateUsers();
     if (candidateUsers != null && !candidateUsers.isBlank()) {
       final var candidateUsersExpression = expressionLanguage.parseExpression(candidateUsers);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -73,7 +73,15 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     }
     final var assignee = assignmentDefinition.getAssignee();
     if (assignee != null && !assignee.isBlank()) {
-      jobWorkerProperties.setAssignee(expressionLanguage.parseExpression(assignee));
+      var assigneeExpression = expressionLanguage.parseExpression(assignee);
+      if (assigneeExpression.isStatic()) {
+        // static assignee values are always treated as string literals
+        assigneeExpression =
+            expressionLanguage.parseExpression(
+                ExpressionTransformer.asFeelExpressionString(
+                    ExpressionTransformer.asStringLiteral(assignee)));
+      }
+      jobWorkerProperties.setAssignee(assigneeExpression);
     }
     final var candidateGroups = assignmentDefinition.getCandidateGroups();
     if (candidateGroups != null && !candidateGroups.isBlank()) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTest.java
@@ -305,6 +305,29 @@ public final class UserTaskTest {
   }
 
   @Test
+  public void shouldCreateJobWithStaticNumberValueAssigneeHeader() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(process(t -> t.zeebeAssignee("1234567891011121314")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> job =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final Map<String, String> customHeaders = job.getValue().getCustomHeaders();
+    assertThat(customHeaders)
+        .hasSize(1)
+        .containsEntry(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "1234567891011121314");
+  }
+
+  @Test
   public void shouldCreateJobWithEvaluatedAssigneeExpressionHeader() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeAssigneeExpression("user"))).deploy();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -59,8 +59,9 @@ class UserTaskTransformerTest {
             Arguments.of(null, null),
             Arguments.of("", null),
             Arguments.of(" ", null),
-            Arguments.of("frodo", "frodo"),
-            Arguments.of("=ring.bearer", "ring.bearer"));
+            Arguments.of("frodo", "\"frodo\""),
+            Arguments.of("=ring.bearer", "ring.bearer"),
+            Arguments.of("12345678", "\"12345678\""));
       }
 
       @DisplayName("Should transform user task with assignee")


### PR DESCRIPTION
## Description

Allow static values for the user task assignee other than String values.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14109 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
