### PR TITLE
[Backport stable/8.2] Fix race condition between snapshot listener and updating currentSnapshot by PassiveRole

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -249,6 +249,7 @@ public class PassiveRole extends InactiveRole {
       pendingSnapshotStartTimestamp = 0L;
       snapshotReplicationMetrics.decrementCount();
       snapshotReplicationMetrics.observeDuration(elapsed);
+      raft.updateCurrentSnapshot();
       onSnapshotReceiveCompletedOrAborted();
     } else {
       setNextExpected(request.nextChunkId());

--- a/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
@@ -24,8 +24,13 @@ import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class DeterministicSingleThreadContext implements ThreadContext {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DeterministicSingleThreadContext.class);
 
   private final DeterministicScheduler deterministicScheduler;
 
@@ -108,8 +113,8 @@ public final class DeterministicSingleThreadContext implements ThreadContext {
       try {
         command.run();
       } catch (final Exception e) {
-        e.printStackTrace();
-        fail("Uncaught exception");
+        LOGGER.error("Uncaught exception", e);
+        fail("Uncaught exception" + e);
       }
     }
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -254,4 +254,19 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
         && id.equals(that.id)
         && chunks.equals(that.chunks);
   }
+
+  @Override
+  public String toString() {
+    return "InMemorySnapshot{"
+        + "index="
+        + index
+        + ", term="
+        + term
+        + ", id='"
+        + id
+        + '\''
+        + ", checksum="
+        + checksum
+        + '}';
+  }
 }


### PR DESCRIPTION
Backport of #15046

closes #14694 

Auto-backport failed because `RaftContext` and `PassiveRole` differs a lot from main. A fix from a previous PR which updates the current snapshot in PassiveRole after committing the snapshot was not backported. That is also added here.

