### PR TITLE
Gateway does not push job if stream is not ready

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -150,6 +150,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
@@ -302,6 +303,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/stream/JobStreamConsumerTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/stream/JobStreamConsumerTest.java
@@ -11,11 +11,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler.JobStreamConsumer;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.msgpack.spec.MsgpackReaderException;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import org.agrona.LangUtil;
 import org.junit.jupiter.api.Test;
 
@@ -26,32 +31,130 @@ final class JobStreamConsumerTest {
   void shouldRethrowExceptionOnPushFailure() {
     // given
     final var failure = new RuntimeException("failed");
-    final var failingObserver = new FailingStreamObserver(failure);
-    final var consumer = new JobStreamConsumer(failingObserver, executor);
+    final var clientObserver = new TestStreamObserver();
+    final var consumer = new JobStreamConsumer(clientObserver, executor);
+    clientObserver.failure = failure;
 
     // when
     final var result = consumer.push(BufferUtil.createCopy(new ActivatedJobImpl()));
 
     // then
-    assertThat(failingObserver.error).isSameAs(failure);
     assertThat(result)
         .failsWithin(Duration.ZERO)
         .withThrowableThat()
         .havingRootCause()
         .isSameAs(failure);
+    assertThat(clientObserver.error).isSameAs(failure);
   }
 
-  private static final class FailingStreamObserver implements StreamObserver<ActivatedJob> {
-    private final Throwable failure;
+  @Test
+  void shouldFailPushOnSerialization() {
+    // given
+    final var clientObserver = new TestStreamObserver();
+    final var consumer = new JobStreamConsumer(clientObserver, executor);
+
+    // when
+    final var result = consumer.push(BufferUtil.wrapString("i am not a job"));
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .havingRootCause()
+        .isInstanceOf(MsgpackReaderException.class);
+    assertThat(clientObserver.error).as("client stream is not closed").isNull();
+  }
+
+  @Test
+  void shouldFailPushOnClientStreamNotReady() {
+    // given
+    final var clientObserver = new TestStreamObserver();
+    final var consumer = new JobStreamConsumer(clientObserver, executor);
+    clientObserver.isReady = false;
+
+    // when
+    final var result = consumer.push(BufferUtil.createCopy(new ActivatedJobImpl()));
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ZERO)
+        .withThrowableThat()
+        .havingRootCause()
+        .isInstanceOf(ClientStreamBlockedException.class);
+    assertThat(clientObserver.error).as("client stream is not closed").isNull();
+  }
+
+  @Test
+  void shouldPushPayload() {
+    // given
+    final var clientObserver = new TestStreamObserver();
+    final var consumer = new JobStreamConsumer(clientObserver, executor);
+    final var job = new ActivatedJobImpl().setJobKey(1);
+
+    // when
+    final var result = consumer.push(BufferUtil.createCopy(job));
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO);
+    assertThat(clientObserver.error).isNull();
+    assertThat(clientObserver.pushed).extracting(ActivatedJob::getKey).containsExactly(1L);
+  }
+
+  private static final class TestStreamObserver extends ServerCallStreamObserver<ActivatedJob>
+      implements StreamObserver<ActivatedJob> {
+    private final List<ActivatedJob> pushed = new ArrayList<>();
+
+    private boolean isReady = true;
+    private Throwable failure;
     private Throwable error;
 
-    private FailingStreamObserver(final Throwable failure) {
-      this.failure = failure;
+    @Override
+    public boolean isCancelled() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setOnCancelHandler(final Runnable onCancelHandler) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCompression(final String compression) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isReady() {
+      return isReady;
+    }
+
+    @Override
+    public void setOnReadyHandler(final Runnable onReadyHandler) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void request(final int count) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMessageCompression(final boolean enable) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void onNext(final ActivatedJob value) {
-      LangUtil.rethrowUnchecked(failure);
+      if (failure != null) {
+        LangUtil.rethrowUnchecked(failure);
+      }
+
+      pushed.add(value);
     }
 
     @Override
@@ -60,6 +163,8 @@ final class JobStreamConsumerTest {
     }
 
     @Override
-    public void onCompleted() {}
+    public void onCompleted() {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -166,6 +166,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamBlockedException.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamBlockedException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.api;
+
+/**
+ * Exception thrown when a client is blocked, i.e. it cannot receive any pushed payloads until
+ * further notice.
+ */
+public final class ClientStreamBlockedException extends Exception {
+
+  public ClientStreamBlockedException(final String message) {
+    super(message);
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImpl.java
@@ -111,12 +111,14 @@ public final class RemoteStreamImpl<M, P extends BufferWriter> implements Remote
       }
 
       final var client = iterator.next();
-      LOGGER.debug("Failed to push payload {}, retrying with next stream", payload);
+      LOGGER.debug(
+          "Failed to push payload (size = {}), retrying with next stream", payload.getLength());
       streamer.pushAsync(payload, (error, data) -> retry(error, data, iterator), client.id());
     }
 
     private void onConsumersExhausted(final Throwable throwable, final P payload) {
-      LOGGER.debug("Failed to push payload {}, no more streams to retry", payload);
+      LOGGER.debug(
+          "Failed to push payload (size = {}), no more streams to retry", payload.getLength());
       errorHandler.handleError(throwable, payload);
     }
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusher.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusher.java
@@ -52,7 +52,7 @@ final class RemoteStreamPusher<P extends BufferWriter> {
     return (error, payload) -> {
       if (error != null) {
         metrics.pushFailed();
-        LOG.debug("Failed to push {} to stream {}", payload, streamId, error);
+        LOG.debug("Failed to push (size = {}) to stream {}", payload.getLength(), streamId, error);
         errorHandler.handleError(error, payload);
       }
     };


### PR DESCRIPTION
## Description

This PR introduces the first rudimentary back pressure between job worker and gateways. Essentially, if the consumer passed to `StreamJobsCommandImpl` blocks long enough for the buffer on the server side to fill up, back pressure is detected (i.e. the `ServerCallStreamObserver#isReady` flag returns false) and we will stop pushing to this stream.

> **Note**
> The buffer in question is managed by gRPC and not accessible to us. Once a specific threshold is reached - hard coded to 32KB at the moment - the flag is toggled to false. This does not actually block any sending, just sets the `isReady` flag to false. It's up to us to respect it. Note that there is also a delay between back pressure detection and actual blocking.

This means that if a job causes the command to stall, at least one other job is going to get buffered before the `isReady` flag is toggled. So there's always one extra job being sent out. This will also work with the manual flow control mechanism in gRPC in much the same way.

I've also updated the logging on the broker side to avoid logging potentially sensitive user data.

## Related issues

closes #15179 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
