### PR TITLE
[Backports stable/8.3] Reset scheduled command cache size metric

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
@@ -61,6 +61,7 @@ public final class BoundedCommandCache {
     final var resizeThreshold = (int) Math.ceil(capacity * 0.9f);
     final var capacityToPreventResize = 2 * capacity - resizeThreshold;
     cache = new LongHashSet(capacityToPreventResize, 0.9f, true);
+    sizeReporter.accept(0);
   }
 
   public void add(final LongHashSet keys) {
@@ -82,6 +83,15 @@ public final class BoundedCommandCache {
 
   public int size() {
     return LockUtil.withLock(lock, cache::size);
+  }
+
+  public void clear() {
+    LockUtil.withLock(
+        lock,
+        () -> {
+          cache.clear();
+          sizeReporter.accept(0);
+        });
   }
 
   private void lockedAdd(final LongHashSet keys) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableSch
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.agrona.collections.LongHashSet;
@@ -80,6 +81,11 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
   }
 
   @Override
+  public void clear() {
+    caches.values().forEach(BoundedCommandCache::clear);
+  }
+
+  @Override
   public StagedScheduledCommandCache stage() {
     return new StagedCache();
   }
@@ -101,6 +107,11 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
     @Override
     public void remove(final Intent intent, final long key) {
       stagedKeys(intent).remove(key);
+    }
+
+    @Override
+    public void clear() {
+      stagedKeys.values().forEach(Set::clear);
     }
 
     @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/ScheduledCommandCacheMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/ScheduledCommandCacheMetrics.java
@@ -42,7 +42,8 @@ public interface ScheduledCommandCacheMetrics {
 
     @Override
     public IntConsumer forIntent(final Intent intent) {
-      return SIZE.labels(partitionId, intent.name())::set;
+      final var intentLabelValue = intent.getClass().getSimpleName() + "." + intent.name();
+      return SIZE.labels(partitionId, intentLabelValue)::set;
     }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
@@ -62,6 +62,33 @@ final class BoundedCommandCacheTest {
     assertThat(reportedSize).hasValue(3);
   }
 
+  @Test
+  void shouldReportSizeToResetMetricOnCreation() {
+    // given
+    final var reportedSize = new AtomicInteger(200);
+
+    // when
+    final var ignored = new BoundedCommandCache(reportedSize::set);
+
+    // then
+    assertThat(reportedSize).hasValue(0);
+  }
+
+  @Test
+  void shouldClearCache() {
+    // given
+    final var reportedSize = new AtomicInteger();
+    final var cache = new BoundedCommandCache(reportedSize::set);
+    cache.add(setOf(1, 2, 3, 4));
+
+    // when
+    cache.clear();
+
+    // then
+    assertThat(cache.size()).isZero();
+    assertThat(reportedSize).hasValue(0);
+  }
+
   private LongHashSet setOf(final long... keys) {
     final var set = new LongHashSet();
     set.addAll(Arrays.stream(keys).boxed().toList());

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
@@ -109,6 +109,23 @@ final class BoundedScheduledCommandCacheTest {
     assertThat(metrics.get(JobIntent.TIME_OUT)).hasValue(1);
   }
 
+  @Test
+  void shouldClearCaches() {
+    // given
+    final var cache =
+        BoundedScheduledCommandCache.ofIntent(
+            NOOP_METRICS, TimerIntent.TRIGGER, JobIntent.TIME_OUT);
+    cache.add(JobIntent.TIME_OUT, 1);
+    cache.add(TimerIntent.TRIGGER, 1);
+
+    // when
+    cache.clear();
+
+    // then
+    assertThat(cache.contains(JobIntent.TIME_OUT, 1)).isFalse();
+    assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isFalse();
+  }
+
   @Nested
   final class StagedTest {
     @Test
@@ -176,6 +193,22 @@ final class BoundedScheduledCommandCacheTest {
       staged.remove(TimerIntent.TRIGGER, 1);
 
       // then
+      assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
+    }
+
+    @Test
+    void shouldClearOnlyStagedKeys() {
+      // given
+      final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
+      final var staged = cache.stage();
+      cache.add(TimerIntent.TRIGGER, 1);
+      staged.add(TimerIntent.TRIGGER, 2);
+
+      // when
+      staged.clear();
+
+      // then
+      assertThat(staged.contains(TimerIntent.TRIGGER, 2)).isFalse();
       assertThat(cache.contains(TimerIntent.TRIGGER, 1)).isTrue();
     }
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -11,8 +11,8 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 
 /**
  * Represents a cache to be used by the {@link
- * io.camunda.zeebe.engine.api.ProcessingScheduleService}, which allows it to cache which commands
- * it has written and avoid writing them again until they've been removed from the cache.
+ * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService}, which allows it to cache which
+ * commands it has written and avoid writing them again until they've been removed from the cache.
  */
 public interface ScheduledCommandCache {
 
@@ -29,6 +29,8 @@ public interface ScheduledCommandCache {
 
   /** Removes the given intent/key pair from the cache. */
   void remove(final Intent intent, final long key);
+
+  void clear();
 
   /** A dummy cache implementation which does nothing, i.e. caches nothing. */
   final class NoopScheduledCommandCache
@@ -47,6 +49,9 @@ public interface ScheduledCommandCache {
 
     @Override
     public void remove(final Intent intent, final long key) {}
+
+    @Override
+    public void clear() {}
 
     @Override
     public StagedScheduledCommandCache stage() {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -30,6 +30,7 @@ public interface ScheduledCommandCache {
   /** Removes the given intent/key pair from the cache. */
   void remove(final Intent intent, final long key);
 
+  /** Clears the underlying cache of all intent/key pairs. */
   void clear();
 
   /** A dummy cache implementation which does nothing, i.e. caches nothing. */
@@ -94,6 +95,8 @@ public interface ScheduledCommandCache {
    *
    * <p>A staged {@link #contains(Intent, long)} first looks up the buffered intent/key pairs, and
    * if not found, will also perform a look-up in the main cache.
+   *
+   * <p>A staged {@link #clear()} only removes the staged keys, and does not touch the main cache.
    */
   interface StagedScheduledCommandCache
       extends ScheduledCommandCache, ScheduledCommandCacheChanges {}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -278,6 +278,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     streamProcessorContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
     replayStateMachine.close();
+    scheduledCommandCache.clear();
   }
 
   private void healthCheckTick() {

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
@@ -32,6 +32,11 @@ public class TestScheduledCommandCache implements ScheduledCommandCache {
     cacheForIntent(intent).remove(key);
   }
 
+  @Override
+  public void clear() {
+    cachedKeys.values().forEach(Set::clear);
+  }
+
   private Set<Long> cacheForIntent(final Intent intent) {
     return cachedKeys.computeIfAbsent(intent, ignored -> new ConcurrentSkipListSet<>());
   }


### PR DESCRIPTION
## Description

This PR backports fixes to the scheduled command cache size metric, notably ensuring we initialize on start and reset it on close, as well as using a specific intent label including the intent class.

(cherry-picked from d83cf2bca9246b65620033561cd95c6f4ddc23d6 8ea78fcef6ead68155359984afeaba8b992390a9 a98b3f2c27a04363dc573ea3a9d0152a61c059ff without merge conflicts)

## Related issues

related to #13870 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
