### PR TITLE
fix: try to close raft server when bootstrap or join failed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -130,10 +130,6 @@ public class DefaultRaftServer implements RaftServer {
    */
   @Override
   public CompletableFuture<Void> shutdown() {
-    if (!started && !stopped) {
-      return CompletableFuture.failedFuture(new IllegalStateException("Server not running"));
-    }
-
     if (stopped) {
       return CompletableFuture.completedFuture(null);
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftBootstrapStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftBootstrapStep.java
@@ -27,12 +27,14 @@ public final class RaftBootstrapStep implements StartupStep<PartitionStartupCont
             .raftPartitionFactory()
             .createRaftPartition(context.partitionMetadata(), context.partitionDirectory());
 
+    // Immediately save the partition to the context, so that it can be closed in case of an error.
+    context.raftPartition(partition);
+
     partition
         .bootstrap(context.partitionManagementService(), context.snapshotStore())
         .whenComplete(
             (raftPartition, throwable) -> {
               if (throwable == null) {
-                context.raftPartition(raftPartition);
                 result.complete(context);
               } else {
                 result.completeExceptionally(throwable);

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftJoinStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftJoinStep.java
@@ -27,12 +27,14 @@ public class RaftJoinStep implements StartupStep<PartitionStartupContext> {
             .raftPartitionFactory()
             .createRaftPartition(context.partitionMetadata(), context.partitionDirectory());
 
+    // Immediately save the partition to the context, so that it can be closed in case of an error.
+    context.raftPartition(partition);
+
     partition
         .join(context.partitionManagementService(), context.snapshotStore())
         .whenComplete(
             (raftPartition, throwable) -> {
               if (throwable == null) {
-                context.raftPartition(raftPartition);
                 result.complete(context);
               } else {
                 result.completeExceptionally(throwable);


### PR DESCRIPTION
Especially in the case the joining fails, the underlying server has (at least partially) started.
This removes a defensive check on shutdown to still stop the server and close the context, even if the `started` flag is not set yet (it's only set on successful join).

