### PR TITLE
[Backport 8.2]: Add log throttling to benchmark apps

### DIFF
--- a/benchmarks/project/pom.xml
+++ b/benchmarks/project/pom.xml
@@ -61,6 +61,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
     </dependency>

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
@@ -22,12 +22,15 @@ import com.typesafe.config.ConfigFactory;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.config.AppCfg;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import io.grpc.ClientInterceptor;
 import io.prometheus.client.exporter.HTTPServer;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.time.Duration;
 import java.util.function.Function;
 import me.dinowernli.grpc.prometheus.Configuration;
 import me.dinowernli.grpc.prometheus.MonitoringClientInterceptor;
@@ -36,7 +39,9 @@ import org.slf4j.LoggerFactory;
 
 abstract class App implements Runnable {
 
-  protected static MonitoringClientInterceptor monitoringInterceptor;
+  protected static ClientInterceptor monitoringInterceptor;
+  private static final Logger THROTTLED_LOGGER =
+      new ThrottledLogger(LoggerFactory.getLogger(App.class), Duration.ofSeconds(5));
   private static final Logger LOG = LoggerFactory.getLogger(App.class);
   private static HTTPServer monitoringServer;
 
@@ -66,7 +71,6 @@ abstract class App implements Runnable {
   }
 
   void printTopology(final ZeebeClient client) {
-    var failureCount = 0;
     while (true) {
       try {
         final Topology topology = client.newTopologyRequest().send().join();
@@ -80,10 +84,7 @@ abstract class App implements Runnable {
                 });
         break;
       } catch (final Exception e) {
-        // retry
-        if ((failureCount++ % 1000) == 0) {
-          LOG.warn("Topology request failed", e);
-        }
+        THROTTLED_LOGGER.warn("Topology request failed", e);
       }
     }
   }

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.StarterCfg;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -37,6 +38,8 @@ import org.slf4j.LoggerFactory;
 
 public class Starter extends App {
 
+  private static final Logger THROTTLED_LOGGER =
+      new ThrottledLogger(LoggerFactory.getLogger(Starter.class), Duration.ofSeconds(5));
   private static final Logger LOG = LoggerFactory.getLogger(Starter.class);
   private static final long NANOS_PER_SECOND = Duration.ofSeconds(1).toNanos();
   private final AppCfg appCfg;
@@ -143,7 +146,7 @@ public class Starter extends App {
         }
 
       } catch (final Exception e) {
-        LOG.error("Error on creating new process instance", e);
+        THROTTLED_LOGGER.error("Error on creating new process instance", e);
       }
     } else {
       countDownLatch.countDown();
@@ -199,7 +202,7 @@ public class Starter extends App {
         client.newDeployResourceCommand().addResourceFromClasspath(bpmnXmlPath).send().join();
         break;
       } catch (final Exception e) {
-        LOG.warn("Failed to deploy process, retrying", e);
+        THROTTLED_LOGGER.warn("Failed to deploy process, retrying", e);
         try {
           Thread.sleep(200);
         } catch (final InterruptedException ex) {

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -21,14 +21,20 @@ import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.WorkerCfg;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Worker extends App {
+  private static final Logger THROTTLED_LOGGER =
+      new ThrottledLogger(LoggerFactory.getLogger(Worker.class), Duration.ofSeconds(5));
   private final AppCfg appCfg;
 
   Worker(final AppCfg appCfg) {
@@ -62,7 +68,7 @@ public class Worker extends App {
                     try {
                       Thread.sleep(completionDelay);
                     } catch (final Exception e) {
-                      e.printStackTrace();
+                      THROTTLED_LOGGER.error("Exception on sleep", e);
                     }
                     requestFutures.add(command.send());
                   }


### PR DESCRIPTION


## Description

Backport https://github.com/camunda/zeebe/pull/15165

Had merge conflicts because of changes with the metrics in the apps, which are not changed in 8.2

> It has been seen in several occasions that our benchmark applications log to much nois especially on fault scenarios, when broker are not available etc.
<!-- Please explain the changes you made here. -->
