### PR TITLE
Apply `ProcessInstance:ELEMENT_MIGRATED` events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -154,6 +154,9 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN,
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState, processState));
+    register(
+        ProcessInstanceIntent.ELEMENT_MIGRATED,
+        new ProcessInstanceElementMigratedApplier(elementInstanceState));
   }
 
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
@@ -24,5 +24,16 @@ final class ProcessInstanceElementMigratedApplier
   }
 
   @Override
-  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {}
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance ->
+            elementInstance
+                .getValue()
+                .setProcessDefinitionKey(value.getProcessDefinitionKey())
+                .setBpmnProcessId(value.getBpmnProcessId())
+                .setVersion(value.getVersion())
+                .setElementId(value.getElementId())
+                .setFlowScopeKey(value.getFlowScopeKey()));
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/** Applies state changes for `ProcessInstance:Element_Migrated` */
+final class ProcessInstanceElementMigratedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceElementMigratedApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -272,6 +272,24 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
+  public void insertProcessInstanceKeyByDefinitionKey(
+      final long processInstanceKey, final long processDefinitionKey) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    elementInstanceKey.wrapLong(processInstanceKey);
+    processInstanceKeyByProcessDefinitionKeyColumnFamily.insert(
+        processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void deleteProcessInstanceKeyByDefinitionKey(
+      final long processInstanceKey, final long processDefinitionKey) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    elementInstanceKey.wrapLong(processInstanceKey);
+    processInstanceKeyByProcessDefinitionKeyColumnFamily.deleteExisting(
+        processInstanceKeyByProcessDefinitionKey);
+  }
+
+  @Override
   public ElementInstance getInstance(final long key) {
     elementInstanceKey.wrapLong(key);
     final ElementInstance elementInstance = elementInstanceColumnFamily.get(elementInstanceKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -60,4 +60,26 @@ public interface MutableElementInstanceState extends ElementInstanceState {
    */
   void decrementNumberOfTakenSequenceFlows(
       final long flowScopeKey, final DirectBuffer gatewayElementId);
+
+  /**
+   * Inserts a new reference from process instance key to process definition key.
+   *
+   * <p>This makes it possible to query for all process instances of a specific process definition
+   * using {@link ElementInstanceState#getProcessInstanceKeysByDefinitionKey(long)}.
+   *
+   * @param processInstanceKey the key of the process instance to insert the reference for
+   * @param processDefinitionKey the key of the process definition to insert the reference for
+   */
+  void insertProcessInstanceKeyByDefinitionKey(long processInstanceKey, long processDefinitionKey);
+
+  /**
+   * Deletes the reference between process instance key and process definition key.
+   *
+   * <p>This makes it possible to query for all process instances of a specific process definition
+   * using {@link ElementInstanceState#getProcessInstanceKeysByDefinitionKey(long)}.
+   *
+   * @param processInstanceKey the key of the process instance to delete the reference for
+   * @param processDefinitionKey the key of the process definition to delete the reference for
+   */
+  void deleteProcessInstanceKeyByDefinitionKey(long processInstanceKey, long processDefinitionKey);
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
@@ -94,7 +94,7 @@ public class ProcessInstanceElementMigratedApplierTest {
   }
 
   @Test
-  void shouldUpdateFlowScopeKey() {
+  void shouldUpdateFlowScopeKeyIfSetToDifferentValue() {
     // given
     final long serviceTaskKey = 3L;
     final var serviceTask =

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class ProcessInstanceElementMigratedApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableElementInstanceState elementInstanceState;
+  private ProcessInstanceElementMigratedApplier processInstanceElementMigratedApplier;
+
+  @BeforeEach
+  public void setup() {
+    elementInstanceState = processingState.getElementInstanceState();
+    processInstanceElementMigratedApplier =
+        new ProcessInstanceElementMigratedApplier(elementInstanceState);
+  }
+
+  @Test
+  void shouldUpdateProcessDefinitionData() {
+    // given
+    final var processInstance =
+        new ProcessInstanceRecord()
+            .setProcessDefinitionKey(1L)
+            .setBpmnProcessId("process")
+            .setVersion(1)
+            .setElementId("process")
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setProcessInstanceKey(2L);
+    elementInstanceState.createInstance(
+        new ElementInstance(
+            processInstance.getProcessInstanceKey(),
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            processInstance));
+
+    // when
+    final var migratedProcessInstance = new ProcessInstanceRecord();
+    migratedProcessInstance.wrap(processInstance);
+    migratedProcessInstance
+        .setProcessDefinitionKey(3L)
+        .setVersion(2)
+        .setBpmnProcessId("another_process")
+        .setElementId("another_process");
+    processInstanceElementMigratedApplier.applyState(
+        processInstance.getProcessInstanceKey(), migratedProcessInstance);
+
+    // then
+    assertThat(elementInstanceState.getInstance(processInstance.getProcessInstanceKey()).getValue())
+        .describedAs("Expect that the process definition data is updated")
+        .hasProcessDefinitionKey(migratedProcessInstance.getProcessDefinitionKey())
+        .hasBpmnProcessId(migratedProcessInstance.getBpmnProcessId())
+        .hasVersion(migratedProcessInstance.getVersion())
+        .hasElementId(migratedProcessInstance.getElementId())
+        .describedAs("Expect that the other data is left unchanged")
+        .hasProcessInstanceKey(processInstance.getProcessInstanceKey())
+        .hasParentElementInstanceKey(processInstance.getParentElementInstanceKey())
+        .hasParentProcessInstanceKey(processInstance.getParentProcessInstanceKey())
+        .hasTenantId(processInstance.getTenantId())
+        .hasBpmnElementType(processInstance.getBpmnElementType())
+        .hasBpmnEventType(processInstance.getBpmnEventType())
+        .hasFlowScopeKey(processInstance.getFlowScopeKey());
+  }
+
+  @Test
+  void shouldUpdateFlowScopeKey() {
+    // given
+    final long serviceTaskKey = 3L;
+    final var serviceTask =
+        new ProcessInstanceRecord()
+            .setProcessDefinitionKey(1L)
+            .setBpmnProcessId("process")
+            .setVersion(1)
+            .setElementId("task")
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setProcessInstanceKey(2L);
+    elementInstanceState.createInstance(
+        new ElementInstance(serviceTaskKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, serviceTask));
+
+    // when
+    final var migratedServiceTask = new ProcessInstanceRecord();
+    migratedServiceTask.wrap(serviceTask);
+    migratedServiceTask
+        .setProcessDefinitionKey(4L)
+        .setVersion(2)
+        .setBpmnProcessId("another_process")
+        .setElementId("another_process")
+        .setFlowScopeKey(5L);
+    processInstanceElementMigratedApplier.applyState(serviceTaskKey, migratedServiceTask);
+
+    // then
+    assertThat(elementInstanceState.getInstance(serviceTaskKey).getValue())
+        .describedAs("Expect that the flow scope key is updated")
+        .hasFlowScopeKey(migratedServiceTask.getFlowScopeKey());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
@@ -80,6 +80,17 @@ public class ProcessInstanceElementMigratedApplierTest {
         .hasBpmnElementType(processInstance.getBpmnElementType())
         .hasBpmnEventType(processInstance.getBpmnEventType())
         .hasFlowScopeKey(processInstance.getFlowScopeKey());
+
+    assertThat(
+            elementInstanceState.getProcessInstanceKeysByDefinitionKey(
+                migratedProcessInstance.getProcessDefinitionKey()))
+        .describedAs("Expect that the instance is migrated to the target process definition")
+        .containsExactly(migratedProcessInstance.getProcessInstanceKey());
+    assertThat(
+            elementInstanceState.getProcessInstanceKeysByDefinitionKey(
+                processInstance.getProcessDefinitionKey()))
+        .describedAs("Expect that there are no instances of the old process definition")
+        .isEmpty();
   }
 
   @Test

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -32,7 +32,9 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
 
   ACTIVATE_ELEMENT((short) 8),
   COMPLETE_ELEMENT((short) 9),
-  TERMINATE_ELEMENT((short) 10);
+  TERMINATE_ELEMENT((short) 10),
+
+  ELEMENT_MIGRATED((short) 11);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
@@ -78,6 +80,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return COMPLETE_ELEMENT;
       case 10:
         return TERMINATE_ELEMENT;
+      case 11:
+        return ELEMENT_MIGRATED;
       default:
         return Intent.UNKNOWN;
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

> [!WARNING]  
> This PR is based on https://github.com/camunda/zeebe/pull/15215. We should merge that first.

Adds an event applier for the `ELEMENT_MIGRATED` intent of the `ProcessInstance` records.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15110

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
