### PR TITLE
Add issue title of java client issue to slack msg

### DIFF
--- a/.github/workflows/java-client-issue.yaml
+++ b/.github/workflows/java-client-issue.yaml
@@ -29,7 +29,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Please check the issue: ${{ github.event.issue.html_url }}\n This message has been sent in order to support you in making our other client's feature complete. @sdk-engineers"
+                    "text": "Please check the issue: <${{ github.event.issue.html_url }}|${{ github.event.issue.title }}>\n This message has been sent in order to support you in making our other client's feature complete. @sdk-engineers"
                   }
                 }
               ]


### PR DESCRIPTION
## Description


Adds the issue title and reference the actual issue with hyperlink.

Should look like this 

![clien](https://github.com/camunda/zeebe/assets/2758593/863ab2c5-851f-4d40-bec0-b0599d6797ad)
