### PR TITLE
feat(topology): export metrics describing topology and changes

### DIFF
--- a/topology/pom.xml
+++ b/topology/pom.xml
@@ -59,6 +59,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestFailedException.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestFailedException.java
@@ -34,8 +34,8 @@ public sealed interface TopologyRequestFailedException {
   }
 
   final class InternalError extends RuntimeException implements TopologyRequestFailedException {
-    public InternalError(final String message) {
-      super(message);
+    public InternalError(final Throwable cause) {
+      super(cause);
     }
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -213,11 +213,11 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
   }
 
   private void failFuture(final ActorFuture<?> future, final Throwable error) {
+    LOG.warn("Failed to handle topology request", error);
     if (error instanceof TopologyRequestFailedException) {
       future.completeExceptionally(error);
     } else {
-      future.completeExceptionally(
-          new TopologyRequestFailedException.InternalError(error.getMessage()));
+      future.completeExceptionally(new TopologyRequestFailedException.InternalError(error));
     }
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiper.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/gossip/ClusterTopologyGossiper.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.topology.TopologyUpdateNotifier;
+import io.camunda.zeebe.topology.metrics.TopologyMetrics;
 import io.camunda.zeebe.topology.serializer.ClusterTopologySerializer;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import java.util.Collections;
@@ -190,6 +191,7 @@ public final class ClusterTopologyGossiper
     LOGGER.trace("Updated local gossipState to {}", updatedTopology);
     gossip();
     notifyListeners(updatedTopology);
+    TopologyMetrics.updateFromTopology(updatedTopology);
   }
 
   private void notifyListeners(final ClusterTopology updatedTopology) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/metrics/TopologyMetrics.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/metrics/TopologyMetrics.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.metrics;
+
+import io.camunda.zeebe.topology.state.ClusterChangePlan;
+import io.camunda.zeebe.topology.state.ClusterChangePlan.Status;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.CompletedChange;
+import io.prometheus.client.Enumeration;
+import io.prometheus.client.Gauge;
+import java.time.Instant;
+import java.util.List;
+
+public final class TopologyMetrics {
+  private static final String NAMESPACE = "zeebe";
+  private static final Gauge TOPOLOGY_VERSION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("cluster_topology_version")
+          .help("The version of the cluster topology")
+          .register();
+  private static final Gauge CHANGE_ID =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("cluster_changes_id")
+          .help("The id of the cluster topology change plan")
+          .register();
+  private static final Enumeration CHANGE_STATUS =
+      Enumeration.build()
+          .namespace(NAMESPACE)
+          .name("cluster_changes_status")
+          .help("The state of the current cluster topology")
+          .states(ClusterChangePlan.Status.class)
+          .register();
+  private static final Gauge CHANGE_VERSION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("cluster_changes_version")
+          .help("The version of the cluster topology change plan")
+          .register();
+
+  private static final Gauge PENDING_OPERATIONS =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("cluster_changes_operations_pending")
+          .help("Number of pending changes in the current change plan")
+          .register();
+  private static final Gauge COMPLETED_OPERATIONS =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("cluster_changes_operations_completed")
+          .help("Number of completed changes in the current change plan")
+          .register();
+  private static final Gauge STARTED_AT =
+      Gauge.build()
+          .name(NAMESPACE)
+          .name("cluster_changes_started_at")
+          .help("Time at which the current topology change was started")
+          .register();
+  private static final Gauge COMPLETED_AT =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("cluster_changes_completed_at")
+          .help("Time at which the current topology change was completed")
+          .register();
+
+  public static void updateFromTopology(final ClusterTopology topology) {
+    TOPOLOGY_VERSION.set(topology.version());
+    CHANGE_STATUS.state(
+        topology
+            .pendingChanges()
+            .map(ClusterChangePlan::status)
+            .or(() -> topology.lastChange().map(CompletedChange::status))
+            .orElse(Status.COMPLETED));
+    CHANGE_ID.set(topology.pendingChanges().map(ClusterChangePlan::id).orElse(0L));
+    CHANGE_VERSION.set(topology.pendingChanges().map(ClusterChangePlan::version).orElse(0));
+    PENDING_OPERATIONS.set(
+        topology
+            .pendingChanges()
+            .map(ClusterChangePlan::pendingOperations)
+            .map(List::size)
+            .orElse(0));
+    COMPLETED_OPERATIONS.set(
+        topology
+            .pendingChanges()
+            .map(ClusterChangePlan::completedOperations)
+            .map(List::size)
+            .orElse(0));
+    STARTED_AT.set(
+        topology
+            .pendingChanges()
+            .map(ClusterChangePlan::startedAt)
+            .or(() -> topology.lastChange().map(CompletedChange::startedAt))
+            .map(Instant::toEpochMilli)
+            .orElse(0L));
+    COMPLETED_AT.set(
+        topology
+            .lastChange()
+            .map(CompletedChange::completedAt)
+            .map(Instant::toEpochMilli)
+            .orElse(0L));
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/metrics/TopologyMetrics.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/metrics/TopologyMetrics.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.CompletedChange;
 import io.prometheus.client.Enumeration;
 import io.prometheus.client.Gauge;
-import java.time.Instant;
 import java.util.List;
 
 public final class TopologyMetrics {
@@ -56,18 +55,6 @@ public final class TopologyMetrics {
           .name("cluster_changes_operations_completed")
           .help("Number of completed changes in the current change plan")
           .register();
-  private static final Gauge STARTED_AT =
-      Gauge.build()
-          .name(NAMESPACE)
-          .name("cluster_changes_started_at")
-          .help("Time at which the current topology change was started")
-          .register();
-  private static final Gauge COMPLETED_AT =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("cluster_changes_completed_at")
-          .help("Time at which the current topology change was completed")
-          .register();
 
   public static void updateFromTopology(final ClusterTopology topology) {
     TOPOLOGY_VERSION.set(topology.version());
@@ -91,18 +78,5 @@ public final class TopologyMetrics {
             .map(ClusterChangePlan::completedOperations)
             .map(List::size)
             .orElse(0));
-    STARTED_AT.set(
-        topology
-            .pendingChanges()
-            .map(ClusterChangePlan::startedAt)
-            .or(() -> topology.lastChange().map(CompletedChange::startedAt))
-            .map(Instant::toEpochMilli)
-            .orElse(0L));
-    COMPLETED_AT.set(
-        topology
-            .lastChange()
-            .map(CompletedChange::completedAt)
-            .map(Instant::toEpochMilli)
-            .orElse(0L));
   }
 }


### PR DESCRIPTION
This exports the current topology as metrics. I've not added a dashboard yet and we might need additional metrics but this should already help in debugging.

I've also included a somewhat unrelated change to ensure that we log failures.

Relates to #15172