### PR TITLE
fix(topology): don't block further operations if initialization fails

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -223,6 +223,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
 
     if (initialized.isLeft()) {
       // TODO: What should we do here? Retry?
+      onGoingTopologyChangeOperation = false;
       LOG.error(
           "Failed to initialize topology change operation {}", operation, initialized.getLeft());
       return;


### PR DESCRIPTION
If an operation could not be initialized, reset the flag for ongoing changes. While we still assume that failed initialization is not retryable, we can at least apply new operations after the current one was cancelled and a new change is requested.

closes #15220