### PR TITLE
feat(topology): all requests support dry-run

### DIFF
--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -23,6 +23,7 @@ paths:
                    to complete the operation.
       parameters:
         - $ref: '#/components/parameters/BrokerId'
+        - $ref: '#/components/parameters/DryRunParameter'
       responses:
         '202':
           $ref: '#/components/responses/AddBrokersResponse'
@@ -42,6 +43,7 @@ paths:
                    running to complete the operation.
       parameters:
         - $ref: '#/components/parameters/BrokerId'
+        - $ref: '#/components/parameters/DryRunParameter'
       responses:
         '202':
           $ref: '#/components/responses/RemoveBrokerResponse'
@@ -69,14 +71,7 @@ paths:
             schema:
               $ref: "#/components/schemas/ScaleRequest"
       parameters:
-        - name: dryRun
-          description: If true, requested changes are only simulated and not actually applied.
-          in: query
-          style: form
-          required: false
-          schema:
-            type: boolean
-            default: false
+        - $ref: '#/components/parameters/DryRunParameter'
       responses:
         '202':
           $ref: "#/components/responses/ScaleBrokersResponse"
@@ -125,6 +120,15 @@ components:
       description: Id of the broker
       schema:
         $ref: '#/components/schemas/BrokerId'
+    DryRunParameter:
+      name: dryRun
+      description: If true, requested changes are only simulated and not actually applied.
+      in: query
+      style: form
+      required: false
+      schema:
+        type: boolean
+        default: false
 
   responses:
     ConcurrentChangeError:

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequest.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequest.java
@@ -15,25 +15,32 @@ public sealed interface TopologyManagementRequest {
 
   /**
    * Marks a request as dry run. Changes are planned and validated but not applied so the cluster
-   * topology remains unchanged. Requests that don't support dry-run return false by default.
+   * topology remains unchanged.
    */
-  default boolean dryRun() {
-    return false;
-  }
+  boolean dryRun();
 
-  record AddMembersRequest(Set<MemberId> members) implements TopologyManagementRequest {}
-
-  record RemoveMembersRequest(Set<MemberId> members) implements TopologyManagementRequest {}
-
-  record JoinPartitionRequest(MemberId memberId, int partitionId, int priority)
+  record AddMembersRequest(Set<MemberId> members, boolean dryRun)
       implements TopologyManagementRequest {}
 
-  record LeavePartitionRequest(MemberId memberId, int partitionId)
+  record RemoveMembersRequest(Set<MemberId> members, boolean dryRun)
       implements TopologyManagementRequest {}
 
-  record ReassignPartitionsRequest(Set<MemberId> members) implements TopologyManagementRequest {}
+  record JoinPartitionRequest(MemberId memberId, int partitionId, int priority, boolean dryRun)
+      implements TopologyManagementRequest {}
+
+  record LeavePartitionRequest(MemberId memberId, int partitionId, boolean dryRun)
+      implements TopologyManagementRequest {}
+
+  record ReassignPartitionsRequest(Set<MemberId> members, boolean dryRun)
+      implements TopologyManagementRequest {}
 
   record ScaleRequest(Set<MemberId> members, boolean dryRun) implements TopologyManagementRequest {}
 
-  record CancelChangeRequest(long changeId) implements TopologyManagementRequest {}
+  record CancelChangeRequest(long changeId) implements TopologyManagementRequest {
+
+    @Override
+    public boolean dryRun() {
+      return false;
+    }
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -115,10 +115,10 @@ public final class TopologyManagementRequestSender {
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterTopology>> cancelTopologyChange(
-      final long changeId) {
+      final TopologyManagementRequest.CancelChangeRequest request) {
     return communicationService.send(
         TopologyRequestTopics.CANCEL_CHANGE.topic(),
-        new TopologyManagementRequest.CancelChangeRequest(changeId),
+        request,
         serializer::encodeCancelChangeRequest,
         serializer::decodeClusterTopologyResponse,
         coordinator,

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -388,6 +388,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
   public byte[] encodeAddMembersRequest(final AddMembersRequest req) {
     return Requests.AddMembersRequest.newBuilder()
         .addAllMemberIds(req.members().stream().map(MemberId::id).toList())
+        .setDryRun(req.dryRun())
         .build()
         .toByteArray();
   }
@@ -396,6 +397,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
   public byte[] encodeRemoveMembersRequest(final RemoveMembersRequest req) {
     return Requests.RemoveMembersRequest.newBuilder()
         .addAllMemberIds(req.members().stream().map(MemberId::id).toList())
+        .setDryRun(req.dryRun())
         .build()
         .toByteArray();
   }
@@ -406,6 +408,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
         .setMemberId(req.memberId().id())
         .setPartitionId(req.partitionId())
         .setPriority(req.priority())
+        .setDryRun(req.dryRun())
         .build()
         .toByteArray();
   }
@@ -415,6 +418,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
     return Requests.LeavePartitionRequest.newBuilder()
         .setMemberId(req.memberId().id())
         .setPartitionId(req.partitionId())
+        .setDryRun(req.dryRun())
         .build()
         .toByteArray();
   }
@@ -424,6 +428,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       final ReassignPartitionsRequest reassignPartitionsRequest) {
     return Requests.ReassignAllPartitionsRequest.newBuilder()
         .addAllMemberIds(reassignPartitionsRequest.members().stream().map(MemberId::id).toList())
+        .setDryRun(reassignPartitionsRequest.dryRun())
         .build()
         .toByteArray();
   }
@@ -452,7 +457,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       return new AddMembersRequest(
           addMemberRequest.getMemberIdsList().stream()
               .map(MemberId::from)
-              .collect(Collectors.toSet()));
+              .collect(Collectors.toSet()),
+          addMemberRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }
@@ -465,7 +471,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       return new RemoveMembersRequest(
           removeMemberRequest.getMemberIdsList().stream()
               .map(MemberId::from)
-              .collect(Collectors.toSet()));
+              .collect(Collectors.toSet()),
+          removeMemberRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }
@@ -478,7 +485,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       return new JoinPartitionRequest(
           MemberId.from(joinPartitionRequest.getMemberId()),
           joinPartitionRequest.getPartitionId(),
-          joinPartitionRequest.getPriority());
+          joinPartitionRequest.getPriority(),
+          joinPartitionRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }
@@ -490,7 +498,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       final var leavePartitionRequest = Requests.LeavePartitionRequest.parseFrom(encodedState);
       return new LeavePartitionRequest(
           MemberId.from(leavePartitionRequest.getMemberId()),
-          leavePartitionRequest.getPartitionId());
+          leavePartitionRequest.getPartitionId(),
+          leavePartitionRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }
@@ -504,7 +513,8 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       return new ReassignPartitionsRequest(
           reassignPartitionsRequest.getMemberIdsList().stream()
               .map(MemberId::from)
-              .collect(Collectors.toSet()));
+              .collect(Collectors.toSet()),
+          reassignPartitionsRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/topology/src/main/resources/proto/requests.proto
+++ b/topology/src/main/resources/proto/requests.proto
@@ -7,21 +7,25 @@ option java_package = "io.camunda.zeebe.topology.protocol";
 
 message AddMembersRequest {
   repeated string memberIds = 1;
+  bool dryRun = 2;
 }
 
 message RemoveMembersRequest {
   repeated string memberIds = 1;
+  bool dryRun = 2;
 }
 
 message JoinPartitionRequest {
   string memberId = 1;
   int32 partitionId = 2;
   int32 priority = 3;
+  bool dryRun = 4;
 }
 
 message LeavePartitionRequest {
   string memberId = 1;
   int32 partitionId = 2;
+  bool dryRun = 3;
 }
 
 message ScaleRequest {
@@ -32,6 +36,7 @@ message ScaleRequest {
 message ReassignAllPartitionsRequest {
   // The ids of the brokers to which all partitions should be re-distributed
   repeated string memberIds = 1;
+  bool dryRun = 2;
 }
 
 message CancelTopologyChangeRequest {

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
@@ -111,7 +111,8 @@ final class TopologyManagementApiTest {
   @Test
   void shouldAddMembers() {
     // given
-    final var request = new TopologyManagementRequest.AddMembersRequest(Set.of(MemberId.from("1")));
+    final var request =
+        new TopologyManagementRequest.AddMembersRequest(Set.of(MemberId.from("1")), false);
 
     // when
     final var changeStatus = clientApi.addMembers(request).join().get();
@@ -130,7 +131,7 @@ final class TopologyManagementApiTest {
             .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of())));
     final var request =
         new TopologyManagementRequest.RemoveMembersRequest(
-            Set.of(MemberId.from("1"), MemberId.from("2")));
+            Set.of(MemberId.from("1"), MemberId.from("2")), false);
 
     // when
     final var changeStatus = clientApi.removeMembers(request).join().get();
@@ -147,7 +148,7 @@ final class TopologyManagementApiTest {
   void shouldJoinPartition() {
     // given
     final var request =
-        new TopologyManagementRequest.JoinPartitionRequest(MemberId.from("1"), 1, 3);
+        new TopologyManagementRequest.JoinPartitionRequest(MemberId.from("1"), 1, 3, false);
 
     // when
     final var changeStatus = clientApi.joinPartition(request).join().get();
@@ -160,7 +161,8 @@ final class TopologyManagementApiTest {
   @Test
   void shouldLeavePartition() {
     // given
-    final var request = new TopologyManagementRequest.LeavePartitionRequest(MemberId.from("1"), 1);
+    final var request =
+        new TopologyManagementRequest.LeavePartitionRequest(MemberId.from("1"), 1, false);
 
     // when
     final var changeStatus = clientApi.leavePartition(request).join().get();
@@ -175,7 +177,7 @@ final class TopologyManagementApiTest {
     // given
     final var request =
         new TopologyManagementRequest.ReassignPartitionsRequest(
-            Set.of(MemberId.from("1"), MemberId.from("2")));
+            Set.of(MemberId.from("1"), MemberId.from("2")), false);
     final ClusterTopology currentTopology =
         ClusterTopology.init()
             .addMember(

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -74,7 +74,7 @@ final class ProtoBufSerializerTest {
   void shouldEncodeAndDecodeAddMembersRequest() {
     // given
     final var addMembersRequest =
-        new AddMembersRequest(Set.of(MemberId.from("1"), MemberId.from("2")));
+        new AddMembersRequest(Set.of(MemberId.from("1"), MemberId.from("2")), false);
 
     // when
     final var encodedRequest = protoBufSerializer.encodeAddMembersRequest(addMembersRequest);
@@ -88,7 +88,7 @@ final class ProtoBufSerializerTest {
   void shouldEncodeAndDecodeRemoveMembersRequest() {
     // given
     final var removeMembersRequest =
-        new RemoveMembersRequest(Set.of(MemberId.from("1"), MemberId.from("2")));
+        new RemoveMembersRequest(Set.of(MemberId.from("1"), MemberId.from("2")), false);
 
     // when
     final var encodedRequest = protoBufSerializer.encodeRemoveMembersRequest(removeMembersRequest);
@@ -102,7 +102,7 @@ final class ProtoBufSerializerTest {
   void shouldEncodeAndDecodeReassignAllPartitionsRequest() {
     // given
     final var reassignPartitionsRequest =
-        new ReassignPartitionsRequest(Set.of(MemberId.from("1"), MemberId.from("2")));
+        new ReassignPartitionsRequest(Set.of(MemberId.from("1"), MemberId.from("2")), false);
 
     // when
     final var encodedRequest =
@@ -116,7 +116,7 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodeJoinPartitionRequest() {
     // given
-    final var joinPartitionRequest = new JoinPartitionRequest(MemberId.from("2"), 3, 5);
+    final var joinPartitionRequest = new JoinPartitionRequest(MemberId.from("2"), 3, 5, false);
 
     // when
     final var encodedRequest = protoBufSerializer.encodeJoinPartitionRequest(joinPartitionRequest);
@@ -129,7 +129,7 @@ final class ProtoBufSerializerTest {
   @Test
   void shouldEncodeAndDecodeLeavePartitionRequest() {
     // given
-    final var leavePartitionRequest = new LeavePartitionRequest(MemberId.from("6"), 2);
+    final var leavePartitionRequest = new LeavePartitionRequest(MemberId.from("6"), 2, false);
 
     // when
     final var encodedRequest =


### PR DESCRIPTION
Builds on top of https://github.com/camunda/zeebe/pull/15170 and adds support for dry-runs for _all_ topology change requests.