### PR TITLE
fix(renovate): add missing colon to message prefix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:base"
   ],
-  "commitMessagePrefix": "deps({{datasource}})",
+  "commitMessagePrefix": "deps({{datasource}}):",
   "baseBranches": [
     "main",
     "/^stable\\/8\\..*/"


### PR DESCRIPTION
## Description

This was missing and violating https://github.com/camunda/zeebe/blob/main/CONTRIBUTING.md/#commit-message-header

## Related issues

relates to #14701