### PR TITLE
Add test to verify broker can restart when coordinator broker is unavailable

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/DynamicClusterTopologyServiceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/DynamicClusterTopologyServiceTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.it.clustering.topology.dynamic;
+package io.camunda.zeebe.it.clustering.dynamic;
 
 import static io.camunda.zeebe.test.util.asserts.TopologyAssert.assertThat;
 


### PR DESCRIPTION
## Description

When restarting a broker in an already bootstrapped cluster, the broker should not wait until broker 0 sends the ClusterTopology. It should use previously generated topology persisted locally.

## Related issues

closes #15313 

