### PR TITLE
fix: broadcast supports dynamic partition membership

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -110,7 +110,7 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
 
   @Override
   public Collection<RaftMember> getMembers() {
-    return configuration.allMembers();
+    return configuration != null ? configuration.allMembers() : null;
   }
 
   private void createInitialConfig(final Collection<MemberId> cluster) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -27,6 +27,7 @@ import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.SnapshotReplicationListener;
+import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.metrics.RaftStartupMetrics;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartition;
@@ -47,6 +48,7 @@ import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -310,5 +312,9 @@ public class RaftPartitionServer implements HealthMonitorable {
 
   public CompletableFuture<RaftServer> promote() {
     return server.promote();
+  }
+
+  public Collection<RaftMember> getMembers() {
+    return server.cluster().getMembers();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -146,7 +146,7 @@ public final class ZeebePartitionFactory {
             partitionListeners,
             partitionRaftListeners,
             new AtomixPartitionMessagingService(
-                communicationService, membershipService, raftPartition.members()),
+                communicationService, membershipService, raftPartition::members),
             actorSchedulingService,
             brokerCfg,
             commandApiService::newCommandResponseWriter,


### PR DESCRIPTION
`AtomixPartitionMessagingService` needs to broadcast to all members of a partition. Since membership is now dynamic, we need to query the underlying `RaftClusterContext` instead of generating the member list once from partition data.

This fixes a newly discovered issue where the exporter state was not broadcasted properly to new members of a partition.