### PR TITLE
test(qa): await until new leaders during scale up or scale down

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
@@ -17,9 +17,11 @@ import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.time.Duration;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -90,6 +92,11 @@ final class ScaleDownBrokersTest {
         .doesNotHaveBroker(brokerToShutdownId);
 
     // Changes are reflected in the topology returned by grpc query
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(zeebeClient.newTopologyRequest().send().join())
+                    .hasLeaderForPartition(3, 0));
     cluster.awaitCompleteTopology(newClusterSize, PARTITIONS_COUNT, 1, Duration.ofSeconds(20));
 
     assertThatAllJobsCanBeCompleted(createdInstances, zeebeClient, JOB_TYPE);
@@ -121,6 +128,12 @@ final class ScaleDownBrokersTest {
         .doesNotHaveBroker(brokerToShutdownId);
 
     // Changes are reflected in the topology returned by grpc query
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(zeebeClient.newTopologyRequest().send().join())
+                    .hasLeaderForPartition(3, 0)
+                    .hasLeaderForPartition(2, 0));
     cluster.awaitCompleteTopology(newClusterSize, PARTITIONS_COUNT, 1, Duration.ofSeconds(20));
 
     assertThatAllJobsCanBeCompleted(createdInstances, zeebeClient, JOB_TYPE);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.nio.file.Path;
@@ -93,6 +94,11 @@ final class ScaleUpBrokersTest {
         .brokerHasPartition(0, 1);
 
     // Changes are reflected in the topology returned by grpc query
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(zeebeClient.newTopologyRequest().send().join())
+                    .hasLeaderForPartition(2, 1));
     cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(10));
 
     // then - verify the cluster can still process
@@ -120,6 +126,11 @@ final class ScaleUpBrokersTest {
     ClusterActuatorAssert.assertThat(cluster).brokerHasPartition(broker3, 3);
 
     // Changes are reflected in the topology returned by grpc query
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(zeebeClient.newTopologyRequest().send().join())
+                    .hasLeaderForPartition(3, 2));
     cluster.awaitCompleteTopology(finalClusterSize, 3, 1, Duration.ofSeconds(10));
   }
 
@@ -139,6 +150,12 @@ final class ScaleUpBrokersTest {
 
     // then
     // Changes are reflected in the topology returned by grpc query
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(zeebeClient.newTopologyRequest().send().join())
+                    .hasLeaderForPartition(2, 1)
+                    .hasLeaderForPartition(3, 2));
     cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(10));
 
     // then - verify the cluster can still process

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
@@ -61,6 +61,7 @@ final class Utils {
       final List<Long> processInstanceKeys, final ZeebeClient zeebeClient, final String jobType) {
     final Set<ActivatedJob> activatedJobs = new HashSet<>();
     Awaitility.await("Jobs from all partitions are activated")
+        .timeout(Duration.ofSeconds(20))
         .untilAsserted(
             () -> {
               final var jobs =


### PR DESCRIPTION
## Description

Found a flaky test in #15214 

The jobs were not activated because gateway does know the leader for a partition. This is because the existing test for complete topology passes while it still has the outdated topology with the old leader. 

