### PR TITLE
Fix flaky ScaleDownBrokerTest

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
@@ -90,7 +90,7 @@ final class ScaleDownBrokersTest {
         .doesNotHaveBroker(brokerToShutdownId);
 
     // Changes are reflected in the topology returned by grpc query
-    cluster.awaitCompleteTopology(newClusterSize, PARTITIONS_COUNT, 1, Duration.ofSeconds(10));
+    cluster.awaitCompleteTopology(newClusterSize, PARTITIONS_COUNT, 1, Duration.ofSeconds(20));
 
     assertThatAllJobsCanBeCompleted(createdInstances, zeebeClient, JOB_TYPE);
   }
@@ -121,7 +121,7 @@ final class ScaleDownBrokersTest {
         .doesNotHaveBroker(brokerToShutdownId);
 
     // Changes are reflected in the topology returned by grpc query
-    cluster.awaitCompleteTopology(newClusterSize, PARTITIONS_COUNT, 1, Duration.ofSeconds(10));
+    cluster.awaitCompleteTopology(newClusterSize, PARTITIONS_COUNT, 1, Duration.ofSeconds(20));
 
     assertThatAllJobsCanBeCompleted(createdInstances, zeebeClient, JOB_TYPE);
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiper.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiper.java
@@ -48,7 +48,7 @@ public final class ClusterTopologyGossiper
   private final Set<TopologyUpdateListener> topologyUpdateListeners = new HashSet<>();
 
   // Reuse the same random ordered list for both sync and gossip
-  private List<MemberId> membersToSync = List.of();
+  private List<MemberId> membersToSync = new LinkedList<>();
 
   // The handler which can merge topology updates and reacts to the changes.
   private final Function<ClusterTopology, ActorFuture<ClusterTopology>>


### PR DESCRIPTION
## Description

The test  was flaky because the clusterSize in the gateway topology was 2 instead of 1. This is updated via the gossip/sync from `ClusterTopologyGossiper`. Since it uses a hard-coded delay of 10s, waiting for only 10s is not enough. To fix the flakiness

- Increase the waiting timeout
- Remove dead nodes from sync list in ClusterTopologyGossiper. This ensures the surviving nodes (in this case the gateway) gets the update in next round of sync. 

A better solution is to make the  delays in ClusterTopologyGossiper configurable. We have pending task for it, and will be done later.

## Related issues

closes #15118 
