### PR TITLE
test(gateway): prevent test failures when topology update runs late

### DIFF
--- a/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -104,6 +105,9 @@ public final class BrokerClientTest {
           topology.addBrokerIfAbsent(0);
           topology.setBrokerAddressIfPresent(0, stubAddress.toString());
         });
+    Awaitility.await("Topology is updated")
+        .untilAsserted(
+            () -> assertThat(topologyManager.getTopology().getPartitions()).isNotEmpty());
 
     client =
         new BrokerClientImpl(


### PR DESCRIPTION
This adds a waiting step to ensure that updating the topology takes effect before making the first requests.
Alternatively, we would have to use the controllable actor scheduler to wait for the update job to run or change the topology manager api to return a future instead of void. Both of the alternatives appeared to be more work with little benefit.

This is not backported because these issues were most likely introduced with various refactorings related to dynamic scaling.

Closes #14895 
Closes #14954