### PR TITLE
Fix flaky RequestTimeoutTest.shouldReturn504

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
@@ -30,4 +31,6 @@ public interface BrokerContext {
   PartitionManager getPartitionManager();
 
   BrokerAdminService getBrokerAdminService();
+
+  ManagedMessagingService getApiMessagingService();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import static java.util.Objects.requireNonNull;
 
+import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
@@ -22,18 +23,21 @@ final class BrokerContextImpl implements BrokerContext {
   private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private final PartitionManager partitionManager;
   private final BrokerAdminService brokerAdminService;
+  private final ManagedMessagingService apiMessagingService;
 
   BrokerContextImpl(
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final ClusterServicesImpl clusterServices,
       final EmbeddedGatewayService embeddedGatewayService,
       final PartitionManager partitionManager,
-      final BrokerAdminService brokerAdminService) {
+      final BrokerAdminService brokerAdminService,
+      final ManagedMessagingService apiMessagingService) {
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.clusterServices = requireNonNull(clusterServices);
     this.embeddedGatewayService = embeddedGatewayService;
     this.partitionManager = requireNonNull(partitionManager);
     this.brokerAdminService = requireNonNull(brokerAdminService);
+    this.apiMessagingService = requireNonNull(apiMessagingService);
   }
 
   @Override
@@ -59,5 +63,10 @@ final class BrokerContextImpl implements BrokerContext {
   @Override
   public BrokerAdminService getBrokerAdminService() {
     return brokerAdminService;
+  }
+
+  @Override
+  public ManagedMessagingService getApiMessagingService() {
+    return apiMessagingService;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -110,6 +110,7 @@ public final class BrokerStartupProcess {
         bsc.getClusterServices(),
         bsc.getEmbeddedGatewayService(),
         bsc.getPartitionManager(),
-        bsc.getBrokerAdminService());
+        bsc.getBrokerAdminService(),
+        bsc.getApiMessagingService());
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -628,12 +628,12 @@ public class ClusteringRule extends ExternalResource {
 
   public void disconnect(final Broker broker) {
     final var cluster = broker.getSystemContext().getCluster();
-
     LOGGER.debug(
         "Disconnecting node {} to cluster",
         broker.getSystemContext().getBrokerConfiguration().getCluster().getNodeId());
     ((NettyUnicastService) cluster.getUnicastService()).stop().join();
     ((NettyMessagingService) cluster.getMessagingService()).stop().join();
+    broker.getBrokerContext().getApiMessagingService().stop().join();
   }
 
   public void connect(final Broker broker) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -630,7 +630,7 @@ public class ClusteringRule extends ExternalResource {
     final var cluster = broker.getSystemContext().getCluster();
 
     LOGGER.debug(
-        "Disonnecting node {} to cluster",
+        "Disconnecting node {} to cluster",
         broker.getSystemContext().getBrokerConfiguration().getCluster().getNodeId());
     ((NettyUnicastService) cluster.getUnicastService()).stop().join();
     ((NettyMessagingService) cluster.getMessagingService()).stop().join();


### PR DESCRIPTION
The nature of the flaky test seemed to be that the disconnect method was missing closing the commandApiMessagingService in the BrokerStartupContextImpl as well. Which caused that we could still reach the broker even after disconnecting. The test would pass most of the time because the timeout limit was smaller than the round trip time of the request, and we would get a 504 timeout.

closes https://github.com/camunda/zeebe/issues/14906

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
