### PR TITLE
Migrate the process instance element instance

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -91,7 +91,7 @@ public final class BpmnProcessors {
         typedRecordProcessors, processingState, writers, bpmnBehaviors, processEngineMetrics);
     addProcessInstanceModificationStreamProcessors(
         typedRecordProcessors, processingState, writers, bpmnBehaviors);
-    addProcessInstanceMigrationStreamProcessors(typedRecordProcessors, writers);
+    addProcessInstanceMigrationStreamProcessors(typedRecordProcessors, processingState, writers);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
 
     return bpmnStreamProcessor;
@@ -225,11 +225,14 @@ public final class BpmnProcessors {
   }
 
   private static void addProcessInstanceMigrationStreamProcessors(
-      final TypedRecordProcessors typedRecordProcessors, final Writers writers) {
+      final TypedRecordProcessors typedRecordProcessors,
+      final ProcessingState processingState,
+      final Writers writers) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         ProcessInstanceMigrationIntent.MIGRATE,
-        new ProcessInstanceMigrationMigrateProcessor(writers));
+        new ProcessInstanceMigrationMigrateProcessor(
+            writers, processingState.getElementInstanceState(), processingState.getProcessState()));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -11,7 +11,12 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
@@ -20,16 +25,55 @@ public class ProcessInstanceMigrationMigrateProcessor
 
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
 
-  public ProcessInstanceMigrationMigrateProcessor(final Writers writers) {
+  public ProcessInstanceMigrationMigrateProcessor(
+      final Writers writers,
+      final ElementInstanceState elementInstanceState,
+      final ProcessState processState) {
     stateWriter = writers.state();
     responseWriter = writers.response();
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
   }
 
   @Override
   public void processRecord(final TypedRecord<ProcessInstanceMigrationRecord> command) {
-    final long processInstanceKey = command.getKey();
     final ProcessInstanceMigrationRecord value = command.getValue();
+    final long processInstanceKey = value.getProcessInstanceKey();
+    final long targetProcessDefinitionKey = value.getTargetProcessDefinitionKey();
+
+    final ElementInstance processInstance = elementInstanceState.getInstance(processInstanceKey);
+    if (processInstance == null) {
+      // todo: we should reject the command explicitly
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected to migrate process instance with key '%d', but process instance not found",
+              processInstanceKey));
+    }
+
+    final DeployedProcess processDefinition =
+        processState.getProcessByKeyAndTenant(
+            targetProcessDefinitionKey, processInstance.getValue().getTenantId());
+    if (processDefinition == null) {
+      // todo: we should reject the command explicitly
+      throw new IllegalStateException(
+          String.format(
+              "Expected to migrate process instance with key '%d' to process definition with key '%d', but process definition not found",
+              value.getProcessInstanceKey(), targetProcessDefinitionKey));
+    }
+
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey,
+        ProcessInstanceIntent.ELEMENT_MIGRATED,
+        processInstance
+            .getValue()
+            .setProcessDefinitionKey(processDefinition.getKey())
+            .setBpmnProcessId(processDefinition.getBpmnProcessId())
+            .setVersion(processDefinition.getVersion())
+            .setElementId(processDefinition.getBpmnProcessId()));
+
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value);
     responseWriter.writeEventOnCommand(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
@@ -13,8 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.ClassRule;
@@ -52,11 +54,7 @@ public class MigrateProcessInstanceTest {
                     .done())
             .deploy();
     final long otherProcessDefinitionKey =
-        deployment.getValue().getProcessesMetadata().stream()
-            .filter(p -> p.getBpmnProcessId().equals(processId2))
-            .findAny()
-            .orElseThrow()
-            .getProcessDefinitionKey();
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
 
@@ -83,5 +81,14 @@ public class MigrateProcessInstanceTest {
             new ProcessInstanceMigrationMappingInstruction()
                 .setSourceElementId("A")
                 .setTargetElementId("B"));
+  }
+
+  private static long extractProcessDefinitionKeyByProcessId(
+      final Record<DeploymentRecordValue> deployment, final String processId) {
+    return deployment.getValue().getProcessesMetadata().stream()
+        .filter(p -> p.getBpmnProcessId().equals(processId))
+        .findAny()
+        .orElseThrow()
+        .getProcessDefinitionKey();
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
@@ -15,9 +15,12 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -81,6 +84,116 @@ public class MigrateProcessInstanceTest {
             new ProcessInstanceMigrationMappingInstruction()
                 .setSourceElementId("A")
                 .setTargetElementId("B"));
+  }
+
+  @Test
+  public void shouldWriteElementMigratedEventForProcessInstance() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String otherProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(otherProcessId)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, otherProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key changed")
+        .hasProcessDefinitionKey(otherProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(otherProcessId)
+        .hasElementId(otherProcessId)
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+  }
+
+  @Test
+  public void shouldWriteElementMigratedEventForProcessInstanceToNewVersion() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("A", a -> a.zeebeJobType("A"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var secondVersionDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .userTask()
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long v2ProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(secondVersionDeployment, processId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(v2ProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .onlyEvents()
+                .withIntent(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key changed")
+        .hasProcessDefinitionKey(v2ProcessDefinitionKey)
+        .describedAs("Expect that version number changed")
+        .hasVersion(2)
+        .describedAs("Expect that bpmn process id and element id did not change")
+        .hasBpmnProcessId(processId)
+        .hasElementId(processId);
   }
 
   private static long extractProcessDefinitionKeyByProcessId(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
@@ -167,7 +167,8 @@ public class MigrateProcessInstanceTest {
     final long v2ProcessDefinitionKey =
         extractProcessDefinitionKeyByProcessId(secondVersionDeployment, processId);
 
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVersion(1).create();
 
     // when
     ENGINE


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

> [!WARNING]  
> This PR is based on https://github.com/camunda/zeebe/pull/15217. We should merge that first.

Migrates the process instance's element instance by appending an `ELEMENT_MIGRATED` event for it.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15111

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
