### PR TITLE
Add endpoint for cancelling an ongoing topology change

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -85,6 +85,13 @@ public class ClusterEndpoint {
     return ResponseEntity.status(500).body(errorResponse);
   }
 
+  private ResponseEntity<Error> invalidRequest(final String message) {
+    // TODO: Map error to proper HTTP status code as defined in spec
+    final var errorResponse = new Error();
+    errorResponse.setMessage(message);
+    return ResponseEntity.status(400).body(errorResponse);
+  }
+
   @PostMapping(path = "/{resource}/{id}")
   public ResponseEntity<?> add(
       @PathVariable("resource") final Resource resource,
@@ -100,24 +107,46 @@ public class ClusterEndpoint {
               .addMembers(new AddMembersRequest(Set.of(new MemberId(String.valueOf(id)))))
               .join());
       case partitions -> ResponseEntity.status(501).body("Adding partitions is not supported");
+      case changes -> ResponseEntity.status(501)
+          .body(
+              "Changing cluster directly is not supported. Use POST /cluster/brokers for scaling the cluster");
     };
   }
 
   @DeleteMapping(path = "/{resource}/{id}")
   public ResponseEntity<?> remove(
       @PathVariable("resource") final Resource resource,
-      @PathVariable final int id,
+      @PathVariable final String id,
       @RequestParam(defaultValue = "false") final boolean dryRun) {
     if (dryRun) {
       return ResponseEntity.status(501).body("This operation does not support dry run");
     }
     return switch (resource) {
       case brokers -> mapOperationResponse(
-          requestSender
-              .removeMembers(new RemoveMembersRequest(Set.of(new MemberId(String.valueOf(id)))))
-              .join());
+          requestSender.removeMembers(new RemoveMembersRequest(Set.of(new MemberId(id)))).join());
       case partitions -> ResponseEntity.status(501).body("Removing partitions is not supported");
+      case changes -> cancelChange(id);
     };
+  }
+
+  /**
+   * Cancels a change with the given id. This is a dangerous operation and should only be used when
+   * the change is stuck and cannot make progress on its own. Cancelling a change will not revert
+   * already applied operations, so the cluster will be in an intermediate state with partially
+   * applied changes. For example, a partition might have been added to a broker, but not removed
+   * from another one; so it has a higher number of replicas than the configured value. In another
+   * case, the configuration in raft might differ from what is reflected in the ClusterTopology. So
+   * a manual intervention would be required to clean up the state.
+   */
+  private ResponseEntity<?> cancelChange(final String changeId) {
+    try {
+      return mapClusterTopologyResponse(
+          requestSender.cancelTopologyChange(Long.parseLong(changeId)).join());
+    } catch (final NumberFormatException ignore) {
+      return invalidRequest("Change id must be a number");
+    } catch (final Exception error) {
+      return mapError(error);
+    }
   }
 
   @PostMapping(path = "/{resource}", consumes = "application/json")
@@ -129,6 +158,9 @@ public class ClusterEndpoint {
       case brokers -> scaleBrokers(ids, dryRun);
       case partitions -> new ResponseEntity<>(
           "Scaling partitions is not supported", HttpStatusCode.valueOf(501));
+      case changes -> ResponseEntity.status(501)
+          .body(
+              "Changing cluster directly is not supported. Use POST /cluster/brokers for scaling the cluster");
     };
   }
 
@@ -174,7 +206,7 @@ public class ClusterEndpoint {
                     new JoinPartitionRequest(
                         MemberId.from(String.valueOf(resourceId)), subResourceId, priority))
                 .join());
-        case brokers -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
+        case brokers, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
       };
       case partitions -> switch (subResource) {
           // POST /cluster/partitions/2/brokers/1
@@ -184,8 +216,9 @@ public class ClusterEndpoint {
                     new JoinPartitionRequest(
                         MemberId.from(String.valueOf(subResourceId)), resourceId, priority))
                 .join());
-        case partitions -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
+        case partitions, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
       };
+      case changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
     };
   }
 
@@ -210,7 +243,7 @@ public class ClusterEndpoint {
                     new LeavePartitionRequest(
                         MemberId.from(String.valueOf(resourceId)), subResourceId))
                 .join());
