### PR TITLE
test(qa): verify that cluster becomes healthy after applying changes

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -195,6 +195,7 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
         concurrencyControl.runOnCompletion(
             partitions.remove(partitionId).stop(),
             (stopped, stopError) -> {
+              topologyManager.onHealthChanged(partitionId, HealthStatus.DEAD);
               if (stopError != null) {
                 LOGGER.error(
                     "Partition {} already failed during startup, now shutdown failed too",
@@ -204,7 +205,6 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
             });
       }
 
-      topologyManager.onHealthChanged(partitionId, HealthStatus.DEAD);
       future.completeExceptionally(error);
       return;
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
@@ -40,7 +40,7 @@ public final class PartitionRegistrationStep implements StartupStep<PartitionSta
     final var partitionId = context.partitionMetadata().id().id();
     context.diskSpaceUsageMonitor().removeDiskUsageListener(context.zeebePartition());
     context.brokerHealthCheckService().removeMonitoredPartition(partitionId);
-    // TODO: Find a way to remove the partition from the topology manager
+    context.topologyManager().removePartition(partitionId);
 
     result.complete(context);
     return result;

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManager.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManager.java
@@ -24,4 +24,6 @@ public interface TopologyManager {
   void addTopologyPartitionListener(TopologyPartitionListener listener);
 
   void onHealthChanged(int partitionId, HealthStatus status);
+
+  void removePartition(int partitionId);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -235,6 +235,11 @@ public final class TopologyManagerImpl extends Actor
         });
   }
 
+  @Override
+  public void removePartition(final int partitionId) {
+    actor.run(() -> localBroker.removePartition(partitionId));
+  }
+
   private void notifyPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
     for (final TopologyPartitionListener listener : topologyPartitionListeners) {
       LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, member));

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -164,6 +164,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
     final int nodeId = distributedBrokerInfo.getNodeId();
 
+    topology.syncPartitions(nodeId, distributedBrokerInfo.getPartitionRoles().keySet());
     distributedBrokerInfo.consumePartitions(
         topology::addPartitionIfAbsent,
         (leaderPartitionId, term) -> topology.setPartitionLeader(leaderPartitionId, nodeId, term),

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -105,6 +105,12 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     partitionHealthStatuses.clear();
   }
 
+  public void removePartition(final int partitionId) {
+    partitionRoles.remove(partitionId);
+    partitionLeaderTerms.remove(partitionId);
+    partitionHealthStatuses.remove(partitionId);
+  }
+
   public int getNodeId() {
     return nodeId;
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertBrokerHasPartit
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsApplied;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsCompleted;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
-import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertClusterBecomesHealthy;
 
 import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -36,10 +35,7 @@ final class PartitionJoinTest {
       assertChangeIsApplied(cluster, response);
       assertBrokerHasPartition(
           cluster, scenario.operation().brokerId(), scenario.operation().partitionId());
-      assertClusterBecomesHealthy(
-          cluster,
-          scenario.initialClusterState().clusterSize(),
-          scenario.initialClusterState().partitionCount());
+      cluster.awaitHealthyTopology();
     }
   }
 
@@ -60,10 +56,7 @@ final class PartitionJoinTest {
       Awaitility.await("Requested change is completed in time")
           .untilAsserted(() -> assertChangeIsCompleted(cluster, leave));
       assertChangeIsApplied(cluster, leave);
-      assertClusterBecomesHealthy(
-          cluster,
-          scenario.initialClusterState().clusterSize(),
-          scenario.initialClusterState().partitionCount());
+      cluster.awaitHealthyTopology();
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertBrokerHasPartit
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsApplied;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsCompleted;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertClusterBecomesHealthy;
 
 import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -35,6 +36,10 @@ final class PartitionJoinTest {
       assertChangeIsApplied(cluster, response);
       assertBrokerHasPartition(
           cluster, scenario.operation().brokerId(), scenario.operation().partitionId());
+      assertClusterBecomesHealthy(
+          cluster,
+          scenario.initialClusterState().clusterSize(),
+          scenario.initialClusterState().partitionCount());
     }
   }
 
