### PR TITLE
Add log throttling to benchmark apps

### DIFF
--- a/benchmarks/project/pom.xml
+++ b/benchmarks/project/pom.xml
@@ -61,6 +61,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
     </dependency>

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.StarterCfg;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -37,6 +38,8 @@ import org.slf4j.LoggerFactory;
 
 public class Starter extends App {
 
+  private static final Logger THROTTLED_LOGGER =
+      new ThrottledLogger(LoggerFactory.getLogger(Starter.class), Duration.ofSeconds(5));
   private static final Logger LOG = LoggerFactory.getLogger(Starter.class);
   private static final long NANOS_PER_SECOND = Duration.ofSeconds(1).toNanos();
   private final AppCfg appCfg;
@@ -143,7 +146,7 @@ public class Starter extends App {
         }
 
       } catch (final Exception e) {
-        LOG.error("Error on creating new process instance", e);
+        THROTTLED_LOGGER.error("Error on creating new process instance", e);
       }
     } else {
       countDownLatch.countDown();
@@ -199,7 +202,7 @@ public class Starter extends App {
         client.newDeployResourceCommand().addResourceFromClasspath(bpmnXmlPath).send().join();
         break;
       } catch (final Exception e) {
-        LOG.warn("Failed to deploy process, retrying", e);
+        THROTTLED_LOGGER.warn("Failed to deploy process, retrying", e);
         try {
           Thread.sleep(200);
         } catch (final InterruptedException ex) {

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -22,15 +22,21 @@ import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.WorkerCfg;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.micrometer.core.instrument.Tags;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Worker extends App {
+  private static final Logger THROTTLED_LOGGER =
+      new ThrottledLogger(LoggerFactory.getLogger(Worker.class), Duration.ofSeconds(5));
   private final AppCfg appCfg;
 
   Worker(final AppCfg appCfg) {
@@ -69,7 +75,7 @@ public class Worker extends App {
                     try {
                       Thread.sleep(completionDelay);
                     } catch (final Exception e) {
-                      e.printStackTrace();
+                      THROTTLED_LOGGER.error("Exception on sleep", e);
                     }
                     requestFutures.add(command.send());
                   }


### PR DESCRIPTION
## Description

It has been seen on several occasions that our benchmark applications log too much noise, especially in fault scenarios, when brokers are not available, etc.

[We can also see that we spent most of our budget on logging](https://camunda.slack.com/archives/C0233V3K92T/p1699026797671809?thread_ts=1699025428.831169&cid=C0233V3K92T), so we should try to reduce this.


[1. Example ](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22zeebe-io%22%0Aresource.labels.location%3D%22europe-west1-b%22%0Aresource.labels.cluster_name%3D%22zeebe-cluster%22%0Alabels.k8s-pod%2Fapp%3D%22starter%22;pinnedLogId=2023-11-13T01:38:31.609371921Z%2F68q0401j3vv2hrit;cursorTimestamp=2023-11-13T01:38:31.609371921Z;startTime=2023-11-12T16:03:58.029Z;endTime=2023-11-13T13:03:58.029081Z?project=zeebe-io)

![logging](https://github.com/camunda/zeebe/assets/2758593/c06e6453-2d8e-46e5-a0cf-85accf1b715a)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->



<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
