### PR TITLE
New compenstaion() API for BPMN modeling

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBoundaryEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBoundaryEventBuilder.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnEdge;
 import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.camunda.zeebe.model.bpmn.instance.dc.Bounds;
 import io.camunda.zeebe.model.bpmn.instance.di.Waypoint;
+import java.util.function.Consumer;
 
 /**
  * @author Sebastian Menski
@@ -128,6 +129,14 @@ public abstract class AbstractBoundaryEventBuilder<B extends AbstractBoundaryEve
     element.getEventDefinitions().add(escalationEventDefinition);
 
     return myself;
+  }
+
+  public AbstractFlowNodeBuilder compensation(final Consumer<AbstractFlowNodeBuilder> consumer) {
+    compensateEventDefinition();
+    compensationStart();
+    consumer.accept(myself);
+    compensationDone();
+    return compensateBoundaryEvent.getAttachedTo().builder();
   }
 
   @Override

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
@@ -1265,6 +1265,36 @@ public class ProcessBuilderTest {
   }
 
   @Test
+  public void testCompensationTaskWithNewAPI() {
+    modelInstance =
+        Bpmn.createProcess()
+            .startEvent()
+            .userTask("task")
+            .boundaryEvent("boundary")
+            .compensation(c -> c.userTask("compensate"))
+            .moveToActivity("task")
+            .endEvent("theend")
+            .done();
+
+    // Checking Association
+    final Collection<Association> associations =
+        modelInstance.getModelElementsByType(Association.class);
+    assertThat(associations).hasSize(1);
+    final Association association = associations.iterator().next();
+    assertThat(association.getSource().getId()).isEqualTo("boundary");
+    assertThat(association.getTarget().getId()).isEqualTo("compensate");
+    assertThat(association.getAssociationDirection()).isEqualTo(AssociationDirection.One);
+
+    // Checking Sequence flow
+    final UserTask task = modelInstance.getModelElementById("task");
+    final Collection<SequenceFlow> outgoing = task.getOutgoing();
+    assertThat(outgoing).hasSize(1);
+    final SequenceFlow flow = outgoing.iterator().next();
+    assertThat(flow.getSource().getId()).isEqualTo("task");
+    assertThat(flow.getTarget().getId()).isEqualTo("theend");
+  }
+
+  @Test
   public void testOnlyOneCompensateBoundaryEventAllowed() {
     // given
     final UserTaskBuilder builder =


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Created a new API for modeling the BPMN with a compensation event.

See below code for the comparison

Using old API:

```
        Bpmn.createProcess()
            .startEvent()
            .userTask("task")
            .boundaryEvent("boundary")
            .compensateEventDefinition()
            .compensateEventDefinitionDone()
            .compensationStart()
            .userTask("compensate")
            .name("compensate")
            .compensationDone()
            .endEvent("theend")
            .done();
```

Using the new one:

```
        Bpmn.createProcess()
            .startEvent()
            .userTask("task")
            .boundaryEvent("boundary")
            .compensation(c -> c.userTask("compensate"))
            .moveToActivity("task")
            .endEvent("theend")
            .done();
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14939 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
