### PR TITLE
Map update GRPc request and response

### DIFF
--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -546,6 +546,16 @@ message UpdateJobRetriesRequest {
 message UpdateJobRetriesResponse {
 }
 
+message UpdateJobTimeoutRequest {
+  // the unique job identifier, as obtained from ActivateJobsResponse
+  int64 jobKey = 1;
+  // the duration of the new timeout in ms, starting from the current moment
+  string timeout = 2;
+}
+
+message UpdateJobTimeoutResponse {
+}
+
 message SetVariablesRequest {
   // the unique identifier of a particular element; can be the process instance key (as
   // obtained during instance creation), or a given element, such as a service task (see
@@ -876,6 +886,20 @@ service Gateway {
    */
   rpc ModifyProcessInstance (ModifyProcessInstanceRequest) returns (ModifyProcessInstanceResponse) {
 
+  }
+
+  /*
+  Updates the deadline of a job using the timeout (in ms) provided. This can be used
+  for extending or shortening the job deadline.
+
+  Errors:
+    NOT_FOUND:
+      - no job exists with the given key
+
+    INVALID_STATE:
+      - no deadline exists for the given job key
+ */
+  rpc UpdateJobTimeout (UpdateJobTimeoutRequest) returns (UpdateJobTimeoutResponse) {
   }
 
   /*

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -550,7 +550,7 @@ message UpdateJobTimeoutRequest {
   // the unique job identifier, as obtained from ActivateJobsResponse
   int64 jobKey = 1;
   // the duration of the new timeout in ms, starting from the current moment
-  string timeout = 2;
+  int64 timeout = 2;
 }
 
 message UpdateJobTimeoutResponse {

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -1060,6 +1060,24 @@
             "name": "UpdateJobRetriesResponse"
           },
           {
+            "name": "UpdateJobTimeoutRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobKey",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "timeout",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "UpdateJobTimeoutResponse"
+          },
+          {
             "name": "SetVariablesRequest",
             "fields": [
               {
@@ -1307,6 +1325,11 @@
                 "name": "ModifyProcessInstance",
                 "in_type": "ModifyProcessInstanceRequest",
                 "out_type": "ModifyProcessInstanceResponse"
+              },
+              {
+                "name": "UpdateJobTimeout",
+                "in_type": "UpdateJobTimeoutRequest",
+                "out_type": "UpdateJobTimeoutResponse"
               },
               {
                 "name": "DeleteResource",

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -64,6 +64,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutResponse;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.VersionUtil;
@@ -361,6 +363,16 @@ public final class EndpointManager {
         request,
         RequestMapper::toUpdateJobRetriesRequest,
         ResponseMapper::toUpdateJobRetriesResponse,
+        responseObserver);
+  }
+
+  public void updateJobTimeout(
+      final UpdateJobTimeoutRequest request,
+      final ServerStreamObserver<UpdateJobTimeoutResponse> responseObserver) {
+    sendRequest(
+        request,
+        RequestMapper::toUpdateJobTimeoutRequest,
+        ResponseMapper::toUpdateJobTimeoutResponse,
         responseObserver);
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
@@ -47,6 +47,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutResponse;
 import io.grpc.stub.StreamObserver;
 
 public class GatewayGrpcService extends GatewayImplBase {
@@ -184,6 +186,14 @@ public class GatewayGrpcService extends GatewayImplBase {
       final ModifyProcessInstanceRequest request,
       final StreamObserver<ModifyProcessInstanceResponse> responseObserver) {
     endpointManager.modifyProcessInstance(
+        request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
+  }
+
+  @Override
+  public void updateJobTimeout(
+      final UpdateJobTimeoutRequest request,
+      final StreamObserver<UpdateJobTimeoutResponse> responseObserver) {
+    endpointManager.updateJobTimeout(
         request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerResolveIncidentRequest
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerThrowErrorRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobRetriesRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobTimeoutRequest;
 import io.camunda.zeebe.gateway.interceptors.impl.IdentityInterceptor;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
@@ -50,6 +51,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.SetVariablesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -123,6 +125,11 @@ public final class RequestMapper {
   public static BrokerUpdateJobRetriesRequest toUpdateJobRetriesRequest(
       final UpdateJobRetriesRequest grpcRequest) {
     return new BrokerUpdateJobRetriesRequest(grpcRequest.getJobKey(), grpcRequest.getRetries());
+  }
+
+  public static BrokerUpdateJobTimeoutRequest toUpdateJobTimeoutRequest(
+      final UpdateJobTimeoutRequest grpcRequest) {
+    return new BrokerUpdateJobTimeoutRequest(grpcRequest.getJobKey(), grpcRequest.getTimeout());
   }
 
   public static BrokerFailJobRequest toFailJobRequest(final FailJobRequest grpcRequest) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentRespon
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.SetVariablesResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutResponse;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -147,6 +148,11 @@ public final class ResponseMapper {
   public static UpdateJobRetriesResponse toUpdateJobRetriesResponse(
       final long key, final JobRecord brokerResponse) {
     return UpdateJobRetriesResponse.getDefaultInstance();
+  }
+
+  public static UpdateJobTimeoutResponse toUpdateJobTimeoutResponse(
+      final long key, final JobRecord brokerResponse) {
+    return UpdateJobTimeoutResponse.getDefaultInstance();
   }
 
   public static FailJobResponse toFailJobResponse(final long key, final JobRecord brokerResponse) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobTimeoutRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobTimeoutRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerUpdateJobTimeoutRequest extends BrokerExecuteCommand<JobRecord> {
+
+  private final JobRecord requestDto = new JobRecord();
+
+  public BrokerUpdateJobTimeoutRequest(final long jobKey, final long timeout) {
+    super(ValueType.JOB, JobIntent.UPDATE_TIMEOUT);
+    request.setKey(jobKey);
+    requestDto.setTimeout(timeout);
+  }
+
+  @Override
+  public JobRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected JobRecord toResponseDto(final DirectBuffer buffer) {
+    final JobRecord responseDto = new JobRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/UpdateJobTimeoutStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/UpdateJobTimeoutStub.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.api.job;
+
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobTimeoutRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+
+public class UpdateJobTimeoutStub extends JobRequestStub
+    implements RequestStub<BrokerUpdateJobTimeoutRequest, BrokerResponse<JobRecord>> {
+
+  @Override
+  public void registerWith(final StubbedBrokerClient gateway) {
+    gateway.registerHandler(BrokerUpdateJobTimeoutRequest.class, this);
+  }
+
+  @Override
+  public BrokerResponse<JobRecord> handle(final BrokerUpdateJobTimeoutRequest request)
+      throws Exception {
+    final JobRecord value = buildDefaultValue();
+    value.setTimeout(request.getRequestWriter().getTimeout());
+
+    return new BrokerResponse<>(value, 0, request.getKey());
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/UpdateJobTimeoutTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/UpdateJobTimeoutTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.api.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobTimeoutRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutResponse;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import org.junit.Test;
+
+public class UpdateJobTimeoutTest extends GatewayTest {
+
+  @Test
+  public void shouldMapRequestAndResponse() {
+    // given
+    final UpdateJobTimeoutStub stub = new UpdateJobTimeoutStub();
+    stub.registerWith(brokerClient);
+
+    final long timeout = 100000;
+
+    final UpdateJobTimeoutRequest request =
+        UpdateJobTimeoutRequest.newBuilder().setJobKey(stub.getKey()).setTimeout(timeout).build();
+
+    // when
+    final UpdateJobTimeoutResponse response = client.updateJobTimeout(request);
+
+    // then
+    assertThat(response).isNotNull();
+
+    final BrokerUpdateJobTimeoutRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
+    assertThat(brokerRequest.getIntent()).isEqualTo(JobIntent.UPDATE_TIMEOUT);
+    assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.JOB);
+
+    final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
+    assertThat(brokerRequestValue.getTimeout()).isEqualTo(timeout);
+  }
+}


### PR DESCRIPTION
## Description

Mapped the `UpdateJobTimeout` request to a `JobRecord`
Created a `toUpdateJobTimeoutRequest` method in the `RequestMapper`
Created a `BrokerUpdateJobTimeoutRequest` object

Mapped the broker response to a `UpdateJobTimeoutResponse`
Created a `toUpdateJobTimeoutResponse` method on the `ResponseMapper`

Created the `UpdateJobTimeout` request in the `EndpointManager`
Created a `updateJobTimeout` method in the `EndpointManager`

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15038
closes #15037 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
