### PR TITLE
Improve stability of ScaleDownBrokersTest

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
@@ -90,8 +90,10 @@ final class Utils {
 
     final List<Long> createdProcessInstances = new ArrayList<>();
     Awaitility.await("Process instances are created in all partitions")
-        .ignoreExceptions() // Might throw exception when a partition has not yet received
-        // deployment distribution
+        // Might throw exception when a partition has not yet received deployment distribution
+        .ignoreExceptions()
+        // If deployment is not distributed, it will be retried after 10 seconds
+        .timeout(Duration.ofSeconds(20))
         .until(
             () -> {
               final var result =


### PR DESCRIPTION
## Description

- A deployment distribution can fail because the leader is not known. Then it is rertied only after 10seconds. This retry delay is not configurable. Instead, to remove flakiness we increase the waiting time.
- Also found out that (unrelated to the linked flaky test) when activating jobs, it can fail to activate from one partition because the gateway did not receive the latest leader info. In that case test will be flaky. To prevent that, we retry activating jobs until all expected jobs are activated.

## Related issues

closes #15218 

