### PR TITLE
Enable coordinator to cancel an ongoing topology change

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -362,6 +362,7 @@ public class ClusterEndpoint {
       case IN_PROGRESS -> StatusEnum.IN_PROGRESS;
       case COMPLETED -> StatusEnum.COMPLETED;
       case FAILED -> StatusEnum.FAILED;
+      case CANCELLED -> StatusEnum.FAILED; // TODO: Define cancelled status
     };
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -362,7 +362,7 @@ public class ClusterEndpoint {
       case IN_PROGRESS -> StatusEnum.IN_PROGRESS;
       case COMPLETED -> StatusEnum.COMPLETED;
       case FAILED -> StatusEnum.FAILED;
-      case CANCELLED -> StatusEnum.FAILED; // TODO: Define cancelled status
+      case CANCELLED -> StatusEnum.CANCELLED; // TODO: Define cancelled status
     };
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -362,7 +362,7 @@ public class ClusterEndpoint {
       case IN_PROGRESS -> StatusEnum.IN_PROGRESS;
       case COMPLETED -> StatusEnum.COMPLETED;
       case FAILED -> StatusEnum.FAILED;
-      case CANCELLED -> StatusEnum.CANCELLED; // TODO: Define cancelled status
+      case CANCELLED -> StatusEnum.CANCELLED;
     };
   }
 

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -243,6 +243,7 @@ components:
             - IN_PROGRESS
             - COMPLETED
             - FAILED
