### PR TITLE
Adding new command intents for the timeout update

### DIFF
--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -44,7 +44,10 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   RECURRED_AFTER_BACKOFF((short) 14),
 
   YIELD((short) 15),
-  YIELDED((short) 16);
+  YIELDED((short) 16),
+
+  UPDATE_TIMEOUT((short) 17),
+  TIMEOUT_UPDATED((short) 18);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -98,6 +101,10 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
         return YIELD;
       case 16:
         return YIELDED;
+      case 17:
+        return UPDATE_TIMEOUT;
+      case 18:
+        return TIMEOUT_UPDATED;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

I've added the following intents:

UPDATE_TIMEOUT
This command will look for the Job in the state and for it's deadline. If it can't find one of those it will return a NOT_FOUND rejection. Otherwise it will write the TIMEOUT_UPDATED event which will modify the deadline in the state.

TIMEOUT_UPDATED
This event will update the JOB_DEADLINES ColumnFamily. Since the key of this ColumnFamily is deadline-jockey we can't just update the existing one. Instead we will need to remove the existing entry for this Job, and
 insert a new value. For this we must have access to the old deadline.
 This is stored in state and should available through the JobRecord.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15034 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
