### PR TITLE
[POC]: BlockingQueue in JobWorker

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -207,6 +207,7 @@ public final class JobWorkerBuilderImpl
     final JobWorkerImpl jobWorker =
         new JobWorkerImpl(
             maxJobsActive,
+            timeout,
             executorService,
             pollInterval,
             jobRunnableFactory,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
@@ -278,9 +278,15 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   }
 
   private void consumeJobFromQueue(final Runnable finalizer) {
+    if (jobsQueue.peek() == null) {
+      // stop if there is nothing - we will triggered by push/poll again
+      return;
+    }
+
     ActivatedJob job;
     try {
       job = jobsQueue.poll(10, TimeUnit.SECONDS);
+      // TODO should we really do a poll ? Maybe a peek and remove it later after handling?
     } catch (final InterruptedException ie) {
       job = null;
     }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
@@ -291,7 +291,14 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       // retry
       scheduleConsumeJob(finalizer);
     } else {
-      executor.execute(jobHandlerFactory.create(job, finalizer));
+      executor.execute(
+          jobHandlerFactory.create(
+              job,
+              () -> {
+                finalizer.run();
+                // we want to try to consume more
+                scheduleConsumeJob(finalizer);
+              }));
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
@@ -23,6 +23,8 @@ import io.camunda.zeebe.client.impl.Loggers;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -76,6 +78,8 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
 
   private volatile long pollInterval;
 
+  private final BlockingQueue<ActivatedJob> jobsQueue;
+
   public JobWorkerImpl(
       final int maxJobsActive,
       final ScheduledExecutorService executor,
@@ -86,6 +90,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       final BackoffSupplier backoffSupplier,
       final JobWorkerMetrics metrics) {
     this.maxJobsActive = maxJobsActive;
+    jobsQueue = new ArrayBlockingQueue<>(maxJobsActive);
     activationThreshold = Math.round(maxJobsActive * 0.3f);
     remainingJobs = new AtomicInteger(0);
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
@@ -58,6 +58,7 @@ final class JobWorkerMetricsTest {
       final JobWorkerMetrics metrics) {
     return new JobWorkerImpl(
         1,
+        Duration.ZERO,
         executor,
         Duration.ofSeconds(30),
         new TestJobRunnableFactory(autoCompleteCount),


### PR DESCRIPTION
## Description POC

In order to block retrieving more jobs and exhausting the resources of a client we introduce a blocking queue which is filled by job poller and streamer. This queue is consumed by the executors, which could be multi-threaded (user specific). 


There are several open questions I marked as todos, most of them are related to error handling. 

On interesting question I had was why we have these "complex" structure of job poller in there first place. I think we could simplify here a lot which help also to implement the logic. I thought first the job poller is also used by the normal job activation command, but this seems to be not the case.


 

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
