### PR TITLE
Migrate active service tasks with jobs

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -232,7 +232,10 @@ public final class BpmnProcessors {
         ValueType.PROCESS_INSTANCE_MIGRATION,
         ProcessInstanceMigrationIntent.MIGRATE,
         new ProcessInstanceMigrationMigrateProcessor(
-            writers, processingState.getElementInstanceState(), processingState.getProcessState()));
+            writers,
+            processingState.getElementInstanceState(),
+            processingState.getProcessState(),
+            processingState.getJobState()));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -186,6 +186,7 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
     register(JobIntent.RECURRED_AFTER_BACKOFF, new JobRecurredApplier(state));
     register(JobIntent.TIMEOUT_UPDATED, new JobTimeoutUpdatedApplier(state));
+    register(JobIntent.MIGRATED, new JobMigratedApplier(state));
   }
 
   private void registerMessageAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobMigratedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobMigratedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+public final class JobMigratedApplier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+
+  public JobMigratedApplier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.migrate(key, value);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -268,6 +268,11 @@ public final class DbJobState implements JobState, MutableJobState {
     }
   }
 
+  @Override
+  public void migrate(final long key, final JobRecord record) {
+    updateJobRecord(key, record);
+  }
+
   private void createJob(final long key, final JobRecord record, final DirectBuffer type) {
     createJobRecord(key, record);
     initializeJobState();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -43,4 +43,6 @@ public interface MutableJobState extends JobState {
   void cleanupBackoffsWithoutJobs();
 
   void updateJobDeadline(long jobKey, long newDeadline);
+
+  void migrate(long key, JobRecord record);
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
@@ -409,10 +409,17 @@ public class MigrateProcessInstanceTest {
         .addMappingInstruction("A", "B")
         .migrate();
 
-    // then
+    // then we can do any operation on the job again
 
     // Note that while the job is migrated, it's type did not change even though it's different in
     // the target process. Because re-evaluation of the job type expression is not yet supported.
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").yield();
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").withRetries(2).fail();
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").withRetries(3).updateRetries();
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").withErrorCode("A1").throwError();
+    ENGINE.incident().ofInstance(processInstanceKey).resolve();
+
+    // and finally complete the job and continue the process
     ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
 
     assertThat(

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -47,7 +47,9 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   YIELDED((short) 16),
 
   UPDATE_TIMEOUT((short) 17),
-  TIMEOUT_UPDATED((short) 18);
+  TIMEOUT_UPDATED((short) 18),
+
+  MIGRATED((short) 19);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -105,6 +107,8 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
         return UPDATE_TIMEOUT;
       case 18:
         return TIMEOUT_UPDATED;
+      case 19:
+        return MIGRATED;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

> [!WARNING]  
> This PR is based on https://github.com/camunda/zeebe/pull/15233. We should merge that first.

This pull request enables users to migrate process instances with active service tasks.

It migrates:
- all element instances of a process instance (direct and indirect descendants)
- all jobs associated to an element instance

It does not:
- re-evaluate the job type expression for the migrated job

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15113

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