+            - CANCELLED
         startedAt:
           type: string
           format: date-time

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -76,9 +76,7 @@ public final class ClusterTopologyManagerService extends Actor implements Topolo
     isCoordinator = localMemberId.id().equals(COORDINATOR_ID);
     if (isCoordinator) {
       // Only a coordinator can start topology change
-      topologyChangeCoordinator =
-          new TopologyChangeCoordinatorImpl(
-              clusterTopologyManager, clusterTopologyGossiper::queryClusterTopology, this);
+      topologyChangeCoordinator = new TopologyChangeCoordinatorImpl(clusterTopologyManager, this);
       topologyRequestServer =
           new TopologyRequestServer(
               communicationService,

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -76,7 +76,9 @@ public final class ClusterTopologyManagerService extends Actor implements Topolo
     isCoordinator = localMemberId.id().equals(COORDINATOR_ID);
     if (isCoordinator) {
       // Only a coordinator can start topology change
-      topologyChangeCoordinator = new TopologyChangeCoordinatorImpl(clusterTopologyManager, this);
+      topologyChangeCoordinator =
+          new TopologyChangeCoordinatorImpl(
+              clusterTopologyManager, clusterTopologyGossiper::queryClusterTopology, this);
       topologyRequestServer =
           new TopologyRequestServer(
               communicationService,

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementApi.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementApi.java
@@ -32,5 +32,8 @@ public interface TopologyManagementApi {
 
   ActorFuture<TopologyChangeResponse> scaleMembers(ScaleRequest scaleRequest);
 
+  ActorFuture<ClusterTopology> cancelTopologyChange(
+      TopologyManagementRequest.CancelChangeRequest cancelChangeRequest);
+
   ActorFuture<ClusterTopology> getTopology();
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequest.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequest.java
@@ -34,4 +34,6 @@ public sealed interface TopologyManagementRequest {
   record ReassignPartitionsRequest(Set<MemberId> members) implements TopologyManagementRequest {}
 
   record ScaleRequest(Set<MemberId> members, boolean dryRun) implements TopologyManagementRequest {}
+
+  record CancelChangeRequest(long changeId) implements TopologyManagementRequest {}
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -113,4 +113,14 @@ public final class TopologyManagementRequestSender {
         coordinator,
         TIMEOUT);
   }
+
+  public CompletableFuture<ClusterTopology> cancelTopologyChange(final long changeId) {
+    return communicationService.send(
+        TopologyRequestTopics.CANCEL_CHANGE.topic(),
+        new TopologyManagementRequest.CancelChangeRequest(changeId),
+        serializer::encodeCancelChangeRequest,
+        serializer::decodeClusterTopology,
+        coordinator,
+        TIMEOUT);
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.topology.api;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.ReassignPartitionsRequest;
@@ -97,6 +98,12 @@ public final class TopologyManagementRequestsHandler implements TopologyManageme
     } else {
       return handleRequest(coordinator::applyOperations, transformer);
     }
+  }
+
+  @Override
+  public ActorFuture<ClusterTopology> cancelTopologyChange(
+      final CancelChangeRequest changeRequest) {
+    return coordinator.cancelChange(changeRequest.changeId());
   }
 
   @Override

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -45,6 +45,7 @@ public final class TopologyRequestServer implements AutoCloseable {
     registerReassignPartitionRequestHandler();
     registerScaleRequestHandler();
     registerGetTopologyQueryHandler();
+    registerTopologyCancelHandler();
   }
 
   @Override
@@ -115,6 +116,14 @@ public final class TopologyRequestServer implements AutoCloseable {
         TopologyRequestTopics.QUERY_TOPOLOGY.topic(),
         Function.identity(),
         request -> topologyManagementApi.getTopology().toCompletableFuture(),
+        serializer::encode);
+  }
+
+  private void registerTopologyCancelHandler() {
+    communicationService.replyTo(
+        TopologyRequestTopics.CANCEL_CHANGE.topic(),
+        serializer::decodeCancelChangeRequest,
+        request -> topologyManagementApi.cancelTopologyChange(request).toCompletableFuture(),
         serializer::encode);
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestTopics.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestTopics.java
@@ -14,7 +14,9 @@ public enum TopologyRequestTopics {
   LEAVE_PARTITION("topology-partition-leave"),
   REASSIGN_PARTITIONS("topology-partition-reassign"),
   SCALE_MEMBERS("topology-member-scale"),
-  QUERY_TOPOLOGY("topology-query");
+  QUERY_TOPOLOGY("topology-query"),
+  CANCEL_CHANGE("topology-change-cancel");
+
   private final String topic;
 
   TopologyRequestTopics(final String topic) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinator.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinator.java
@@ -40,6 +40,17 @@ public interface TopologyChangeCoordinator {
    */
   ActorFuture<TopologyChangeResult> simulateOperations(TopologyChangeRequest requestTransformer);
 
+  /**
+   * Cancels a topology change. This is an unsafe operation and should be called only when the
+   * operation is stuck and cannot make progress on its own. When a change is cancelled, already
+   * applied operations are not reverted. So the ClusterTopology will be in an intermediate state
+   * with partially applied operations.
+   *
+   * @param changeId the id of the change to cancel
+   * @return a future which is completed when the change has been cancelled successfully.
+   */
+  ActorFuture<ClusterTopology> cancelChange(long changeId);
+
   record TopologyChangeResult(
       // The current topology before applying the operations.
       ClusterTopology currentTopology,

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.topology.changes;
 
-import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.topology.ClusterTopologyManager;
@@ -21,7 +20,6 @@ import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.CompletedChange;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import java.util.List;
-import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,14 +27,10 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
   private static final Logger LOG = LoggerFactory.getLogger(TopologyChangeCoordinatorImpl.class);
   private final ClusterTopologyManager clusterTopologyManager;
   private final ConcurrencyControl executor;
-  private final Function<MemberId, ActorFuture<ClusterTopology>> syncRequester;
 
   public TopologyChangeCoordinatorImpl(
-      final ClusterTopologyManager clusterTopologyManager,
-      final Function<MemberId, ActorFuture<ClusterTopology>> syncRequester,
-      final ConcurrencyControl executor) {
+      final ClusterTopologyManager clusterTopologyManager, final ConcurrencyControl executor) {
     this.clusterTopologyManager = clusterTopologyManager;
-    this.syncRequester = syncRequester;
     this.executor = executor;
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -599,6 +599,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       case IN_PROGRESS -> Topology.ChangeStatus.IN_PROGRESS;
       case COMPLETED -> Topology.ChangeStatus.COMPLETED;
       case FAILED -> Topology.ChangeStatus.FAILED;
+      case CANCELLED -> Topology.ChangeStatus.FAILED; // TODO: Define cancelled status
     };
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -13,6 +13,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.api.ErrorResponse;
 import io.camunda.zeebe.topology.api.TopologyChangeResponse;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.topology.api.TopologyManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.ReassignPartitionsRequest;
@@ -433,6 +434,14 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
   }
 
   @Override
+  public byte[] encodeCancelChangeRequest(final CancelChangeRequest cancelChangeRequest) {
+    return Requests.CancelTopologyChangeRequest.newBuilder()
+        .setChangeId(cancelChangeRequest.changeId())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
   public AddMembersRequest decodeAddMembersRequest(final byte[] encodedState) {
     try {
       final var addMemberRequest = Requests.AddMembersRequest.parseFrom(encodedState);
@@ -504,6 +513,16 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       return new ScaleRequest(
           scaleRequest.getMemberIdsList().stream().map(MemberId::from).collect(Collectors.toSet()),
           scaleRequest.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public CancelChangeRequest decodeCancelChangeRequest(final byte[] encodedState) {
+    try {
+      final var cancelChangeRequest = Requests.CancelTopologyChangeRequest.parseFrom(encodedState);
+      return new CancelChangeRequest(cancelChangeRequest.getChangeId());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.topology.protocol.Requests.ErrorCode;
 import io.camunda.zeebe.topology.protocol.Requests.Response;
 import io.camunda.zeebe.topology.protocol.Requests.TopologyChangeResponse.Builder;
 import io.camunda.zeebe.topology.protocol.Topology;
+import io.camunda.zeebe.topology.protocol.Topology.ChangeStatus;
 import io.camunda.zeebe.topology.protocol.Topology.CompletedChange;
 import io.camunda.zeebe.topology.protocol.Topology.MemberState;
 import io.camunda.zeebe.topology.state.ClusterChangePlan;
@@ -599,7 +600,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       case IN_PROGRESS -> Topology.ChangeStatus.IN_PROGRESS;
       case COMPLETED -> Topology.ChangeStatus.COMPLETED;
       case FAILED -> Topology.ChangeStatus.FAILED;
-      case CANCELLED -> Topology.ChangeStatus.FAILED; // TODO: Define cancelled status
+      case CANCELLED -> ChangeStatus.CANCELLED;
     };
   }
 
@@ -608,6 +609,7 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
       case IN_PROGRESS -> ClusterChangePlan.Status.IN_PROGRESS;
       case COMPLETED -> ClusterChangePlan.Status.COMPLETED;
       case FAILED -> ClusterChangePlan.Status.FAILED;
+      case CANCELLED -> ClusterChangePlan.Status.CANCELLED;
       default -> throw new IllegalStateException("Unknown status: " + status);
     };
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
@@ -28,6 +28,9 @@ public interface TopologyRequestsSerializer {
 
   byte[] encodeScaleRequest(TopologyManagementRequest.ScaleRequest scaleRequest);
 
+  byte[] encodeCancelChangeRequest(
+      TopologyManagementRequest.CancelChangeRequest cancelChangeRequest);
+
   TopologyManagementRequest.AddMembersRequest decodeAddMembersRequest(byte[] encodedState);
 
   TopologyManagementRequest.RemoveMembersRequest decodeRemoveMembersRequest(byte[] encodedState);
@@ -40,6 +43,8 @@ public interface TopologyRequestsSerializer {
       byte[] encodedState);
 
   TopologyManagementRequest.ScaleRequest decodeScaleRequest(byte[] encodedState);
+
+  TopologyManagementRequest.CancelChangeRequest decodeCancelChangeRequest(byte[] encodedState);
 
   byte[] encodeResponse(TopologyChangeResponse response);
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterChangePlan.java
@@ -73,11 +73,16 @@ public record ClusterChangePlan(
     return !pendingOperations().isEmpty();
   }
 
+  public CompletedChange cancel() {
+    return new CompletedChange(id, Status.CANCELLED, startedAt(), Instant.now());
+  }
+
   public record CompletedOperation(TopologyChangeOperation operation, Instant completedAt) {}
 
   public enum Status {
     IN_PROGRESS,
     COMPLETED,
-    FAILED;
+    FAILED,
+    CANCELLED;
   }
 }

--- a/topology/src/main/resources/proto/requests.proto
+++ b/topology/src/main/resources/proto/requests.proto
@@ -34,6 +34,10 @@ message ReassignAllPartitionsRequest {
   repeated string memberIds = 1;
 }
 
+message CancelTopologyChangeRequest {
+  int64 changeId = 1;
+}
+
 message TopologyChangeResponse {
   int64 changeId = 1;
   map<string, topology_protocol.MemberState> currentTopology = 2;

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -91,6 +91,7 @@ enum ChangeStatus {
   IN_PROGRESS = 1;
   COMPLETED = 2;
   FAILED = 3;
+  CANCELLED = 4;
 }
 
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/RecordingChangeCoordinator.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/RecordingChangeCoordinator.java
@@ -57,6 +57,11 @@ final class RecordingChangeCoordinator implements TopologyChangeCoordinator {
     throw new UnsupportedOperationException("Simulating changes is not supported in tests");
   }
 
+  @Override 
+  public ActorFuture<ClusterTopology> cancelChange(final long changeId) {
+    return TestActorFuture.failedFuture(new UnsupportedOperationException());
+  }
+
   public List<TopologyChangeOperation> getLastAppliedOperation() {
     return lastAppliedOperation;
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/RecordingChangeCoordinator.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/RecordingChangeCoordinator.java
@@ -57,7 +57,7 @@ final class RecordingChangeCoordinator implements TopologyChangeCoordinator {
     throw new UnsupportedOperationException("Simulating changes is not supported in tests");
   }
 
-  @Override 
+  @Override
   public ActorFuture<ClusterTopology> cancelChange(final long changeId) {
     return TestActorFuture.failedFuture(new UnsupportedOperationException());
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
@@ -166,7 +166,8 @@ final class TopologyChangeCoordinatorImplTest {
         List.of(new PartitionJoinOperation(MemberId.from("1"), 1, 1));
 
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(
+            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
 
     // when
     final var simulationResult = coordinator.simulateOperations(getTransformer(operations));

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
@@ -49,8 +49,7 @@ final class TopologyChangeCoordinatorImplTest {
     // given
     clusterTopologyManager.setClusterTopology(ClusterTopology.init());
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(
-            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
 
     // when
 
@@ -79,8 +78,7 @@ final class TopologyChangeCoordinatorImplTest {
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
             .updateMember(MemberId.from("1"), m -> m.addPartition(1, PartitionState.active(1))));
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(
-            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
 
     // when
 
@@ -108,8 +106,7 @@ final class TopologyChangeCoordinatorImplTest {
         ClusterTopology.init()
             .startTopologyChange(List.of(new PartitionLeaveOperation(MemberId.from("1"), 1))));
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(
-            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
 
     // when
     final var applyFuture =
@@ -138,8 +135,7 @@ final class TopologyChangeCoordinatorImplTest {
         List.of(new PartitionJoinOperation(MemberId.from("1"), 1, 1));
 
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(
-            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
 
     // when
     final var applyFuture = coordinator.applyOperations(getTransformer(operations));
@@ -166,8 +162,7 @@ final class TopologyChangeCoordinatorImplTest {
         List.of(new PartitionJoinOperation(MemberId.from("1"), 1, 1));
 
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(
-            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
 
     // when
     final var simulationResult = coordinator.simulateOperations(getTransformer(operations));
@@ -184,8 +179,7 @@ final class TopologyChangeCoordinatorImplTest {
     // given
     clusterTopologyManager.setClusterTopology(ClusterTopology.init());
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(
-            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
 
     // when
 
@@ -217,8 +211,7 @@ final class TopologyChangeCoordinatorImplTest {
         List.of(new PartitionJoinOperation(MemberId.from("1"), 1, 1));
 
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(
-            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
     final var applyResult = coordinator.applyOperations(getTransformer(operations)).join();
 
     // when
@@ -254,8 +247,7 @@ final class TopologyChangeCoordinatorImplTest {
         List.of(new PartitionJoinOperation(MemberId.from("1"), 1, 1));
 
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(
-            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
     final var applyResult = coordinator.applyOperations(getTransformer(operations)).join();
 
     // when

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
@@ -16,9 +16,12 @@ import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.topology.ClusterTopologyAssert;
 import io.camunda.zeebe.topology.ClusterTopologyManager;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException;
+import io.camunda.zeebe.topology.api.TopologyRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.OperationNotAllowed;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator.TopologyChangeRequest;
+import io.camunda.zeebe.topology.state.ClusterChangePlan;
 import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.CompletedChange;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
@@ -26,6 +29,7 @@ import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOp
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -179,7 +183,8 @@ final class TopologyChangeCoordinatorImplTest {
     // given
     clusterTopologyManager.setClusterTopology(ClusterTopology.init());
     final var coordinator =
-        new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
+        new TopologyChangeCoordinatorImpl(
+            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
 
     // when
 
@@ -194,6 +199,73 @@ final class TopologyChangeCoordinatorImplTest {
         .withCauseInstanceOf(TopologyRequestFailedException.InvalidRequest.class)
         .withMessageContaining(
             "Expected to leave partition, but the local member does not exist in the topology");
+  }
+
+  @Test
+  void shouldCancelOngoingChange() {
+    // given
+    final ClusterTopology initialTopology =
+        ClusterTopology.init()
+            .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
+            .addMember(
+                MemberId.from("2"),
+                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+    clusterTopologyManager.setClusterTopology(initialTopology);
+
+    final List<TopologyChangeOperation> operations =
+        List.of(new PartitionJoinOperation(MemberId.from("1"), 1, 1));
+
+    final var coordinator =
+        new TopologyChangeCoordinatorImpl(
+            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+    final var applyResult = coordinator.applyOperations(getTransformer(operations)).join();
+
+    // when
+    final var cancelFuture = coordinator.cancelChange(applyResult.changeId());
+
+    // then
+    assertThat(cancelFuture).succeedsWithin(Duration.ofMillis(100));
+    final ClusterTopology cancelledTopology = clusterTopologyManager.getClusterTopology().join();
+    assertThat(cancelledTopology.lastChange())
+        .isNotEmpty()
+        .get()
+        .extracting(CompletedChange::status)
+        .isEqualTo(ClusterChangePlan.Status.CANCELLED);
+    assertThat(cancelledTopology.pendingChanges()).isEmpty();
+    assertThat(cancelledTopology.members())
+        .usingRecursiveComparison()
+        .ignoringFieldsOfTypes(Instant.class)
+        .isEqualTo(initialTopology.members());
+  }
+
+  @Test
+  void shouldNotCancelOngoingChangeIdIsDifferent() {
+    // given
+    final ClusterTopology initialTopology =
+        ClusterTopology.init()
+            .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
+            .addMember(
+                MemberId.from("2"),
+                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+    clusterTopologyManager.setClusterTopology(initialTopology);
+
+    final List<TopologyChangeOperation> operations =
+        List.of(new PartitionJoinOperation(MemberId.from("1"), 1, 1));
+
+    final var coordinator =
+        new TopologyChangeCoordinatorImpl(
+            clusterTopologyManager, syncRequester, new TestConcurrencyControl());
+    final var applyResult = coordinator.applyOperations(getTransformer(operations)).join();
+
+    // when
+    final var cancelFuture = coordinator.cancelChange(applyResult.changeId() - 1);
+
+    // then
+    assertThat(cancelFuture)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(InvalidRequest.class)
+        .withMessageContaining("it is not the current change");
   }
 
   private static final class TestClusterTopologyManager implements ClusterTopologyManager {


### PR DESCRIPTION
## Description

Add support for cancelling an ongoing change. 

The change is cancelled by the coordinator. Alternative is to forward the request to the member that is currently applying the change. But I decided to keep it simple and let the coordinator cancels it.

The rest endpoint in the gateway will be added in a follow up PR.

## Related issues

related #15147

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
