### PR TITLE
fix(raft): improve `join` reliability

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -43,6 +43,7 @@ public class RaftPartitionConfig {
   private int preferSnapshotReplicationThreshold = DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD;
   private RaftStorageConfig storageConfig;
   private EntryValidator entryValidator;
+  private Duration configurationChangeTimeout;
 
   /**
    * Returns the Raft leader election timeout.
@@ -134,6 +135,14 @@ public class RaftPartitionConfig {
     this.snapshotRequestTimeout = snapshotRequestTimeout;
   }
 
+  public Duration getConfigurationChangeTimeout() {
+    return configurationChangeTimeout;
+  }
+
+  public void setConfigurationChangeTimeout(final Duration configurationChangeTimeout) {
+    this.configurationChangeTimeout = configurationChangeTimeout;
+  }
+
   public int getMinStepDownFailureCount() {
     return minStepDownFailureCount;
   }
@@ -208,6 +217,8 @@ public class RaftPartitionConfig {
         + requestTimeout
         + ", snapshotRequestTimeout="
         + snapshotRequestTimeout
+        + ", configurationChangeTimeout="
+        + configurationChangeTimeout
         + ", minStepDownFailureCount="
         + minStepDownFailureCount
         + ", maxQuorumResponseTimeout="

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -66,6 +66,8 @@ public class RaftPartitionServer implements HealthMonitorable {
   private final PartitionMetadata partitionMetadata;
   private final Duration requestTimeout;
   private final Duration snapshotRequestTimeout;
+  private final Duration configurationChangeTimeout;
+
   private final ReceivableSnapshotStore persistedSnapshotStore;
   private final RaftServer server;
 
@@ -90,6 +92,7 @@ public class RaftPartitionServer implements HealthMonitorable {
     this.partitionMetadata = partitionMetadata;
     requestTimeout = config.getRequestTimeout();
     snapshotRequestTimeout = config.getSnapshotRequestTimeout();
+    configurationChangeTimeout = config.getConfigurationChangeTimeout();
     server = buildServer();
   }
 
@@ -303,7 +306,8 @@ public class RaftPartitionServer implements HealthMonitorable {
         Serializer.using(RaftNamespaces.RAFT_PROTOCOL),
         clusterCommunicator,
         requestTimeout,
-        snapshotRequestTimeout);
+        snapshotRequestTimeout,
+        configurationChangeTimeout);
   }
 
   public CompletableFuture<Void> stepDown() {

--- a/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -186,6 +186,26 @@ final class ReconfigurationTest {
   @Nested
   final class Joining {
     @Test
+    void rejoinShouldBeSuccessful(@TempDir final Path tmp) {
+      // given - a cluster with 3 members
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var id3 = MemberId.from("3");
+
+      final var m1 = createServer(tmp, createMembershipService(id1, id2, id3));
+      final var m2 = createServer(tmp, createMembershipService(id2, id1, id3));
+      final var m3 = createServer(tmp, createMembershipService(id3, id2, id1));
+
+      // when - m3 joined once
+      CompletableFuture.allOf(m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3)).join();
+      m3.join(id1, id2).join();
+
+      // then - m3 can join again
+      m3.shutdown().join();
+      m3.join(id1, id2).join();
+    }
+
+    @Test
     void shouldJoinExistingMembers(@TempDir final Path tmp) {
       // given - a cluster with 3 members
       final var id1 = MemberId.from("1");

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -85,6 +85,8 @@ public final class RaftPartitionFactory {
     partitionConfig.setRequestTimeout(brokerCfg.getExperimental().getRaft().getRequestTimeout());
     partitionConfig.setSnapshotRequestTimeout(
         brokerCfg.getExperimental().getRaft().getSnapshotRequestTimeout());
+    partitionConfig.setConfigurationChangeTimeout(
+        brokerCfg.getExperimental().getRaft().getConfigurationChangeTimeout());
     partitionConfig.setMaxQuorumResponseTimeout(
         brokerCfg.getExperimental().getRaft().getMaxQuorumResponseTimeout());
     partitionConfig.setMinStepDownFailureCount(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -14,6 +14,8 @@ import java.time.Duration;
 public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public static final Duration DEFAULT_SNAPSHOT_REQUEST_TIMEOUT = Duration.ofMillis(2500);
+  private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
+
   // Requests should time out faster than the election timeout to ensure that a single missed
   // heartbeat does not cause immediate re-election.
   private static final Duration DEFAULT_REQUEST_TIMEOUT = DEFAULT_ELECTION_TIMEOUT;
@@ -23,6 +25,7 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private Duration snapshotRequestTimeout = DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
+  private Duration configurationChangeTimeout = DEFAULT_CONFIGURATION_CHANGE_TIMEOUT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
@@ -43,6 +46,14 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public void setSnapshotRequestTimeout(final Duration snapshotRequestTimeout) {
     this.snapshotRequestTimeout = snapshotRequestTimeout;
+  }
+
+  public Duration getConfigurationChangeTimeout() {
+    return configurationChangeTimeout;
+  }
+
+  public void setConfigurationChangeTimeout(final Duration configurationChangeTimeout) {
+    this.configurationChangeTimeout = configurationChangeTimeout;
   }
 
   public Duration getMaxQuorumResponseTimeout() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -82,6 +82,20 @@ public final class RaftPartitionFactoryTest {
   }
 
   @Test
+  void shouldSetRaftConfigurationChangeTimeout() {
+    // given
+    final Duration expected = Duration.ofSeconds(15);
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getRaft().setConfigurationChangeTimeout(expected);
+
+    // when
+    final var partition = buildRaftPartition(brokerCfg);
+
+    // then
+    assertThat(partition.getPartitionConfig().getConfigurationChangeTimeout()).isEqualTo(expected);
+  }
+
+  @Test
   void shouldSetRaftMaxQuorumResponseTimeout() {
     // given
     final Duration expected = Duration.ofSeconds(13);

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -952,6 +952,11 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_SNAPSHOTREQUESTTIMEOUT.
         # snapshotRequestTimeout: 2500ms
 
+        # Sets the timeout for configuration change requests such as joining or leaving. Since changes are usually a multi-step
+        # process with multiple commits, a higher timeout than the default requestTimeout is recommended.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_CONFIGURATIONCHANGEREQUESTTIMEOUT.
+        # configurationChangeRequestTimeout: 10000ms
+
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures
         # reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step down.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -843,6 +843,11 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_SNAPSHOTREQUESTTIMEOUT.
         # snapshotRequestTimeout: 2500ms
 
+        # Sets the timeout for configuration change requests such as joining or leaving. Since changes are usually a multi-step
+        # process with multiple commits, a higher timeout than the default requestTimeout is recommended.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_CONFIGURATIONCHANGEREQUESTTIMEOUT.
+        # configurationChangeRequestTimeout: 10000ms
+
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures
         # reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step down.


### PR DESCRIPTION
This fixes a bug where a retried join that did not result in a configuration change would leave the raft partition in `INACTIVE` state, effectively blocking the join operation. Additionally, we also improve reliability by introducing a new configurable timeout for making configuration changes. By default, this is 10 seconds so much longer than the usual request timeout of 2.5 seconds. 

 Additional logs should help us diagnose further bugs in that area.