### PR TITLE
Provide default service config for gateway_protocol.Gateway service

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -119,7 +119,8 @@ public final class ClientProperties {
   public static final String CLOUD_CLIENT_SECRET = "zeebe.client.cloud.secret";
 
   /**
-   * @see ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep4#withRegion(java.lang.String)
+   * @see
+   *     io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4#withRegion(String)
    */
   public static final String CLOUD_REGION = "zeebe.client.cloud.region";
 
@@ -127,6 +128,11 @@ public final class ClientProperties {
    * @see ZeebeClientBuilder#defaultJobWorkerStreamEnabled(boolean)
    */
   public static final String STREAM_ENABLED = "zeebe.client.worker.stream.enabled";
+
+  /**
+   * @see ZeebeClientBuilder#useDefaultRetryPolicy(boolean)
+   */
+  public static final String USE_DEFAULT_RETRY_POLICY = "zeebe.client.useDefaultRetryPolicy";
 
   private ClientProperties() {}
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -176,6 +176,14 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder defaultJobWorkerStreamEnabled(boolean streamEnabled);
 
   /**
+   * If enabled, the client will make use of the default retry policy defined. False by default.
+   *
+   * <p>NOTE: the default retry policy is taken from the {@code gateway-service-config.json} in the
+   * {@code io.camunda:zeebe-gateway-protocol-impl} JAR.
+   */
+  ZeebeClientBuilder useDefaultRetryPolicy(final boolean useDefaultRetryPolicy);
+
+  /**
    * @return a new {@link ZeebeClient} with the provided configuration options.
    */
   ZeebeClient build();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -123,4 +123,9 @@ public interface ZeebeClientConfiguration {
    * @see ZeebeClientBuilder#defaultJobWorkerStreamEnabled(boolean)
    */
   boolean getDefaultJobWorkerStreamEnabled();
+
+  /**
+   * @see ZeebeClientBuilder#useDefaultRetryPolicy(boolean)
+   */
+  boolean useDefaultRetryPolicy();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -22,6 +22,7 @@ import static io.camunda.zeebe.client.ClientProperties.KEEP_ALIVE;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.OVERRIDE_AUTHORITY;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
+import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.BuilderUtils.appendProperty;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
@@ -58,6 +59,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
       "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
   public static final String DEFAULT_JOB_WORKER_NAME = "default";
+  public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private boolean applyEnvironmentVariableOverrides = true;
 
@@ -83,6 +85,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private boolean streamEnabled = false;
   private ScheduledExecutorService jobWorkerExecutor;
   private boolean ownsJobWorkerExecutor;
+  private boolean useDefaultRetryPolicy;
 
   @Override
   public String getGatewayAddress() {
@@ -190,6 +193,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
+  public boolean useDefaultRetryPolicy() {
+    return useDefaultRetryPolicy;
+  }
+
+  @Override
   public ZeebeClientBuilder withProperties(final Properties properties) {
     if (properties.containsKey(ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES)) {
       applyEnvironmentVariableOverrides(
@@ -266,6 +274,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
     if (properties.containsKey(STREAM_ENABLED)) {
       defaultJobWorkerStreamEnabled(Boolean.parseBoolean(properties.getProperty(STREAM_ENABLED)));
+    }
+    if (properties.containsKey(USE_DEFAULT_RETRY_POLICY)) {
+      useDefaultRetryPolicy(Boolean.parseBoolean(properties.getProperty(USE_DEFAULT_RETRY_POLICY)));
     }
     return this;
   }
@@ -406,6 +417,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
+  public ZeebeClientBuilder useDefaultRetryPolicy(final boolean useDefaultRetryPolicy) {
+    this.useDefaultRetryPolicy = useDefaultRetryPolicy;
+    return this;
+  }
+
+  @Override
   public ZeebeClient build() {
     if (applyEnvironmentVariableOverrides) {
       applyOverrides();
@@ -456,6 +473,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     if (Environment.system().isDefined(ZEEBE_CLIENT_WORKER_STREAM_ENABLED)) {
       defaultJobWorkerStreamEnabled(
           Boolean.parseBoolean(Environment.system().get(ZEEBE_CLIENT_WORKER_STREAM_ENABLED)));
+    }
+
+    if (Environment.system().isDefined(USE_DEFAULT_RETRY_POLICY_VAR)) {
+      useDefaultRetryPolicy(
+          Boolean.parseBoolean(Environment.system().get(USE_DEFAULT_RETRY_POLICY_VAR)));
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -236,7 +236,13 @@ public class ZeebeClientCloudBuilderImpl
   @Override
   public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
     innerBuilder.defaultJobWorkerStreamEnabled(streamEnabled);
-    return null;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder useDefaultRetryPolicy(final boolean useDefaultRetryPolicy) {
+    innerBuilder.useDefaultRetryPolicy(useDefaultRetryPolicy);
+    return this;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -148,10 +148,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
     channelBuilder.userAgent("zeebe-client-java/" + VersionUtil.getVersion());
     channelBuilder.maxInboundMessageSize(config.getMaxMessageSize());
 
-    final Map<String, Object> serviceConfig = defaultServiceConfig();
-    if (!serviceConfig.isEmpty()) {
-      channelBuilder.defaultServiceConfig(serviceConfig);
-      channelBuilder.enableRetry();
+    if (config.useDefaultRetryPolicy()) {
+      final Map<String, Object> serviceConfig = defaultServiceConfig();
+      if (!serviceConfig.isEmpty()) {
+        channelBuilder.defaultServiceConfig(serviceConfig);
+        channelBuilder.enableRetry();
+      }
     }
 
     return channelBuilder.build();
@@ -211,7 +213,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
     final URL defaultServiceConfig =
         ClassLoader.getSystemClassLoader().getResource("gateway-service-config.json");
     if (defaultServiceConfig == null) {
-      Loggers.LOGGER.warn(
+      Loggers.LOGGER.info(
           "No default service config found on classpath; will not configure a default retry policy");
       return new HashMap<>();
     }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -20,6 +20,7 @@ import static io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
+import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CA_CERTIFICATE_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
@@ -27,6 +28,7 @@ import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_TENANT
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.KEEP_ALIVE_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.OVERRIDE_AUTHORITY_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.PLAINTEXT_CONNECTION_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.USE_DEFAULT_RETRY_POLICY_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.ZEEBE_CLIENT_WORKER_STREAM_ENABLED;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -724,5 +726,48 @@ public final class ZeebeClientTest extends ClientTest {
         .describedAs(
             "This method has no effect on the cloud client builder while under development")
         .isEqualTo(builder);
+  }
+
+  @Test
+  public void shouldUseDefaultRetryPolicy() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.useDefaultRetryPolicy(true);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.useDefaultRetryPolicy()).isTrue();
+  }
+
+  @Test
+  public void shouldOverrideDefaultRetryPolicyWithEnvVar() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.useDefaultRetryPolicy(true);
+    Environment.system().put(USE_DEFAULT_RETRY_POLICY_VAR, "false");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.useDefaultRetryPolicy()).isFalse();
+  }
+
+  @Test
+  public void shouldOverrideDefaultRetryPolicyWithProperty() {
+    // given
+    final Properties properties = new Properties();
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.useDefaultRetryPolicy(true);
+    properties.setProperty(USE_DEFAULT_RETRY_POLICY, "false");
+    builder.withProperties(properties);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.useDefaultRetryPolicy()).isFalse();
   }
 }

--- a/gateway-protocol-impl/pom.xml
+++ b/gateway-protocol-impl/pom.xml
@@ -58,6 +58,30 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gateway-protocol-impl/src/main/resources/gateway-service-config.json
+++ b/gateway-protocol-impl/src/main/resources/gateway-service-config.json
@@ -27,6 +27,7 @@
         {"service": "gateway_protocol.Gateway", "method": "BroadcastSignal"},
         {"service": "gateway_protocol.Gateway", "method": "CreateProcessInstance"},
         {"service": "gateway_protocol.Gateway", "method": "CreateProcessInstanceWithResult"},
+        {"service": "gateway_protocol.Gateway", "method": "DeployProcess"},
         {"service": "gateway_protocol.Gateway", "method": "DeployResource"},
         {"service": "gateway_protocol.Gateway", "method": "ModifyProcessInstance"},
         {"service": "gateway_protocol.Gateway", "method": "PublishMessage"},

--- a/gateway-protocol-impl/src/main/resources/gateway-service-config.json
+++ b/gateway-protocol-impl/src/main/resources/gateway-service-config.json
@@ -1,0 +1,50 @@
+{
+  "methodConfig": [
+    {
+      "name": [
+        {"service": "gateway_protocol.Gateway", "method": "ActivateJobs"},
+        {"service": "gateway_protocol.Gateway", "method": "CancelProcessInstance"},
+        {"service": "gateway_protocol.Gateway", "method": "CompleteJob"},
+        {"service": "gateway_protocol.Gateway", "method": "DeleteResource"},
+        {"service": "gateway_protocol.Gateway", "method": "EvaluateDecision"},
+        {"service": "gateway_protocol.Gateway", "method": "FailJob"},
+        {"service": "gateway_protocol.Gateway", "method": "ResolveIncident"},
+        {"service": "gateway_protocol.Gateway", "method": "SetVariables"},
+        {"service": "gateway_protocol.Gateway", "method": "StreamActivatedJobs"},
+        {"service": "gateway_protocol.Gateway", "method": "Topology"}
+      ],
+      "waitForReady": true,
+      "retryPolicy": {
+        "maxAttempts": 5.0,
+        "initialBackoff": "0.1s",
+        "maxBackoff": "5s",
+        "backoffMultiplier": 3.0,
+        "retryableStatusCodes": ["UNAVAILABLE", "RESOURCE_EXHAUSTED", "DEADLINE_EXCEEDED"]
+      }
+    },
+    {
+      "name": [
+        {"service": "gateway_protocol.Gateway", "method": "BroadcastSignal"},
+        {"service": "gateway_protocol.Gateway", "method": "CreateProcessInstance"},
+        {"service": "gateway_protocol.Gateway", "method": "CreateProcessInstanceWithResult"},
+        {"service": "gateway_protocol.Gateway", "method": "DeployResource"},
+        {"service": "gateway_protocol.Gateway", "method": "ModifyProcessInstance"},
+        {"service": "gateway_protocol.Gateway", "method": "PublishMessage"},
+        {"service": "gateway_protocol.Gateway", "method": "ThrowError"},
+        {"service": "gateway_protocol.Gateway", "method": "UpdateJobRetries"},
+        {"service": "gateway_protocol.Gateway", "method": "UpdateJobTimeout"}
+      ],
+      "waitForReady": true,
+      "retryPolicy": {
+        "maxAttempts": 5.0,
+        "initialBackoff": "0.1s",
+        "maxBackoff": "5s",
+        "backoffMultiplier": 3.0,
+        "retryableStatusCodes": ["UNAVAILABLE", "RESOURCE_EXHAUSTED"]
+      }
+    }
+  ],
+  "healthCheckConfig": {
+    "serviceName": "gateway_protocol.Gateway"
+  }
+}

--- a/gateway-protocol-impl/src/test/java/io/camunda/zeebe/gateway/protocol/ServiceConfigTest.java
+++ b/gateway-protocol-impl/src/test/java/io/camunda/zeebe/gateway/protocol/ServiceConfigTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.gateway.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServiceDescriptor;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import org.assertj.core.api.Condition;
+import org.assertj.core.condition.VerboseCondition;
+import org.junit.jupiter.api.Test;
+
+final class ServiceConfigTest {
+
+  /**
+   * Verifies that every method/RPC of the Gateway service (as defined in gateway.proto) has a
+   * corresponding retry policy defined in gateway-service-config.json (see this module's
+   * resources).
+   *
+   * <p>If one is missing, you will need to either add the method to one of the existing policies,
+   * or if none of the existing policies match, create a new policy for this method.
+   *
+   * <p>See <a
+   * href="https://github.com/grpc/grpc/blob/master/doc/service_config.md">service_config.md</a> for
+   * more about the syntax.
+   */
+  @Test
+  void shouldHaveAPolicyForAllServiceMethods() throws IOException {
+    // given
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final ServiceDescriptor serviceDescriptor = GatewayGrpc.getServiceDescriptor();
+    final Collection<MethodDescriptor<?, ?>> methods = serviceDescriptor.getMethods();
+    final URL configUrl =
+        ClassLoader.getSystemClassLoader().getResource("gateway-service-config.json");
+    final PartialServiceConfig serviceConfig =
+        objectMapper.readValue(configUrl, PartialServiceConfig.class);
+
+    // when - then
+    for (final MethodDescriptor<?, ?> method : methods) {
+      assertThat(serviceConfig).has(hasRetryPolicyFor(method, configUrl));
+    }
+  }
+
+  private Condition<? super PartialServiceConfig> hasRetryPolicyFor(
+      final MethodDescriptor<?, ?> method, final URL configUrl) {
+    final MethodName expected = new MethodName(method.getServiceName(), method.getBareMethodName());
+    return VerboseCondition.verboseCondition(
+        config ->
+            config.methodConfig.stream()
+                .filter(m -> m.name.contains(expected))
+                .anyMatch(m -> m.retryPolicy != null),
+        String.format(
+            "a service config with a retry policy for method '%s' defined",
+            method.getFullMethodName()),
+        config -> String.format(" but no such retry policy was found in '%s'", configUrl));
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class PartialMethodConfig {
+    private final List<MethodName> name;
+    private final Object retryPolicy;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public PartialMethodConfig(
+        final @JsonProperty("name") List<MethodName> name,
+        final @JsonProperty("retryPolicy") Object retryPolicy) {
+      this.name = name;
+      this.retryPolicy = retryPolicy;
+    }
+
+    @Override
+    public String toString() {
+      return "PartialMethodConfig{" + "name=" + name + ", retryPolicy=" + retryPolicy + '}';
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class MethodName {
+    private final String service;
+    private final String method;
+
+    @JsonCreator(mode = Mode.PROPERTIES)
+    public MethodName(
+        final @JsonProperty("service") String service,
+        final @JsonProperty("method") String method) {
+      this.service = service;
+      this.method = method;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(service, method);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final MethodName that = (MethodName) o;
+      return Objects.equals(service, that.service) && Objects.equals(method, that.method);
+    }
+
+    @Override
+    public String toString() {
+      return "MethodName{" + "service='" + service + '\'' + ", method='" + method + '\'' + '}';
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class PartialServiceConfig {
+    private final List<PartialMethodConfig> methodConfig;
+
+    @JsonCreator
+    public PartialServiceConfig(
+        final @JsonProperty("methodConfig") List<PartialMethodConfig> methodConfig) {
+      this.methodConfig = methodConfig;
+    }
+
+    @Override
+    public String toString() {
+      return "PartialServiceConfig{" + "methodConfig=" + methodConfig + '}';
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR creates a [default service config](https://github.com/grpc/grpc/blob/master/doc/service_config.md) for the gRPC Gateway service. It defines a retry policy per call, with default retry-able calls, a max number of retries, as well as a back off policy.

As an example, this configuration is also loaded as the default service config for the Java client. To use with the Go client, you would simply use the [WithDefaultServiceConfig](https://pkg.go.dev/google.golang.org/grpc#WithDefaultServiceConfig) `DialOption`.

The default service config can be superseded by local user configuration, or a DNS provided service config for the given gateway endpoint.

This _may_ deprecate the use of the back off policy in the worker, but not necessarily. There, the policy throttles the polling logic, whereas the retry here is on a per call basis. So they could be made to work in conjunction.

The nice thing about providing a default service config is that other clients could also use it in the future, as most gRPC libraries provide support for it.

I did not add tests for this, but I did confirm manually that this works. 

**One thing to note**: when `DEADLINE_EXCEEDED` is added as a retry-able call, this refers to `DEADLINE_EXCEEDED` returned by the server. In case the client is the one cancelling with a timeout (which the client will observe as `DEADLINE_EXCEEDED`, though it's generated locally), no retry is performed, as it's assumed the user would not want to retry after the request timeout.

Regarding the policy itself, I suspect the ZPA team will have a better idea of what codes are actually retry-able and what aren't. In the future, it also means that whenever you add new calls/RPCs, you would need to think about adding them to the default config.

## Related issues

related to #14217

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
