### PR TITLE
Use specified http status code for errors in ClusterEndpoint

### DIFF
--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -26,6 +26,8 @@ paths:
       responses:
         '202':
           $ref: '#/components/responses/AddBrokersResponse'
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
         '409':
           $ref: '#/components/responses/ConcurrentChangeError'
         '500':
@@ -43,6 +45,8 @@ paths:
       responses:
         '202':
           $ref: '#/components/responses/RemoveBrokerResponse'
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
         '409':
           $ref: '#/components/responses/ConcurrentChangeError'
         '500':
@@ -76,6 +80,8 @@ paths:
       responses:
         '202':
           $ref: "#/components/responses/ScaleBrokersResponse"
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
         '409':
           $ref: '#/components/responses/ConcurrentChangeError'
         '500':
@@ -103,7 +109,12 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/GetTopologyResponse"
-
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '502':
+          $ref: '#/components/responses/GatewayError'
+        '504':
+          $ref: '#/components/responses/TimeoutError'
 
 components:
   parameters:
@@ -118,6 +129,13 @@ components:
   responses:
     ConcurrentChangeError:
       description: Failed to accept request. Another topology change is in progress.
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"
+
+    InvalidRequest:
+      description: Invalid request.
       content:
         application/json:
           schema:

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointErrorResponseIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointErrorResponseIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import static org.assertj.core.api.Assertions.*;
+
+import feign.FeignException;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Timeout(2 * 60) // 2 minutes
+@ZeebeIntegration
+final class ClusterEndpointErrorResponseIT {
+  @Nested
+  class InvalidRequests {
+    @TestZeebe(awaitCompleteTopology = false, awaitReady = false)
+    static TestCluster cluster =
+        TestCluster.builder()
+            .withEmbeddedGateway(true)
+            .withBrokersCount(1)
+            .withPartitionsCount(1)
+            .withReplicationFactor(1)
+            .withBrokerConfig(
+                broker ->
+                    broker
+                        .brokerConfig()
+                        .getExperimental()
+                        .getFeatures()
+                        .setEnableDynamicClusterTopology(true))
+            .build();
+
+    @Test
+    void shouldRejectWith409WhenOngoingOperation() {
+      // given
+      final var actuator = ClusterActuator.of(cluster.anyGateway());
+      actuator.scaleBrokers(List.of(0, 1));
+      // operation cannot complete because broker 1 is not up
+
+      // when
+      assertThatThrownBy(() -> actuator.scaleBrokers(List.of(0, 1)))
+          .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
+          .extracting(FeignException::status)
+          .isEqualTo(409);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidRequests")
+    void shouldRejectWith400WhenInvalidRequest(final Consumer<ClusterActuator> operation) {
+      // given
+      final var actuator = ClusterActuator.of(cluster.anyGateway());
+
+      // when
+      assertThatThrownBy(() -> operation.accept(actuator))
+          .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
+          .extracting(FeignException::status)
+          .isEqualTo(400);
+    }
+
+    static Stream<Arguments> provideInvalidRequests() {
+      final List<Tuple<String, Consumer<ClusterActuator>>> operations =
+          List.of(
+              Tuple.of("Empty scale request", a -> a.scaleBrokers(List.of())),
+              Tuple.of(
+                  "Scale request with invalid brokerId",
+                  a -> a.scaleBrokersInvalidType(List.of("a", "b", "c"))),
+              Tuple.of(
+                  "Add broker request with invalid brokerId", a -> a.addBrokerInvalidType("a")));
+      return operations.stream().map(c -> Arguments.of(Named.of(c.getLeft(), c.getRight())));
+    }
+  }
+
+  @Nested
+  class CoordinatorNotKnown {
+    @TestZeebe(awaitCompleteTopology = false, awaitReady = false)
+    static TestCluster cluster =
+        TestCluster.builder()
+            .withGatewaysCount(1)
+            .withEmbeddedGateway(false)
+            .withBrokersCount(0)
+            .build();
+
+    @ParameterizedTest
+    @MethodSource("provideRequests")
+    void shouldRejectWith502WhenBrokerNotReachable(final Consumer<ClusterActuator> operation) {
+      // given
+      final var actuator = ClusterActuator.of(cluster.anyGateway());
+      cluster.brokers().forEach((id, broker) -> broker.stop());
+
+      // when
+      assertThatThrownBy(() -> operation.accept(actuator))
+          .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
+          .extracting(FeignException::status)
+          .isEqualTo(502);
+    }
+
+    static Stream<Arguments> provideRequests() {
+      final List<Consumer<ClusterActuator>> operations =
+          List.of(ClusterActuator::getTopology, a -> a.scaleBrokers(List.of(0, 1)));
+      return operations.stream().map(Arguments::of);
+    }
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -143,4 +143,18 @@ public interface ClusterActuator {
   @RequestLine("DELETE /changes/{changeId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   GetTopologyResponse cancelChange(@Param final long changeId);
+
+  // invalid parameter types
+  @RequestLine("POST /brokers")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PostOperationResponse scaleBrokersInvalidType(@RequestBody List<String> ids);
+
+  /**
+   * Request that the broker is added to the cluster.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /brokers/{brokerId}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PostOperationResponse addBrokerInvalidType(@Param final String brokerId);
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -162,7 +162,7 @@ public final class TopologyRequestServer implements AutoCloseable {
           new ErrorResponse(ErrorCode.INVALID_REQUEST, invalidRequest.getMessage()));
       case final ConcurrentModificationException concurrentModificationException -> Either.left(
           new ErrorResponse(
-              ErrorCode.INVALID_REQUEST, concurrentModificationException.getMessage()));
+              ErrorCode.CONCURRENT_MODIFICATION, concurrentModificationException.getMessage()));
       default -> Either.left(new ErrorResponse(ErrorCode.INTERNAL_ERROR, throwable.getMessage()));
     };
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -176,7 +176,7 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
     } else if (currentClusterTopology.hasPendingChanges()) {
       failFuture(
           validationFuture,
-          new OperationNotAllowed(
+          new ConcurrentModificationException(
               String.format(
                   "Cannot apply topology change. Another topology change [%s] is in progress.",
                   currentClusterTopology)));

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.topology.ClusterTopologyAssert;
 import io.camunda.zeebe.topology.ClusterTopologyManager;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException;
+import io.camunda.zeebe.topology.api.TopologyRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.InvalidRequest;
-import io.camunda.zeebe.topology.api.TopologyRequestFailedException.OperationNotAllowed;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator.TopologyChangeRequest;
 import io.camunda.zeebe.topology.state.ClusterChangePlan;
 import io.camunda.zeebe.topology.state.ClusterTopology;
@@ -117,7 +117,7 @@ final class TopologyChangeCoordinatorImplTest {
     assertThat(applyFuture)
         .failsWithin(Duration.ofMillis(100))
         .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(OperationNotAllowed.class);
+        .withCauseInstanceOf(ConcurrentModificationException.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

- Added tests for some of the error cases
- Adjusted the error status code 
- Added missing error responses in the spec

## Related issues

closes #15273 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
