### PR TITLE
New process instance migration record

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
@@ -60,6 +61,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchRecord::new);
     RECORDS_BY_TYPE.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER_TASK, UserTaskRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -752,6 +752,7 @@
         #     processInstance: true
         #     processInstanceBatch: false
         #     processInstanceCreation: true
+        #     processInstanceMigration: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
         #     resourceDeletion: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -832,6 +832,7 @@
         #     processInstance: true
         #     processInstanceBatch: false
         #     processInstanceCreation: true
+        #     processInstanceMigration: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
         #     resourceDeletion: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -644,6 +644,7 @@
         #     processInstance: true
         #     processInstanceBatch: false
         #     processInstanceCreation: true
+        #     processInstanceMigration: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
         #     resourceDeletion: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -724,6 +724,7 @@
         #     processInstance: true
         #     processInstanceBatch: false
         #     processInstanceCreation: true
+        #     processInstanceMigration: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
         #     resourceDeletion: true

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -291,6 +291,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.userTask) {
         createValueIndexTemplate(ValueType.USER_TASK);
       }
+      if (index.processInstanceMigration) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -88,6 +88,8 @@ public class ElasticsearchExporterConfiguration {
         return index.processInstanceBatch;
       case PROCESS_INSTANCE_CREATION:
         return index.processInstanceCreation;
+      case PROCESS_INSTANCE_MIGRATION:
+        return index.processInstanceMigration;
       case PROCESS_INSTANCE_MODIFICATION:
         return index.processInstanceModification;
       case PROCESS_MESSAGE_SUBSCRIPTION:
@@ -168,6 +170,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean processInstance = true;
     public boolean processInstanceBatch = false;
     public boolean processInstanceCreation = true;
+    public boolean processInstanceMigration = true;
     public boolean processInstanceModification = true;
     public boolean processMessageSubscription = true;
     public boolean variable = true;
@@ -250,6 +253,8 @@ public class ElasticsearchExporterConfiguration {
           + processInstanceBatch
           + ", processInstanceCreation="
           + processInstanceCreation
+          + ", processInstanceMigration="
+          + processInstanceMigration
           + ", processInstanceModification="
           + processInstanceModification
           + ", processMessageSubscription="

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
@@ -1,0 +1,30 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-migration_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-migration": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
@@ -21,6 +21,19 @@
           "properties": {
             "processInstanceKey": {
               "type": "long"
+            },
+            "targetProcessDefinitionKey": {
+              "type": "long"
+            },
+            "mappingInstructions": {
+              "properties": {
+                "sourceElementId": {
+                  "type": "keyword"
+                },
+                "targetElementId": {
+                  "type": "keyword"
+                }
+              }
             }
           }
         }

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -62,6 +62,7 @@ final class TestSupport {
       case VARIABLE -> config.variable = value;
       case VARIABLE_DOCUMENT -> config.variableDocument = value;
       case PROCESS_INSTANCE_CREATION -> config.processInstanceCreation = value;
+      case PROCESS_INSTANCE_MIGRATION -> config.processInstanceMigration = value;
       case PROCESS_INSTANCE_MODIFICATION -> config.processInstanceModification = value;
       case ERROR -> config.error = value;
       case PROCESS -> config.process = value;

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -238,6 +238,9 @@ public class OpensearchExporter implements Exporter {
       if (index.processInstanceCreation) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
       }
+      if (index.processInstanceMigration) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION);
+      }
       if (index.processInstanceModification) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION);
       }

