### PR TITLE
fix(topology): ignore topology updates via gossip until initialized

### DIFF
--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -167,6 +167,23 @@ final class ClusterTopologyManagerTest {
   }
 
   @Test
+  void shouldNotUpdateLocalTopologyOnGossipEventBeforeInitialization() {
+    // given - not started cluster topology manager
+    final ClusterTopologyManagerImpl clusterTopologyManager = createTopologyManager();
+
+    // when
+    final ClusterTopology topologyFromOtherMember =
+        clusterTopologyManager
+            .getClusterTopology()
+            .join()
+            .addMember(MemberId.from("10"), MemberState.initializeAsActive(Map.of()));
+    clusterTopologyManager.onGossipReceived(topologyFromOtherMember).join();
+
+    // then
+    assertThat(persistedClusterTopology.getTopology().isUninitialized()).isTrue();
+  }
+
+  @Test
   void shouldInitiateClusterTopologyChangeOnGossip() {
     // given
     final ClusterTopologyManagerImpl clusterTopologyManager =


### PR DESCRIPTION
## Description

Do not update local topology until `ClusterTopologyManager` is initialized.

PS:- @oleschoenburg This feel like a hack fix. I think a re-design to de-couple gossiper with the ClusterTopologyManager would be interesting. But right now I don't have a good idea on how it should look like. If you have any ideas, let's discuss.

## Related issues

closes #15219 