-        case brokers -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
+        case brokers, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
       };
       case partitions -> switch (subResource) {
         case brokers -> mapOperationResponse(
@@ -219,8 +252,9 @@ public class ClusterEndpoint {
                     new LeavePartitionRequest(
                         MemberId.from(String.valueOf(subResourceId)), resourceId))
                 .join());
-        case partitions -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
+        case partitions, changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
       };
+      case changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
     };
   }
 
@@ -419,6 +453,7 @@ public class ClusterEndpoint {
 
   public enum Resource {
     brokers,
-    partitions;
+    partitions,
+    changes
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/CancelChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/CancelChangeTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+final class CancelChangeTest {
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .useRecordingExporter(true)
+          .withEmbeddedGateway(true)
+          .withBrokersCount(1)
+          .withBrokerConfig(
+              b ->
+                  b.brokerConfig()
+                      .getExperimental()
+                      .getFeatures()
+                      .setEnableDynamicClusterTopology(true))
+          .build();
+
+  @Test
+  void shouldCancelOngoingChange() {
+    // given
+    final ClusterActuator actuator = ClusterActuator.of(cluster.availableGateway());
+    final var initialTopology = actuator.getTopology();
+
+    // broker does not exist, so operation will never complete
+    final var addResponse = actuator.addBroker(1);
+    Utils.assertChangeIsPlanned(addResponse);
+
+    // when
+    final var cancelResponse = actuator.cancelChange(addResponse.getChangeId());
+
+    // then
+    assertThat(cancelResponse.getChange().getStatus()).isEqualTo(StatusEnum.CANCELLED);
+    assertThat(cancelResponse.getChange().getId()).isEqualTo(addResponse.getChangeId());
+    assertThat(cancelResponse.getBrokers())
+        .describedAs("Topology is not changed")
+        .isEqualTo(initialTopology.getBrokers());
+    assertThat(cancelResponse).isEqualTo(actuator.getTopology());
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -139,4 +139,8 @@ public interface ClusterActuator {
   @RequestLine("DELETE /brokers/{brokerId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   PostOperationResponse removeBroker(@Param final int brokerId);
+
+  @RequestLine("DELETE /changes/{changeId}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  GetTopologyResponse cancelChange(@Param final long changeId);
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -44,7 +44,7 @@ public final class TopologyManagementRequestSender {
         TopologyRequestTopics.ADD_MEMBER.topic(),
         addMembersRequest,
         serializer::encodeAddMembersRequest,
-        serializer::decodeResponse,
+        serializer::decodeTopologyChangeResponse,
         coordinator,
         TIMEOUT);
   }
@@ -55,7 +55,7 @@ public final class TopologyManagementRequestSender {
         TopologyRequestTopics.REMOVE_MEMBER.topic(),
         removeMembersRequest,
         serializer::encodeRemoveMembersRequest,
-        serializer::decodeResponse,
+        serializer::decodeTopologyChangeResponse,
         coordinator,
         TIMEOUT);
   }
@@ -66,7 +66,7 @@ public final class TopologyManagementRequestSender {
         TopologyRequestTopics.JOIN_PARTITION.topic(),
         joinPartitionRequest,
         serializer::encodeJoinPartitionRequest,
-        serializer::decodeResponse,
+        serializer::decodeTopologyChangeResponse,
         coordinator,
         TIMEOUT);
   }
@@ -77,7 +77,7 @@ public final class TopologyManagementRequestSender {
         TopologyRequestTopics.LEAVE_PARTITION.topic(),
         leavePartitionRequest,
         serializer::encodeLeavePartitionRequest,
-        serializer::decodeResponse,
+        serializer::decodeTopologyChangeResponse,
         coordinator,
         TIMEOUT);
   }
@@ -88,7 +88,7 @@ public final class TopologyManagementRequestSender {
         TopologyRequestTopics.REASSIGN_PARTITIONS.topic(),
         reassignPartitionsRequest,
         serializer::encodeReassignPartitionsRequest,
-        serializer::decodeResponse,
+        serializer::decodeTopologyChangeResponse,
         coordinator,
         TIMEOUT);
   }
@@ -99,27 +99,28 @@ public final class TopologyManagementRequestSender {
         TopologyRequestTopics.SCALE_MEMBERS.topic(),
         scaleRequest,
         serializer::encodeScaleRequest,
-        serializer::decodeResponse,
+        serializer::decodeTopologyChangeResponse,
         coordinator,
         TIMEOUT);
   }
 
-  public CompletableFuture<ClusterTopology> getTopology() {
+  public CompletableFuture<Either<ErrorResponse, ClusterTopology>> getTopology() {
     return communicationService.send(
         TopologyRequestTopics.QUERY_TOPOLOGY.topic(),
         new byte[0],
         Function.identity(),
-        serializer::decodeClusterTopology,
+        serializer::decodeClusterTopologyResponse,
         coordinator,
         TIMEOUT);
   }
 
-  public CompletableFuture<ClusterTopology> cancelTopologyChange(final long changeId) {
+  public CompletableFuture<Either<ErrorResponse, ClusterTopology>> cancelTopologyChange(
+      final long changeId) {
     return communicationService.send(
         TopologyRequestTopics.CANCEL_CHANGE.topic(),
         new TopologyManagementRequest.CancelChangeRequest(changeId),
         serializer::encodeCancelChangeRequest,
-        serializer::decodeClusterTopology,
+        serializer::decodeClusterTopologyResponse,
         coordinator,
         TIMEOUT);
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.topology.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.topology.serializer.TopologyRequestsSerializer;
+import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.util.Either;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -71,6 +72,14 @@ public final class TopologyRequestServer implements AutoCloseable {
     }
   }
 
+  byte[] encodeClusterTopologyResponse(final Either<ErrorResponse, ClusterTopology> response) {
+    if (response.isLeft()) {
+      return serializer.encodeResponse(response.getLeft());
+    } else {
+      return serializer.encodeResponse(response.get());
+    }
+  }
+
   private void registerRemoveMemberRequestsHandler() {
     communicationService.replyTo(
         TopologyRequestTopics.REMOVE_MEMBER.topic(),
@@ -115,16 +124,16 @@ public final class TopologyRequestServer implements AutoCloseable {
     communicationService.replyTo(
         TopologyRequestTopics.QUERY_TOPOLOGY.topic(),
         Function.identity(),
-        request -> topologyManagementApi.getTopology().toCompletableFuture(),
-        serializer::encode);
+        request -> mapClusterTopologyResponse(topologyManagementApi.getTopology()),
+        this::encodeClusterTopologyResponse);
   }
 
   private void registerTopologyCancelHandler() {
     communicationService.replyTo(
         TopologyRequestTopics.CANCEL_CHANGE.topic(),
         serializer::decodeCancelChangeRequest,
-        request -> topologyManagementApi.cancelTopologyChange(request).toCompletableFuture(),
-        serializer::encode);
+        request -> mapClusterTopologyResponse(topologyManagementApi.cancelTopologyChange(request)),
+        this::encodeClusterTopologyResponse);
   }
 
   private CompletableFuture<Either<ErrorResponse, TopologyChangeResponse>> mapResponse(
@@ -132,10 +141,18 @@ public final class TopologyRequestServer implements AutoCloseable {
     return topologyManagementApi
         .toCompletableFuture()
         .thenApply(Either::<ErrorResponse, TopologyChangeResponse>right)
-        .exceptionally(this::mapError);
+        .exceptionally(TopologyRequestServer::mapError);
   }
 
-  private Either<ErrorResponse, TopologyChangeResponse> mapError(final Throwable throwable) {
+  private CompletableFuture<Either<ErrorResponse, ClusterTopology>> mapClusterTopologyResponse(
+      final ActorFuture<ClusterTopology> topologyManagementApi) {
+    return topologyManagementApi
+        .toCompletableFuture()
+        .thenApply(Either::<ErrorResponse, ClusterTopology>right)
+        .exceptionally(TopologyRequestServer::mapError);
+  }
+
+  private static <T> Either<ErrorResponse, T> mapError(final Throwable throwable) {
     // throwable is always CompletionException
     return switch (throwable.getCause()) {
       case final TopologyRequestFailedException.OperationNotAllowed operationNotAllowed -> Either

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -59,6 +59,21 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
                   if (!validateCancel(changeId, clusterTopology, future)) {
                     return clusterTopology;
                   }
+                  final var completedOperation =
+                      clusterTopology
+                          .pendingChanges()
+                          .map(ClusterChangePlan::completedOperations)
+                          .orElse(List.of());
+                  final var cancelledOperations =
+                      clusterTopology
+                          .pendingChanges()
+                          .map(ClusterChangePlan::pendingOperations)
+                          .orElse(List.of());
+                  LOG.info(
+                      "Cancelling topology change '{}'. Following operations have been already applied: {}. Following pending operations won't be applied: {}",
+                      changeId,
+                      completedOperation,
+                      cancelledOperations);
                   final var cancelledTopology = clusterTopology.cancelPendingChanges();
                   future.complete(cancelledTopology);
                   return cancelledTopology;

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -69,7 +69,7 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
                           .pendingChanges()
                           .map(ClusterChangePlan::pendingOperations)
                           .orElse(List.of());
-                  LOG.info(
+                  LOG.warn(
                       "Cancelling topology change '{}'. Following operations have been already applied: {}. Following pending operations won't be applied: {}",
                       changeId,
                       completedOperation,

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/DecodingFailed.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/DecodingFailed.java
@@ -12,4 +12,8 @@ public final class DecodingFailed extends RuntimeException {
   public DecodingFailed(final Throwable cause) {
     super(cause);
   }
+
+  public DecodingFailed(final String message) {
+    super(message);
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
@@ -56,8 +56,4 @@ public interface TopologyRequestsSerializer {
       byte[] encodedResponse);
 
   Either<ErrorResponse, ClusterTopology> decodeClusterTopologyResponse(byte[] encodedResponse);
-
-  byte[] encode(ClusterTopology clusterTopology);
-
-  ClusterTopology decodeClusterTopology(byte[] encodedClusterTopology);
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/TopologyRequestsSerializer.java
@@ -48,9 +48,14 @@ public interface TopologyRequestsSerializer {
 
   byte[] encodeResponse(TopologyChangeResponse response);
 
+  byte[] encodeResponse(ClusterTopology response);
+
   byte[] encodeResponse(ErrorResponse response);
 
-  Either<ErrorResponse, TopologyChangeResponse> decodeResponse(byte[] encodedResponse);
+  Either<ErrorResponse, TopologyChangeResponse> decodeTopologyChangeResponse(
+      byte[] encodedResponse);
+
+  Either<ErrorResponse, ClusterTopology> decodeClusterTopologyResponse(byte[] encodedResponse);
 
   byte[] encode(ClusterTopology clusterTopology);
 

--- a/topology/src/main/resources/proto/requests.proto
+++ b/topology/src/main/resources/proto/requests.proto
@@ -47,8 +47,9 @@ message TopologyChangeResponse {
 
 message Response {
   oneof response {
+    ErrorResponse error = 1;
     TopologyChangeResponse topologyChangeResponse = 2;
-    ErrorResponse error = 3;
+    topology_protocol.ClusterTopology clusterTopology = 3;
   }
 }
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
@@ -105,7 +105,7 @@ final class TopologyManagementApiTest {
     final var topology = clientApi.getTopology().join();
 
     // then
-    assertThat(topology).isEqualTo(expectedTopology);
+    assertThat(topology.get()).isEqualTo(expectedTopology);
   }
 
   @Test

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -159,7 +159,8 @@ final class ProtoBufSerializerTest {
     final var encodedResponse = protoBufSerializer.encodeResponse(topologyChangeResponse);
 
     // then
-    final var decodedResponse = protoBufSerializer.decodeResponse(encodedResponse).get();
+    final var decodedResponse =
+        protoBufSerializer.decodeTopologyChangeResponse(encodedResponse).get();
     assertThat(decodedResponse).isEqualTo(topologyChangeResponse);
   }
 


### PR DESCRIPTION
## Description

Adds an endpoint for cancelling an ongoing change

This PR also have a bunch of refactoring to allow sending an error or a success response for get topology query and cancel request. Previously, only requests to change topology could send a proper error code back to the gateway.

## Related issues

closes #15147 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
