### PR TITLE
Respond to `MIGRATE` command with `MIGRATED` event

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -46,7 +46,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.FORM);
+      EnumSet.range(ValueType.JOB, ValueType.PROCESS_INSTANCE_MIGRATION);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTe
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithResultProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -39,6 +40,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -89,6 +91,7 @@ public final class BpmnProcessors {
         typedRecordProcessors, processingState, writers, bpmnBehaviors, processEngineMetrics);
     addProcessInstanceModificationStreamProcessors(
         typedRecordProcessors, processingState, writers, bpmnBehaviors);
+    addProcessInstanceMigrationStreamProcessors(typedRecordProcessors, writers);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
 
     return bpmnStreamProcessor;
@@ -219,6 +222,14 @@ public final class BpmnProcessors {
         ValueType.PROCESS_INSTANCE_MODIFICATION,
         ProcessInstanceModificationIntent.MODIFY,
         modificationProcessor);
+  }
+
+  private static void addProcessInstanceMigrationStreamProcessors(
+      final TypedRecordProcessors typedRecordProcessors, final Writers writers) {
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE_MIGRATION,
+        ProcessInstanceMigrationIntent.MIGRATE,
+        new ProcessInstanceMigrationMigrateProcessor(writers));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelP
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithResultProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor;
-import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationModifyProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -212,8 +212,8 @@ public final class BpmnProcessors {
       final ProcessingState processingState,
       final Writers writers,
       final BpmnBehaviors bpmnBehaviors) {
-    final ProcessInstanceModificationProcessor modificationProcessor =
-        new ProcessInstanceModificationProcessor(
+    final ProcessInstanceModificationModifyProcessor modificationProcessor =
+        new ProcessInstanceModificationModifyProcessor(
             writers,
             processingState.getElementInstanceState(),
             processingState.getProcessState(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -47,9 +47,9 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
-public final class ProcessEventProcessors {
+public final class BpmnProcessors {
 
-  public static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(
+  public static TypedRecordProcessor<ProcessInstanceRecord> addBpmnStreamProcessor(
       final MutableProcessingState processingState,
       final Supplier<ScheduledTaskState> scheduledTaskState,
       final BpmnBehaviors bpmnBehaviors,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -206,7 +206,7 @@ public final class EngineProcessors {
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
       final DueDateTimerChecker timerChecker) {
-    return ProcessEventProcessors.addProcessProcessors(
+    return BpmnProcessors.addBpmnStreamProcessor(
         processingState,
         scheduledTaskState,
         bpmnBehaviors,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class ProcessInstanceMigrationMigrateProcessor
+    implements TypedRecordProcessor<ProcessInstanceMigrationRecord> {
+
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+
+  public ProcessInstanceMigrationMigrateProcessor(final Writers writers) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceMigrationRecord> command) {
+    final long processInstanceKey = command.getKey();
+    final ProcessInstanceMigrationRecord value = command.getValue();
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value);
+    responseWriter.writeEventOnCommand(
+        processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value, command);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -56,7 +56,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.agrona.Strings;
 
-public final class ProcessInstanceModificationProcessor
+public final class ProcessInstanceModificationModifyProcessor
     implements TypedRecordProcessor<ProcessInstanceModificationRecord> {
 
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
@@ -148,7 +148,7 @@ public final class ProcessInstanceModificationProcessor
   private final ElementActivationBehavior elementActivationBehavior;
   private final VariableBehavior variableBehavior;
 
-  public ProcessInstanceModificationProcessor(
+  public ProcessInstanceModificationModifyProcessor(
       final Writers writers,
       final ElementInstanceState elementInstanceState,
       final ProcessState processState,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateProcessInstanceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldWriteMigratedEventForProcessInstance() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long otherProcessDefinitionKey =
+        deployment.getValue().getProcessesMetadata().stream()
+            .filter(p -> p.getBpmnProcessId().equals(processId2))
+            .findAny()
+            .orElseThrow()
+            .getProcessDefinitionKey();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    // when
+    final var event =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+            .withMappingInstruction("A", "B")
+            .migrate();
+
+    // then
+    assertThat(event)
+        .hasKey(processInstanceKey)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
+
+    assertThat(event.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .hasMappingInstructions(
+            new ProcessInstanceMigrationMappingInstruction()
+                .setSourceElementId("A")
+                .setTargetElementId("B"));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
@@ -67,7 +67,7 @@ public class MigrateProcessInstanceTest {
             .withInstanceKey(processInstanceKey)
             .migration()
             .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
-            .withMappingInstruction("A", "B")
+            .addMappingInstruction("A", "B")
             .migrate();
 
     // then

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
@@ -22,9 +24,11 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -269,6 +273,10 @@ public final class ProcessInstanceClient {
     public ProcessInstanceModificationClient modification() {
       return new ProcessInstanceModificationClient(writer, processInstanceKey, authorizedTenants);
     }
+
+    public ProcessInstanceMigrationClient migration() {
+      return new ProcessInstanceMigrationClient(writer, processInstanceKey, authorizedTenants);
+    }
   }
 
   public static class ProcessInstanceModificationClient {
@@ -482,6 +490,115 @@ public final class ProcessInstanceClient {
                 .setVariables(variables);
         activateInstruction.addVariableInstruction(variableInstruction);
         return this;
+      }
+    }
+  }
+
+  public static class ProcessInstanceMigrationClient {
+
+    private static final Function<Long, Record<ProcessInstanceMigrationRecordValue>>
+        SUCCESS_EXPECTATION =
+            (position) ->
+                RecordingExporter.processInstanceMigrationRecords()
+                    .withIntent(ProcessInstanceMigrationIntent.MIGRATED)
+                    .withSourceRecordPosition(position)
+                    .getFirst();
+
+    private static final Function<Long, Record<ProcessInstanceMigrationRecordValue>>
+        REJECTION_EXPECTATION =
+            (processInstanceKey) ->
+                RecordingExporter.processInstanceMigrationRecords()
+                    .onlyCommandRejections()
+                    .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
+                    .withRecordKey(processInstanceKey)
+                    .withProcessInstanceKey(processInstanceKey)
+                    .getFirst();
+
+    private Function<Long, Record<ProcessInstanceMigrationRecordValue>> expectation =
+        SUCCESS_EXPECTATION;
+
+    private final CommandWriter writer;
+    private final long processInstanceKey;
+    private final ProcessInstanceMigrationRecord record;
+    private final List<ProcessInstanceMigrationMappingInstruction> mappingInstructions;
+    private String[] authorizedTenants;
+
+    public ProcessInstanceMigrationClient(
+        final CommandWriter writer,
+        final long processInstanceKey,
+        final String[] authorizedTenants) {
+      this.writer = writer;
+      this.processInstanceKey = processInstanceKey;
+      this.authorizedTenants = authorizedTenants;
+      record = new ProcessInstanceMigrationRecord();
+      mappingInstructions = new ArrayList<>();
+    }
+
+    /**
+     * Set the target process definition key.
+     *
+     * @param processDefinitionKey The process definition key of the target process
+     * @return this client builder for chaining
+     */
+    public ProcessInstanceMigrationClient withTargetProcessDefinitionKey(
+        final long processDefinitionKey) {
+      record.setTargetProcessDefinitionKey(processDefinitionKey);
+      return this;
+    }
+
+    /**
+     * Add a mapping instruction. Can be chained to add multiple instructions.
+     *
+     * @param sourceElementId The element id of the source element
+     * @param targetElementId The element id of the target element
+     * @return this client builder for chaining
+     */
+    public ProcessInstanceMigrationClient withMappingInstruction(
+        final String sourceElementId, final String targetElementId) {
+      final var mappingInstruction =
+          new ProcessInstanceMigrationMappingInstruction()
+              .setSourceElementId(sourceElementId)
+              .setTargetElementId(targetElementId);
+      mappingInstructions.add(mappingInstruction);
+      return this;
+    }
+
+    public ProcessInstanceMigrationClient forAuthorizedTenants(final String... authorizedTenants) {
+      this.authorizedTenants = authorizedTenants;
+      return this;
+    }
+
+    /**
+     * Expect the migration to be rejected. Fails the test if the migration is not rejected.
+     *
+     * @return this client builder for chaining
+     */
+    public ProcessInstanceMigrationClient expectRejection() {
+      expectation = REJECTION_EXPECTATION;
+      return this;
+    }
+
+    /**
+     * Migrate the process instance. Awaits the defined expectation. Fails the test if the
+     * expectation is not met.
+     *
+     * @return the resulting record of the migration
+     */
+    public Record<ProcessInstanceMigrationRecordValue> migrate() {
+      record.setProcessInstanceKey(processInstanceKey);
+      mappingInstructions.forEach(record::addMappingInstruction);
+
+      final var position =
+          writer.writeCommand(
+              processInstanceKey,
+              ProcessInstanceMigrationIntent.MIGRATE,
+              record,
+              authorizedTenants);
+
+      if (expectation == REJECTION_EXPECTATION) {
+        return expectation.apply(processInstanceKey);
+      } else {
+        return expectation.apply(position);
       }
     }
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -553,7 +553,7 @@ public final class ProcessInstanceClient {
      * @param targetElementId The element id of the target element
      * @return this client builder for chaining
      */
-    public ProcessInstanceMigrationClient withMappingInstruction(
+    public ProcessInstanceMigrationClient addMappingInstruction(
         final String sourceElementId, final String targetElementId) {
       final var mappingInstruction =
           new ProcessInstanceMigrationMappingInstruction()

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
@@ -69,6 +70,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord.class);
     registry.put(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationRecord.class);
     registry.put(ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecord.class);
+    registry.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecord.class);
     registry.put(ValueType.ERROR, ErrorRecord.class);
     registry.put(ValueType.PROCESS_INSTANCE_RESULT, ProcessInstanceResultRecord.class);
     registry.put(ValueType.PROCESS, ProcessRecord.class);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceMigrationRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceMigrationRecordStream.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+import java.util.stream.Stream;
+
+public final class ProcessInstanceMigrationRecordStream
+    extends ExporterRecordStream<
+        ProcessInstanceMigrationRecordValue, ProcessInstanceMigrationRecordStream> {
+
+  public ProcessInstanceMigrationRecordStream(
+      final Stream<Record<ProcessInstanceMigrationRecordValue>> records) {
+    super(records);
+  }
+
+  @Override
+  protected ProcessInstanceMigrationRecordStream supply(
+      final Stream<Record<ProcessInstanceMigrationRecordValue>> wrappedStream) {
+    return new ProcessInstanceMigrationRecordStream(wrappedStream);
+  }
+
+  public ProcessInstanceMigrationRecordStream withProcessInstanceKey(
+      final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
@@ -47,6 +48,7 @@ import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecor
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
@@ -322,6 +324,16 @@ public final class RecordingExporter implements Exporter {
   public static ProcessInstanceModificationRecordStream processInstanceModificationRecords(
       final ProcessInstanceModificationIntent intent) {
     return processInstanceModificationRecords().withIntent(intent);
+  }
+
+  public static ProcessInstanceMigrationRecordStream processInstanceMigrationRecords() {
+    return new ProcessInstanceMigrationRecordStream(
+        records(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecordValue.class));
+  }
+
+  public static ProcessInstanceMigrationRecordStream processInstanceMigrationRecords(
+      final ProcessInstanceMigrationIntent intent) {
+    return processInstanceMigrationRecords().withIntent(intent);
   }
 
   public static ProcessInstanceResultRecordStream processInstanceResultRecords() {


### PR DESCRIPTION
## Description

> [!WARNING]
> This PR is based on #15164. We should merge that first.

<!-- Please explain the changes you made here. -->
Adds a new `ProcessInstanceMigrationProcessor` that processes the new `ProcessInstanceMigration:MIGRATE` command, by:
- appending the `MIGRATED` event
- responding the `MIGRATED` event

This pull request also builds up the necessary testing infrastructure and boyscouts some small naming improvements.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15107

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
