### PR TITLE
Disable jwt issuedAt verification

### DIFF
--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
@@ -73,12 +73,7 @@ public class JwtAuthorizationDecoder
    */
   @Override
   public DecodedJWT build() {
-    try {
-      return validateJwtToken();
-    } catch (final JWTVerificationException | NullPointerException ex) {
-      LOGGER.error("Authorization data unavailable: {}", ex.getMessage());
-      throw new UnrecoverableException("Authorization data unavailable: " + ex.getMessage(), ex);
-    }
+    return validateJwtToken();
   }
 
   @Override

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
@@ -73,19 +73,8 @@ public class JwtAuthorizationDecoder
    */
   @Override
   public DecodedJWT build() {
-    final Verification verificationBuilder =
-        JWT.require(signingAlgorithm)
-            .withIssuer(issuer)
-            .withAudience(audience)
-            .withSubject(subject);
-
-    for (final String claim : claims) {
-      verificationBuilder.withClaimPresence(claim);
-    }
-    final JWTVerifier jwtVerification = verificationBuilder.build();
-
     try {
-      return jwtVerification.verify(jwtToken);
+      return validateJwtToken();
     } catch (final JWTVerificationException | NullPointerException ex) {
       LOGGER.error("Authorization data unavailable: {}", ex.getMessage());
       throw new UnrecoverableException("Authorization data unavailable: " + ex.getMessage(), ex);
@@ -121,5 +110,26 @@ public class JwtAuthorizationDecoder
   public JwtAuthorizationDecoder withJwtToken(final String token) {
     jwtToken = token;
     return this;
+  }
+
+  private DecodedJWT validateJwtToken() {
+    final Verification verificationBuilder =
+        JWT.require(signingAlgorithm)
+            .withIssuer(issuer)
+            .withAudience(audience)
+            .withSubject(subject)
+            .ignoreIssuedAt();
+
+    for (final String claim : claims) {
+      verificationBuilder.withClaimPresence(claim);
+    }
+    final JWTVerifier jwtVerification = verificationBuilder.build();
+
+    try {
+      return jwtVerification.verify(jwtToken);
+    } catch (final JWTVerificationException | NullPointerException ex) {
+      LOGGER.error("Authorization data unavailable: {}", ex.getMessage());
+      throw new UnrecoverableException("Authorization data unavailable: " + ex.getMessage(), ex);
+    }
   }
 }

--- a/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationEncoder.java
+++ b/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationEncoder.java
@@ -13,7 +13,6 @@ import com.auth0.jwt.exceptions.JWTCreationException;
 import io.camunda.zeebe.auth.api.AuthorizationEncoder;
 import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -63,7 +62,6 @@ public class JwtAuthorizationEncoder
           .withIssuer(issuer)
           .withAudience(audience)
           .withSubject(subject)
-          .withIssuedAt(Instant.now())
           .withPayload(claims)
           .sign(signingAlgorithm);
     } catch (final IllegalArgumentException | JWTCreationException ex) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Disable the `issuedAt` verification for Zeebe JWT tokens. 

Zeebe only uses unsigned JWT tokens for transporting data internally, so validating an `issuedAt` claim is not necessary. 

It actually may cause the `stream processor` to fail if the Gateway and Broker clocks are (even slightly) out of sync. If the Broke clock is behing the Gateway clock, an error showing `Authorization data unavailable: The Token can't be used before xxx` is thrown.

Note: I decided to only disable the `issuedAt` verification, but still verify the JWT token, since it's useful to detect if there are cases where the `AUTHORIZED_TENANTS` claim is not included.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15047

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
