### PR TITLE
Retry failed topology change operation indefinitely

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -15,7 +15,9 @@ import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
@@ -44,18 +46,17 @@ import org.slf4j.LoggerFactory;
  */
 public final class ClusterTopologyManagerImpl implements ClusterTopologyManager {
   private static final Logger LOG = LoggerFactory.getLogger(ClusterTopologyManagerImpl.class);
-
+  private static final Duration DEFAULT_RETRY_DELAY = Duration.ofSeconds(10);
   private final ConcurrencyControl executor;
   private final PersistedClusterTopology persistedClusterTopology;
-
   private Consumer<ClusterTopology> topologyGossiper;
   private final ActorFuture<Void> startFuture;
-
   private TopologyChangeAppliers changeAppliers;
   private final MemberId localMemberId;
-
   // Indicates whether there is a topology change operation in progress on this member.
   private boolean onGoingTopologyChangeOperation = false;
+  private boolean shouldRetry = false;
+  private final Duration retryDelay;
 
   ClusterTopologyManagerImpl(
       final ConcurrencyControl executor,
@@ -65,6 +66,20 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     this.persistedClusterTopology = persistedClusterTopology;
     startFuture = executor.createFuture();
     this.localMemberId = localMemberId;
+    retryDelay = DEFAULT_RETRY_DELAY;
+  }
+
+  @VisibleForTesting
+  ClusterTopologyManagerImpl(
+      final ConcurrencyControl executor,
+      final MemberId localMemberId,
+      final PersistedClusterTopology persistedClusterTopology,
+      final Duration retryDelay) {
+    this.executor = executor;
+    this.persistedClusterTopology = persistedClusterTopology;
+    startFuture = executor.createFuture();
+    this.localMemberId = localMemberId;
+    this.retryDelay = retryDelay;
   }
 
   @Override
@@ -183,7 +198,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     // operation is triggered locally only when the local topology is changes. However, as
     // an extra precaution we check if there is an ongoing operation before applying
     // one.
-    return !onGoingTopologyChangeOperation
+    return (!onGoingTopologyChangeOperation || shouldRetry)
         && mergedTopology.pendingChangesFor(localMemberId).isPresent()
         // changeApplier is registered only after PartitionManager in the Broker is started.
         && changeAppliers != null;
@@ -195,6 +210,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     }
 
     onGoingTopologyChangeOperation = true;
+    shouldRetry = false;
     final var operation = mergedTopology.pendingChangesFor(localMemberId).orElseThrow();
     LOG.info("Applying topology change operation {}", operation);
     final var operationApplier = changeAppliers.getApplier(operation);
@@ -216,6 +232,16 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
         .onComplete((transformer, error) -> onOperationApplied(operation, transformer, error));
   }
 
+  private void retryLastAppliedOperation() {
+    shouldRetry = true;
+    executor.schedule(
+        retryDelay,
+        () -> {
+          LOG.debug("Retrying last applied operation");
+          applyTopologyChangeOperation(persistedClusterTopology.getTopology());
+        });
+  }
+
   private void onOperationApplied(
       final TopologyChangeOperation operation,
       final UnaryOperator<MemberState> transformer,
@@ -231,7 +257,12 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     } else {
       // TODO: Retry after a fixed delay. The failure is most likely due to timeouts such
       // as when joining a raft partition.
-      LOG.error("Failed to apply topology change operation {}", operation, error);
+      LOG.error(
+          "Failed to apply topology change operation {}. Will be retried in {}.",
+          operation,
+          retryDelay,
+          error);
+      retryLastAppliedOperation();
     }
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
 
-/** */
+@FunctionalInterface
 public interface TopologyChangeAppliers {
 
   /**


### PR DESCRIPTION
## Description

This PR adds a very basic strategy to retry - retry indefinitely with a fixed delay - if the operation apply failed. The hope is that it is a recoverable error and will be resolved eventually by retrying. The operation is not retried if `init` fails. If init fails it is most likely unrecoverable.

We have to improve this strategy and provide a way to mark the operation as failed if it encounters an unrecoverable failure. This must be handled in followups.

## Related issues

related #14959 
