### PR TITLE
Improve resilience of remote stream restart

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
@@ -32,7 +32,7 @@ public class MessagingException extends IOException {
 
   /** Exception indicating no remote registered remote handler. */
   public static class NoRemoteHandler extends MessagingException {
-    public NoRemoteHandler(String subject) {
+    public NoRemoteHandler(final String subject) {
       super(
           String.format(
               "No remote message handler registered for this message, subject %s", subject));
@@ -41,7 +41,7 @@ public class MessagingException extends IOException {
 
   /** Exception indicating handler failure. */
   public static class RemoteHandlerFailure extends MessagingException {
-    public RemoteHandlerFailure(String message) {
+    public RemoteHandlerFailure(final String message) {
       super(String.format("Remote handler failed to handle message, cause: %s", message));
     }
   }
@@ -56,10 +56,12 @@ public class MessagingException extends IOException {
   }
 
   public static class NoSuchMemberException extends MessagingException {
-    public NoSuchMemberException(final Address sender) {
-      super(
-          "Failed to handle incoming message, sender %s is not a known cluster member"
-              .formatted(sender));
+    public NoSuchMemberException(final Address address) {
+      super("Failed to handle message, host %s is not a known cluster member".formatted(address));
+    }
+
+    public NoSuchMemberException(final String message) {
+      super(message);
     }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterCommunicationService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterCommunicationService.java
@@ -26,10 +26,10 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.cluster.messaging.ManagedClusterCommunicationService;
 import io.atomix.cluster.messaging.MessagingException;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.cluster.messaging.UnicastService;
 import io.atomix.utils.net.Address;
-import java.net.ConnectException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
@@ -212,7 +212,7 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
         String.format(
             "Expected to send a message with subject '%s' to member '%s', but member is not known. Known members are '%s'.",
             subject, toMemberId, membershipService.getMembers());
-    return CompletableFuture.failedFuture(new ConnectException(errorMessage));
+    return CompletableFuture.failedFuture(new NoSuchMemberException(errorMessage));
   }
 
   @Override
@@ -302,7 +302,7 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
 
     InternalMessageBiResponder(
         final Function<byte[], M> decoder,
-        Function<R, byte[]> encoder,
+        final Function<R, byte[]> encoder,
         final BiFunction<MemberId, M, R> handler,
         final Executor executor) {
       this.decoder = decoder;

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
@@ -11,13 +11,15 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Control interface to schedule tasks or follow-up tasks such that different tasks scheduled via
  * the same {@code ConcurrencyControl} object are never executed concurrently
  */
-public interface ConcurrencyControl {
+public interface ConcurrencyControl extends Executor {
 
   /**
    * Schedules a callback to be invoked after the future has completed
@@ -65,5 +67,10 @@ public interface ConcurrencyControl {
    */
   default <V> ActorFuture<V> createCompletedFuture() {
     return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  default void execute(@NotNull final Runnable command) {
+    run(command);
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
@@ -93,7 +93,7 @@ public class RemoteStreamServiceImpl<M, P extends BufferWriter>
     if (type == Type.MEMBER_REMOVED) {
       apiServer.removeAll(event.subject().id());
     } else if (type == Type.MEMBER_ADDED) {
-      apiServer.recreateStreams(event.subject().id());
+      apiServer.restartStreams(event.subject().id());
     }
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -9,28 +9,53 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.transport.stream.impl.messages.AddStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.MessageUtil;
 import io.camunda.zeebe.transport.stream.impl.messages.RemoveStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
+import io.camunda.zeebe.util.ExponentialBackoff;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.LongUnaryOperator;
+import org.agrona.collections.ArrayUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Server-side actor which takes care of the network communication between the remote stream clients
+ * (e.g. gateways) and servers (e.g. brokers). Sets up handlers for shared topics to receive add,
+ * remove, and remove all requests, and manages sending restart requests to added clients.
+ *
+ * @param <M> type of the stream's metadata
+ */
 public final class RemoteStreamTransport<M> extends Actor {
-  private static final byte[] EMPTY_PAYLOAD = new byte[0];
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private static final Logger LOG = LoggerFactory.getLogger(RemoteStreamTransport.class);
+  private static final int INITIAL_RETRY_DELAY_MS = 100;
+
   private final ClusterCommunicationService transport;
   private final RemoteStreamApiHandler<M> requestHandler;
+  private final LongUnaryOperator retryDelaySupplier;
 
   public RemoteStreamTransport(
       final ClusterCommunicationService transport, final RemoteStreamApiHandler<M> requestHandler) {
+    this(transport, requestHandler, new ExponentialBackoff());
+  }
+
+  @VisibleForTesting
+  RemoteStreamTransport(
+      final ClusterCommunicationService transport,
+      final RemoteStreamApiHandler<M> requestHandler,
+      final LongUnaryOperator retryDelaySupplier) {
     this.transport = transport;
     this.requestHandler = requestHandler;
+    this.retryDelaySupplier = retryDelaySupplier;
   }
 
   @Override
@@ -69,45 +94,109 @@ public final class RemoteStreamTransport<M> extends Actor {
 
   private byte[] onAdd(final MemberId sender, final AddStreamRequest request) {
     requestHandler.add(sender, request);
-    return EMPTY_PAYLOAD;
+    return ArrayUtil.EMPTY_BYTE_ARRAY;
   }
 
   private byte[] onRemove(final MemberId sender, final RemoveStreamRequest request) {
     requestHandler.remove(sender, request);
-    return EMPTY_PAYLOAD;
+    return ArrayUtil.EMPTY_BYTE_ARRAY;
   }
 
   private byte[] onRemoveAll(final MemberId sender, final byte[] ignored) {
     requestHandler.removeAll(sender);
-    return EMPTY_PAYLOAD;
+    return ArrayUtil.EMPTY_BYTE_ARRAY;
   }
 
-  public void recreateStreams(final MemberId receiver) {
+  public CompletableFuture<Void> restartStreams(final MemberId receiver) {
+    final var completed = new CompletableFuture<Void>();
+    sendRestartStreamsRequest(receiver, completed, INITIAL_RETRY_DELAY_MS);
+    return completed;
+  }
+
+  private void sendRestartStreamsRequest(
+      final MemberId receiver, final CompletableFuture<Void> completed, final long retryDelayMs) {
     try {
-      LOG.debug("Restarting streams with for newly added member '{}'", receiver);
-      sendRestartStreamsCommand(receiver)
-          .whenComplete(
-              (ok, error) -> {
-                if (error != null) {
-                  LOG.warn("Failed to restart streams for member '{}'", receiver, error);
-                } else {
-                  LOG.debug("Restarted streams for member '{}'", receiver);
-                }
-              });
+      sendRestartStreamsRequest(receiver)
+          .whenCompleteAsync(
+              (ok, error) -> onRestartStreamsResponse(receiver, error, completed, retryDelayMs),
+              actor);
     } catch (final Exception e) {
       LOG.warn("Failed to restart streams for member '{}'", receiver, e);
     }
   }
 
-  private CompletableFuture<Void> sendRestartStreamsCommand(final MemberId receiver) {
+  private CompletableFuture<Void> sendRestartStreamsRequest(final MemberId receiver) {
     return transport
         .send(
             StreamTopics.RESTART_STREAMS.topic(),
-            EMPTY_PAYLOAD,
+            ArrayUtil.EMPTY_BYTE_ARRAY,
             Function.identity(),
             Function.identity(),
             receiver,
             REQUEST_TIMEOUT)
         .thenApply(ok -> null);
+  }
+
+  private void onRestartStreamsResponse(
+      final MemberId receiver,
+      final Throwable error,
+      final CompletableFuture<Void> completed,
+      final long retryDelayMs) {
+    if (error == null) {
+      LOG.debug("Requested streams from client service member '{}'", receiver);
+      completed.complete(null);
+      return;
+    }
+
+    final var cause = error.getCause();
+    switch (cause) {
+        // it's possible that the member that was just added has since been removed in between
+        // retries;
+        // if this is the case, it'll be re-added eventually
+      case final NoSuchMemberException e -> {
+        LOG.trace(
+            """
+            Failed to restart streams for member '{}', which has been removed from the
+            membership protocol; can be safely ignored.""",
+            receiver,
+            e);
+        completed.complete(null);
+      }
+        // this error means the remote member is not handling requests of this type; either it's not
+        // a
+        // gateway, or it's still starting up or shutting down. in either case, restarting streams
+        // makes
+        // no sense
+      case final NoRemoteHandler e -> {
+        LOG.trace(
+            """
+            Failed to restart streams for member '{}'; either it's not a client
+            stream service, or it's still starting up. Can be safely ignored.""",
+            receiver,
+            e);
+        completed.complete(null);
+      }
+        // no point retrying if the remote handler failed to handle our request
+      case final RemoteHandlerFailure e -> {
+        LOG.warn(
+            """
+            Failed to restart streams for member '{}'; unrecoverable error occurred on recipient
+            side, will not retry.""",
+            receiver,
+            e);
+        completed.completeExceptionally(e);
+      }
+      default -> {
+        LOG.warn(
+            "Failed to restart streams for member '{}', retrying in {}ms",
+            receiver,
+            retryDelayMs,
+            error);
+        final var nextRetryDelay = retryDelaySupplier.applyAsLong(retryDelayMs);
+        actor.schedule(
+            Duration.ofMillis(nextRetryDelay),
+            () -> sendRestartStreamsRequest(receiver, completed, nextRetryDelay));
+      }
+    }
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -163,10 +163,8 @@ public final class RemoteStreamTransport<M> extends Actor {
         completed.complete(null);
       }
         // this error means the remote member is not handling requests of this type; either it's not
-        // a
-        // gateway, or it's still starting up or shutting down. in either case, restarting streams
-        // makes
-        // no sense
+        // a gateway, or it's still starting up or shutting down. in either case, restarting streams
+        // makes no sense
       case final NoRemoteHandler e -> {
         LOG.trace(
             """

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
+import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.LongUnaryOperator;
+import org.agrona.collections.ArrayUtil;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Usage of actual {@link AtomixCluster} instances here is on purpose. The important part is that we
+ * test with an actual {@link io.atomix.cluster.messaging.ClusterCommunicationService} since we're
+ * dealing with expected error handling/propagation. If there's ever an easy way to build that
+ * without building a whole cluster instance, then we can refactor this.
+ */
+@AutoCloseResources
+final class RemoteStreamTransportTest {
+  private final List<Node> nodes = List.of(createNode("sender"), createNode("receiver"));
+  private final RecordingBackoffSupplier senderBackoffSupplier = new RecordingBackoffSupplier();
+
+  @AutoCloseResource private final AtomixCluster sender = createClusterNode(nodes.get(0), nodes);
+
+  @AutoCloseResource
+  private final RemoteStreamTransport<TestSerializableData> transport =
+      new RemoteStreamTransport<>(
+          sender.getCommunicationService(),
+          new RemoteStreamApiHandler<>(
+              new RemoteStreamRegistry<>(RemoteStreamMetrics.noop()),
+              buffer -> {
+                final var data = new TestSerializableData();
+                data.wrap(buffer, 0, buffer.capacity());
+                return data;
+              }),
+          senderBackoffSupplier);
+
+  @AutoCloseResource
+  private final ActorScheduler scheduler =
+      ActorScheduler.newActorScheduler()
+          .setCpuBoundActorThreadCount(1)
+          .setIoBoundActorThreadCount(0)
+          .build();
+
+  @AutoCloseResource private final AtomixCluster receiver = createClusterNode(nodes.get(1), nodes);
+
+  @BeforeEach
+  void beforeEach() {
+    sender.start().join();
+    receiver.start().join();
+
+    scheduler.start();
+    scheduler.submitActor(transport).join();
+  }
+
+  @Test
+  void shouldNotRetryUnknownMembers() {
+    // given
+    final var unknown = MemberId.anonymous();
+
+    // when
+    final var completed = transport.restartStreams(unknown);
+
+    // then
+    assertThat(completed).succeedsWithin(Duration.ofSeconds(5));
+    assertThat(senderBackoffSupplier.recorded).as("no retries executed").isEmpty();
+  }
+
+  @Test
+  void shouldNotRetryIfMemberNotHandlingRequest() {
+    // given
+    // when
+    final var completed =
+        transport.restartStreams(receiver.getMembershipService().getLocalMember().id());
+
+    // then
+    assertThat(completed).succeedsWithin(Duration.ofSeconds(5));
+    assertThat(senderBackoffSupplier.recorded).as("no retries executed").isEmpty();
+  }
+
+  @Test
+  void shouldRetryOnError() throws Exception {
+    // given
+    receiver.stop().join();
+
+    // when
+    final var completed =
+        transport.restartStreams(receiver.getMembershipService().getLocalMember().id());
+    Awaitility.await("until we've retried at least twice")
+        .pollInSameThread()
+        .untilAsserted(
+            () -> assertThat(senderBackoffSupplier.recorded).hasSizeGreaterThanOrEqualTo(2));
+    try (final var newReceiver = createClusterNode(nodes.get(1), nodes)) {
+      newReceiver.start().join();
+      newReceiver
+          .getCommunicationService()
+          .replyTo(
+              StreamTopics.RESTART_STREAMS.topic(),
+              Function.identity(),
+              (id, ignored) -> ArrayUtil.EMPTY_BYTE_ARRAY,
+              Function.identity(),
+              Runnable::run);
+
+      // then
+      assertThat(completed).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(senderBackoffSupplier.recorded).startsWith(100L, 200L);
+    }
+  }
+
+  @Test
+  void shouldNotRetryOnRemoteHandlerFailure() {
+    // given
+    receiver
+        .getCommunicationService()
+        .replyTo(
+            StreamTopics.RESTART_STREAMS.topic(),
+            Function.identity(),
+            (id, ignored) -> {
+              throw new RuntimeException("I have become error, destroyer of worlds");
+            },
+            Function.identity(),
+            Runnable::run);
+
+    // when
+    final var completed =
+        transport.restartStreams(receiver.getMembershipService().getLocalMember().id());
+
+    // then
+    assertThat(completed)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableThat()
+        .havingRootCause()
+        .isInstanceOf(RemoteHandlerFailure.class);
+    assertThat(senderBackoffSupplier.recorded).isEmpty();
+  }
+
+  private Node createNode(final String id) {
+    return Node.builder().withId(id).withPort(SocketUtil.getNextAddress().getPort()).build();
+  }
+
+  private AtomixCluster createClusterNode(final Node localNode, final Collection<Node> nodes) {
+    return AtomixCluster.builder()
+        .withAddress(localNode.address())
+        .withMemberId(localNode.id().id())
+        .withMembershipProvider(new BootstrapDiscoveryProvider(nodes))
+        .withMembershipProtocol(new DiscoveryMembershipProtocol())
+        .build();
+  }
+
+  // a back off supplier which records given delays and returns them multiplied by 2
+  private static final class RecordingBackoffSupplier implements LongUnaryOperator {
+    private final List<Long> recorded = new ArrayList<>();
+
+    @Override
+    public long applyAsLong(final long operand) {
+      recorded.add(operand);
+      return operand * 2;
+    }
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoff.java
+++ b/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoff.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.DoubleSupplier;
+import java.util.function.LongUnaryOperator;
+
+/**
+ * An simple implementation of exponential backoff, which multiples the previous delay with an
+ * increasing multiplier and adding some jitter to avoid multiple clients polling at the same time
+ * even with back off.
+ *
+ * <p>The next delay is calculated as:
+ *
+ * <pre> max(min(maxDelay, currentDelay * backoffFactor), minDelay) + (rand(0.0, 1.0) *
+ * (currentDelay * jitterFactor) + (currentDelay * -jitterFactor)) </pre>
+ */
+public final class ExponentialBackoff implements LongUnaryOperator {
+
+  private static final long DEFAULT_MAX_RETRY_DELAY_MS = 5000;
+  private static final long DEFAULT_MIN_RETRY_DELAY_MS = 100;
+
+  // defaults are taken from gRPC's own exponential backoff policy
+  private static final double DEFAULT_BACKOFF_FACTOR = 1.6;
+  private static final double DEFAULT_JITTER_FACTOR = 0.1;
+
+  private final long maxDelay;
+  private final long minDelay;
+  private final double backoffFactor;
+  private final double jitterFactor;
+  private final DoubleSupplier random;
+
+  public ExponentialBackoff() {
+    this(
+        DEFAULT_MAX_RETRY_DELAY_MS,
+        DEFAULT_MIN_RETRY_DELAY_MS,
+        DEFAULT_BACKOFF_FACTOR,
+        DEFAULT_JITTER_FACTOR);
+  }
+
+  public ExponentialBackoff(final long maxDelay, final long minDelay) {
+    this(maxDelay, minDelay, DEFAULT_BACKOFF_FACTOR, DEFAULT_JITTER_FACTOR);
+  }
+
+  public ExponentialBackoff(
+      final long maxDelay,
+      final long minDelay,
+      final double backoffFactor,
+      final double jitterFactor) {
+    this(
+        maxDelay,
+        minDelay,
+        backoffFactor,
+        jitterFactor,
+        () -> ThreadLocalRandom.current().nextDouble());
+  }
+
+  @VisibleForTesting
+  ExponentialBackoff(
+      final long maxDelay,
+      final long minDelay,
+      final double backoffFactor,
+      final double jitterFactor,
+      final DoubleSupplier random) {
+    this.maxDelay = maxDelay;
+    this.minDelay = minDelay;
+    this.backoffFactor = backoffFactor;
+    this.jitterFactor = jitterFactor;
+    this.random = random;
+  }
+
+  @Override
+  public long applyAsLong(final long operand) {
+    return supplyRetryDelay(operand);
+  }
+
+  public long supplyRetryDelay(final long currentRetryDelay) {
+    final var delay = Math.max(Math.min(maxDelay, currentRetryDelay * backoffFactor), minDelay);
+    final var jitter = computeJitter(delay);
+    return Math.round(delay + jitter);
+  }
+
+  private double computeJitter(final double value) {
+    final var minFactor = value * -jitterFactor;
+    final var maxFactor = value * jitterFactor;
+
+    return (random.getAsDouble() * (maxFactor - minFactor)) + minFactor;
+  }
+}


### PR DESCRIPTION
## Description

This PR improves the resilience of the remote stream restart call. It adds error handling to the `RemoteStreamTransport#restartStreams` API. This API triggers newly added members (from the membership protocol) to send the broker their existing streams. It's required to ensure a consistent state on both gateways/brokers in the case where a broker would be restarted too fast, such that the gateways would not detect it ever left the membership group, and thus, would not register their existing streams on the new broker.

To avoid temporary network errors, the request is retried (with randomized exponential backoff) forever until one of the following cases is met:

- The remote member does not subscribe to the restart stream topic. This can happen when sending the request to, say, another broker. It can also happen with gateways if the gateway is still starting up or if it's shutting down. In all cases, it's fine to not retry and suppress the error.
- The remote member has since been removed from the membership protocol. If this happens, then we know either the remote member is dead, or it's temporarily unavailable. Either way, no point retrying until it's added back to the protocol, at which point `restartStreams` will be called again.
- The remote member threw an uncaught exception while handling the request. If the request nnot be processed, there's no point retrying.

Any other error - time outs, connection errors, etc. - will be retried infinitely, up to once per 5 seconds.

A few other minor things:

- `ConcurrencyControl` is now also an `Executor`
- I cloned the `ExponentialBackoff` utility from the client. We don't actually have a shared utility module between the client and the gateway/brokers, so I wasn't too sure where to put it, and didn't want to create a new module right now. Plus, I think eventually it would make sense to build retry/backoff/rate limit/etc. into our transport directly.
- On a similar note, I figured better copy that little utility than go for a heavy duty dependency like Resilience4J. We should look at that in the future, but for now it's that one class is fine I think.
- The tests use actual `AtomixCluster` only so they can get a real `ClusterCommunicationService`. Since we're testing the actual error behavior, I didn't feel comfortable mocking it with no easy way to later get integration tests for that.

## Related issues

closes #14884 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
