### PR TITLE
fix: Enrich incident messages with evaluation warnings

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -404,8 +404,9 @@ public final class ExpressionProcessor {
       final var formattedWarnings =
           evaluationWarnings.stream()
               .map(warning -> "[%s] %s".formatted(warning.getType(), warning.getMessage()))
-              .collect(Collectors.joining("; "));
-      message += " The evaluation reported the following warnings: %s".formatted(formattedWarnings);
+              .collect(Collectors.joining("\n"));
+      message +=
+          " The evaluation reported the following warnings:\n%s".formatted(formattedWarnings);
     }
 
     return new Failure(message, ErrorType.EXTRACT_VALUE_ERROR, variableScopeKey);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ScriptTaskExpressionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ScriptTaskExpressionTest.java
@@ -304,9 +304,9 @@ public final class ScriptTaskExpressionTest {
             """
             Assertion failure on evaluate the expression 'assert(x, x != null)': \
             The condition is not fulfilled \
-            The evaluation reported the following warnings: \
-            [NO_VARIABLE_FOUND] No variable found with name 'x'; \
-            [NO_VARIABLE_FOUND] No variable found with name 'x'; \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'x'
+            [NO_VARIABLE_FOUND] No variable found with name 'x'
             [ASSERT_FAILURE] The condition is not fulfilled""")
         .hasBpmnProcessId(scriptTask.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(scriptTask.getValue().getProcessDefinitionKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ScriptTaskExpressionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ScriptTaskExpressionTest.java
@@ -303,7 +303,11 @@ public final class ScriptTaskExpressionTest {
         .hasErrorMessage(
             """
             Assertion failure on evaluate the expression 'assert(x, x != null)': \
-            The condition is not fulfilled""")
+            The condition is not fulfilled \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'x'; \
+            [NO_VARIABLE_FOUND] No variable found with name 'x'; \
+            [ASSERT_FAILURE] The condition is not fulfilled""")
         .hasBpmnProcessId(scriptTask.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(scriptTask.getValue().getProcessDefinitionKey())
         .hasProcessInstanceKey(scriptTask.getValue().getProcessInstanceKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -87,6 +88,139 @@ class ExpressionProcessorTest {
           Arguments.of(
               "= [null]",
               "Expected result of the expression ' [null]' to be 'ARRAY' containing 'STRING' items, but was 'ARRAY' containing at least one non-'STRING' item."));
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class EvaluationWarningsTest {
+
+    @Test
+    void testStringExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
+      assertThat(processor.evaluateStringExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Expected result of the expression 'x' to be 'STRING', but was 'NULL'. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+
+    @Test
+    void testLongExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
+      assertThat(processor.evaluateLongExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Expected result of the expression 'x' to be 'NUMBER', but was 'NULL'. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+
+    @Test
+    void testBooleanExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
+      assertThat(processor.evaluateBooleanExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Expected result of the expression 'x' to be 'BOOLEAN', but was 'NULL'. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+
+    @Test
+    void testIntervalExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
+      assertThat(processor.evaluateIntervalExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Expected result of the expression 'x' to be one of '[DURATION, PERIOD, STRING]', but was 'NULL'. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+
+    @Test
+    void testDateTimeExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
+      assertThat(processor.evaluateDateTimeExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Expected result of the expression 'x' to be one of '[DATE_TIME, STRING]', but was 'NULL'. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+
+    @Test
+    void testArrayExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
+      assertThat(processor.evaluateArrayExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Expected result of the expression 'x' to be 'ARRAY', but was 'NULL'. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+
+    @Test
+    void testStringArrayExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=[x]");
+      assertThat(processor.evaluateArrayOfStringsExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Expected result of the expression '[x]' to be 'ARRAY' containing 'STRING' items, \
+              but was 'ARRAY' containing at least one non-'STRING' item. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+
+    @Test
+    void testMessageCorrelationKeyExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
+      assertThat(processor.evaluateMessageCorrelationKeyExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Failed to extract the correlation key for 'x': \
+              The value must be either a string or a number, but was 'NULL'. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+
+    @Test
+    void testVariableMappingExpression() {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
+      assertThat(processor.evaluateVariableMappingExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(r -> r.getLeft().getMessage())
+          .isEqualTo(
+              """
+              Expected result of the expression 'x' to be 'OBJECT', but was 'NULL'. \
+              The evaluation reported the following warnings: \
+              [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -105,7 +105,7 @@ class ExpressionProcessorTest {
           .isEqualTo(
               """
               Expected result of the expression 'x' to be 'STRING', but was 'NULL'. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
 
@@ -119,7 +119,7 @@ class ExpressionProcessorTest {
           .isEqualTo(
               """
               Expected result of the expression 'x' to be 'NUMBER', but was 'NULL'. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
 
@@ -133,7 +133,7 @@ class ExpressionProcessorTest {
           .isEqualTo(
               """
               Expected result of the expression 'x' to be 'BOOLEAN', but was 'NULL'. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
 
@@ -147,7 +147,7 @@ class ExpressionProcessorTest {
           .isEqualTo(
               """
               Expected result of the expression 'x' to be one of '[DURATION, PERIOD, STRING]', but was 'NULL'. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
 
@@ -161,7 +161,7 @@ class ExpressionProcessorTest {
           .isEqualTo(
               """
               Expected result of the expression 'x' to be one of '[DATE_TIME, STRING]', but was 'NULL'. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
 
@@ -175,7 +175,7 @@ class ExpressionProcessorTest {
           .isEqualTo(
               """
               Expected result of the expression 'x' to be 'ARRAY', but was 'NULL'. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
 
@@ -190,7 +190,7 @@ class ExpressionProcessorTest {
               """
               Expected result of the expression '[x]' to be 'ARRAY' containing 'STRING' items, \
               but was 'ARRAY' containing at least one non-'STRING' item. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
 
@@ -205,7 +205,7 @@ class ExpressionProcessorTest {
               """
               Failed to extract the correlation key for 'x': \
               The value must be either a string or a number, but was 'NULL'. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
 
@@ -219,7 +219,7 @@ class ExpressionProcessorTest {
           .isEqualTo(
               """
               Expected result of the expression 'x' to be 'OBJECT', but was 'NULL'. \
-              The evaluation reported the following warnings: \
+              The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
     }
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -197,7 +197,7 @@ public class DeploymentRejectionTest {
             Expected to deploy new resources, but encountered the following errors:
             'p1.bpmn': - Element: start-event-1
                 - ERROR: Invalid timer cycle expression (Expected result of the expression 'INVALID_CYCLE_EXPRESSION' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'INVALID_CYCLE_EXPRESSION')
             """);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -194,10 +194,12 @@ public class DeploymentRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             """
-                Expected to deploy new resources, but encountered the following errors:
-                'p1.bpmn': - Element: start-event-1
-                    - ERROR: Invalid timer cycle expression (Expected result of the expression 'INVALID_CYCLE_EXPRESSION' to be 'STRING', but was 'NULL'.)
-                """);
+            Expected to deploy new resources, but encountered the following errors:
+            'p1.bpmn': - Element: start-event-1
+                - ERROR: Invalid timer cycle expression (Expected result of the expression 'INVALID_CYCLE_EXPRESSION' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'INVALID_CYCLE_EXPRESSION')
+            """);
   }
 
   // https://github.com/camunda/zeebe/issues/8026

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/TimerValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/TimerValidationTest.java
@@ -47,7 +47,7 @@ public final class TimerValidationTest {
         process,
         expect(
             timerEventElementId,
-            "Invalid timer duration expression (Invalid duration format 'foo' for expression 'foo')"));
+            "Invalid timer duration expression (Invalid duration format 'foo' for expression 'foo'.)"));
   }
 
   @ParameterizedTest(name = "[{index}] {0}")
@@ -62,7 +62,7 @@ public final class TimerValidationTest {
         process,
         expect(
             timerEventElementId,
-            "Invalid timer date expression (Invalid date-time format 'foo' for expression 'foo')"));
+            "Invalid timer date expression (Invalid date-time format 'foo' for expression 'foo'.)"));
   }
 
   @ParameterizedTest(name = "[{index}] {1}")

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -167,7 +167,10 @@ public class BusinessRuleTaskIncidentTest {
     assertIncidentCreated(processInstanceKey, taskActivating.getKey())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'decisionIdVariable' to be 'STRING', but was 'NULL'.");
+            """
+            Expected result of the expression 'decisionIdVariable' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'decisionIdVariable'""");
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -169,7 +169,7 @@ public class BusinessRuleTaskIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'decisionIdVariable' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'decisionIdVariable'""");
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -134,7 +134,10 @@ public final class CallActivityIncidentTest {
     assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'wfChild' to be 'STRING', but was 'NULL'.");
+            """
+            Expected result of the expression 'wfChild' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'wfChild'""");
   }
 
   @Test
@@ -188,7 +191,10 @@ public final class CallActivityIncidentTest {
     assertIncidentCreated(incident, elementInstance, tenantId)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'wfChild' to be 'STRING', but was 'NULL'.");
+            """
+            Expected result of the expression 'wfChild' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'wfChild'""");
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -136,7 +136,7 @@ public final class CallActivityIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'wfChild' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'wfChild'""");
   }
 
@@ -193,7 +193,7 @@ public final class CallActivityIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'wfChild' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'wfChild'""");
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ConditionIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ConditionIncidentTest.java
@@ -114,7 +114,10 @@ public final class ConditionIncidentTest {
     Assertions.assertThat(incidentEvent.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'foo > 10' to be 'BOOLEAN', but was 'NULL'.")
+            """
+            Expected result of the expression 'foo > 10' to be 'BOOLEAN', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NOT_COMPARABLE] Can't compare '"bar"' with '10'""")
         .hasBpmnProcessId(failingEvent.getValue().getBpmnProcessId())
         .hasProcessInstanceKey(failingEvent.getValue().getProcessInstanceKey())
         .hasElementId(failingEvent.getValue().getElementId())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ConditionIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ConditionIncidentTest.java
@@ -116,7 +116,7 @@ public final class ConditionIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'foo > 10' to be 'BOOLEAN', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NOT_COMPARABLE] Can't compare '"bar"' with '10'""")
         .hasBpmnProcessId(failingEvent.getValue().getBpmnProcessId())
         .hasProcessInstanceKey(failingEvent.getValue().getProcessInstanceKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
@@ -441,7 +441,7 @@ public final class ErrorEventIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'unknown_error_code' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'unknown_error_code'""")
         .hasBpmnProcessId(endEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(endEvent.getValue().getProcessDefinitionKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
@@ -439,7 +439,10 @@ public final class ErrorEventIncidentTest {
     Assertions.assertThat(incidentEvent.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'unknown_error_code' to be 'STRING', but was 'NULL'.")
+            """
+            Expected result of the expression 'unknown_error_code' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'unknown_error_code'""")
         .hasBpmnProcessId(endEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(endEvent.getValue().getProcessDefinitionKey())
         .hasProcessInstanceKey(endEvent.getValue().getProcessInstanceKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EscalationIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EscalationIncidentTest.java
@@ -69,7 +69,10 @@ public class EscalationIncidentTest {
     Assertions.assertThat(incidentEvent.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'escalationCodeLookup' to be 'STRING', but was 'NULL'.")
+            """
+            Expected result of the expression 'escalationCodeLookup' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'escalationCodeLookup'""")
         .hasBpmnProcessId(endEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(endEvent.getValue().getProcessDefinitionKey())
         .hasProcessInstanceKey(endEvent.getValue().getProcessInstanceKey())
@@ -154,7 +157,10 @@ public class EscalationIncidentTest {
     Assertions.assertThat(incidentEvent.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'escalationCodeLookup' to be 'STRING', but was 'NULL'.")
+            """
+            Expected result of the expression 'escalationCodeLookup' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'escalationCodeLookup'""")
         .hasBpmnProcessId(intermediateThrowEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(intermediateThrowEvent.getValue().getProcessDefinitionKey())
         .hasProcessInstanceKey(intermediateThrowEvent.getValue().getProcessInstanceKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EscalationIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EscalationIncidentTest.java
@@ -71,7 +71,7 @@ public class EscalationIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'escalationCodeLookup' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'escalationCodeLookup'""")
         .hasBpmnProcessId(endEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(endEvent.getValue().getProcessDefinitionKey())
@@ -159,7 +159,7 @@ public class EscalationIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'escalationCodeLookup' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'escalationCodeLookup'""")
         .hasBpmnProcessId(intermediateThrowEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(intermediateThrowEvent.getValue().getProcessDefinitionKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EventSubscriptionIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EventSubscriptionIncidentTest.java
@@ -289,7 +289,7 @@ public final class EventSubscriptionIncidentTest {
             """
             Failed to extract the correlation key for 'key2': \
             The value must be either a string or a number, but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'key2'""")
         .hasBpmnProcessId(processId)
         .hasProcessInstanceKey(processInstanceKey)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EventSubscriptionIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EventSubscriptionIncidentTest.java
@@ -288,7 +288,9 @@ public final class EventSubscriptionIncidentTest {
         .hasErrorMessage(
             """
             Failed to extract the correlation key for 'key2': \
-            The value must be either a string or a number, but was NULL.""")
+            The value must be either a string or a number, but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'key2'""")
         .hasBpmnProcessId(processId)
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId(failureEvent.getValue().getElementId())
@@ -322,9 +324,9 @@ public final class EventSubscriptionIncidentTest {
     Assertions.assertThat(incidentRecord.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Failed to extract the correlation key for '"
-                + CORRELATION_VARIABLE_2
-                + "': The value must be either a string or a number, but was ARRAY.")
+            """
+            Failed to extract the correlation key for 'key2': \
+            The value must be either a string or a number, but was 'ARRAY'.""")
         .hasBpmnProcessId(processId)
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId(failureEvent.getValue().getElementId())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -95,7 +95,11 @@ public class JobWorkerElementIncidentTest {
 
     Assertions.assertThat(incidentCreated.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
-        .hasErrorMessage("Expected result of the expression 'x' to be 'STRING', but was 'NULL'.")
+        .hasErrorMessage(
+            """
+            Expected result of the expression 'x' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'x'""")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
@@ -199,7 +203,11 @@ public class JobWorkerElementIncidentTest {
 
     Assertions.assertThat(incidentCreated.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
-        .hasErrorMessage("Expected result of the expression 'x' to be 'NUMBER', but was 'NULL'.")
+        .hasErrorMessage(
+            """
+            Expected result of the expression 'x' to be 'NUMBER', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'x'""")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -98,7 +98,7 @@ public class JobWorkerElementIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'x' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'x'""")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
@@ -206,7 +206,7 @@ public class JobWorkerElementIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'x' to be 'NUMBER', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'x'""")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MessageIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MessageIncidentTest.java
@@ -90,7 +90,7 @@ public final class MessageIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'nameLookup' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'nameLookup'""")
         .hasBpmnProcessId("UNRESOLVABLE_NAME_EXPRESSION")
         .hasProcessInstanceKey(processInstanceKey)
@@ -204,7 +204,7 @@ public final class MessageIncidentTest {
             """
             Failed to extract the correlation key for 'orderId': \
             The value must be either a string or a number, but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'orderId'""")
         .hasBpmnProcessId(PROCESS_ID)
         .hasProcessInstanceKey(processInstanceKey)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MessageIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MessageIncidentTest.java
@@ -88,7 +88,10 @@ public final class MessageIncidentTest {
     Assertions.assertThat(incidentRecord.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'nameLookup' to be 'STRING', but was 'NULL'.")
+            """
+            Expected result of the expression 'nameLookup' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'nameLookup'""")
         .hasBpmnProcessId("UNRESOLVABLE_NAME_EXPRESSION")
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId("catch")
@@ -200,7 +203,9 @@ public final class MessageIncidentTest {
         .hasErrorMessage(
             """
             Failed to extract the correlation key for 'orderId': \
-            The value must be either a string or a number, but was NULL.""")
+            The value must be either a string or a number, but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'orderId'""")
         .hasBpmnProcessId(PROCESS_ID)
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId("catch")
@@ -231,7 +236,7 @@ public final class MessageIncidentTest {
     Assertions.assertThat(incidentRecord.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Failed to extract the correlation key for 'orderId': The value must be either a string or a number, but was BOOLEAN.")
+            "Failed to extract the correlation key for 'orderId': The value must be either a string or a number, but was 'BOOLEAN'.")
         .hasBpmnProcessId(PROCESS_ID)
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementId("catch")

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -105,7 +105,10 @@ public final class MultiInstanceIncidentTest {
     assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression 'items' to be 'ARRAY', but was 'NULL'.");
+            """
+            Expected result of the expression 'items' to be 'ARRAY', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'items'""");
   }
 
   @Test
@@ -169,7 +172,11 @@ public final class MultiInstanceIncidentTest {
             """
             Assertion failure on evaluate the expression \
             '{x: assert(undefined_var, undefined_var != null)}': \
-            The condition is not fulfilled""");
+            The condition is not fulfilled \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'undefined_var'; \
+            [NO_VARIABLE_FOUND] No variable found with name 'undefined_var'; \
+            [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
   @Test
@@ -433,7 +440,11 @@ public final class MultiInstanceIncidentTest {
 
     Assertions.assertThat(incidentEvent.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
-        .hasErrorMessage("Expected result of the expression 'x' to be 'BOOLEAN', but was 'NULL'.")
+        .hasErrorMessage(
+            """
+            Expected result of the expression 'x' to be 'BOOLEAN', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'x'""")
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementInstanceKey(activityEvent.getKey())
         .hasVariableScopeKey(activityEvent.getKey());

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -107,7 +107,7 @@ public final class MultiInstanceIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'items' to be 'ARRAY', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'items'""");
   }
 
@@ -173,9 +173,9 @@ public final class MultiInstanceIncidentTest {
             Assertion failure on evaluate the expression \
             '{x: assert(undefined_var, undefined_var != null)}': \
             The condition is not fulfilled \
-            The evaluation reported the following warnings: \
-            [NO_VARIABLE_FOUND] No variable found with name 'undefined_var'; \
-            [NO_VARIABLE_FOUND] No variable found with name 'undefined_var'; \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'undefined_var'
+            [NO_VARIABLE_FOUND] No variable found with name 'undefined_var'
             [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
@@ -443,7 +443,7 @@ public final class MultiInstanceIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'x' to be 'BOOLEAN', but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'x'""")
         .hasProcessInstanceKey(processInstanceKey)
         .hasElementInstanceKey(activityEvent.getKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
@@ -112,9 +112,13 @@ public final class TimerIncidentTest {
     assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression '"
-                + DATETIME_EXPRESSION
-                + "' to be one of '[DATE_TIME, STRING]', but was 'NULL'");
+            """
+          Expected result of the expression 'date and time(date(timer_duration),time("T00:00:00@UTC"))' \
+          to be one of '[DATE_TIME, STRING]', but was 'NULL'. \
+          The evaluation reported the following warnings: \
+          [NO_VARIABLE_FOUND] No variable found with name 'timer_duration'; \
+          [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'date': Illegal arguments: 'null'; \
+          [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'date and time': Illegal arguments: 'null', '00:00:00@UTC'""");
   }
 
   @Test
@@ -144,7 +148,7 @@ public final class TimerIncidentTest {
         .hasErrorMessage(
             "Invalid date-time format 'not_a_duration_expression' for expression '"
                 + DURATION_VARIABLE
-                + "'");
+                + "'.");
   }
 
   @Test
@@ -167,9 +171,11 @@ public final class TimerIncidentTest {
     assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression '"
-                + DURATION_EXPRESSION
-                + "' to be one of '[DURATION, PERIOD, STRING]', but was 'NULL'");
+            """
+            Expected result of the expression 'duration(timer_duration)' to be one of '[DURATION, PERIOD, STRING]', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'timer_duration'; \
+            [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'duration': Illegal arguments: 'null'""");
   }
 
   @Test
@@ -199,7 +205,7 @@ public final class TimerIncidentTest {
         .hasErrorMessage(
             "Invalid duration format 'not_a_duration_expression' for expression '"
                 + DURATION_VARIABLE
-                + "'");
+                + "'.");
   }
 
   @Test
@@ -227,9 +233,11 @@ public final class TimerIncidentTest {
     assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression '"
-                + CYCLE_EXPRESSION
-                + "' to be 'STRING', but was 'NULL'.");
+            """
+            Expected result of the expression 'cycle(duration(timer_duration))' to be 'STRING', but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'duration': Failed to parse duration from 'not_a_duration_expression'; \
+            [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'cycle': cycle function expected an interval (duration) parameter, but found 'null'""");
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/TimerIncidentTest.java
@@ -113,12 +113,12 @@ public final class TimerIncidentTest {
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             """
-          Expected result of the expression 'date and time(date(timer_duration),time("T00:00:00@UTC"))' \
-          to be one of '[DATE_TIME, STRING]', but was 'NULL'. \
-          The evaluation reported the following warnings: \
-          [NO_VARIABLE_FOUND] No variable found with name 'timer_duration'; \
-          [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'date': Illegal arguments: 'null'; \
-          [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'date and time': Illegal arguments: 'null', '00:00:00@UTC'""");
+            Expected result of the expression 'date and time(date(timer_duration),time("T00:00:00@UTC"))' \
+            to be one of '[DATE_TIME, STRING]', but was 'NULL'. \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'timer_duration'
+            [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'date': Illegal arguments: 'null'
+            [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'date and time': Illegal arguments: 'null', '00:00:00@UTC'""");
   }
 
   @Test
@@ -173,8 +173,8 @@ public final class TimerIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'duration(timer_duration)' to be one of '[DURATION, PERIOD, STRING]', but was 'NULL'. \
-            The evaluation reported the following warnings: \
-            [NO_VARIABLE_FOUND] No variable found with name 'timer_duration'; \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'timer_duration'
             [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'duration': Illegal arguments: 'null'""");
   }
 
@@ -235,8 +235,8 @@ public final class TimerIncidentTest {
         .hasErrorMessage(
             """
             Expected result of the expression 'cycle(duration(timer_duration))' to be 'STRING', but was 'NULL'. \
-            The evaluation reported the following warnings: \
-            [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'duration': Failed to parse duration from 'not_a_duration_expression'; \
+            The evaluation reported the following warnings:
+            [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'duration': Failed to parse duration from 'not_a_duration_expression'
             [FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'cycle': cycle function expected an interval (duration) parameter, but found 'null'""");
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/UserTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/UserTaskIncidentTest.java
@@ -100,9 +100,9 @@ public class UserTaskIncidentTest {
             """
             Assertion failure on evaluate the expression \
             'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
-            The evaluation reported the following warnings: \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
             [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
@@ -239,9 +239,9 @@ public class UserTaskIncidentTest {
             """
             Assertion failure on evaluate the expression \
             'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
-            The evaluation reported the following warnings: \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
             [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
@@ -367,9 +367,9 @@ public class UserTaskIncidentTest {
             """
             Assertion failure on evaluate the expression \
             'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
-            The evaluation reported the following warnings: \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
             [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
@@ -498,9 +498,9 @@ public class UserTaskIncidentTest {
             """
             Assertion failure on evaluate the expression \
             'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
-            The evaluation reported the following warnings: \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
             [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
@@ -641,9 +641,9 @@ public class UserTaskIncidentTest {
             """
             Assertion failure on evaluate the expression \
             'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
-            The evaluation reported the following warnings: \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
-            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'
             [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/UserTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/UserTaskIncidentTest.java
@@ -99,7 +99,11 @@ public class UserTaskIncidentTest {
         .hasErrorMessage(
             """
             Assertion failure on evaluate the expression \
-            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled""");
+            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
   @Test
@@ -234,7 +238,11 @@ public class UserTaskIncidentTest {
         .hasErrorMessage(
             """
             Assertion failure on evaluate the expression \
-            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled""");
+            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
   @Test
@@ -358,7 +366,11 @@ public class UserTaskIncidentTest {
         .hasErrorMessage(
             """
             Assertion failure on evaluate the expression \
-            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled""");
+            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
   @Test
@@ -485,7 +497,11 @@ public class UserTaskIncidentTest {
         .hasErrorMessage(
             """
             Assertion failure on evaluate the expression \
-            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled""");
+            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
   @Test
@@ -510,7 +526,7 @@ public class UserTaskIncidentTest {
     assertIncidentCreated(processInstanceKey, userTaskActivating.getKey())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression '[1,2,3]' to be one of '[DATE_TIME, STRING]', but was 'ARRAY'");
+            "Expected result of the expression '[1,2,3]' to be one of '[NULL, DATE_TIME, STRING]', but was 'ARRAY'.");
   }
 
   @Test
@@ -624,7 +640,11 @@ public class UserTaskIncidentTest {
         .hasErrorMessage(
             """
             Assertion failure on evaluate the expression \
-            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled""");
+            'assert(MISSING_VAR, MISSING_VAR != null)': The condition is not fulfilled \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [NO_VARIABLE_FOUND] No variable found with name 'MISSING_VAR'; \
+            [ASSERT_FAILURE] The condition is not fulfilled""");
   }
 
   @Test
@@ -649,7 +669,7 @@ public class UserTaskIncidentTest {
     assertIncidentCreated(processInstanceKey, userTaskActivating.getKey())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression '[1,2,3]' to be one of '[DATE_TIME, STRING]', but was 'ARRAY'");
+            "Expected result of the expression '[1,2,3]' to be one of '[NULL, DATE_TIME, STRING]', but was 'ARRAY'.");
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -195,7 +195,9 @@ public class CreateProcessInstanceRejectionTest {
             """
             Expected to subscribe to catch event(s) of 'subprocess' but \
             Failed to extract the correlation key for 'unknown_var': \
-            The value must be either a string or a number, but was NULL.""");
+            The value must be either a string or a number, but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'unknown_var'""");
 
     Assertions.assertThat(
             RecordingExporter.records()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -196,7 +196,7 @@ public class CreateProcessInstanceRejectionTest {
             Expected to subscribe to catch event(s) of 'subprocess' but \
             Failed to extract the correlation key for 'unknown_var': \
             The value must be either a string or a number, but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'unknown_var'""");
 
     Assertions.assertThat(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -181,7 +181,7 @@ public class ModifyProcessInstanceRejectionTest {
             Expected to subscribe to catch event(s) of 'sp' but \
             Failed to extract the correlation key for 'missingVariable': \
             The value must be either a string or a number, but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'missingVariable'""");
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -180,7 +180,9 @@ public class ModifyProcessInstanceRejectionTest {
             """
             Expected to subscribe to catch event(s) of 'sp' but \
             Failed to extract the correlation key for 'missingVariable': \
-            The value must be either a string or a number, but was NULL.""");
+            The value must be either a string or a number, but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'missingVariable'""");
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerCatchEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerCatchEventTest.java
@@ -822,6 +822,6 @@ public final class TimerCatchEventTest {
             """
             Expected result of the expression 'today() + duration("P1D")' \
             to be one of '[DURATION, PERIOD, STRING]', \
-            but was 'DATE'""");
+            but was 'DATE'.""");
   }
 }

--- a/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationResult.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationResult.java
@@ -35,6 +35,13 @@ public interface EvaluationResult {
   String getFailureMessage();
 
   /**
+   * Returns warnings from the evaluation that can help to reason about the result.
+   *
+   * @return evaluation warnings, can be empty
+   */
+  List<EvaluationWarning> getWarnings();
+
+  /**
    * @return the type of the evaluation result, or {@code null} if the evaluation failed
    */
   ResultType getType();

--- a/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationWarning.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationWarning.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.el;
+
+/** A warning related to an expression evaluation. */
+public interface EvaluationWarning {
+
+  /**
+   * @return the type of warning
+   */
+  String getType();
+
+  /**
+   * @return a detailed warning message
+   */
+  String getMessage();
+}

--- a/expression-language/src/main/java/io/camunda/zeebe/el/impl/EvaluationFailure.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/impl/EvaluationFailure.java
@@ -8,11 +8,13 @@
 package io.camunda.zeebe.el.impl;
 
 import io.camunda.zeebe.el.EvaluationResult;
+import io.camunda.zeebe.el.EvaluationWarning;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ResultType;
 import java.time.Duration;
 import java.time.Period;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
@@ -20,10 +22,19 @@ public final class EvaluationFailure implements EvaluationResult {
 
   private final Expression expression;
   private final String failureMessage;
+  private final List<EvaluationWarning> warnings;
 
   public EvaluationFailure(final Expression expression, final String failureMessage) {
+    this(expression, failureMessage, Collections.emptyList());
+  }
+
+  public EvaluationFailure(
+      final Expression expression,
+      final String failureMessage,
+      final List<EvaluationWarning> warnings) {
     this.expression = expression;
     this.failureMessage = failureMessage;
+    this.warnings = warnings;
   }
 
   @Override
@@ -39,6 +50,11 @@ public final class EvaluationFailure implements EvaluationResult {
   @Override
   public String getFailureMessage() {
     return failureMessage;
+  }
+
+  @Override
+  public List<EvaluationWarning> getWarnings() {
+    return warnings;
   }
 
   @Override

--- a/expression-language/src/main/java/io/camunda/zeebe/el/impl/FeelEvaluationWarning.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/impl/FeelEvaluationWarning.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.el.impl;
+
+import io.camunda.zeebe.el.EvaluationWarning;
+
+public class FeelEvaluationWarning implements EvaluationWarning {
+
+  private final String type;
+  private final String message;
+
+  public FeelEvaluationWarning(final String type, final String message) {
+    this.type = type;
+    this.message = message;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/expression-language/src/main/java/io/camunda/zeebe/el/impl/StaticExpression.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/impl/StaticExpression.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.el.impl;
 import static io.camunda.zeebe.el.impl.Loggers.LOGGER;
 
 import io.camunda.zeebe.el.EvaluationResult;
+import io.camunda.zeebe.el.EvaluationWarning;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ResultType;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Period;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -78,6 +80,11 @@ public final class StaticExpression implements Expression, EvaluationResult {
   @Override
   public boolean isFailure() {
     return false;
+  }
+
+  @Override
+  public List<EvaluationWarning> getWarnings() {
+    return Collections.emptyList();
   }
 
   @Override

--- a/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
+++ b/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
@@ -7,18 +7,20 @@
  */
 package io.camunda.zeebe.el.impl.feel
 
-import io.camunda.zeebe.el.{EvaluationResult, Expression, ResultType}
+import io.camunda.zeebe.el.{EvaluationResult, EvaluationWarning, Expression, ResultType}
 import io.camunda.zeebe.util.buffer.BufferUtil.cloneBuffer
 import org.agrona.DirectBuffer
 import org.camunda.feel.syntaxtree._
 
 import java.time.{Duration, Period, ZoneId, ZonedDateTime}
 import java.{lang, util}
+import java.util.{List => JavaList}
 import scala.collection.JavaConverters._
 
 class FeelEvaluationResult(
                             expression: Expression,
                             result: Val,
+                            warnings: JavaList[EvaluationWarning],
                             messagePackTransformer: Val => DirectBuffer)
   extends EvaluationResult {
 
@@ -27,6 +29,9 @@ class FeelEvaluationResult(
   override def isFailure: Boolean = false
 
   override def getFailureMessage: String = null
+
+
+  override def getWarnings: JavaList[EvaluationWarning] = warnings
 
   override def getType: ResultType = result match {
     case ValNull => ResultType.NULL

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
@@ -341,6 +341,8 @@ public final class CreateProcessInstanceTest {
             Expected to subscribe to catch event(s) of \
             'process-shouldRejectCreateWithStartInstructions-2' but \
             Failed to extract the correlation key for 'missing_var': \
-            The value must be either a string or a number, but was NULL.""");
+            The value must be either a string or a number, but was 'NULL'. \
+            The evaluation reported the following warnings: \
+            [NO_VARIABLE_FOUND] No variable found with name 'missing_var'""");
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateProcessInstanceTest.java
@@ -342,7 +342,7 @@ public final class CreateProcessInstanceTest {
             'process-shouldRejectCreateWithStartInstructions-2' but \
             Failed to extract the correlation key for 'missing_var': \
             The value must be either a string or a number, but was 'NULL'. \
-            The evaluation reported the following warnings: \
+            The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'missing_var'""");
   }
 }


### PR DESCRIPTION
## Description

If an incident is created, it can be hard to understand why. For example, if an expression invokes a function but with wrong arguments or a typo in the function name. 

To help the user find the root cause, this change adds evaluation warnings to the incident message. These warnings are retrieved from the FEEL engine that evaluates the expressions. 

A new incident message may look like:

```
Expected result of the expression 'duration(timer_duration)' to be one of '[DURATION, PERIOD, STRING]', but was 'NULL'.
The evaluation reported the following warnings: 
[NO_VARIABLE_FOUND] No variable found with name 'timer_duration'; 
[FUNCTION_INVOCATION_FAILURE] Failed to invoke function 'duration': Illegal arguments: 'null'
```   

## Related issues

closes #8938 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
