### PR TITLE
fix(qa/util): do not wait forever for cluster startup

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -37,6 +37,8 @@
             <include>**/*Tests.java</include>
             <include>**/*TestCase.java</include>
           </includes>
+          <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
+          <!-- 15 minutes -->
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Description

Some qa tests are timing out. The reason is not known because the logs are not available when it timesout. But the assumption is that it waits for the cluster startup. To interrupt the waiting, we add an arbitrary limit of 3 minutes for the cluster startup. This helps to collect the logs and root cause it.

