### PR TITLE
Backoff retrying failed topology change operation

### DIFF
--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -92,7 +92,8 @@ final class ClusterTopologyManagerTest {
             new TestConcurrencyControl(),
             localMemberId,
             persistedClusterTopology,
-            Duration.ofMillis(100));
+            Duration.ofMillis(100),
+            Duration.ofMillis(200));
     clusterTopologyManager.setTopologyGossiper(gossipHandler);
     return clusterTopologyManager;
   }

--- a/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoffRetryDelay.java
+++ b/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoffRetryDelay.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import java.time.Duration;
+
+/** Retry delay strategy that uses {@link ExponentialBackoff} to calculate the next retry delay. */
+public class ExponentialBackoffRetryDelay implements RetryDelayStrategy {
+
+  private final ExponentialBackoff exponentialBackoff;
+  private long currentDelay = 0; // starts with minDelay
+
+  public ExponentialBackoffRetryDelay(final Duration maxDelay, final Duration minDelay) {
+    exponentialBackoff = new ExponentialBackoff(maxDelay.toMillis(), minDelay.toMillis());
+  }
+
+  @Override
+  public Duration nextDelay() {
+    currentDelay = exponentialBackoff.supplyRetryDelay(currentDelay);
+    return Duration.ofMillis(currentDelay);
+  }
+
+  @Override
+  public void reset() {
+    currentDelay = 0;
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/RetryDelayStrategy.java
+++ b/util/src/main/java/io/camunda/zeebe/util/RetryDelayStrategy.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import java.time.Duration;
+
+public interface RetryDelayStrategy {
+
+  /**
+   * @return the duration for the next retry
+   */
+  Duration nextDelay();
+
+  /** resets the retry delay to the initial value */
+  void reset();
+}


### PR DESCRIPTION
## Description

Apply a backoff when retrying failed topology change operation.

## Related issues

related #14959 
