### PR TITLE
Create timeout update applier

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -182,6 +182,7 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.RETRIES_UPDATED, new JobRetriesUpdatedApplier(state));
     register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
     register(JobIntent.RECURRED_AFTER_BACKOFF, new JobRecurredApplier(state));
+    register(JobIntent.TIMEOUT_UPDATED, new JobTimeoutUpdatedApplier(state));
   }
 
   private void registerMessageAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobTimeoutUpdatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobTimeoutUpdatedApplier.java
@@ -22,5 +22,7 @@ public class JobTimeoutUpdatedApplier implements TypedEventApplier<JobIntent, Jo
   }
 
   @Override
-  public void applyState(final long key, final JobRecord value) {}
+  public void applyState(final long key, final JobRecord value) {
+    jobState.updateJobDeadline(key, value.getTimeout());
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobTimeoutUpdatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobTimeoutUpdatedApplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+public class JobTimeoutUpdatedApplier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+
+  public JobTimeoutUpdatedApplier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -256,9 +256,9 @@ public final class DbJobState implements JobState, MutableJobState {
     final JobRecord job = getJob(jobKey);
 
     if (job != null) {
-      final long deadline = job.getDeadline();
+      final long oldDeadline = job.getDeadline();
 
-      deadlineKey.wrapLong(deadline);
+      deadlineKey.wrapLong(oldDeadline);
       deadlinesColumnFamily.deleteExisting(deadlineJobKey);
 
       job.setDeadline(newDeadline);
@@ -375,6 +375,13 @@ public final class DbJobState implements JobState, MutableJobState {
       return jobRecord;
     }
     return null;
+  }
+
+  @Override
+  public boolean jobDeadlineExists(final long jobKey, final long deadline) {
+    this.jobKey.wrapLong(jobKey);
+    deadlineKey.wrapLong(deadline);
+    return deadlinesColumnFamily.exists(deadlineJobKey);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -250,6 +250,24 @@ public final class DbJobState implements JobState, MutableJobState {
         });
   }
 
+  @Override
+  public void updateJobDeadline(final long jobKey, final long newDeadline) {
+    this.jobKey.wrapLong(jobKey);
+    final JobRecord job = getJob(jobKey);
+
+    if (job != null) {
+      final long deadline = job.getDeadline();
+
+      deadlineKey.wrapLong(deadline);
+      deadlinesColumnFamily.deleteExisting(deadlineJobKey);
+
+      job.setDeadline(newDeadline);
+      updateJobRecord(jobKey, job);
+
+      addJobDeadline(jobKey, newDeadline);
+    }
+  }
+
   private void createJob(final long key, final JobRecord record, final DirectBuffer type) {
     createJobRecord(key, record);
     initializeJobState();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -378,13 +378,6 @@ public final class DbJobState implements JobState, MutableJobState {
   }
 
   @Override
-  public boolean jobDeadlineExists(final long jobKey, final long deadline) {
-    this.jobKey.wrapLong(jobKey);
-    deadlineKey.wrapLong(deadline);
-    return deadlinesColumnFamily.exists(deadlineJobKey);
-  }
-
-  @Override
   public long findBackedOffJobs(final long timestamp, final BiPredicate<Long, JobRecord> callback) {
     nextBackOffDueDate = -1L;
     backoffColumnFamily.whileTrue(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -41,4 +41,6 @@ public interface MutableJobState extends JobState {
   void cleanupTimeoutsWithoutJobs();
 
   void cleanupBackoffsWithoutJobs();
+
+  void updateJobDeadline(long jobKey, long newDeadline);
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -354,6 +354,35 @@ public final class JobStateTest {
   }
 
   @Test
+  public void shouldUpdateDeadline() {
+    // given
+    final long jobKey = 1L;
+    final long deadline = 300000;
+    final long newDeadline = 600000;
+    final JobRecord jobRecord = newJobRecord().setDeadline(deadline);
+    jobState.create(jobKey, jobRecord);
+    jobState.activate(jobKey, jobRecord);
+
+    // when
+    jobState.updateJobDeadline(jobKey, newDeadline);
+
+    // then
+    assertThat(jobState.exists(jobKey)).isTrue();
+    assertThat(jobState.getJob(jobKey).getDeadline()).isEqualTo(newDeadline);
+
+    final List<JobRecord> timedOutJobs = new ArrayList<>();
+    jobState.forEachTimedOutEntry(
+        newDeadline + 1,
+        (key, value) -> {
+          timedOutJobs.add(value);
+          return true;
+        });
+
+    assertThat(timedOutJobs.size()).isEqualTo(1);
+    assertThat(timedOutJobs.get(0).getDeadline()).isEqualTo(newDeadline);
+  }
+
+  @Test
   public void shouldFailJobWithRetriesLeft() {
     // given
     final long key = 1L;

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -77,6 +77,9 @@
                 "deadline": {
                   "type": "date"
                 },
+                "timeout": {
+                  "type": "long"
+                },
                 "variables": {
                   "enabled": false
                 },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -58,6 +58,9 @@
             "deadline": {
               "type": "long"
             },
+            "timeout": {
+              "type": "long"
+            },
             "variables": {
               "enabled": false
             },

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -77,6 +77,9 @@
                 "deadline": {
                   "type": "date"
                 },
+                "timeout": {
+                  "type": "long"
+                },
                 "variables": {
                   "enabled": false
                 },

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -58,6 +58,9 @@
             "deadline": {
               "type": "long"
             },
+            "timeout": {
+              "type": "long"
+            },
             "variables": {
               "enabled": false
             },

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -40,6 +40,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   private final StringProperty workerProp = new StringProperty("worker", EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty("deadline", -1);
+  private final LongProperty timeoutProp = new LongProperty("timeout", -1);
   private final IntegerProperty retriesProp = new IntegerProperty(RETRIES, -1);
   private final LongProperty retryBackoffProp = new LongProperty("retryBackoff", 0);
   private final LongProperty recurringTimeProp = new LongProperty("recurringTime", -1);
@@ -65,6 +66,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord() {
     declareProperty(deadlineProp)
+        .declareProperty(timeoutProp)
         .declareProperty(workerProp)
         .declareProperty(retriesProp)
         .declareProperty(retryBackoffProp)
@@ -85,6 +87,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public void wrapWithoutVariables(final JobRecord record) {
     deadlineProp.setValue(record.getDeadline());
+    timeoutProp.setValue(record.getTimeout());
     workerProp.setValue(record.getWorkerBuffer());
     retriesProp.setValue(record.getRetries());
     retryBackoffProp.setValue(record.getRetryBackoff());
@@ -161,6 +164,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @Override
   public long getDeadline() {
     return deadlineProp.getValue();
+  }
+
+  @Override
+  public long getTimeout() {
+    return timeoutProp.getValue();
   }
 
   @Override
@@ -244,6 +252,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setErrorMessage(final DirectBuffer buf) {
     return setErrorMessage(buf, 0, buf.capacity());
+  }
+
+  public JobRecord setTimeout(final long val) {
+    timeoutProp.setValue(val);
+    return this;
   }
 
   public JobRecord setDeadline(final long val) {

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -637,6 +637,7 @@ final class JsonSerializableToJsonTest {
               "errorCode": "error",
               "customHeaders": {},
               "deadline": 1000,
+              "timeout": -1,
               "tenantId": "<default>"
             }
           ],
@@ -679,6 +680,7 @@ final class JsonSerializableToJsonTest {
               final String type = "myType";
               final int retries = 12;
               final int deadline = 13;
+              final int timeout = 14;
 
               final String bpmnProcessId = "test-process";
               final int processDefinitionKey = 13;
@@ -699,6 +701,7 @@ final class JsonSerializableToJsonTest {
                       .setRetryBackoff(1003)
                       .setRecurringTime(1004)
                       .setDeadline(deadline)
+                      .setTimeout(timeout)
                       .setErrorMessage("failed message")
                       .setErrorCode(wrapString("error"))
                       .setBpmnProcessId(wrapString(bpmnProcessId))
@@ -733,6 +736,7 @@ final class JsonSerializableToJsonTest {
             "workerVersion": "42"
           },
           "deadline": 13,
+          "timeout": 14,
           "tenantId": "<default>"
         }
         """
@@ -762,6 +766,7 @@ final class JsonSerializableToJsonTest {
           "errorCode": "",
           "customHeaders": {},
           "deadline": -1,
+          "timeout": -1,
           "tenantId": "<default>"
         }
         """
@@ -789,6 +794,7 @@ final class JsonSerializableToJsonTest {
             "foo": null
           },
           "deadline": -1,
+          "timeout": -1,
           "worker": "",
           "retries": -1,
           "retryBackoff": 0,

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -72,6 +72,12 @@ public interface JobRecordValue
   long getDeadline();
 
   /**
+   * @return the duration used to update the deadline. If this property is not set it will return
+   *     '-1'.
+   */
+  long getTimeout();
+
+  /**
    * @return the message that contains additional context of the failure/error. It is set by the job
    *     worker then the processing fails because of a technical failure or a non-technical error.
    */


### PR DESCRIPTION
## Description

The following changes were made:

- Added `JobTimeoutUpdatedApplier`
- Added `timeoutProperty` to `JobRecord`
- Added `timeout` property to Elasticsearch and OpenSearch templates
- Added `updateJobDeadline` method to `DbJobState` to change the deadline in the state
- Added corresponding unit test

`updateJobDeadline` does the following:
- Deletes the old deadline from the column family
- Updates `JobRecord` `deadline` property
- Inserts the new deadline into the column family

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15035

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
