### PR TITLE
QA tests for restart during scaling operations

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.it.clustering.dynamic;
 
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertThatAllJobsCanBeCompleted;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
-import static io.camunda.zeebe.it.clustering.dynamic.Utils.scale;
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.scaleAndWait;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -78,7 +78,7 @@ final class ScaleDownBrokersTest {
 
     // when
     final int newClusterSize = CLUSTER_SIZE - 1;
-    scale(cluster, newClusterSize);
+    scaleAndWait(cluster, newClusterSize);
     brokerToShutdown.close();
 
     // then
@@ -101,7 +101,7 @@ final class ScaleDownBrokersTest {
     final var createdInstances =
         createInstanceWithAJobOnAllPartitions(zeebeClient, JOB_TYPE, PARTITIONS_COUNT);
 
-    scale(cluster, CLUSTER_SIZE - 1);
+    scaleAndWait(cluster, CLUSTER_SIZE - 1);
     cluster.brokers().get(MemberId.from(String.valueOf(CLUSTER_SIZE - 1))).close();
 
     // when
@@ -109,7 +109,7 @@ final class ScaleDownBrokersTest {
     final int brokerToShutdownId = CLUSTER_SIZE - 2;
     final var brokerToShutdown =
         cluster.brokers().get(MemberId.from(String.valueOf(brokerToShutdownId)));
-    scale(cluster, newClusterSize);
+    scaleAndWait(cluster, newClusterSize);
     brokerToShutdown.close();
 
     // then

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleResiliencyTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleResiliencyTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.management.cluster.PartitionStateCode;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ScaleResiliencyTest {
+
+  private static Path getDataDirectory(final Path tmpDir, final int brokerId) {
+    final var path = tmpDir.resolve(String.valueOf(brokerId));
+    try {
+      Files.createDirectory(path);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+    return path;
+  }
+
+  private static TestCluster createCluster(
+      final int initialClusterSize,
+      final int partitionsCount,
+      final int replicationFactor,
+      final Path tmpDir) {
+    final var cluster =
+        TestCluster.builder()
+            .useRecordingExporter(true)
+            .withGatewaysCount(1)
+            .withGatewayConfig(
+                g ->
+                    g.gatewayConfig()
+                        .getCluster()
+                        .getMembership()
+                        // Decrease the timeouts for fast convergence of gateway topology.
+                        .setSyncInterval(Duration.ofSeconds(1))
+                        .setFailureTimeout(Duration.ofSeconds(2)))
+            .withEmbeddedGateway(false)
+            .withBrokersCount(initialClusterSize)
+            .withPartitionsCount(partitionsCount)
+            .withReplicationFactor(replicationFactor)
+            .withBrokerConfig(
+                b -> {
+                  b.brokerConfig()
+                      .getExperimental()
+                      .getFeatures()
+                      .setEnableDynamicClusterTopology(true);
+                  b.brokerConfig()
+                      .getCluster()
+                      .getMembership()
+                      // Decrease the timeouts for fast convergence of gateway topology.
+                      .setSyncInterval(Duration.ofSeconds(1))
+                      .setFailureTimeout(Duration.ofSeconds(2));
+                  b.withWorkingDirectory(
+                      getDataDirectory(tmpDir, b.brokerConfig().getCluster().getNodeId()));
+                })
+            .build();
+    cluster.start();
+    cluster.awaitCompleteTopology();
+    return cluster;
+  }
+
+  @Nested
+  class ScaleUp {
+    private static final int REPLICATION_FACTOR = 2;
+    private static final int PARTITIONS_COUNT = 2;
+    private static final int INITIAL_CLUSTER_SIZE = 2;
+    @TempDir Path tmpDir;
+    private final List<TestStandaloneBroker> newBrokers = new ArrayList<>();
+    private TestCluster cluster;
+
+    @BeforeEach
+    void setup() {
+      cluster = createCluster(INITIAL_CLUSTER_SIZE, PARTITIONS_COUNT, REPLICATION_FACTOR, tmpDir);
+    }
+
+    @AfterEach
+    void shutdownNewBrokers() {
+      newBrokers.forEach(TestStandaloneBroker::close);
+      newBrokers.clear();
+      cluster.shutdown();
+    }
+
+    @Test
+    void shouldContinueScaleAfterRestart() {
+      // given cluster size 2, partitions 2, replicationFactor 2;
+
+      // shutdown broker 1
+      cluster.brokers().get(MemberId.from("1")).stop();
+      final var newClusterSize = INITIAL_CLUSTER_SIZE + 1;
+      final var newBroker =
+          createNewBroker(
+              newClusterSize, newClusterSize - 1, getDataDirectory(tmpDir, newClusterSize - 1));
+
+      // scale to 3
+      Utils.scale(cluster, newClusterSize);
+      // wait until broker 2 is added to the cluster
+      Awaitility.await()
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(cluster).hasActiveBroker(newClusterSize - 1));
+      // applying operations is stuck because there is no leader for partitions, so partitions
+      // cannot be moved.
+
+      // when
+      // stop broker 2
+      newBroker.stop();
+      // restart broker 1
+      cluster.brokers().get(MemberId.from("1")).start();
+      // restart broker 2
+      newBroker.start();
+
+      // then
+      // scale is completed
+      Awaitility.await()
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(cluster).doesNotHavePendingChanges());
+      cluster.awaitCompleteTopology(
+          newClusterSize, PARTITIONS_COUNT, REPLICATION_FACTOR, Duration.ofSeconds(10));
+    }
+
+    private TestStandaloneBroker createNewBroker(
+        final int newClusterSize, final int newBrokerId, final Path dataDirectory) {
+      final var newBroker =
+          new TestStandaloneBroker()
+              .withBrokerConfig(
+                  b -> {
+                    b.getExperimental().getFeatures().setEnableDynamicClusterTopology(true);
+                    b.getCluster().setClusterSize(newClusterSize);
+                    b.getCluster().setNodeId(newBrokerId);
+                    b.getCluster()
+                        .setInitialContactPoints(
+                            List.of(
+                                cluster
+                                    .brokers()
+                                    .get(MemberId.from("0"))
+                                    .address(TestZeebePort.CLUSTER)));
+                  })
+              .withWorkingDirectory(dataDirectory);
+      newBrokers.add(newBroker);
+      newBroker.start();
+      return newBroker;
+    }
+  }
+
+  @Nested
+  class ScaleDown {
+    private static final int REPLICATION_FACTOR = 2;
+    private static final int PARTITIONS_COUNT = 2;
+    private static final int INITIAL_CLUSTER_SIZE = 3;
+    @TempDir Path tmpDir;
+    private final List<TestStandaloneBroker> newBrokers = new ArrayList<>();
+    private TestCluster cluster;
+
+    @BeforeEach
+    void setup() {
+      cluster = createCluster(INITIAL_CLUSTER_SIZE, PARTITIONS_COUNT, REPLICATION_FACTOR, tmpDir);
+    }
+
+    @AfterEach
+    void shutdownNewBrokers() {
+      newBrokers.forEach(TestStandaloneBroker::close);
+      newBrokers.clear();
+      cluster.shutdown();
+    }
+
+    // Simulate scale down by using individual join/leave operations so that we can control when a
+    // broker restarts
+    @Test
+    void shouldContinueScaleDownAfterRestart() {
+      // given  -- partition 1 in broker 0 and 1, and partition 2 in broker 0, 1 and 2
+      ClusterActuator.of(cluster.availableGateway()).joinPartition(0, 2, 1);
+      // wait until broker 0 has partition 2
+      Awaitility.await()
+          .untilAsserted(
+              () ->
+                  ClusterActuatorAssert.assertThat(cluster)
+                      .brokerHasPartitionAtState(0, 2, PartitionStateCode.ACTIVE));
+
+      cluster.brokers().get(MemberId.from("1")).stop();
+
+      // when -- restart during leaving
+
+      ClusterActuator.of(cluster.availableGateway()).leavePartition(2, 2);
+      // wait until partition 2 is marked as leaving
+      Awaitility.await()
+          .untilAsserted(
+              () ->
+                  ClusterActuatorAssert.assertThat(cluster)
+                      .brokerHasPartitionAtState(2, 2, PartitionStateCode.LEAVING));
+      // Leave cannot complete because broker 1 is not running. So joint consensus cannot commit.
+      // Restart at this point.
+      cluster.brokers().get(MemberId.from("2")).stop();
+      cluster.brokers().get(MemberId.from("2")).start();
+
+      // restart broker 1 so that leave can complete
+      cluster.brokers().get(MemberId.from("1")).start();
+
+      // then
+      // leave is completed
+      Awaitility.await()
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(cluster).doesNotHavePendingChanges());
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleResiliencyTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleResiliencyTest.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
+@Timeout(3 * 60)
 class ScaleResiliencyTest {
 
   private static Path getDataDirectory(final Path tmpDir, final int brokerId) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.it.clustering.dynamic;
 
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertThatAllJobsCanBeCompleted;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
-import static io.camunda.zeebe.it.clustering.dynamic.Utils.scale;
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.scaleAndWait;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -83,7 +83,7 @@ final class ScaleUpBrokersTest {
 
     // when
     createNewBroker(newClusterSize, newBrokerId);
-    scale(cluster, newClusterSize);
+    scaleAndWait(cluster, newClusterSize);
 
     // then
     // verify partition 2 is moved from broker 0 to 1
@@ -108,13 +108,13 @@ final class ScaleUpBrokersTest {
 
     // scale to clusterSize 2
     createNewBroker(clusterSize2, broker2);
-    scale(cluster, clusterSize2);
+    scaleAndWait(cluster, clusterSize2);
 
     // when - scale to clusterSize 3
     final int broker3 = broker2 + 1;
     final int finalClusterSize = clusterSize2 + 1;
     createNewBroker(finalClusterSize, broker3);
-    scale(cluster, finalClusterSize);
+    scaleAndWait(cluster, finalClusterSize);
 
     // then -- partition 3 must be moved to new broker
     ClusterActuatorAssert.assertThat(cluster).brokerHasPartition(broker3, 3);
@@ -135,7 +135,7 @@ final class ScaleUpBrokersTest {
     // when
     createNewBroker(newClusterSize, currentClusterSize);
     createNewBroker(newClusterSize, currentClusterSize + 1);
-    scale(cluster, newClusterSize);
+    scaleAndWait(cluster, newClusterSize);
 
     // then
     // Changes are reflected in the topology returned by grpc query

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -194,6 +194,22 @@ public final class TestCluster implements CloseableSilently {
   }
 
   /**
+   * Returns the first gateway which is running. The gateway may not be ready to accept requests.
+   *
+   * <p>NOTE: this includes brokers with embedded gateways.
+   *
+   * @return a gateway
+   * @throws NoSuchElementException if there are no such gateways (e.g. none are started, or they
+   *     are dead, etc.)
+   */
+  public TestGateway<?> anyGateway() {
+    return allGateways()
+        .filter(TestApplication::isStarted)
+        .findFirst()
+        .orElseThrow(() -> new NoSuchElementException("No available gateway for cluster"));
+  }
+
+  /**
    * Returns a map of the gateways in the cluster, where the keys are the memberIds, and the values
    * the gateway containers.
    *

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
@@ -30,7 +30,7 @@ public final class ClusterActuatorAssert
 
   public static ClusterActuatorAssert assertThat(final TestCluster actuator) {
     return new ClusterActuatorAssert(
-        ClusterActuator.of(actuator.availableGateway()), ClusterActuatorAssert.class);
+        ClusterActuator.of(actuator.anyGateway()), ClusterActuatorAssert.class);
   }
 
   public ClusterActuatorAssert doesNotHaveBroker(final int brokerId) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/util/TopologyUtil.java
@@ -13,6 +13,7 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.PartitionState;
+import io.camunda.zeebe.topology.state.PartitionState.State;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -63,9 +64,13 @@ public final class TopologyUtil {
               for (final Entry<Integer, PartitionState> entry : member.partitions().entrySet()) {
                 final Integer partitionId = entry.getKey();
                 final PartitionState partitionState = entry.getValue();
-                memberPriorityByPartition
-                    .computeIfAbsent(partitionId, k -> new HashMap<>())
-                    .put(memberId, partitionState.priority());
+                if (partitionState.state().equals(State.ACTIVE)
+                    || partitionState.state().equals(State.LEAVING)) {
+                  // only add active and leaving partitions because only those has to be started
+                  memberPriorityByPartition
+                      .computeIfAbsent(partitionId, k -> new HashMap<>())
+                      .put(memberId, partitionState.priority());
+                }
               }
             });
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/util/TopologyUtilTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/util/TopologyUtilTest.java
@@ -94,11 +94,23 @@ class TopologyUtilTest {
             .addMember(
                 member(0),
                 MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(3))))
+                    Map.of(
+                        1,
+                        PartitionState.active(1),
+                        2,
+                        PartitionState.active(3),
+                        // A joining member should not be included in the partition distribution
+                        3,
+                        PartitionState.joining(4))))
             .addMember(
                 member(1),
                 MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(2), 2, PartitionState.active(2))))
+                    Map.of(
+                        1,
+                        PartitionState.active(2),
+                        // A leaving member should be included in the partition distribution
+                        2,
+                        PartitionState.active(2).toLeaving())))
             .addMember(
                 member(2),
                 MemberState.initializeAsActive(


### PR DESCRIPTION
## Description

- Verify scaling by adding multiple brokers at once
- Verify scaling can continue after restart. This test found a bug where partition that are not yet joined are started after a restart. This prevents joining operation from completing because PartitionManager has already started a partition and rejects applying join operation. 

## Related issues

related #14953 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
