### PR TITLE
feat(dist): enable dynamic cluster management feature by default

### DIFF
--- a/atomix/utils/src/main/java/io/atomix/utils/Version.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/Version.java
@@ -41,6 +41,18 @@ public final class Version implements Comparable<Version> {
     this.build = Build.from(build).toString();
   }
 
+  public int major() {
+    return major;
+  }
+
+  public int minor() {
+    return minor;
+  }
+
+  public int patch() {
+    return patch;
+  }
+
   /**
    * Returns a new version from the given version string.
    *

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -57,7 +57,9 @@ final class PartitionLeaveTest {
               clusterCfg.setPartitionsCount(1);
               clusterCfg.setReplicationFactor(2);
             });
-    CompletableFuture.allOf(broker0.start(), broker1.start()).join();
+    CompletableFuture.allOf(
+            CompletableFuture.runAsync(broker0::start), CompletableFuture.runAsync(broker1::start))
+        .join();
 
     try (final var client =
         ZeebeClient.newClientBuilder()

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1136,6 +1136,6 @@
 
         # When enabled, the broker relies on the new cluster topology management to determine partition distribution.
         # When disabled, the broker generates partition distribution on every restart from the provided cluster configuration.
-        # This feature should be enabled to use dynamic scaling feature (which is not available yet).
+        # This feature should be enabled to use dynamic scaling feature.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEDYNAMICCLUSTERTOPOLOGY
-        # enableDynamicClusterTopology: false
+        # enableDynamicClusterTopology: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1027,6 +1027,6 @@
 
         # When enabled, the broker relies on the new cluster topology management to determine partition distribution.
         # When disabled, the broker generates partition distribution on every restart from the provided cluster configuration.
-        # This feature should be enabled to use dynamic scaling feature (which is not available yet).
+        # This feature should be enabled to use dynamic scaling feature.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEDYNAMICCLUSTERTOPOLOGY
-        # enableDynamicClusterTopology: false
+        # enableDynamicClusterTopology: true

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -42,6 +42,7 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -206,7 +207,7 @@ class BackupMultiPartitionTest {
     // when
     brokerIds.forEach(this::stopBrokerAndDeleteData);
     brokerIds.forEach(broker -> restoreBroker(backupId, broker));
-    brokerIds.forEach(b -> clusteringRule.getBroker(b).start());
+    brokerIds.forEach(b -> CompletableFuture.runAsync(() -> clusteringRule.getBroker(b).start()));
 
     clusteringRule.waitForTopology(
         topology -> topology.hasLeaderForEachPartition(clusteringRule.getPartitionCount()));

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
@@ -314,7 +314,7 @@ public interface TopologyInitializer {
       }
 
       final Version version = membershipService.getLocalMember().version();
-      if (isVersion8_4(version)) {
+      if (isVersion84(version)) {
         final boolean knowOtherMembers = hasOtherReachableMembers(membershipService);
         if (knowOtherMembers && isRollingUpdate(membershipService)) {
           LOGGER.debug(
@@ -355,10 +355,10 @@ public interface TopologyInitializer {
             "Cannot determine version of local member. Assuming this is not rolling update and skip initialization.");
         return false;
       }
-      return otherMembers.stream().map(Member::version).anyMatch(this::isVersion8_3);
+      return otherMembers.stream().map(Member::version).anyMatch(this::isVersion83);
     }
 
-    private boolean isVersion8_4(final Version version) {
+    private boolean isVersion84(final Version version) {
       if (version == null) {
         // This is mainly required for testing, where the DiscoveryMembershipProvider cannot
         // determine version of remote members.
@@ -369,7 +369,7 @@ public interface TopologyInitializer {
       return version.major() == 8 && version.minor() == 4;
     }
 
-    private boolean isVersion8_3(final Version version) {
+    private boolean isVersion83(final Version version) {
       return version.major() == 8 && version.minor() == 3;
     }
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/MemberState.java
@@ -28,7 +28,7 @@ public record MemberState(
     long version, Instant lastUpdated, State state, Map<Integer, PartitionState> partitions) {
   public static MemberState initializeAsActive(
       final Map<Integer, PartitionState> initialPartitions) {
-    return new MemberState(0, Instant.now(), State.ACTIVE, Map.copyOf(initialPartitions));
+    return new MemberState(0, Instant.MIN, State.ACTIVE, Map.copyOf(initialPartitions));
   }
 
   public static MemberState uninitialized() {

--- a/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -53,7 +53,7 @@ public record FeatureFlags(
   private static final boolean ENABLE_DUE_DATE_CHECKER_ASYNC = false;
   private static final boolean ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR = true;
 
-  private static final boolean ENABLE_DYNAMIC_CLUSTER_TOPOLOGY = false;
+  private static final boolean ENABLE_DYNAMIC_CLUSTER_TOPOLOGY = true;
 
   public static FeatureFlags createDefault() {
     return new FeatureFlags(
@@ -78,7 +78,7 @@ public record FeatureFlags(
         true, /* ENABLE_MSG_TTL_CHECKER_ASYNC */
         true, /* ENABLE_DUE_DATE_CHECKER_ASYNC */
         true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
-        false /* ENABLE_DYNAMIC_CLUSTER_TOPOLOGY */
+        true /* ENABLE_DYNAMIC_CLUSTER_TOPOLOGY */
         /*, FOO_DEFAULT*/ );
   }
 


### PR DESCRIPTION
## Description

Enable dynamic cluster management feature by default. All tests and weekly benchmarks will now run with this feature enabled. We are planning to enabled this by default in 8.4. So enabling this feature now will give enough time for us to find any issues.

Enabling this unveiled the [rolling update bug Ole reported](https://github.com/camunda/zeebe/issues/13642#issuecomment-1809205407). This PR also fixed this by introducing an initializer that can detect it is rolling update from 8.3 to 8.4 and handle it differently. This initialize can be removed after 8.4 release.

Some other tests needs to be adjusted now that the startup is blocked until the nodes can talk to each other.

## Related issues

related to #13642 