@@ -55,6 +60,10 @@ final class PartitionJoinTest {
       Awaitility.await("Requested change is completed in time")
           .untilAsserted(() -> assertChangeIsCompleted(cluster, leave));
       assertChangeIsApplied(cluster, leave);
+      assertClusterBecomesHealthy(
+          cluster,
+          scenario.initialClusterState().clusterSize(),
+          scenario.initialClusterState().partitionCount());
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertBrokerDoesNotHa
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsApplied;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsCompleted;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
-import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertClusterBecomesHealthy;
 
 import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -37,10 +36,7 @@ final class PartitionLeaveTest {
       assertChangeIsApplied(cluster, response);
       assertBrokerDoesNotHavePartition(
           cluster, scenario.operation().brokerId(), scenario.operation().partitionId());
-      assertClusterBecomesHealthy(
-          cluster,
-          scenario.initialClusterState().clusterSize(),
-          scenario.initialClusterState().partitionCount());
+      cluster.awaitHealthyTopology();
     }
   }
 
@@ -62,10 +58,7 @@ final class PartitionLeaveTest {
           .timeout(Duration.ofMinutes(1))
           .untilAsserted(() -> assertChangeIsCompleted(cluster, join));
       assertChangeIsApplied(cluster, join);
-      assertClusterBecomesHealthy(
-          cluster,
-          scenario.initialClusterState().clusterSize(),
-          scenario.initialClusterState().partitionCount());
+      cluster.awaitHealthyTopology();
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertBrokerDoesNotHa
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsApplied;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsCompleted;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertClusterBecomesHealthy;
 
 import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -36,12 +37,16 @@ final class PartitionLeaveTest {
       assertChangeIsApplied(cluster, response);
       assertBrokerDoesNotHavePartition(
           cluster, scenario.operation().brokerId(), scenario.operation().partitionId());
+      assertClusterBecomesHealthy(
+          cluster,
+          scenario.initialClusterState().clusterSize(),
+          scenario.initialClusterState().partitionCount());
     }
   }
 
   @ParameterizedTest
   @MethodSource("testScenarios")
-  void canJoinPartitionAfterLeaving(final Scenario scenario) throws InterruptedException {
+  void canJoinPartitionAfterLeaving(final Scenario scenario) {
     // given
     try (final var cluster = setupCluster(scenario.initialClusterState())) {
       final var leave = runOperation(cluster, scenario.operation());
@@ -57,6 +62,10 @@ final class PartitionLeaveTest {
           .timeout(Duration.ofMinutes(1))
           .untilAsserted(() -> assertChangeIsCompleted(cluster, join));
       assertChangeIsApplied(cluster, join);
+      assertClusterBecomesHealthy(
+          cluster,
+          scenario.initialClusterState().clusterSize(),
+          scenario.initialClusterState().partitionCount());
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
@@ -13,9 +13,7 @@ import io.camunda.zeebe.management.cluster.PostOperationResponse;
 import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
-import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import java.time.OffsetDateTime;
-import org.awaitility.Awaitility;
 
 final class Utils {
   public static void assertChangeIsPlanned(final PostOperationResponse response) {
@@ -64,18 +62,5 @@ final class Utils {
         .matches(
             b -> b.getPartitions().stream().noneMatch(p -> p.getId() == partitionId),
             "Broker %d does not have partition %d".formatted(brokerId, partitionId));
-  }
-
-  public static void assertClusterBecomesHealthy(
-      final TestCluster cluster, final int brokerCount, final int partitionCount) {
-    try (final var client = cluster.newClientBuilder().build()) {
-      Awaitility.await("Cluster is healthy")
-          .untilAsserted(
-              () ->
-                  TopologyAssert.assertThat(client.newTopologyRequest().send().join())
-                      .hasLeaderForEachPartition(partitionCount)
-                      .hasBrokersCount(brokerCount)
-                      .isHealthy());
-    }
   }
 }


### PR DESCRIPTION
This adds tests and implements some missing pieces to ensure that the Cluster is considered healthy after applying changes and that the gateway cleans up when a broker leaves a partition.

Relates to https://github.com/camunda/zeebe/issues/14905