### PR TITLE
Cache scheduled written commands and prevent duplicate writes

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
@@ -38,10 +38,6 @@ public final class BoundedCommandCache {
     this(capacity, ignored -> {});
   }
 
-  public BoundedCommandCache() {
-    this(ignored -> {});
-  }
-
   /** Returns a bounded cache which will report size changes to the given consumer. */
   public BoundedCommandCache(final IntConsumer sizeReporter) {
     this(DEFAULT_CAPACITY, sizeReporter);

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
@@ -61,6 +61,7 @@ public final class BoundedCommandCache {
     final var resizeThreshold = (int) Math.ceil(capacity * 0.9f);
     final var capacityToPreventResize = 2 * capacity - resizeThreshold;
     cache = new LongHashSet(capacityToPreventResize, 0.9f, true);
+    sizeReporter.accept(0);
   }
 
   public void add(final LongHashSet keys) {
@@ -82,6 +83,15 @@ public final class BoundedCommandCache {
 
   public int size() {
     return LockUtil.withLock(lock, cache::size);
+  }
+
+  public void clear() {
+    LockUtil.withLock(
+        lock,
+        () -> {
+          cache.clear();
+          sizeReporter.accept(0);
+        });
   }
 
   private void lockedAdd(final LongHashSet keys) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
@@ -34,6 +34,10 @@ public final class BoundedCommandCache {
   private final LongHashSet cache;
   private final IntConsumer sizeReporter;
 
+  public BoundedCommandCache(final int capacity) {
+    this(capacity, ignored -> {});
+  }
+
   public BoundedCommandCache() {
     this(ignored -> {});
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.engine.impl;
+
+import io.camunda.zeebe.util.LockUtil;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.agrona.collections.LongHashSet;
+
+final class BoundedCommandCache {
+  private static final int DEFAULT_CAPACITY = 100_000;
+
+  private final Lock lock = new ReentrantLock();
+
+  private final int capacity;
+  private final LongHashSet cache;
+
+  BoundedCommandCache() {
+    this(DEFAULT_CAPACITY);
+  }
+
+  /**
+   * You can estimate the size based on the capacity as followed. Since we use a {@link LongHashSet}
+   * primitives, each element takes about 8 bytes. There is some minimal overhead for state
+   * management and the likes, which means in the end, amortized, each entry takes about 8.4 bytes.
+   *
+   * <p>So the default capacity, 100,000 entries, will use about 840KB of memory, even when full.
+   *
+   * @param capacity the maximum capacity of the command cache
+   */
+  BoundedCommandCache(final int capacity) {
+    this.capacity = capacity;
+
+    // to avoid resizing, we set a load factor of 0.9, and increase the internal capacity
+    // preemptively
+    final var resizeThreshold = (int) Math.ceil(capacity * 0.9f);
+    final var capacityToPreventResize = 2 * capacity - resizeThreshold;
+    cache = new LongHashSet(capacityToPreventResize, 0.9f, true);
+  }
+
+  void add(final LongHashSet keys) {
+    LockUtil.withLock(lock, () -> lockedAdd(keys));
+  }
+
+  boolean contains(final long key) {
+    return LockUtil.withLock(lock, () -> cache.contains(key));
+  }
+
+  void remove(final long key) {
+    LockUtil.withLock(lock, (Runnable) () -> cache.remove(key));
+  }
+
+  private void lockedAdd(final LongHashSet keys) {
+    final int evictionCount = cache.size() + keys.size() - capacity;
+    if (evictionCount > 0) {
+      evict(evictionCount);
+    }
+
+    cache.addAll(keys);
+  }
+
+  private void evict(final int count) {
+    final var evictionStartIndex = ThreadLocalRandom.current().nextInt(0, capacity - count);
+    final int evictionEndIndex = evictionStartIndex + count;
+    final var iterator = cache.iterator();
+
+    for (int i = 0; i < evictionEndIndex && iterator.hasNext(); i++, iterator.next()) {
+      if (i >= evictionStartIndex) {
+        iterator.remove();
+      }
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableSch
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.agrona.collections.LongHashSet;
@@ -80,6 +81,11 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
   }
 
   @Override
+  public void clear() {
+    caches.values().forEach(BoundedCommandCache::clear);
+  }
+
+  @Override
   public StagedScheduledCommandCache stage() {
     return new StagedCache();
   }
@@ -101,6 +107,11 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
     @Override
     public void remove(final Intent intent, final long key) {
       stagedKeys(intent).remove(key);
+    }
+
+    @Override
+    public void clear() {
+      stagedKeys.values().forEach(Set::clear);
     }
 
     @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -95,12 +95,7 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
 
     @Override
     public void remove(final Intent intent, final long key) {
-      if (!stagedKeys(intent).remove(key)) {
-        final var cache = caches.get(intent);
-        if (cache != null) {
-          cache.remove(key);
-        }
-      }
+      stagedKeys(intent).remove(key);
     }
 
     @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -25,6 +25,7 @@ import org.agrona.collections.LongHashSet;
  * <p>NOTE: the staged cache return via {@link #stage()} is not thread-safe!
  */
 public final class BoundedScheduledCommandCache implements StageableScheduledCommandCache {
+
   private final Map<Intent, BoundedCommandCache> caches;
 
   /**
@@ -43,10 +44,14 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
    * @param intents the intents to cache
    * @return a thread-safe command cache
    */
-  public static BoundedScheduledCommandCache ofIntent(final Intent... intents) {
+  public static BoundedScheduledCommandCache ofIntent(
+      final ScheduledCommandCacheMetrics metrics, final Intent... intents) {
     final Map<Intent, BoundedCommandCache> caches =
         Arrays.stream(intents)
-            .collect(Collectors.toMap(Function.identity(), ignored -> new BoundedCommandCache()));
+            .collect(
+                Collectors.toMap(
+                    Function.identity(),
+                    intent -> new BoundedCommandCache(metrics.forIntent(intent))));
     return new BoundedScheduledCommandCache(caches);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.engine.impl;
+
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.agrona.collections.LongHashSet;
+
+public final class BoundedScheduledCommandCache implements StageableScheduledCommandCache {
+  private final Map<Intent, BoundedCommandCache> caches;
+
+  private BoundedScheduledCommandCache(final Map<Intent, BoundedCommandCache> caches) {
+    this.caches = caches;
+  }
+
+  public static BoundedScheduledCommandCache ofIntent(final Intent... intents) {
+    final Map<Intent, BoundedCommandCache> caches =
+        Arrays.stream(intents)
+            .collect(Collectors.toMap(Function.identity(), ignored -> new BoundedCommandCache()));
+    return new BoundedScheduledCommandCache(caches);
+  }
+
+  @Override
+  public void add(final Intent intent, final long key) {
+    final var cache = caches.get(intent);
+    if (cache != null) {
+      final var singleton = new LongHashSet();
+      singleton.add(key);
+      cache.add(singleton);
+    }
+  }
+
+  @Override
+  public boolean isCached(final Intent intent, final long key) {
+    final var cache = caches.get(intent);
+    return cache != null && cache.contains(key);
+  }
+
+  @Override
+  public void remove(final Intent intent, final long key) {
+    final var cache = caches.get(intent);
+    if (cache != null) {
+      cache.remove(key);
+    }
+  }
+
+  @Override
+  public StagedScheduledCommandCache stage() {
+    return new StagedCache();
+  }
+
+  private final class StagedCache implements StagedScheduledCommandCache {
+    private final Map<Intent, LongHashSet> stagedKeys = new HashMap<>();
+
+    @Override
+    public void add(final Intent intent, final long key) {
+      stagedKeys(intent).add(key);
+    }
+
+    @Override
+    public boolean isCached(final Intent intent, final long key) {
+      return stagedKeys(intent).contains(key)
+          || (caches.containsKey(intent) && caches.get(intent).contains(key));
+    }
+
+    @Override
+    public void remove(final Intent intent, final long key) {
+      if (!stagedKeys(intent).remove(key)) {
+        final var cache = caches.get(intent);
+        if (cache != null) {
+          cache.remove(key);
+        }
+      }
+    }
+
+    @Override
+    public void persist() {
+      for (final var entry : stagedKeys.entrySet()) {
+        final var cache = caches.get(entry.getKey());
+        if (cache != null) {
+          cache.add(entry.getValue());
+        }
+      }
+    }
+
+    private LongHashSet stagedKeys(final Intent intent) {
+      return stagedKeys.computeIfAbsent(intent, ignored -> new LongHashSet());
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/ScheduledCommandCacheMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/ScheduledCommandCacheMetrics.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.engine.impl;
+
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.prometheus.client.Gauge;
+import java.util.function.IntConsumer;
+
+/** Defines metrics for scheduled command cache implementations. */
+public interface ScheduledCommandCacheMetrics {
+
+  /**
+   * Returns a consumer for a given intent, which will be called whenever the underlying cache for
+   * this intent changes size.
+   */
+  IntConsumer forIntent(final Intent intent);
+
+  /**
+   * A metrics implementation specifically for the {@link
+   * io.camunda.zeebe.broker.engine.impl.BoundedScheduledCommandCache}.
+   */
+  class BoundedCommandCacheMetrics implements ScheduledCommandCacheMetrics {
+    private static final Gauge SIZE =
+        Gauge.build()
+            .namespace("zeebe")
+            .subsystem("stream_processor")
+            .name("scheduled_command_cache_size")
+            .labelNames("partitionId", "intent")
+            .help("Reports the size of each bounded cache per partition and intent")
+            .register();
+
+    private final String partitionId;
+
+    public BoundedCommandCacheMetrics(final int partitionId) {
+      this.partitionId = String.valueOf(partitionId);
+    }
+
+    @Override
+    public IntConsumer forIntent(final Intent intent) {
+      return SIZE.labels(partitionId, intent.name())::set;
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.NoopScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.impl.BufferedTaskResultBuilder;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
@@ -62,7 +63,8 @@ final class RemoteJobStreamErrorHandler implements RemoteStreamErrorHandler<Acti
       return;
     }
 
-    final var resultBuilder = new BufferedTaskResultBuilder(writer::canWriteEvents);
+    final var resultBuilder =
+        new BufferedTaskResultBuilder(writer::canWriteEvents, new NoopScheduledCommandCache());
     errorHandler.handleError(job, error, resultBuilder);
 
     final var result = resultBuilder.build();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -8,10 +8,14 @@
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.engine.impl.BoundedScheduledCommandCache;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.engine.Engine;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -135,6 +139,12 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
     final var engine = new Engine(context.getTypedRecordProcessorFactory(), engineCfg);
     final List<RecordProcessor> recordProcessors =
         List.of(engine, context.getCheckpointProcessor());
+    final var scheduledCommandCache =
+        BoundedScheduledCommandCache.ofIntent(
+            TimerIntent.TRIGGER,
+            JobIntent.TIME_OUT,
+            JobIntent.RECUR_AFTER_BACKOFF,
+            MessageIntent.EXPIRE);
 
     return StreamProcessor.builder()
         .logStream(context.getLogStream())
@@ -158,6 +168,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
             })
         .streamProcessorMode(streamProcessorMode)
         .partitionCommandSender(context.getPartitionCommandSender())
+        .scheduledCommandCache(scheduledCommandCache)
         .build();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.engine.impl.BoundedScheduledCommandCache;
+import io.camunda.zeebe.broker.engine.impl.ScheduledCommandCacheMetrics.BoundedCommandCacheMetrics;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.engine.Engine;
@@ -141,6 +142,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         List.of(engine, context.getCheckpointProcessor());
     final var scheduledCommandCache =
         BoundedScheduledCommandCache.ofIntent(
+            new BoundedCommandCacheMetrics(context.getPartitionId()),
             TimerIntent.TRIGGER,
             JobIntent.TIME_OUT,
             JobIntent.RECUR_AFTER_BACKOFF,

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.engine.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.agrona.collections.LongHashSet;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ final class BoundedCommandCacheTest {
   @Test
   void shouldNotExceedCapacity() {
     // given
-    final var cache = new BoundedCommandCache(4);
+    final var cache = new BoundedCommandCache();
     cache.add(setOf(1, 2, 3, 4));
 
     // when
@@ -27,6 +28,21 @@ final class BoundedCommandCacheTest {
     assertThat(cache.size()).isEqualTo(4);
     assertThat(cache.contains(5)).isTrue();
     assertThat(cache.contains(6)).isTrue();
+  }
+
+  @Test
+  void shouldReportSizeChanges() {
+    // given
+    final var reportedSize = new AtomicInteger();
+    final var cache = new BoundedCommandCache(reportedSize::set);
+
+    // when - then
+    cache.add(setOf(1, 2, 3, 4));
+    assertThat(reportedSize).hasValue(4);
+
+    // when - then
+    cache.remove(1);
+    assertThat(reportedSize).hasValue(3);
   }
 
   private LongHashSet setOf(final long... keys) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
@@ -18,7 +18,7 @@ final class BoundedCommandCacheTest {
   @Test
   void shouldNotExceedCapacity() {
     // given
-    final var cache = new BoundedCommandCache();
+    final var cache = new BoundedCommandCache(4);
     cache.add(setOf(1, 2, 3, 4));
 
     // when

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
@@ -62,6 +62,33 @@ final class BoundedCommandCacheTest {
     assertThat(reportedSize).hasValue(3);
   }
 
+  @Test
+  void shouldReportSizeToResetMetricOnCreation() {
+    // given
+    final var reportedSize = new AtomicInteger(200);
+
+    // when
+    final var ignored = new BoundedCommandCache(reportedSize::set);
+
+    // then
+    assertThat(reportedSize).hasValue(0);
+  }
+
+  @Test
+  void shouldClearCache() {
+    // given
+    final var reportedSize = new AtomicInteger();
+    final var cache = new BoundedCommandCache(reportedSize::set);
+    cache.add(setOf(1, 2, 3, 4));
+
+    // when
+    cache.clear();
+
+    // then
+    assertThat(cache.size()).isZero();
+    assertThat(reportedSize).hasValue(0);
+  }
+
   private LongHashSet setOf(final long... keys) {
     final var set = new LongHashSet();
     set.addAll(Arrays.stream(keys).boxed().toList());

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.engine.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import org.agrona.collections.LongHashSet;
+import org.junit.jupiter.api.Test;
+
+final class BoundedCommandCacheTest {
+  @Test
+  void shouldNotExceedCapacity() {
+    // given
+    final var cache = new BoundedCommandCache(4);
+    cache.add(setOf(1, 2, 3, 4));
+
+    // when
+    cache.add(setOf(5, 6));
+
+    // then
+    assertThat(cache.size()).isEqualTo(4);
+    assertThat(cache.contains(5)).isTrue();
+    assertThat(cache.contains(6)).isTrue();
+  }
+
+  private LongHashSet setOf(final long... keys) {
+    final var set = new LongHashSet();
+    set.addAll(Arrays.stream(keys).boxed().toList());
+    return set;
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.agrona.collections.LongHashSet;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +29,22 @@ final class BoundedCommandCacheTest {
     assertThat(cache.size()).isEqualTo(4);
     assertThat(cache.contains(5)).isTrue();
     assertThat(cache.contains(6)).isTrue();
+  }
+
+  @Test
+  void shouldEvictRandomKeysOnCapacityReached() {
+    // given
+    final var cache = new BoundedCommandCache(4);
+    final var initialKeys = setOf(1, 2, 3, 4);
+    cache.add(initialKeys);
+
+    // when
+    cache.add(setOf(5, 6));
+
+    // then
+    final var remainingInitialKeys =
+        initialKeys.stream().filter(cache::contains).collect(Collectors.toSet());
+    assertThat(remainingInitialKeys).hasSize(2).containsAnyElementsOf(initialKeys);
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
@@ -135,5 +135,19 @@ final class BoundedScheduledCommandCacheTest {
       assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isFalse();
       assertThat(staged.contains(TimerIntent.TRIGGER, 1)).isTrue();
     }
+
+    @Test
+    void shouldNotRemoveFromMainCache() {
+      // given
+      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var staged = cache.stage();
+      cache.add(TimerIntent.TRIGGER, 1);
+
+      // when
+      staged.remove(TimerIntent.TRIGGER, 1);
+
+      // then
+      assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
+    }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
@@ -9,16 +9,23 @@ package io.camunda.zeebe.broker.engine.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class BoundedScheduledCommandCacheTest {
+
+  private static final ScheduledCommandCacheMetrics NOOP_METRICS = ignored -> i -> {};
+
   @Test
   void shouldNotCacheUnknownIntents() {
     // given
-    final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+    final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
 
     // when
     cache.add(JobIntent.TIME_OUT, 1);
@@ -30,7 +37,7 @@ final class BoundedScheduledCommandCacheTest {
   @Test
   void shouldAdd() {
     // given
-    final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+    final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
 
     // when
     cache.add(TimerIntent.TRIGGER, 1);
@@ -42,7 +49,7 @@ final class BoundedScheduledCommandCacheTest {
   @Test
   void shouldNotContainNonCachedKeyIntentPairWithSameIntent() {
     // given
-    final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+    final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
 
     // when
     cache.add(TimerIntent.TRIGGER, 1);
@@ -55,7 +62,8 @@ final class BoundedScheduledCommandCacheTest {
   void shouldNotContainNonCachedKeyIntentPairWithSameKey() {
     // given
     final var cache =
-        BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER, JobIntent.TIME_OUT);
+        BoundedScheduledCommandCache.ofIntent(
+            NOOP_METRICS, TimerIntent.TRIGGER, JobIntent.TIME_OUT);
 
     // when
     cache.add(JobIntent.TIME_OUT, 1);
@@ -68,7 +76,8 @@ final class BoundedScheduledCommandCacheTest {
   void shouldRemoveCachedIntentKeyPair() {
     // given
     final var cache =
-        BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER, JobIntent.TIME_OUT);
+        BoundedScheduledCommandCache.ofIntent(
+            NOOP_METRICS, TimerIntent.TRIGGER, JobIntent.TIME_OUT);
     cache.add(JobIntent.TIME_OUT, 1);
     cache.add(TimerIntent.TRIGGER, 1);
 
@@ -80,12 +89,32 @@ final class BoundedScheduledCommandCacheTest {
     assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
   }
 
+  @Test
+  void shouldReportSizePerIntent() {
+    // given
+    final Map<Intent, AtomicInteger> metrics = new HashMap<>();
+    final var cache =
+        BoundedScheduledCommandCache.ofIntent(
+            i -> metrics.computeIfAbsent(i, ignored -> new AtomicInteger())::set,
+            TimerIntent.TRIGGER,
+            JobIntent.TIME_OUT);
+
+    // when
+    cache.add(JobIntent.TIME_OUT, 1);
+    cache.add(TimerIntent.TRIGGER, 1);
+    cache.add(TimerIntent.TRIGGER, 2);
+
+    // then
+    assertThat(metrics.get(TimerIntent.TRIGGER)).hasValue(2);
+    assertThat(metrics.get(JobIntent.TIME_OUT)).hasValue(1);
+  }
+
   @Nested
   final class StagedTest {
     @Test
     void shouldNotContainStagedKeys() {
       // given
-      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
       final var staged = cache.stage();
 
       // when
@@ -98,7 +127,7 @@ final class BoundedScheduledCommandCacheTest {
     @Test
     void shouldPersistStagedKeys() {
       // given
-      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
       final var staged = cache.stage();
       staged.add(TimerIntent.TRIGGER, 1);
 
@@ -112,7 +141,7 @@ final class BoundedScheduledCommandCacheTest {
     @Test
     void shouldContainPersistedKeys() {
       // given
-      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
       cache.add(TimerIntent.TRIGGER, 1);
 
       // when
@@ -125,7 +154,7 @@ final class BoundedScheduledCommandCacheTest {
     @Test
     void shouldContainStagedKeys() {
       // given
-      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
       final var staged = cache.stage();
 
       // when
@@ -139,7 +168,7 @@ final class BoundedScheduledCommandCacheTest {
     @Test
     void shouldNotRemoveFromMainCache() {
       // given
-      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
       final var staged = cache.stage();
       cache.add(TimerIntent.TRIGGER, 1);
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
@@ -109,6 +109,23 @@ final class BoundedScheduledCommandCacheTest {
     assertThat(metrics.get(JobIntent.TIME_OUT)).hasValue(1);
   }
 
+  @Test
+  void shouldClearCaches() {
+    // given
+    final var cache =
+        BoundedScheduledCommandCache.ofIntent(
+            NOOP_METRICS, TimerIntent.TRIGGER, JobIntent.TIME_OUT);
+    cache.add(JobIntent.TIME_OUT, 1);
+    cache.add(TimerIntent.TRIGGER, 1);
+
+    // when
+    cache.clear();
+
+    // then
+    assertThat(cache.contains(JobIntent.TIME_OUT, 1)).isFalse();
+    assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isFalse();
+  }
+
   @Nested
   final class StagedTest {
     @Test
@@ -176,6 +193,22 @@ final class BoundedScheduledCommandCacheTest {
       staged.remove(TimerIntent.TRIGGER, 1);
 
       // then
+      assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
+    }
+
+    @Test
+    void shouldClearOnlyStagedKeys() {
+      // given
+      final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
+      final var staged = cache.stage();
+      cache.add(TimerIntent.TRIGGER, 1);
+      staged.add(TimerIntent.TRIGGER, 2);
+
+      // when
+      staged.clear();
+
+      // then
+      assertThat(staged.contains(TimerIntent.TRIGGER, 2)).isFalse();
       assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
     }
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.engine.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class BoundedScheduledCommandCacheTest {
+  @Test
+  void shouldNotCacheUnknownIntents() {
+    // given
+    final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+
+    // when
+    cache.add(JobIntent.TIME_OUT, 1);
+
+    // then
+    assertThat(cache.contains(JobIntent.TIME_OUT, 1)).isFalse();
+  }
+
+  @Test
+  void shouldAdd() {
+    // given
+    final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+
+    // when
+    cache.add(TimerIntent.TRIGGER, 1);
+
+    // then
+    assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
+  }
+
+  @Test
+  void shouldNotContainNonCachedKeyIntentPairWithSameIntent() {
+    // given
+    final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+
+    // when
+    cache.add(TimerIntent.TRIGGER, 1);
+
+    // then
+    assertThat(cache.contains(TimerIntent.TRIGGER, 2)).isFalse();
+  }
+
+  @Test
+  void shouldNotContainNonCachedKeyIntentPairWithSameKey() {
+    // given
+    final var cache =
+        BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER, JobIntent.TIME_OUT);
+
+    // when
+    cache.add(JobIntent.TIME_OUT, 1);
+
+    // then
+    assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isFalse();
+  }
+
+  @Test
+  void shouldRemoveCachedIntentKeyPair() {
+    // given
+    final var cache =
+        BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER, JobIntent.TIME_OUT);
+    cache.add(JobIntent.TIME_OUT, 1);
+    cache.add(TimerIntent.TRIGGER, 1);
+
+    // when
+    cache.remove(JobIntent.TIME_OUT, 1);
+
+    // then
+    assertThat(cache.contains(JobIntent.TIME_OUT, 1)).isFalse();
+    assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
+  }
+
+  @Nested
+  final class StagedTest {
+    @Test
+    void shouldNotContainStagedKeys() {
+      // given
+      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var staged = cache.stage();
+
+      // when
+      staged.add(TimerIntent.TRIGGER, 1);
+
+      // then
+      assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isFalse();
+    }
+
+    @Test
+    void shouldPersistStagedKeys() {
+      // given
+      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var staged = cache.stage();
+      staged.add(TimerIntent.TRIGGER, 1);
+
+      // when
+      staged.persist();
+
+      // then
+      assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
+    }
+
+    @Test
+    void shouldContainPersistedKeys() {
+      // given
+      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      cache.add(TimerIntent.TRIGGER, 1);
+
+      // when
+      final var staged = cache.stage();
+
+      // then
+      assertThat(staged.contains(TimerIntent.TRIGGER, 1)).isTrue();
+    }
+
+    @Test
+    void shouldContainStagedKeys() {
+      // given
+      final var cache = BoundedScheduledCommandCache.ofIntent(TimerIntent.TRIGGER);
+      final var staged = cache.stage();
+
+      // when
+      staged.add(TimerIntent.TRIGGER, 1);
+
+      // then
+      assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isFalse();
+      assertThat(staged.contains(TimerIntent.TRIGGER, 1)).isTrue();
+    }
+  }
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.api.scheduling;
+
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
+public interface ScheduledCommandCache {
+  void add(final Intent intent, final long key);
+
+  boolean isCached(final Intent intent, final long key);
+
+  void remove(final Intent intent, final long key);
+
+  interface ScheduledCommandCacheChanges {
+
+    void persist();
+  }
+
+  interface StageableScheduledCommandCache extends ScheduledCommandCache {
+    StagedScheduledCommandCache stage();
+  }
+
+  interface StagedScheduledCommandCache
+      extends ScheduledCommandCache, ScheduledCommandCacheChanges {}
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 public interface ScheduledCommandCache {
   void add(final Intent intent, final long key);
 
-  boolean isCached(final Intent intent, final long key);
+  boolean contains(final Intent intent, final long key);
 
   void remove(final Intent intent, final long key);
 
@@ -26,7 +26,7 @@ public interface ScheduledCommandCache {
     public void add(final Intent intent, final long key) {}
 
     @Override
-    public boolean isCached(final Intent intent, final long key) {
+    public boolean contains(final Intent intent, final long key) {
       return false;
     }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -9,13 +9,28 @@ package io.camunda.zeebe.stream.api.scheduling;
 
 import io.camunda.zeebe.protocol.record.intent.Intent;
 
+/**
+ * Represents a cache to be used by the {@link
+ * io.camunda.zeebe.engine.api.ProcessingScheduleService}, which allows it to cache which commands
+ * it has written and avoid writing them again until they've been removed from the cache.
+ */
 public interface ScheduledCommandCache {
+
+  /**
+   * Add the given intent and key pair to the cache.
+   *
+   * @param intent intent to cache
+   * @param key key to cache
+   */
   void add(final Intent intent, final long key);
 
+  /** Returns true if the given intent and key pair is already cached. */
   boolean contains(final Intent intent, final long key);
 
+  /** Removes the given intent/key pair from the cache. */
   void remove(final Intent intent, final long key);
 
+  /** A dummy cache implementation which does nothing, i.e. caches nothing. */
   final class NoopScheduledCommandCache
       implements StageableScheduledCommandCache, StagedScheduledCommandCache {
 
@@ -39,15 +54,42 @@ public interface ScheduledCommandCache {
     }
   }
 
+  /**
+   * Represents staged changes to the cache that have not been persisted yet. Call {@link
+   * #persist()} to do so.
+   *
+   * <p>See {@link StageableScheduledCommandCache} for more.
+   */
   interface ScheduledCommandCacheChanges {
 
     void persist();
   }
 
+  /**
+   * A {@link ScheduledCommandCache} which allows staging changes before persisting them. This
+   * enables you to stage new keys to be added to the cache, and only actually commit them to the
+   * real cache when you're sure that the scheduled commands have been written.
+   */
   interface StageableScheduledCommandCache extends ScheduledCommandCache {
+
+    /** Returns a new stage for this cache, where modifications are temporary. */
     StagedScheduledCommandCache stage();
   }
 
+  /**
+   * A cache where modifications are staged but not added to the main cache which produced it. Call
+   * {@link #persist()} to do so.
+   *
+   * <p>The semantics of each operation are changed slightly:
+   *
+   * <p>A staged {@link #add(Intent, long)} will buffer the intent/key pair, and all buffered pairs
+   * are added to the main cache on {@link #persist()}.
+   *
+   * <p>A staged {@link #remove(Intent, long)} only removes buffered intent/key pairs.
+   *
+   * <p>A staged {@link #contains(Intent, long)} first looks up the buffered intent/key pairs, and
+   * if not found, will also perform a look-up in the main cache.
+   */
   interface StagedScheduledCommandCache
       extends ScheduledCommandCache, ScheduledCommandCacheChanges {}
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -11,8 +11,8 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 
 /**
  * Represents a cache to be used by the {@link
- * io.camunda.zeebe.engine.api.ProcessingScheduleService}, which allows it to cache which commands
- * it has written and avoid writing them again until they've been removed from the cache.
+ * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService}, which allows it to cache which
+ * commands it has written and avoid writing them again until they've been removed from the cache.
  */
 public interface ScheduledCommandCache {
 
@@ -29,6 +29,8 @@ public interface ScheduledCommandCache {
 
   /** Removes the given intent/key pair from the cache. */
   void remove(final Intent intent, final long key);
+
+  void clear();
 
   /** A dummy cache implementation which does nothing, i.e. caches nothing. */
   final class NoopScheduledCommandCache
@@ -47,6 +49,9 @@ public interface ScheduledCommandCache {
 
     @Override
     public void remove(final Intent intent, final long key) {}
+
+    @Override
+    public void clear() {}
 
     @Override
     public StagedScheduledCommandCache stage() {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -16,6 +16,29 @@ public interface ScheduledCommandCache {
 
   void remove(final Intent intent, final long key);
 
+  final class NoopScheduledCommandCache
+      implements StageableScheduledCommandCache, StagedScheduledCommandCache {
+
+    @Override
+    public void persist() {}
+
+    @Override
+    public void add(final Intent intent, final long key) {}
+
+    @Override
+    public boolean isCached(final Intent intent, final long key) {
+      return false;
+    }
+
+    @Override
+    public void remove(final Intent intent, final long key) {}
+
+    @Override
+    public StagedScheduledCommandCache stage() {
+      return this;
+    }
+  }
+
   interface ScheduledCommandCacheChanges {
 
     void persist();

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -30,6 +30,7 @@ public interface ScheduledCommandCache {
   /** Removes the given intent/key pair from the cache. */
   void remove(final Intent intent, final long key);
 
+  /** Clears the underlying cache of all intent/key pairs. */
   void clear();
 
   /** A dummy cache implementation which does nothing, i.e. caches nothing. */
@@ -94,6 +95,8 @@ public interface ScheduledCommandCache {
    *
    * <p>A staged {@link #contains(Intent, long)} first looks up the buffered intent/key pairs, and
    * if not found, will also perform a look-up in the main cache.
+   *
+   * <p>A staged {@link #clear()} only removes the staged keys, and does not touch the main cache.
    */
   interface StagedScheduledCommandCache
       extends ScheduledCommandCache, ScheduledCommandCacheChanges {}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
@@ -45,7 +45,7 @@ public final class BufferedTaskResultBuilder implements TaskResultBuilder {
       throw new IllegalStateException("Missing value type mapping for record: " + value.getClass());
     }
 
-    if (cache.isCached(intent, key)) {
+    if (cache.contains(intent, key)) {
       return true;
     }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
@@ -30,7 +30,7 @@ public final class BufferedTaskResultBuilder implements TaskResultBuilder {
   private final MutableRecordBatch mutableRecordBatch;
   private final StagedScheduledCommandCache cache;
 
-  BufferedTaskResultBuilder(
+  public BufferedTaskResultBuilder(
       final RecordBatchSizePredicate predicate, final StagedScheduledCommandCache cache) {
     mutableRecordBatch = new RecordBatch(predicate);
     this.cache = cache;

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.MutableRecordBatch;
 import io.camunda.zeebe.stream.api.records.RecordBatchSizePredicate;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StagedScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import io.camunda.zeebe.stream.impl.records.RecordBatch;
@@ -27,19 +28,25 @@ import io.camunda.zeebe.stream.impl.records.RecordBatch;
 public final class BufferedTaskResultBuilder implements TaskResultBuilder {
 
   private final MutableRecordBatch mutableRecordBatch;
+  private final StagedScheduledCommandCache cache;
 
-  public BufferedTaskResultBuilder(final RecordBatchSizePredicate predicate) {
+  BufferedTaskResultBuilder(
+      final RecordBatchSizePredicate predicate, final StagedScheduledCommandCache cache) {
     mutableRecordBatch = new RecordBatch(predicate);
+    this.cache = cache;
   }
 
   @Override
   public boolean appendCommandRecord(
       final long key, final Intent intent, final UnifiedRecordValue value) {
-
     final ValueType valueType = TypedEventRegistry.TYPE_REGISTRY.get(value.getClass());
     if (valueType == null) {
       // usually happens when the record is not registered at the TypedStreamEnvironment
       throw new IllegalStateException("Missing value type mapping for record: " + value.getClass());
+    }
+
+    if (cache.isCached(intent, key)) {
+      return true;
     }
 
     final var metadata =
@@ -51,6 +58,7 @@ public final class BufferedTaskResultBuilder implements TaskResultBuilder {
             .valueType(valueType);
     final var either = mutableRecordBatch.appendRecord(key, metadata, -1, value);
 
+    either.ifRight(ok -> cache.add(intent, key));
     return either.isRight();
   }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache;
 import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
 import io.camunda.zeebe.stream.impl.metrics.ProcessingMetrics;
 import io.camunda.zeebe.stream.impl.metrics.StreamProcessorMetrics;
@@ -159,13 +160,16 @@ public final class ProcessingStateMachine {
   private final int maxCommandsInBatch;
   private int processedCommandsCount;
   private final ProcessingMetrics processingMetrics;
+  private final ScheduledCommandCache scheduledCommandCache;
 
   public ProcessingStateMachine(
       final StreamProcessorContext context,
       final BooleanSupplier shouldProcessNext,
-      final List<RecordProcessor> recordProcessors) {
+      final List<RecordProcessor> recordProcessors,
+      final ScheduledCommandCache scheduledCommandCache) {
     this.context = context;
     this.recordProcessors = recordProcessors;
+    this.scheduledCommandCache = scheduledCommandCache;
     actor = context.getActor();
     recordValues = context.getRecordValues();
     logStreamReader = context.getLogStreamReader();
@@ -539,6 +543,7 @@ public final class ProcessingStateMachine {
                   updateState();
                 });
           } else {
+            scheduledCommandCache.remove(metadata.getIntent(), currentRecord.getKey());
             executeSideEffects();
           }
         });

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
 import io.camunda.zeebe.stream.impl.metrics.StreamProcessorMetrics;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
@@ -87,6 +88,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private final List<StreamProcessorLifecycleAware> lifecycleAwareListeners;
   private final Set<FailureListener> failureListeners = new HashSet<>();
   private final StreamProcessorMetrics metrics;
+  private final StageableScheduledCommandCache scheduledCommandCache;
 
   // log stream
   private final LogStream logStream;
@@ -110,12 +112,12 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private ProcessingScheduleServiceImpl processorActorService;
   private ProcessingScheduleServiceImpl asyncScheduleService;
   private AsyncProcessingScheduleServiceActor asyncActor;
-  private final int nodeId;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     actorSchedulingService = processorBuilder.getActorSchedulingService();
     lifecycleAwareListeners = new ArrayList<>(processorBuilder.getLifecycleListeners());
     zeebeDb = processorBuilder.getZeebeDb();
+    scheduledCommandCache = processorBuilder.scheduledCommandCache();
 
     streamProcessorContext =
         processorBuilder
@@ -125,7 +127,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             .abortCondition(this::isClosed);
     logStream = streamProcessorContext.getLogStream();
     partitionId = logStream.getPartitionId();
-    nodeId = processorBuilder.getNodeId();
     actorName = buildActorName("StreamProcessor", partitionId);
     metrics = new StreamProcessorMetrics(partitionId);
     recordProcessors.addAll(processorBuilder.getRecordProcessors());
@@ -166,12 +167,14 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
           new ProcessingScheduleServiceImpl(
               streamProcessorContext::getStreamProcessorPhase,
               streamProcessorContext.getAbortCondition(),
-              logStream::newLogStreamWriter);
+              logStream::newLogStreamWriter,
+              scheduledCommandCache);
       asyncScheduleService =
           new ProcessingScheduleServiceImpl(
               streamProcessorContext::getStreamProcessorPhase, // this is volatile
               () -> false, // we will just stop the actor in this case, no need to provide this
-              logStream::newLogStreamWriter);
+              logStream::newLogStreamWriter,
+              scheduledCommandCache);
       asyncActor = new AsyncProcessingScheduleServiceActor(asyncScheduleService, partitionId);
       final var extendedProcessingScheduleService =
           new ExtendedProcessingScheduleServiceImpl(
@@ -325,7 +328,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void startProcessing(final LastProcessingPositions lastProcessingPositions) {
     processingStateMachine =
         new ProcessingStateMachine(
-            streamProcessorContext, this::shouldProcessNext, recordProcessors);
+            streamProcessorContext,
+            this::shouldProcessNext,
+            recordProcessors,
+            scheduledCommandCache);
 
     logStream.registerRecordAvailableListener(this);
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -278,6 +278,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     streamProcessorContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
     replayStateMachine.close();
+    scheduledCommandCache.clear();
   }
 
   private void healthCheckTick() {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,6 +29,7 @@ public final class StreamProcessorBuilder {
   private int nodeId;
 
   private List<RecordProcessor> recordProcessors;
+  private StageableScheduledCommandCache scheduledCommandCache;
 
   public StreamProcessorBuilder() {
     streamProcessorContext = new StreamProcessorContext();
@@ -107,6 +109,16 @@ public final class StreamProcessorBuilder {
 
   public List<RecordProcessor> getRecordProcessors() {
     return recordProcessors;
+  }
+
+  public StreamProcessorBuilder scheduledCommandCache(
+      final StageableScheduledCommandCache scheduledCommandCache) {
+    this.scheduledCommandCache = scheduledCommandCache;
+    return this;
+  }
+
+  public StageableScheduledCommandCache scheduledCommandCache() {
+    return scheduledCommandCache;
   }
 
   public StreamProcessor build() {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.NoopScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,7 +30,7 @@ public final class StreamProcessorBuilder {
   private int nodeId;
 
   private List<RecordProcessor> recordProcessors;
-  private StageableScheduledCommandCache scheduledCommandCache;
+  private StageableScheduledCommandCache scheduledCommandCache = new NoopScheduledCommandCache();
 
   public StreamProcessorBuilder() {
     streamProcessorContext = new StreamProcessorContext();

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -20,12 +20,15 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.NoopScheduledCommandCache;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
@@ -37,6 +40,10 @@ import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -51,6 +58,7 @@ class ProcessingScheduleServiceTest {
   @RegisterExtension
   ControlledActorSchedulerExtension actorScheduler = new ControlledActorSchedulerExtension();
 
+  private final TestCommandCache commandCache = new TestCommandCache();
   private LifecycleSupplier lifecycleSupplier;
   private WriterAsyncSupplier writerAsyncSupplier;
   private TestScheduleServiceActorDecorator scheduleService;
@@ -61,10 +69,7 @@ class ProcessingScheduleServiceTest {
     writerAsyncSupplier = new WriterAsyncSupplier();
     final var processingScheduleService =
         new ProcessingScheduleServiceImpl(
-            lifecycleSupplier,
-            lifecycleSupplier,
-            writerAsyncSupplier,
-            new NoopScheduledCommandCache());
+            lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier, commandCache);
 
     scheduleService = new TestScheduleServiceActorDecorator(processingScheduleService);
     actorScheduler.submitActor(scheduleService);
@@ -296,6 +301,68 @@ class ProcessingScheduleServiceTest {
     verify(mockedTask, never()).execute(any());
   }
 
+  @Test
+  void shouldCacheWrittenCommands() {
+    // given
+
+    // when
+    scheduleService.runDelayed(
+        Duration.ZERO,
+        (builder) -> {
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, Records.processInstance(1));
+          return builder.build();
+        });
+    actorScheduler.workUntilDone();
+
+    // then - it's sufficient to assert it was staged for caching, and then the staged cache was
+    // persisted
+    assertThat(commandCache.stagedCache.isCached(ACTIVATE_ELEMENT, 1)).isTrue();
+    assertThat(commandCache.stagedCache.persisted).isTrue();
+    assertThat(writerAsyncSupplier.writer.entries)
+        .extracting(LogAppendEntry::key)
+        .containsExactly(1L);
+  }
+
+  @Test
+  void shouldNotWriteCachedCommands() {
+    // given
+    commandCache.add(ACTIVATE_ELEMENT, 1);
+
+    // when
+    scheduleService.runDelayed(
+        Duration.ZERO,
+        (builder) -> {
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, Records.processInstance(1));
+          return builder.build();
+        });
+    actorScheduler.workUntilDone();
+
+    // then
+    assertThat(writerAsyncSupplier.writer.entries).isEmpty();
+  }
+
+  @Test
+  void shouldNotCacheWrittenCommandsIfWriteFails() {
+    // given
+    writerAsyncSupplier.writer.acceptWrites.set(
+        () -> {
+          throw new RuntimeException("failure");
+        });
+
+    // when
+    scheduleService.runDelayed(
+        Duration.ZERO,
+        (builder) -> {
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, Records.processInstance(1));
+          return builder.build();
+        });
+    actorScheduler.workUntilDone();
+
+    // then - write was staged for caching, but not persisted due to error
+    assertThat(commandCache.stagedCache.isCached(ACTIVATE_ELEMENT, 1)).isTrue();
+    assertThat(commandCache.stagedCache.persisted).isFalse();
+  }
+
   /**
    * This decorator is an actor and implements {@link ProcessingScheduleService} and delegates to
    * {@link ProcessingScheduleServiceImpl}, on each call it will submit an extra job to the related
@@ -394,6 +461,54 @@ class ProcessingScheduleServiceTest {
 
       entries.addAll(appendEntries);
       return Either.right((long) entries.size());
+    }
+  }
+
+  private static final class TestCommandCache extends TestScheduledCommandCache
+      implements StageableScheduledCommandCache {
+    private final StagedCache stagedCache = new StagedCache();
+
+    @Override
+    public StagedScheduledCommandCache stage() {
+      return stagedCache;
+    }
+
+    private final class StagedCache extends TestScheduledCommandCache
+        implements StagedScheduledCommandCache {
+      private volatile boolean persisted;
+
+      @Override
+      public boolean isCached(final Intent intent, final long key) {
+        return super.isCached(intent, key) || TestCommandCache.this.isCached(intent, key);
+      }
+
+      @Override
+      public void persist() {
+        persisted = true;
+      }
+    }
+  }
+
+  private static class TestScheduledCommandCache implements ScheduledCommandCache {
+    private final Map<Intent, Set<Long>> cachedKeys = new ConcurrentHashMap<>();
+
+    @Override
+    public void add(final Intent intent, final long key) {
+      cacheForIntent(intent).add(key);
+    }
+
+    @Override
+    public boolean isCached(final Intent intent, final long key) {
+      return cacheForIntent(intent).contains(key);
+    }
+
+    @Override
+    public void remove(final Intent intent, final long key) {
+      cacheForIntent(intent).remove(key);
+    }
+
+    private Set<Long> cacheForIntent(final Intent intent) {
+      return cachedKeys.computeIfAbsent(intent, ignored -> new ConcurrentSkipListSet<>());
     }
   }
 }

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -310,9 +310,9 @@ class ProcessingScheduleServiceTest {
 
     // then - it's sufficient to assert it was staged for caching, and then the staged cache was
     // persisted
-    assertThat(commandCache.stagedCache().isCached(ACTIVATE_ELEMENT, 1)).isTrue();
+    assertThat(commandCache.stagedCache().contains(ACTIVATE_ELEMENT, 1)).isTrue();
     assertThat(commandCache.stagedCache().persisted()).isTrue();
-    assertThat(commandCache.isCached(ACTIVATE_ELEMENT, 1)).isTrue();
+    assertThat(commandCache.contains(ACTIVATE_ELEMENT, 1)).isTrue();
     assertThat(writerAsyncSupplier.writer.entries)
         .extracting(LogAppendEntry::key)
         .containsExactly(1L);
@@ -354,9 +354,9 @@ class ProcessingScheduleServiceTest {
     actorScheduler.workUntilDone();
 
     // then - write was staged for caching, but not persisted due to error
-    assertThat(commandCache.stagedCache().isCached(ACTIVATE_ELEMENT, 1)).isTrue();
+    assertThat(commandCache.stagedCache().contains(ACTIVATE_ELEMENT, 1)).isTrue();
     assertThat(commandCache.stagedCache().persisted()).isFalse();
-    assertThat(commandCache.isCached(ACTIVATE_ELEMENT, 1)).isFalse();
+    assertThat(commandCache.contains(ACTIVATE_ELEMENT, 1)).isFalse();
   }
 
   /**

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.NoopScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
@@ -60,7 +61,10 @@ class ProcessingScheduleServiceTest {
     writerAsyncSupplier = new WriterAsyncSupplier();
     final var processingScheduleService =
         new ProcessingScheduleServiceImpl(
-            lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier);
+            lifecycleSupplier,
+            lifecycleSupplier,
+            writerAsyncSupplier,
+            new NoopScheduledCommandCache());
 
     scheduleService = new TestScheduleServiceActorDecorator(processingScheduleService);
     actorScheduler.submitActor(scheduleService);
@@ -150,7 +154,10 @@ class ProcessingScheduleServiceTest {
     lifecycleSupplier.currentPhase = Phase.PAUSED;
     final var notOpenScheduleService =
         new ProcessingScheduleServiceImpl(
-            lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier);
+            lifecycleSupplier,
+            lifecycleSupplier,
+            writerAsyncSupplier,
+            new NoopScheduledCommandCache());
     final var mockedTask = spy(new DummyTask());
 
     // when
@@ -169,7 +176,10 @@ class ProcessingScheduleServiceTest {
     final var notOpenScheduleService =
         new TestScheduleServiceActorDecorator(
             new ProcessingScheduleServiceImpl(
-                lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier));
+                lifecycleSupplier,
+                lifecycleSupplier,
+                writerAsyncSupplier,
+                new NoopScheduledCommandCache()));
 
     // when
     final var actorFuture = actorScheduler.submitActor(notOpenScheduleService);

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -1360,7 +1360,7 @@ public final class StreamProcessorTest {
     // then
     verify(testProcessor, timeout(5000)).process(any(), any());
     Awaitility.await("until command is removed from cache after processing")
-        .untilAsserted(() -> assertThat(commandCache.isCached(ACTIVATE_ELEMENT, 1)).isFalse());
+        .untilAsserted(() -> assertThat(commandCache.contains(ACTIVATE_ELEMENT, 1)).isFalse());
   }
 
   private static final class TestProcessor implements RecordProcessor {

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -1346,6 +1346,23 @@ public final class StreamProcessorTest {
     inOrder.verifyNoMoreInteractions();
   }
 
+  @Test
+  void shouldRemoveCachedScheduledCommandOnProcess() {
+    // given
+    final var testProcessor = spy(new TestProcessor());
+    streamPlatform.withRecordProcessors(List.of(testProcessor)).startStreamProcessor();
+    final var commandCache = streamPlatform.scheduledCommandCache();
+    commandCache.add(ACTIVATE_ELEMENT, 1);
+
+    // when
+    streamPlatform.writeBatch(command().key(1).processInstance(ACTIVATE_ELEMENT, RECORD));
+
+    // then
+    verify(testProcessor, timeout(5000)).process(any(), any());
+    Awaitility.await("until command is removed from cache after processing")
+        .untilAsserted(() -> assertThat(commandCache.isCached(ACTIVATE_ELEMENT, 1)).isFalse());
+  }
+
   private static final class TestProcessor implements RecordProcessor {
 
     ProcessingResult processingResult = EmptyProcessingResult.INSTANCE;

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -1355,7 +1355,10 @@ public final class StreamProcessorTest {
     commandCache.add(ACTIVATE_ELEMENT, 1);
 
     // when
-    streamPlatform.writeBatch(command().key(1).processInstance(ACTIVATE_ELEMENT, RECORD));
+    streamPlatform.writeBatch(
+        RecordToWrite.command()
+            .key(1)
+            .processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
 
     // then
     verify(testProcessor, timeout(5000)).process(any(), any());

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
@@ -32,6 +32,11 @@ public class TestScheduledCommandCache implements ScheduledCommandCache {
     cacheForIntent(intent).remove(key);
   }
 
+  @Override
+  public void clear() {
+    cachedKeys.values().forEach(Set::clear);
+  }
+
   private Set<Long> cacheForIntent(final Intent intent) {
     return cachedKeys.computeIfAbsent(intent, ignored -> new ConcurrentSkipListSet<>());
   }

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
@@ -23,7 +23,7 @@ public class TestScheduledCommandCache implements ScheduledCommandCache {
   }
 
   @Override
-  public boolean isCached(final Intent intent, final long key) {
+  public boolean contains(final Intent intent, final long key) {
     return cacheForIntent(intent).contains(key);
   }
 
@@ -56,8 +56,8 @@ public class TestScheduledCommandCache implements ScheduledCommandCache {
       private volatile boolean persisted;
 
       @Override
-      public boolean isCached(final Intent intent, final long key) {
-        return super.isCached(intent, key) || TestCommandCache.this.isCached(intent, key);
+      public boolean contains(final Intent intent, final long key) {
+        return super.contains(intent, key) || TestCommandCache.this.contains(intent, key);
       }
 
       @Override

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+public class TestScheduledCommandCache implements ScheduledCommandCache {
+  protected final Map<Intent, Set<Long>> cachedKeys = new ConcurrentHashMap<>();
+
+  @Override
+  public void add(final Intent intent, final long key) {
+    cacheForIntent(intent).add(key);
+  }
+
+  @Override
+  public boolean isCached(final Intent intent, final long key) {
+    return cacheForIntent(intent).contains(key);
+  }
+
+  @Override
+  public void remove(final Intent intent, final long key) {
+    cacheForIntent(intent).remove(key);
+  }
+
+  private Set<Long> cacheForIntent(final Intent intent) {
+    return cachedKeys.computeIfAbsent(intent, ignored -> new ConcurrentSkipListSet<>());
+  }
+
+  public static final class TestCommandCache extends TestScheduledCommandCache
+      implements StageableScheduledCommandCache {
+    private final StagedCache stagedCache = new StagedCache();
+
+    @Override
+    public StagedScheduledCommandCache stage() {
+      stagedCache.persisted = false;
+      return stagedCache;
+    }
+
+    public StagedCache stagedCache() {
+      return stagedCache;
+    }
+
+    public final class StagedCache extends TestScheduledCommandCache
+        implements StagedScheduledCommandCache {
+
+      private volatile boolean persisted;
+
+      @Override
+      public boolean isCached(final Intent intent, final long key) {
+        return super.isCached(intent, key) || TestCommandCache.this.isCached(intent, key);
+      }
+
+      @Override
+      public void persist() {
+        persisted = true;
+        cachedKeys.forEach((i, keys) -> keys.forEach(key -> TestCommandCache.this.add(i, key)));
+        cachedKeys.clear();
+      }
+
+      public boolean persisted() {
+        return persisted;
+      }
+    }
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/LockUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/LockUtil.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.util;
 
 import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
 import org.agrona.ErrorHandler;
+import org.agrona.LangUtil;
 
 /** Utility class for common tasks with {@link Lock} instances. */
 public final class LockUtil {
@@ -30,6 +32,17 @@ public final class LockUtil {
 
   /**
    * Runs the given operation only when the lock has been obtained. Locks interruptibly, meaning if
+   * the thread is interrupted while waiting for the lock, the runnable is not executed.
+   *
+   * @param lock the lock to acquire
+   * @param callable the operation to run
+   */
+  public static <V> V withLock(final Lock lock, final Supplier<V> callable) {
+    return withLock(lock, callable, IGNORE_ERROR_HANDLER);
+  }
+
+  /**
+   * Runs the given operation only when the lock has been obtained. Locks interruptibly, meaning if
    * the thread is interrupted while waiting for the lock, the runnable is not executed. If
    * interrupted, calls the error handler.
    *
@@ -44,11 +57,39 @@ public final class LockUtil {
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       errorHandler.onError(e);
+      LangUtil.rethrowUnchecked(e);
       return;
     }
 
     try {
       runnable.run();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Runs the given operation only when the lock has been obtained. Locks interruptibly, meaning if
+   * the thread is interrupted while waiting for the lock, the runnable is not executed. If
+   * interrupted, calls the error handler.
+   *
+   * @param lock the lock to acquire
+   * @param callable the operation to run
+   * @param errorHandler called if an error occurs during interruption
+   */
+  public static <V> V withLock(
+      final Lock lock, final Supplier<V> callable, final ErrorHandler errorHandler) {
+    try {
+      lock.lockInterruptibly();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      errorHandler.onError(e);
+      LangUtil.rethrowUnchecked(e);
+      return null; // unreachable
+    }
+
+    try {
+      return callable.get();
     } finally {
       lock.unlock();
     }


### PR DESCRIPTION
## Description

This PR forwards port https://github.com/camunda/zeebe/pull/15135 (the 8.3 port) to main. This one had 0 merge conflicts :tada: 

## Related issues

closes #13870

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
