### PR TITLE
test(qa): configure correct replicationFactor when creating new node

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleResiliencyTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleResiliencyTest.java
@@ -113,7 +113,10 @@ class ScaleResiliencyTest {
       final var newClusterSize = INITIAL_CLUSTER_SIZE + 1;
       final var newBroker =
           createNewBroker(
-              newClusterSize, newClusterSize - 1, getDataDirectory(tmpDir, newClusterSize - 1));
+              newClusterSize,
+              newClusterSize - 1,
+              REPLICATION_FACTOR,
+              getDataDirectory(tmpDir, newClusterSize - 1));
 
       // scale to 3
       Utils.scale(cluster, newClusterSize);
@@ -143,7 +146,10 @@ class ScaleResiliencyTest {
     }
 
     private TestStandaloneBroker createNewBroker(
-        final int newClusterSize, final int newBrokerId, final Path dataDirectory) {
+        final int newClusterSize,
+        final int newBrokerId,
+        final int replicationFactor,
+        final Path dataDirectory) {
       final var newBroker =
           new TestStandaloneBroker()
               .withBrokerConfig(
@@ -151,6 +157,7 @@ class ScaleResiliencyTest {
                     b.getExperimental().getFeatures().setEnableDynamicClusterTopology(true);
                     b.getCluster().setClusterSize(newClusterSize);
                     b.getCluster().setNodeId(newBrokerId);
+                    b.getCluster().setReplicationFactor(replicationFactor);
                     b.getCluster()
                         .setInitialContactPoints(
                             List.of(


### PR DESCRIPTION
## Description

Test is flaky because the newly created node is configured with incorrect `replicationFactor`. Since the gateway topology is still updated based on the static configuration, depending on the order in which it receives the properties, it may overwrite the topology with the incorrect replication factor. 

## Related issues

closes #15238 

