### PR TITLE
Blocking executor for Jobworker

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -190,6 +190,17 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/BlockingExecutor.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/BlockingExecutor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import java.time.Duration;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+class BlockingExecutor {
+  public static final TimeUnit TIMEOUT_UNIT = TimeUnit.MILLISECONDS;
+
+  private final Executor wrappedExecutor;
+  private final Semaphore semaphore;
+  private final long timeoutMillis;
+
+  public BlockingExecutor(
+      final Executor wrappedExecutor, final int maxActivate, final Duration jobActivationTimeout) {
+    this.wrappedExecutor = wrappedExecutor;
+    semaphore = new Semaphore(maxActivate);
+    timeoutMillis = jobActivationTimeout.toMillis();
+  }
+
+  public void execute(final Runnable command) throws RejectedExecutionException {
+    try {
+      if (!semaphore.tryAcquire(timeoutMillis, TIMEOUT_UNIT)) {
+        throw new RejectedExecutionException(
+            String.format(
+                "Not able to acquire lease in %d%s", timeoutMillis, TIMEOUT_UNIT.toString()));
+      }
+
+      wrappedExecutor.execute(
+          () -> {
+            try {
+              command.run();
+            } finally {
+              semaphore.release();
+            }
+          });
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -207,6 +207,7 @@ public final class JobWorkerBuilderImpl
     final JobWorkerImpl jobWorker =
         new JobWorkerImpl(
             maxJobsActive,
+            timeout,
             executorService,
             pollInterval,
             jobRunnableFactory,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
@@ -253,7 +253,12 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     try {
       executor.execute(jobHandlerFactory.create(job, finalizer));
     } catch (final RejectedExecutionException e) {
-      // drop job
+      if (scheduledExecutorService.isShutdown() || scheduledExecutorService.isTerminated()) {
+        LOG.warn("Underlying executor was closed before the worker. Closing the worker now.", e);
+        close();
+        return;
+      }
+
       LOG.warn(ERROR_MSG, job.getKey(), e);
     }
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.client.impl.Loggers;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -62,7 +64,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   private final AtomicInteger remainingJobs;
 
   // job execution facilities
-  private final ScheduledExecutorService executor;
+  private final BlockingExecutor executor;
   private final JobRunnableFactory jobHandlerFactory;
   private final long initialPollInterval;
   private final JobStreamer jobStreamer;
@@ -89,7 +91,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     activationThreshold = Math.round(maxJobsActive * 0.3f);
     remainingJobs = new AtomicInteger(0);
 
-    this.executor = executor;
+    this.executor = BlockingExecutor.of(executor, maxJobsActive);
     this.jobHandlerFactory = jobHandlerFactory;
     this.jobStreamer = jobStreamer;
     initialPollInterval = pollInterval.toMillis();
@@ -253,5 +255,49 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
 
   private void handleStreamJobFinished() {
     metrics.jobHandled(1);
+  }
+
+  private static class BlockingExecutor implements Executor {
+
+    public static final int TIMEOUT = 10;
+    private final ScheduledExecutorService wrappedExecutor;
+    private final Semaphore semaphore;
+
+    private BlockingExecutor(
+        final ScheduledExecutorService wrappedExecutor, final int maxActivate) {
+      this.wrappedExecutor = wrappedExecutor;
+      semaphore = new Semaphore(maxActivate);
+    }
+
+    public static BlockingExecutor of(final ScheduledExecutorService executor, final int maxJobs) {
+      return new BlockingExecutor(executor, maxJobs);
+    }
+
+    public void schedule(final Runnable runnable, final long timeout, final TimeUnit unit) {
+      wrappedExecutor.schedule(runnable, timeout, unit);
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+      try {
+        if (!semaphore.tryAcquire(TIMEOUT, TimeUnit.SECONDS)) {
+          // handle timeout
+          LOG.warn(
+              "We reached the time out of {}s, we will drop the job, since it will be made available again for other workers in the meantime.",
+              TIMEOUT);
+        }
+
+        wrappedExecutor.execute(
+            () -> {
+              try {
+                command.run();
+              } finally {
+                semaphore.release();
+              }
+            });
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerImpl.java
@@ -253,6 +253,10 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     try {
       executor.execute(jobHandlerFactory.create(job, finalizer));
     } catch (final RejectedExecutionException e) {
+      if (isClosed()) {
+        return;
+      }
+
       if (scheduledExecutorService.isShutdown() || scheduledExecutorService.isTerminated()) {
         LOG.warn("Underlying executor was closed before the worker. Closing the worker now.", e);
         close();

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/BlockingExecutorTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/BlockingExecutorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public class BlockingExecutorTest {
+
+  @Test
+  public void shouldExecuteRunnable() {
+    // given
+    final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+    final BlockingExecutor executor = new BlockingExecutor(Runnable::run, 1, Duration.ofMillis(10));
+
+    // when
+    executor.execute(() -> atomicBoolean.set(true));
+
+    // then
+    assertThat(atomicBoolean).isTrue();
+  }
+
+  @Test
+  public void shouldThrowRejectOnFull() {
+    // given
+    final Executor noop = command -> {};
+    final BlockingExecutor executor = new BlockingExecutor(noop, 1, Duration.ofMillis(10));
+
+    // when - then throw
+    executor.execute(() -> {});
+    assertThatThrownBy(() -> executor.execute(() -> {}))
+        .isInstanceOf(RejectedExecutionException.class);
+  }
+
+  @Test
+  public void shouldReleaseAndRun() {
+    // given
+    final ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
+    try {
+      final BlockingExecutor executor =
+          new BlockingExecutor(wrappedExecutor, 1, Duration.ofSeconds(1));
+      final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+      final CountDownLatch countDownLatch = new CountDownLatch(1);
+      executor.execute(() -> Uninterruptibles.awaitUninterruptibly(countDownLatch));
+
+      // when
+      new Thread(() -> executor.execute(() -> atomicBoolean.set(true))).start();
+
+      // then
+      assertThat(atomicBoolean).isFalse();
+      countDownLatch.countDown();
+
+      Awaitility.await("Second runnable should be executed after latch is released")
+          .untilAtomic(atomicBoolean, Matchers.equalTo(true));
+    } finally {
+      wrappedExecutor.shutdownNow();
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
@@ -57,7 +57,7 @@ final class JobWorkerMetricsTest {
       final JobStreamer streamer,
       final JobWorkerMetrics metrics) {
     return new JobWorkerImpl(
-        1,
+        32,
         Duration.ofSeconds(1),
         executor,
         Duration.ofSeconds(30),

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
@@ -58,6 +58,7 @@ final class JobWorkerMetricsTest {
       final JobWorkerMetrics metrics) {
     return new JobWorkerImpl(
         1,
+        Duration.ZERO,
         executor,
         Duration.ofSeconds(30),
         new TestJobRunnableFactory(autoCompleteCount),

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerMetricsTest.java
@@ -58,7 +58,7 @@ final class JobWorkerMetricsTest {
       final JobWorkerMetrics metrics) {
     return new JobWorkerImpl(
         1,
-        Duration.ZERO,
+        Duration.ofSeconds(1),
         executor,
         Duration.ofSeconds(30),
         new TestJobRunnableFactory(autoCompleteCount),

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/TestData.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/TestData.java
@@ -23,8 +23,12 @@ import java.util.stream.IntStream;
 
 final class TestData {
   static GatewayOuterClass.ActivatedJob job() {
+    return job(12);
+  }
+
+  static GatewayOuterClass.ActivatedJob job(final long key) {
     return GatewayOuterClass.ActivatedJob.newBuilder()
-        .setKey(12)
+        .setKey(key)
         .setType("foo")
         .setProcessInstanceKey(123)
         .setBpmnProcessId("test1")
@@ -41,6 +45,6 @@ final class TestData {
   }
 
   static List<ActivatedJob> jobs(final int numberOfJobs) {
-    return IntStream.range(0, numberOfJobs).mapToObj(i -> job()).collect(Collectors.toList());
+    return IntStream.range(0, numberOfJobs).mapToObj(TestData::job).collect(Collectors.toList());
   }
 }

--- a/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationContext.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationContext.java
@@ -12,7 +12,6 @@ import org.agrona.DirectBuffer;
 
 /** The context for evaluating an expression. */
 public interface EvaluationContext {
-
   /**
    * Returns the value of the variable with the given name.
    *

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/JobWorkerTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/JobWorkerTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.grpc.internal.AbstractStream.TransportState;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -296,6 +297,7 @@ final class JobWorkerTest {
                     latch.await();
                   })
               .maxJobsActive(1)
+              .pollInterval(Duration.ofMillis(10))
               .streamEnabled(true)
               .open();
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/RecordingJobHandler.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/RecordingJobHandler.java
@@ -10,13 +10,12 @@ package io.camunda.zeebe.it.util;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class RecordingJobHandler implements JobHandler {
   protected final JobHandler[] jobHandlers;
-  protected final List<ActivatedJob> handledJobs = Collections.synchronizedList(new ArrayList<>());
+  protected final List<ActivatedJob> handledJobs = new CopyOnWriteArrayList<>();
   protected int nextJobHandler = 0;
 
   public RecordingJobHandler() {


### PR DESCRIPTION
## Description

This PR adds a new BlockingExecutor to the JobWorker, which wraps the injected ScheduledExecutor. 

The idea is that no more Jobs than the configured maxJobsActive are handled concurrently, and we are blocking the jobPoller and jobStream to create natural backpressure to the gRPC streams. 

gRPC will start to buffer incoming messages until a certain threshold, before it marks the stream as no longer ready. The Gateway will (or should) detect this and stop pushing more jobs threw the stream. Here, we will distribute the load to other clients first and if no more are available it will YIELD the job. This means it will return the job to the broker, and make it activatable again, so a job poller could take it if available. 


### Goal

All of this is to reduce the impact of pushing too much load threw the streams and the client or gateway is not able to handle the load, causing failures of the application. 

We were able to show in one of our benchmarks that before that we were easily able to overwhelm the client, later when [only blocking in the client the gateway was crashing](https://github.com/camunda/zeebe/pull/15234#issuecomment-1814539833), now with adjustment on the gateway the performance will decrease but no longer failures are happening. See related [comment below](https://github.com/camunda/zeebe/pull/15234#issuecomment-1815989825). 



<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/15181
closes https://github.com/camunda/zeebe/issues/15183

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
