### PR TITLE
fix: reject partition join if partition has no active members

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -21,11 +21,13 @@ import java.util.function.Predicate;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @ZeebeIntegration
 @Execution(ExecutionMode.CONCURRENT)
+@Timeout(2 * 60) // 2 minutes
 final class ClusterEndpointIT {
   private static final int BROKER_COUNT = 2;
   private static final int PARTITION_COUNT = 2;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -22,11 +22,8 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @ZeebeIntegration
-@Execution(ExecutionMode.CONCURRENT)
 @Timeout(2 * 60) // 2 minutes
 final class ClusterEndpointIT {
   private static final int BROKER_COUNT = 2;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import java.util.List;
 import java.util.function.Predicate;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -23,7 +22,6 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-@ZeebeIntegration
 @Timeout(2 * 60) // 2 minutes
 final class ClusterEndpointIT {
   private static final int BROKER_COUNT = 2;

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagementIntegrationTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagementIntegrationTest.java
@@ -265,6 +265,12 @@ class ClusterTopologyManagementIntegrationTest {
             Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")),
             Map.of(MemberId.from("0"), 1, MemberId.from("1"), 2, MemberId.from("2"), 3),
             3,
+            MemberId.from("2")),
+        new PartitionMetadata(
+            PartitionId.from("test", 2),
+            Set.of(MemberId.from("2")),
+            Map.of(MemberId.from("2"), 1),
+            1,
             MemberId.from("2")));
   }
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionJoinApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionJoinApplierTest.java
@@ -111,6 +111,23 @@ final class PartitionJoinApplierTest {
   }
 
   @Test
+  void shouldRejectJoinIfPartitionDoesNotHaveActiveMembers() {
+    // given
+    final var topologyWithoutActiveMembers =
+        ClusterTopology.init().addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = partitionJoinApplier.init(topologyWithoutActiveMembers);
+
+    // then
+    assertThat(result).isLeft();
+
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("partition has no active members");
+  }
+
+  @Test
   void shouldInitializeStateToJoining() {
     // when
     final var updater = partitionJoinApplier.init(initialClusterTopology).get();

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
@@ -117,7 +117,10 @@ final class TopologyChangeCoordinatorImplTest {
     // given
     final ClusterTopology initialTopology =
         ClusterTopology.init()
-            .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()));
+            .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
+            .addMember(
+                MemberId.from("2"),
+                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
     clusterTopologyManager.setClusterTopology(initialTopology);
 
     final List<TopologyChangeOperation> operations =


### PR DESCRIPTION
This adds validation to the `PartitionJoinApplier` to verify that the partition has at least one active member. If there is none, the partition does not exist and we can't join.

Based on https://github.com/camunda/zeebe/pull/14956 to test the error response.
Related to https://github.com/camunda/zeebe/issues/14905