### PR TITLE
Cleanup ByteBuf memory leak

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -113,15 +113,18 @@ public class NettyUnicastService implements ManagedUnicastService {
         .resolve(address.socketAddress())
         .addListener(
             resolvedAddress -> {
+              var cleanUpFuture = group.next().newSucceededFuture((Void) null);
               if (resolvedAddress.isSuccess()) {
-                channel.writeAndFlush(
-                    new DatagramPacket(buf, (InetSocketAddress) resolvedAddress.get()));
+                cleanUpFuture =
+                    channel.writeAndFlush(
+                        new DatagramPacket(buf, (InetSocketAddress) resolvedAddress.get()));
               } else {
                 log.warn(
                     "Failed sending unicast message (destination address {} cannot be resolved)",
                     address,
                     resolvedAddress.exceptionNow());
               }
+              cleanUpFuture.addListener(future -> buf.release());
             });
   }
 


### PR DESCRIPTION
## Description

[ByteBuf allocated by Channel](https://github.com/camunda/zeebe/blob/main/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java#L107), uses internally a direct memory pool and reference counting. [The reference counting and error log allowed us to detect that there was a memory leak, since we didn't closed the ByteBuf before.](https://console.cloud.google.com/errors/detail/CL6e5dX6lKLQvQE;service=zeebe;time=P7D?project=camunda-cloud-240911)

This PR uses futures to clean up the buffer when the requests were send or in case of error that it is still released.

I'm not 100% satisfied by it, if you have a better idea let me know.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/15048
