### PR TITLE
fix: use an executor when handling topology requests

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -84,7 +84,9 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
 
   @Override
   public ActorFuture<ClusterTopology> getClusterTopology() {
-    return executor.call(persistedClusterTopology::getTopology);
+    final var future = executor.<ClusterTopology>createFuture();
+    executor.run(() -> future.complete(persistedClusterTopology.getTopology()));
+    return future;
   }
 
   @Override

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -97,22 +97,24 @@ public final class TopologyManagementRequestsHandler implements TopologyManageme
   private ActorFuture<TopologyChangeResponse> handleRequest(
       final TopologyChangeRequest transformer) {
     final ActorFuture<TopologyChangeResponse> responseFuture = executor.createFuture();
-    coordinator
-        .applyOperations(transformer)
-        .onComplete(
-            (result, error) -> {
-              if (error == null) {
-                final var changeStatus =
-                    new TopologyChangeResponse(
-                        result.changeId(),
-                        result.currentTopology().members(),
-                        result.finalTopology().members(),
-                        result.operations());
-                responseFuture.complete(changeStatus);
-              } else {
-                responseFuture.completeExceptionally(error);
-              }
-            });
+    executor.run(
+        () ->
+            coordinator
+                .applyOperations(transformer)
+                .onComplete(
+                    (result, error) -> {
+                      if (error == null) {
+                        final var changeStatus =
+                            new TopologyChangeResponse(
+                                result.changeId(),
+                                result.currentTopology().members(),
+                                result.finalTopology().members(),
+                                result.operations());
+                        responseFuture.complete(changeStatus);
+                      } else {
+                        responseFuture.completeExceptionally(error);
+                      }
+                    }));
     return responseFuture;
   }
 }


### PR DESCRIPTION
Gets rid of at least some of the warning logs when requesting and applying topology changes.