### PR TITLE
Deploy a process with compensation event subprocesses

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/EmbeddedSubProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/EmbeddedSubProcessBuilder.java
@@ -40,6 +40,12 @@ public class EmbeddedSubProcessBuilder
     return startEvent(null);
   }
 
+  public StartEventBuilder startEvent(final String id, final Consumer<StartEventBuilder> consumer) {
+    final StartEventBuilder builder = startEvent(id);
+    consumer.accept(builder);
+    return builder;
+  }
+
   public StartEventBuilder startEvent(final String id) {
     final StartEvent start = subProcessBuilder.createChild(StartEvent.class, id);
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
@@ -39,7 +40,8 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
           MessageEventDefinition.class,
           ErrorEventDefinition.class,
           SignalEventDefinition.class,
-          EscalationEventDefinition.class);
+          EscalationEventDefinition.class,
+          CompensateEventDefinition.class);
 
   @Override
   public Class<SubProcess> getElementType() {
@@ -77,6 +79,12 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
     if (!start.getEventDefinitions().isEmpty()) {
       validationResultCollector.addError(0, "Start events in subprocesses must be of type none");
     }
+
+    if (start.getEventDefinitions().stream()
+        .anyMatch(CompensateEventDefinition.class::isInstance)) {
+      validationResultCollector.addError(
+          0, "A compensation event subprocess is not allowed on the process level");
+    }
   }
 
   private void validateEventSubprocess(
@@ -85,7 +93,7 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
     if (eventDefinitions.isEmpty()) {
       validationResultCollector.addError(
           0,
-          "Start events in event subprocesses must be one of: message, timer, error, signal, escalation");
+          "Start events in event subprocesses must be one of: message, timer, error, signal, escalation, compensation");
     }
 
     eventDefinitions.forEach(
@@ -93,7 +101,7 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
           if (SUPPORTED_START_TYPES.stream().noneMatch(type -> type.isInstance(def))) {
             validationResultCollector.addError(
                 0,
-                "Start events in event subprocesses must be one of: message, timer, error, signal, escalation");
+                "Start events in event subprocesses must be one of: message, timer, error, signal, escalation, compensation");
           }
         });
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventTest.java
@@ -143,11 +143,11 @@ public class CompensationEventTest {
         Bpmn.createExecutableProcess("compensation-process")
             .startEvent()
             .subProcess(
-                "subprocess",
+                "embedded-subprocess",
                 s ->
                     s.embeddedSubProcess()
                         .eventSubProcess(
-                            "embedded-subprocess",
+                            "subprocess",
                             eventSubProcess ->
                                 eventSubProcess
                                     .startEvent(
@@ -175,23 +175,7 @@ public class CompensationEventTest {
   @Test
   public void shouldNotDeployCompensationEventSubprocessOnProcessLevel() {
     final var process =
-        Bpmn.createExecutableProcess("compensation-process")
-            .startEvent()
-            .subProcess(
-                "subprocess",
-                s ->
-                    s.embeddedSubProcess()
-                        .startEvent("compensation-start", AbstractStartEventBuilder::compensation)
-                        .intermediateThrowEvent(
-                            "compensation-throw-event",
-                            AbstractThrowEventBuilder::compensateEventDefinition)
-                        .userTask("B")
-                        .endEvent()
-                        .done())
-            .endEvent(
-                "compensation-end-event",
-                end -> end.compensateEventDefinition().compensateEventDefinitionDone())
-            .done();
+        createModelFromClasspathResource("/compensation/compensation-not-embedded-subprocess.bpmn");
 
     ProcessValidationUtil.validateProcess(
         process,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventTest.java
@@ -11,9 +11,12 @@ import io.camunda.zeebe.engine.processing.deployment.model.validation.ExpectedVa
 import io.camunda.zeebe.engine.processing.deployment.model.validation.ProcessValidationUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractStartEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
 import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
+import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.Task;
 import org.junit.jupiter.api.Test;
 
@@ -132,6 +135,69 @@ public class CompensationEventTest {
         process,
         ExpectedValidationResult.expect(
             Task.class, "A compensation handler should have no boundary events"));
+  }
+
+  @Test
+  public void shouldDeployCompensationEventSubprocess() {
+    final var process =
+        Bpmn.createExecutableProcess("compensation-process")
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .eventSubProcess(
+                            "embedded-subprocess",
+                            eventSubProcess ->
+                                eventSubProcess
+                                    .startEvent(
+                                        "compensation-start",
+                                        AbstractStartEventBuilder::compensation)
+                                    .intermediateThrowEvent(
+                                        "compensation-throw-event",
+                                        AbstractThrowEventBuilder::compensateEventDefinition)
+                                    .userTask("B")
+                                    .endEvent())
+                        .startEvent()
+                        .userTask("A")
+                        .boundaryEvent()
+                        .compensation(c -> c.userTask("undo-A"))
+                        .endEvent()
+                        .done())
+            .endEvent(
+                "compensation-end-event",
+                end -> end.compensateEventDefinition().compensateEventDefinitionDone())
+            .done();
+
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  @Test
+  public void shouldNotDeployCompensationEventSubprocessOnProcessLevel() {
+    final var process =
+        Bpmn.createExecutableProcess("compensation-process")
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent("compensation-start", AbstractStartEventBuilder::compensation)
+                        .intermediateThrowEvent(
+                            "compensation-throw-event",
+                            AbstractThrowEventBuilder::compensateEventDefinition)
+                        .userTask("B")
+                        .endEvent()
+                        .done())
+            .endEvent(
+                "compensation-end-event",
+                end -> end.compensateEventDefinition().compensateEventDefinitionDone())
+            .done();
+
+    ProcessValidationUtil.validateProcess(
+        process,
+        ExpectedValidationResult.expect(
+            SubProcess.class,
+            "A compensation event subprocess is not allowed on the process level"));
   }
 
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {

--- a/engine/src/test/resources/compensation/compensation-not-embedded-subprocess.bpmn
+++ b/engine/src/test/resources/compensation/compensation-not-embedded-subprocess.bpmn
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="definitions_114f3101-1b05-43a4-937b-221ef0993b45" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="Camunda Modeler" exporterVersion="5.15.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <process id="compensation-process" isExecutable="true">
+    <startEvent id="Event_0643g55">
+      <outgoing>Flow_0j7e31s</outgoing>
+    </startEvent>
+    <sequenceFlow id="Flow_0j7e31s" sourceRef="Event_0643g55" targetRef="Activity_07kp3cl" />
+    <userTask id="Activity_07kp3cl">
+      <incoming>Flow_0j7e31s</incoming>
+      <outgoing>Flow_1jfrnxg</outgoing>
+    </userTask>
+    <boundaryEvent id="Event_125xwyw" attachedToRef="Activity_07kp3cl">
+      <compensateEventDefinition id="CompensateEventDefinition_0zcgvs4" />
+    </boundaryEvent>
+    <sequenceFlow id="Flow_1jfrnxg" sourceRef="Activity_07kp3cl" targetRef="Event_1nsw16z" />
+    <intermediateThrowEvent id="Event_1nsw16z">
+      <incoming>Flow_1jfrnxg</incoming>
+      <outgoing>Flow_1a86ltw</outgoing>
+      <compensateEventDefinition id="CompensateEventDefinition_18c6d54" />
+    </intermediateThrowEvent>
+    <endEvent id="Event_147xfm7">
+      <incoming>Flow_1a86ltw</incoming>
+    </endEvent>
+    <sequenceFlow id="Flow_1a86ltw" sourceRef="Event_1nsw16z" targetRef="Event_147xfm7" />
+    <userTask id="Activity_08wsb8t" isForCompensation="true" />
+    <subProcess id="subprocess" name="subprocess" triggeredByEvent="true">
+      <intermediateThrowEvent id="compensation-throw-event" name="compensation-throw-event">
+        <incoming>sequenceFlow_7085e289-68f7-4dc0-91cc-19cebb8c3d1a</incoming>
+        <outgoing>sequenceFlow_1b8efbb5-39a0-41d6-bf8e-bd5cf724d02c</outgoing>
+        <compensateEventDefinition id="compensateEventDefinition_12160ccc-f4b9-439c-92c0-60cf4e8aa6f5" />
+      </intermediateThrowEvent>
+      <userTask id="B" name="B">
+        <incoming>sequenceFlow_1b8efbb5-39a0-41d6-bf8e-bd5cf724d02c</incoming>
+        <outgoing>sequenceFlow_39b671b5-f493-4283-a4af-56db8a0c3377</outgoing>
+      </userTask>
+      <endEvent id="endEvent_9739cf9c-9cf4-41e4-9f2f-44ba996671d4">
+        <incoming>sequenceFlow_39b671b5-f493-4283-a4af-56db8a0c3377</incoming>
+      </endEvent>
+      <sequenceFlow id="sequenceFlow_7085e289-68f7-4dc0-91cc-19cebb8c3d1a" sourceRef="compensation-start" targetRef="compensation-throw-event" />
+      <sequenceFlow id="sequenceFlow_1b8efbb5-39a0-41d6-bf8e-bd5cf724d02c" sourceRef="compensation-throw-event" targetRef="B" />
+      <sequenceFlow id="sequenceFlow_39b671b5-f493-4283-a4af-56db8a0c3377" sourceRef="B" targetRef="endEvent_9739cf9c-9cf4-41e4-9f2f-44ba996671d4" />
+      <startEvent id="compensation-start" name="compensation-start">
+        <outgoing>sequenceFlow_7085e289-68f7-4dc0-91cc-19cebb8c3d1a</outgoing>
+        <compensateEventDefinition id="CompensateEventDefinition_1b1gdlo" />
+      </startEvent>
+    </subProcess>
+    <association id="Association_0t5z23r" associationDirection="One" sourceRef="Event_125xwyw" targetRef="Activity_08wsb8t" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_b184f2f4-3c12-466c-b605-e6c88932e3ef">
+    <bpmndi:BPMNPlane id="BPMNPlane_abc9181e-ea9f-4aca-baab-f525c1732440" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="Activity_1ta13c5_di" bpmnElement="Activity_07kp3cl">
+        <dc:Bounds x="290" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0643g55_di" bpmnElement="Event_0643g55">
+        <dc:Bounds x="172" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_115x7s2_di" bpmnElement="Event_1nsw16z">
+        <dc:Bounds x="472" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_147xfm7_di" bpmnElement="Event_147xfm7">
+        <dc:Bounds x="592" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kxv83k_di" bpmnElement="Activity_08wsb8t">
+        <dc:Bounds x="460" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0t5z23r_di" bpmnElement="Association_0t5z23r">
+        <di:waypoint x="390" y="188" />
+        <di:waypoint x="390" y="250" />
+        <di:waypoint x="460" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_19a7ao9_di" bpmnElement="subprocess" isExpanded="true">
+        <dc:Bounds x="160" y="410" width="494" height="208" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_fdc112cd-dbd2-4d5c-8aef-eec3b9bc5bf9" bpmnElement="compensation-throw-event">
+        <dc:Bounds x="332" y="500" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="314" y="536" width="73" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_299ad898-c37d-49e9-8206-0f2b31897879" bpmnElement="B">
+        <dc:Bounds x="418" y="478" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_4d7c4c18-f563-40ed-b75c-589e2a53bd8d" bpmnElement="endEvent_9739cf9c-9cf4-41e4-9f2f-44ba996671d4">
+        <dc:Bounds x="568" y="500" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ngbfx2_di" bpmnElement="compensation-start">
+        <dc:Bounds x="246" y="500" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="228" y="536" width="73" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_a6689c35-2ba1-4c82-8cd3-a89cdfaa1145" bpmnElement="sequenceFlow_7085e289-68f7-4dc0-91cc-19cebb8c3d1a">
+        <di:waypoint x="282" y="518" />
+        <di:waypoint x="332" y="518" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_030f6970-a193-4784-9c3e-e127d1bcd8f6" bpmnElement="sequenceFlow_1b8efbb5-39a0-41d6-bf8e-bd5cf724d02c">
+        <di:waypoint x="368" y="518" />
+        <di:waypoint x="418" y="518" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_171e28ac-5660-4b27-8f8f-ebb5ee7fdc73" bpmnElement="sequenceFlow_39b671b5-f493-4283-a4af-56db8a0c3377">
+        <di:waypoint x="518" y="518" />
+        <di:waypoint x="568" y="518" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0p7dkn7_di" bpmnElement="Event_125xwyw">
+        <dc:Bounds x="372" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0j7e31s_di" bpmnElement="Flow_0j7e31s">
+        <di:waypoint x="208" y="130" />
+        <di:waypoint x="290" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jfrnxg_di" bpmnElement="Flow_1jfrnxg">
+        <di:waypoint x="390" y="130" />
+        <di:waypoint x="472" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a86ltw_di" bpmnElement="Flow_1a86ltw">
+        <di:waypoint x="508" y="130" />
+        <di:waypoint x="592" y="130" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR enable the deploy of a Process with compensation events subprocess

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14943 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