--- a/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -87,6 +87,8 @@ public class OpensearchExporterConfiguration {
         return index.processInstanceBatch;
       case PROCESS_INSTANCE_CREATION:
         return index.processInstanceCreation;
+      case PROCESS_INSTANCE_MIGRATION:
+        return index.processInstanceMigration;
       case PROCESS_INSTANCE_MODIFICATION:
         return index.processInstanceModification;
       case PROCESS_MESSAGE_SUBSCRIPTION:
@@ -167,6 +169,7 @@ public class OpensearchExporterConfiguration {
     public boolean processInstance = true;
     public boolean processInstanceBatch = false;
     public boolean processInstanceCreation = true;
+    public boolean processInstanceMigration = true;
     public boolean processInstanceModification = true;
     public boolean processMessageSubscription = true;
     public boolean variable = true;
@@ -247,6 +250,8 @@ public class OpensearchExporterConfiguration {
           + processInstance
           + ", processInstanceCreation="
           + processInstanceCreation
+          + ", processInstanceMigration="
+          + processInstanceMigration
           + ", processInstanceModification="
           + processInstanceModification
           + ", processMessageSubscription="

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
@@ -1,0 +1,30 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-migration_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-migration": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
@@ -21,6 +21,19 @@
           "properties": {
             "processInstanceKey": {
               "type": "long"
+            },
+            "targetProcessDefinitionKey": {
+              "type": "long"
+            },
+            "mappingInstructions": {
+              "properties": {
+                "sourceElementId": {
+                  "type": "keyword"
+                },
+                "targetElementId": {
+                  "type": "keyword"
+                }
+              }
             }
           }
         }

--- a/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -61,6 +61,7 @@ final class TestSupport {
       case VARIABLE -> config.variable = value;
       case VARIABLE_DOCUMENT -> config.variableDocument = value;
       case PROCESS_INSTANCE_CREATION -> config.processInstanceCreation = value;
+      case PROCESS_INSTANCE_MIGRATION -> config.processInstanceMigration = value;
       case PROCESS_INSTANCE_MODIFICATION -> config.processInstanceModification = value;
       case ERROR -> config.error = value;
       case PROCESS -> config.process = value;

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationMappingInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationMappingInstruction.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue.ProcessInstanceMigrationMappingInstructionValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
+})
+public class ProcessInstanceMigrationMappingInstruction extends ObjectValue
+    implements ProcessInstanceMigrationMappingInstructionValue {
+
+  private final StringProperty sourceElementIdProperty = new StringProperty("sourceElementId", "");
+  private final StringProperty targetElementIdProperty = new StringProperty("targetElementId", "");
+
+  public ProcessInstanceMigrationMappingInstruction() {
+    declareProperty(sourceElementIdProperty).declareProperty(targetElementIdProperty);
+  }
+
+  @Override
+  public String getSourceElementId() {
+    return BufferUtil.bufferAsString(getSourceElementIdBuffer());
+  }
+
+  public ProcessInstanceMigrationMappingInstruction setSourceElementId(
+      final String sourceElementId) {
+    sourceElementIdProperty.setValue(sourceElementId);
+    return this;
+  }
+
+  public ProcessInstanceMigrationMappingInstruction setSourceElementId(
+      final DirectBuffer sourceElementId) {
+    sourceElementIdProperty.setValue(sourceElementId);
+    return this;
+  }
+
+  @Override
+  public String getTargetElementId() {
+    return BufferUtil.bufferAsString(getTargetElementIdBuffer());
+  }
+
+  public ProcessInstanceMigrationMappingInstruction setTargetElementId(
+      final String targetElementId) {
+    targetElementIdProperty.setValue(targetElementId);
+    return this;
+  }
+
+  public ProcessInstanceMigrationMappingInstruction setTargetElementId(
+      final DirectBuffer targetElementId) {
+    targetElementIdProperty.setValue(targetElementId);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getSourceElementIdBuffer() {
+    return sourceElementIdProperty.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getTargetElementIdBuffer() {
+    return targetElementIdProperty.getValue();
+  }
+
+  public void copy(final ProcessInstanceMigrationMappingInstruction other) {
+    sourceElementIdProperty.setValue(other.getSourceElementIdBuffer());
+    targetElementIdProperty.setValue(other.getTargetElementIdBuffer());
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+
+public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
+    implements ProcessInstanceMigrationRecordValue {
+
+  private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+
+  public ProcessInstanceMigrationRecord() {
+    declareProperty(processInstanceKeyProperty);
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceMigrationRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
@@ -7,17 +7,28 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+import java.util.List;
 
 public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
     implements ProcessInstanceMigrationRecordValue {
 
   private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+  private final LongProperty targetProcessDefinitionKeyProperty =
+      new LongProperty("targetProcessDefinitionKey");
+  private final ArrayProperty<ProcessInstanceMigrationMappingInstruction>
+      mappingInstructionsProperty =
+          new ArrayProperty<>(
+              "mappingInstructions", ProcessInstanceMigrationMappingInstruction::new);
 
   public ProcessInstanceMigrationRecord() {
-    declareProperty(processInstanceKeyProperty);
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(targetProcessDefinitionKeyProperty)
+        .declareProperty(mappingInstructionsProperty);
   }
 
   @Override
@@ -27,6 +38,49 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
 
   public ProcessInstanceMigrationRecord setProcessInstanceKey(final long processInstanceKey) {
     processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getTargetProcessDefinitionKey() {
+    return targetProcessDefinitionKeyProperty.getValue();
+  }
+
+  public ProcessInstanceMigrationRecord setTargetProcessDefinitionKey(
+      final long targetProcessDefinitionKey) {
+    targetProcessDefinitionKeyProperty.setValue(targetProcessDefinitionKey);
+    return this;
+  }
+
+  /**
+   * This method is expensive because it copies each element before returning it. It is recommended
+   * to use {@link #hasMappingInstructions()} before calling this.
+   *
+   * <p>{@inheritDoc}
+   */
+  @Override
+  public List<ProcessInstanceMigrationMappingInstructionValue> getMappingInstructions() {
+    // we need to make a copy of each element in the ArrayProperty while iterating it because the
+    // inner values are updated during the iteration
+    return mappingInstructionsProperty.stream()
+        .map(
+            element -> {
+              final var elementCopy = new ProcessInstanceMigrationMappingInstruction();
+              elementCopy.copy(element);
+              return (ProcessInstanceMigrationMappingInstructionValue) elementCopy;
+            })
+        .toList();
+  }
+
+  /** Returns true if this record has mapping instructions, otherwise false. */
+  @JsonIgnore
+  public boolean hasMappingInstructions() {
+    return !mappingInstructionsProperty.isEmpty();
+  }
+
+  public ProcessInstanceMigrationRecord addMappingInstruction(
+      final ProcessInstanceMigrationMappingInstruction mappingInstruction) {
+    mappingInstructionsProperty.add().copy(mappingInstruction);
     return this;
   }
 }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
@@ -2165,6 +2166,34 @@ final class JsonSerializableToJsonTest {
         "tenantId": "<default>"
       }
       """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////// ProcessInstanceMigrationRecord ///////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ProcessInstanceMigrationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> new ProcessInstanceMigrationRecord().setProcessInstanceKey(123L),
+        """
+        {
+          "processInstanceKey": 123
+        }
+        """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////// Empty ProcessInstanceMigrationRecord /////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty ProcessInstanceMigrationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> new ProcessInstanceMigrationRecord().setProcessInstanceKey(123L),
+        """
+        {
+          "processInstanceKey": 123
+        }
+        """
       },
     };
   }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
@@ -2174,10 +2175,34 @@ final class JsonSerializableToJsonTest {
       {
         "ProcessInstanceMigrationRecord",
         (Supplier<UnifiedRecordValue>)
-            () -> new ProcessInstanceMigrationRecord().setProcessInstanceKey(123L),
+            () ->
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(123L)
+                    .setTargetProcessDefinitionKey(456L)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("sourceId")
+                            .setTargetElementId("targetId"))
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("sourceId2"))
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setTargetElementId("targetId3")),
         """
         {
-          "processInstanceKey": 123
+          "processInstanceKey": 123,
+          "targetProcessDefinitionKey": 456,
+          "mappingInstructions": [{
+            "sourceElementId": "sourceId",
+            "targetElementId": "targetId"
+          }, {
+            "sourceElementId": "sourceId2",
+            "targetElementId": ""
+          }, {
+            "sourceElementId": "",
+            "targetElementId": "targetId3"
+          }]
         }
         """
       },
@@ -2188,10 +2213,15 @@ final class JsonSerializableToJsonTest {
       {
         "Empty ProcessInstanceMigrationRecord",
         (Supplier<UnifiedRecordValue>)
-            () -> new ProcessInstanceMigrationRecord().setProcessInstanceKey(123L),
+            () ->
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(123L)
+                    .setTargetProcessDefinitionKey(456L),
         """
         {
-          "processInstanceKey": 123
+          "processInstanceKey": 123,
+          "targetProcessDefinitionKey": 456,
+          "mappingInstructions": []
         }
         """
       },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
@@ -64,6 +65,7 @@ import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
@@ -211,6 +213,10 @@ public final class ValueTypeMapping {
     mapping.put(ValueType.FORM, new Mapping<>(Form.class, FormIntent.class));
     mapping.put(
         ValueType.USER_TASK, new Mapping<>(UserTaskRecordValue.class, UserTaskIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_MIGRATION,
+        new Mapping<>(
+            ProcessInstanceMigrationRecordValue.class, ProcessInstanceMigrationIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -54,7 +54,8 @@ public interface Intent {
           CommandDistributionIntent.class,
           ProcessInstanceBatchIntent.class,
           FormIntent.class,
-          UserTaskIntent.class);
+          UserTaskIntent.class,
+          ProcessInstanceMigrationIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -129,6 +130,8 @@ public interface Intent {
         return FormIntent.from(intent);
       case USER_TASK:
         return UserTaskIntent.from(intent);
+      case PROCESS_INSTANCE_MIGRATION:
+        return ProcessInstanceMigrationIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -200,6 +203,8 @@ public interface Intent {
         return FormIntent.valueOf(intent);
       case USER_TASK:
         return UserTaskIntent.valueOf(intent);
+      case PROCESS_INSTANCE_MODIFICATION:
+        return ProcessInstanceModificationIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -203,8 +203,8 @@ public interface Intent {
         return FormIntent.valueOf(intent);
       case USER_TASK:
         return UserTaskIntent.valueOf(intent);
-      case PROCESS_INSTANCE_MODIFICATION:
-        return ProcessInstanceModificationIntent.valueOf(intent);
+      case PROCESS_INSTANCE_MIGRATION:
+        return ProcessInstanceMigrationIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceMigrationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceMigrationIntent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ProcessInstanceMigrationIntent implements Intent, ProcessInstanceRelatedIntent {
+  MIGRATE((short) 0),
+  MIGRATED((short) 1);
+
+  private final short value;
+
+  ProcessInstanceMigrationIntent(final short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return MIGRATE;
+      case 1:
+        return MIGRATED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public boolean shouldBanInstanceOnError() {
+    // Process Instance Migration has transactional error handling. No need to ban the instance.
+    return false;
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableProcessInstanceMigrationRecordValue.Builder.class)
+public interface ProcessInstanceMigrationRecordValue extends RecordValue, ProcessInstanceRelated {}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
@@ -17,8 +17,54 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceMigrationRecordValue.Builder.class)
-public interface ProcessInstanceMigrationRecordValue extends RecordValue, ProcessInstanceRelated {}
+public interface ProcessInstanceMigrationRecordValue extends RecordValue, ProcessInstanceRelated {
+
+  /**
+   * @return the key of the process definition to migrate to
+   */
+  long getTargetProcessDefinitionKey();
+
+  /**
+   * @return the mapping instructions, or an empty list if no instructions are available
+   */
+  List<ProcessInstanceMigrationMappingInstructionValue> getMappingInstructions();
+
+  /**
+   * Mapping instructions for the migration describe how to map elements from the source process
+   * definition to the target process definition.
+   *
+   * <p>For example, let's consider a source process definition with a service task with id {@code
+   * "task1"} and the target process definition with a service task with id {@code "task2"}. The
+   * mapping instruction could be:
+   *
+   * <pre>{@code
+   * {
+   *   "sourceElementId": "task1",
+   *   "targetElementId": "task2"
+   * }
+   * }</pre>
+   *
+   * This mapping would migrate instances of the service task with id {@code "task1"} to the service
+   * task with id {@code "task2"}.
+   */
+  @Value.Immutable
+  @ImmutableProtocol(
+      builder = ImmutableProcessInstanceMigrationMappingInstructionValue.Builder.class)
+  interface ProcessInstanceMigrationMappingInstructionValue {
+
+    /**
+     * @return the source element id, or an empty string
+     */
+    String getSourceElementId();
+
+    /**
+     * @return the target element id, or an empty string
+     */
+    String getTargetElementId();
+  }
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -52,6 +52,7 @@
       <validValue name="MESSAGE_BATCH">35</validValue>
       <validValue name="FORM">36</validValue>
       <validValue name="USER_TASK">37</validValue>
+      <validValue name="PROCESS_INSTANCE_MIGRATION">38</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Introduces a new record value type: `PROCESS_INSTANCE_MIGRATION`, with intents `MIGRATE` and `MIGRATED`.

To add these, I've followed the steps described in the developer handbook [how to create a new record](https://github.com/camunda/zeebe/blob/main/docs/developer_handbook.md#how-to-create-a-new-record).

This PR:
- Adds the associated interfaces, and classes to the protocol and protocol-impl modules. 
- Allows the Broker's Command API to handle incoming requests with this payload (necessary for when the gateway sends requests to the broker)
- Adds support for the new record value type to the Elasticsearch and OpenSearch exporters (they are exported by default)
- Documents their configuration in the dist modules' configuration templates

This documentation will also be copied to docs.camunda.io via:
- https://github.com/camunda/camunda-docs/issues/2910

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15106

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
