### PR TITLE
Fix race condition between snapshot listener and updating currentSnapshot by PassiveRole

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -259,7 +259,7 @@ public class PassiveRole extends InactiveRole {
       pendingSnapshotStartTimestamp = 0L;
       snapshotReplicationMetrics.decrementCount();
       snapshotReplicationMetrics.observeDuration(elapsed);
-      raft.setCurrentSnapshot(persistedSnapshot);
+      raft.updateCurrentSnapshot();
       onSnapshotReceiveCompletedOrAborted();
     } else {
       setNextExpected(request.nextChunkId());

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -48,6 +48,7 @@ import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
 import io.camunda.zeebe.journal.JournalException.InvalidIndex;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -187,8 +188,16 @@ public class PassiveRole extends InactiveRole {
                     .build()));
       }
 
-      pendingSnapshot =
-          raft.getPersistedSnapshotStore().newReceivedSnapshot(snapshotChunk.getSnapshotId());
+      try {
+        pendingSnapshot =
+            raft.getPersistedSnapshotStore().newReceivedSnapshot(snapshotChunk.getSnapshotId());
+      } catch (final SnapshotAlreadyExistsException snapshotAlreadyExists) {
+        // This should not happen because we previously check for the latest snapshot. But, if it
+        // happens, instead of crashing raft thread, we respond with success because we already have
+        // the snapshot.
+        return CompletableFuture.completedFuture(
+            logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
+      }
       log.info("Started receiving new snapshot {} from {}", pendingSnapshot, request.leader());
       pendingSnapshotStartTimestamp = System.currentTimeMillis();
       snapshotReplicationMetrics.incrementCount();

--- a/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
@@ -24,8 +24,13 @@ import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class DeterministicSingleThreadContext implements ThreadContext {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DeterministicSingleThreadContext.class);
 
   private final DeterministicScheduler deterministicScheduler;
 
@@ -108,8 +113,8 @@ public final class DeterministicSingleThreadContext implements ThreadContext {
       try {
         command.run();
       } catch (final Exception e) {
-        e.printStackTrace();
-        fail("Uncaught exception");
+        LOGGER.error("Uncaught exception", e);
+        fail("Uncaught exception" + e);
       }
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -254,4 +254,19 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
         && id.equals(that.id)
         && chunks.equals(that.chunks);
   }
+
+  @Override
+  public String toString() {
+    return "InMemorySnapshot{"
+        + "index="
+        + index
+        + ", term="
+        + term
+        + ", id='"
+        + id
+        + '\''
+        + ", checksum="
+        + checksum
+        + '}';
+  }
 }


### PR DESCRIPTION
## Description

The current snapshot is updated two ways.
1. When a new snapshot is committed by the SnapshotStore, and the listener is executed
   asynchrously.
2. When the follower recieves a snapshot, the current snapshot is updated immediately after
   it is committed.

Since the listener from step 1 is scheduled on the Raft context, it might be executed after
another `InstallRequest` is processed. If that happens, the listener might overwrite the
`currentSnapshot` with an older one. Eventually the cached snapshot will be updated to the latest
one. But there can be a short time when it is not reflecting the latest one. This can
cause issues in append requests and install requests.

A specific scenario is described [here](https://github.com/camunda/zeebe/issues/14694#issuecomment-1794824736)

To prevent this race condition, we update the cached snapshot by directly reading it from the
persisted snapshot store. This way the out of order execution of the listener will not
overwrite the current snapshot info. The listener is just a way to notify that a new snapshot
is available in the snapshot store.

## Related issues

closes #14694 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
