### PR TITLE
Stabilize S3BackupAcceptanceIT#shouldDeleteBackup

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
@@ -91,7 +91,13 @@ final class S3BackupAcceptanceIT {
     store = new S3BackupStore(config);
 
     try (final var client = S3BackupStore.buildClient(config)) {
-      client.createBucket(builder -> builder.bucket(config.bucketName()).build()).join();
+      // it's possible to query to fast and get a 503 from the server here, so simply retry after
+      Awaitility.await("unil bucket is created")
+          .untilAsserted(
+              () ->
+                  client
+                      .createBucket(builder -> builder.bucket(config.bucketName()).build())
+                      .join());
     }
 
     // we have to configure the cluster here, after minio is started, as otherwise we won't have

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
@@ -65,7 +65,7 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
 
   public WaitStrategy defaultWaitStrategy() {
     return new HttpWaitStrategy()
-        .forPath("/minio/health/ready")
+        .forPath("/minio/health/live")
         .forPort(PORT)
         .withStartupTimeout(Duration.ofMinutes(1));
   }


### PR DESCRIPTION
## Description

This PR attempts to stabilize the back up tests by using the liveness check instead of ready check before marking the container as started, and also retrying the bucket creation request.

The idea is that Zeebe itself will retry requests to S3, but not necessarily our test, and from the error message it sounded like it's just a matter of querying too fast.

Unfortunately I couldn't reproduce it, so it's just an attempt :crossed_fingers: 

## Related issues

closes #14344 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
