### PR TITLE
fix(snapshot): do not include term when comparing snapshotId

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotId.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotId.java
@@ -40,10 +40,9 @@ public interface SnapshotId extends Comparable<SnapshotId> {
   String getSnapshotIdAsString();
 
   /**
-   * A snapshot is considered "lower" if its term is less than that of the other snapshot. If they
-   * are the same, then it is considered "lower" if its index is less then the other, if they are
-   * equal then the processed positions are compared, and then exported positions are compared. If
-   * they are the same then these snapshots are the same order-wise.
+   * A snapshot is considered "lower" if its index is less then the other, if they are equal then
+   * the processed positions are compared, and then exported positions are compared. If they are the
+   * same then these snapshots are the same order-wise.
    *
    * @param other the snapshot to compare against
    * @return -1 if {@code this} is less than {@code other}, 0 if they are the same, 1 if it is
@@ -51,8 +50,7 @@ public interface SnapshotId extends Comparable<SnapshotId> {
    */
   @Override
   default int compareTo(final SnapshotId other) {
-    return Comparator.comparingLong(SnapshotId::getTerm)
-        .thenComparing(SnapshotId::getIndex)
+    return Comparator.comparingLong(SnapshotId::getIndex)
         .thenComparing(SnapshotId::getProcessedPosition)
         .thenComparing(SnapshotId::getExportedPosition)
         .compare(this, other);


### PR DESCRIPTION
## Description

#14509 had another consequence that since the term is reset, no new snapshots can be taken until the term increases to a higher value than the one before the backup. As a result, logs are not compacted and disk usage grows high. One can prevent this if they use the version with the bug fix when restoring from a backup. But if not, there is no easy way to recover from this once it has happened. Upgrading to version won't help recovering from it. So as a solution, I propose not to include "term" in the snapshot Id comparison. Term and index is fixed to the same log entry. So if one changes the other one also change. So it is enough to use index to order the snapshot ids. 

## Related issues

related #14509

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
