### PR TITLE
fix: don't use specific generation templates

### DIFF
--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -32,26 +32,18 @@ jobs:
       - uses: actions/checkout@v4
       - run: git fetch --tags
       - run: |
-          latest_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr | head -n1)
           latest_major_minor=$(echo $latest_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
-          previous_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "${latest_major_minor}" | sort -Vr | head -n1)
           previous_major_minor=$(echo $previous_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
-          previous_previous_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "${latest_major_minor}" | grep -v "${previous_major_minor}" | sort -Vr | head -n1)
           previous_previous_major_minor=$(echo $previous_previous_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
 
-          if [ ! -z $latest_major_minor_patch ] && [ ! -z $previous_major_minor_patch ] && [ ! -z $previous_previous_major_minor_patch ]; then
+          if [ ! -z $latest_major_minor ] && [ ! -z $previous_major_minor ] && [ ! -z $previous_previous_major_minor ]; then
             echo "Successfully computed latest versions: ${latest_major_minor_patch} and ${previous_major_minor_patch} and ${previous_previous_major_minor_patch}"
           else
             echo "Failed to compute latest versions"
           fi
 
-          echo "LATEST_MAJOR_MINOR_PATCH_VERSION=${latest_major_minor_patch}" >> $GITHUB_ENV
           echo "LATEST_MAJOR_MINOR_VERSION=${latest_major_minor}" >> $GITHUB_ENV
-
-          echo "PREVIOUS_LATEST_MAJOR_MINOR_PATCH_VERSION=${previous_major_minor_patch}" >> $GITHUB_ENV
           echo "PREVIOUS_LATEST_MAJOR_MINOR_VERSION=${previous_major_minor}" >> $GITHUB_ENV
-
-          echo "PREVIOUS_PREVIOUS_LATEST_MINOR_PATCH_VERSION=${previous_previous_major_minor_patch}" >> $GITHUB_ENV
           echo "PREVIOUS_PREVIOUS_LATEST_MINOR_VERSION=${previous_previous_major_minor}" >> $GITHUB_ENV
 
   e2e:
@@ -68,13 +60,18 @@ jobs:
           - ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
         include:
           - branch: 'main'
+            generation_template: 'Zeebe SNAPSHOT'
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-major-minor-version) }}
+            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.latest-major-minor-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-major-minor-version) }}
+            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.latest-major-minor-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
+            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.latest-major-minor-version) }}
     name: Weekly E2E
     uses: ./.github/workflows/e2e-testbench.yaml
     with:
       branch: ${{ matrix.branch }}
+      generation: ${{ matrix.generation_template }}
       maxTestDuration: P5D
       clusterPlan: Production - M
     secrets: inherit

--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -68,18 +68,13 @@ jobs:
           - ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
         include:
           - branch: 'main'
-            generation_template: 'Zeebe SNAPSHOT'
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-major-minor-version) }}
-            generation_template: ${{ format('Camunda {0}', needs.get-versions.outputs.latest-major-minor-patch-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-major-minor-version) }}
-            generation_template: ${{ format('Camunda {0}', needs.get-versions.outputs.previous-latest-major-minor-patch-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
-            generation_template: ${{ format('Camunda {0}', needs.get-versions.outputs.previous-previous-latest-major-minor-patch-version) }}
     name: Weekly E2E
     uses: ./.github/workflows/e2e-testbench.yaml
     with:
       branch: ${{ matrix.branch }}
-      generation: ${{ matrix.generation_template }}
       maxTestDuration: P5D
       clusterPlan: Production - M
     secrets: inherit


### PR DESCRIPTION
## Description

Use the general Zeebe Snapshot generation as a template, since this is part of the right channel. Otherwise creation of clusters will likely fail since specific generations often are not part of the expected channel.

See related investigation https://github.com/camunda/zeebe/issues/14780#issuecomment-1820688311
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/14780
