### PR TITLE
Add response and error response to add stream request

### DIFF
--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -86,6 +86,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/StreamResponseException.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/StreamResponseException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.api;
+
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+
+/** An exception returned */
+public class StreamResponseException extends UnrecoverableException {
+
+  public StreamResponseException(final ErrorResponse response) {
+    super(
+        "Remote stream server error: [code=%s, message='%s']"
+            .formatted(response.code(), response.message()));
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/AddStreamResponse.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/AddStreamResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl.messages;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public final class AddStreamResponse implements StreamResponse {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final AddStreamResponseEncoder messageEncoder = new AddStreamResponseEncoder();
+  private final AddStreamResponseDecoder messageDecoder = new AddStreamResponseDecoder();
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+  }
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength() + messageEncoder.sbeBlockLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+  }
+
+  @Override
+  public int templateId() {
+    return messageDecoder.sbeTemplateId();
+  }
+
+  @Override
+  public String toString() {
+    return "AddStreamResponse{}";
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl.messages;
+
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class ErrorResponse implements StreamResponse {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final ErrorResponseEncoder messageEncoder = new ErrorResponseEncoder();
+  private final ErrorResponseDecoder messageDecoder = new ErrorResponseDecoder();
+
+  private final DirectBuffer message = new UnsafeBuffer();
+  private ErrorCode code;
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+    code = messageDecoder.code();
+    messageDecoder.wrapMessage(message);
+  }
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength()
+        + messageEncoder.sbeBlockLength()
+        + ErrorResponseEncoder.messageHeaderLength()
+        + message.capacity();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    messageEncoder
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
+        .code(code)
+        .putMessage(message, 0, message.capacity());
+  }
+
+  @Override
+  public int templateId() {
+    return messageDecoder.sbeTemplateId();
+  }
+
+  public ErrorResponse code(final ErrorCode code) {
+    this.code = code;
+    return this;
+  }
+
+  public ErrorResponse message(final DirectBuffer message) {
+    this.message.wrap(message);
+    return this;
+  }
+
+  public ErrorResponse message(final String message) {
+    final var bytes = message.getBytes(StandardCharsets.UTF_8);
+    this.message.wrap(bytes);
+
+    return this;
+  }
+
+  public ErrorCode code() {
+    return code;
+  }
+
+  public String message() {
+    return message.capacity() > 0 ? BufferUtil.bufferAsString(message) : "";
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message, code);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ErrorResponse that = (ErrorResponse) o;
+    return Objects.equals(message, that.message) && code == that.code;
+  }
+
+  @Override
+  public String toString() {
+    return "ErrorResponse{" + "message=" + message() + ", code=" + code + '}';
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/PushStreamResponse.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/PushStreamResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl.messages;
+
+import io.camunda.zeebe.util.buffer.BufferReader;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public final class PushStreamResponse implements BufferReader, StreamResponse {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final PushStreamResponseEncoder messageEncoder = new PushStreamResponseEncoder();
+  private final PushStreamResponseDecoder messageDecoder = new PushStreamResponseDecoder();
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+  }
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength() + messageEncoder.sbeBlockLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+  }
+
+  @Override
+  public int templateId() {
+    return messageDecoder.sbeTemplateId();
+  }
+
+  @Override
+  public String toString() {
+    return "PushStreamResponse{}";
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/RemoveStreamResponse.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/RemoveStreamResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl.messages;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public final class RemoveStreamResponse implements StreamResponse {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final RemoveStreamResponseEncoder messageEncoder = new RemoveStreamResponseEncoder();
+  private final RemoveStreamResponseDecoder messageDecoder = new RemoveStreamResponseDecoder();
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+  }
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength() + messageEncoder.sbeBlockLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+  }
+
+  @Override
+  public int templateId() {
+    return messageDecoder.sbeTemplateId();
+  }
+
+  @Override
+  public String toString() {
+    return "RemoveStreamResponse{}";
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamResponse.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl.messages;
+
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+
+/** Generic response type for all stream topics listed in {@link StreamTopics} */
+public interface StreamResponse extends BufferReader, BufferWriter {
+
+  /** The expected template ID of this response type, used for deserialization */
+  int templateId();
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamResponseReader.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamResponseReader.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl.messages;
+
+import io.camunda.zeebe.util.Either;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class StreamResponseReader {
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final DirectBuffer buffer = new UnsafeBuffer();
+
+  public <T extends StreamResponse> Either<ErrorResponse, T> read(
+      final byte[] bytes, final T response) {
+    buffer.wrap(bytes);
+    headerDecoder.wrap(buffer, 0);
+
+    if (headerDecoder.schemaId() != headerDecoder.sbeSchemaId()) {
+      return Either.left(
+          new ErrorResponse()
+              .code(ErrorCode.MALFORMED)
+              .message(
+                  "Invalid schema ID; expected '%d', got '%d'"
+                      .formatted(headerDecoder.sbeSchemaId(), headerDecoder.schemaId())));
+    }
+
+    if (headerDecoder.templateId() == ErrorResponseDecoder.TEMPLATE_ID) {
+      final var errorResponse = new ErrorResponse();
+      errorResponse.wrap(buffer, 0, buffer.capacity());
+      return Either.left(errorResponse);
+    }
+
+    if (headerDecoder.templateId() != response.templateId()) {
+      return Either.left(
+          new ErrorResponse()
+              .code(ErrorCode.MALFORMED)
+              .message(
+                  "Invalid template ID; expected '%d', got '%d'"
+                      .formatted(headerDecoder.templateId(), response.templateId())));
+    }
+
+    response.wrap(buffer, 0, buffer.capacity());
+    return Either.right(response);
+  }
+}

--- a/transport/src/main/resources/stream-protocol.xml
+++ b/transport/src/main/resources/stream-protocol.xml
@@ -8,7 +8,7 @@
   -->
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.transport.stream.impl.messages"
-  id="2" version="1" semanticVersion="${project.version}"
+  id="2" version="2" semanticVersion="${project.version}"
   description="Zeebe Protocol" byteOrder="littleEndian">
 
   <xi:include href="../../../protocol/src/main/resources/common-types.xml"/>
@@ -18,22 +18,49 @@
       <type name="high" primitiveType="int64" />
       <type name="low" primitiveType="int64" />
     </composite>
+
+    <enum name="errorCode" encodingType="uint8" semanticType="String"
+      description="The unique identifier of an error">
+      <validValue name="INTERNAL_ERROR">0</validValue>
+      <validValue name="NOT_FOUND">1</validValue>
+      <validValue name="INVALID">2</validValue>
+      <validValue name="MALFORMED">3</validValue>
+      <validValue name="EXHAUSTED">4</validValue>
+      <validValue name="BLOCKED">5</validValue>
+    </enum>
   </types>
 
 
   <!-- Gateway Stream messages 400-499 -->
   <sbe:message name="AddStreamRequest" id="400" description="Adds a gateway stream to a broker">
-    <field name="id" id="1" type="UUID" />
-    <data name="streamType" id="2" type="varDataEncoding" />
-    <data name="metadata" id="3" type="varDataEncoding" />
+    <field name="id" id="1" type="UUID" description="The unique ID of the stream to add" />
+    <data name="streamType" id="2" type="varDataEncoding" description="The type of the stream, used for aggregation"/>
+    <data name="metadata" id="3" type="varDataEncoding" description="Optional, free-form metadata associated with the stream" />
+  </sbe:message>
+
+  <sbe:message name="AddStreamResponse" id="403" description="Result of adding a gateway stream to a broker">
+
   </sbe:message>
 
   <sbe:message name="RemoveStreamRequest" id="401" description="Removes a gateway stream from a broker">
-    <field name="id" id="1" type="UUID" />
+    <field name="id" id="1" type="UUID" description="The unique ID of the stream to remove" />
+  </sbe:message>
+
+  <sbe:message name="RemoveStreamResponse" id="404" description="Result of removing a gateway stream to a broker">
+
   </sbe:message>
 
   <sbe:message name="PushStreamRequest" id="402" description="Pushes a payload over a stream">
-    <field name="id" id="1" type="UUID" />
-    <data name="payload" id="2" type="varDataEncoding"/>
+    <field name="id" id="1" type="UUID" description="The unique stream ID to push on" />
+    <data name="payload" id="2" type="varDataEncoding" description="The payload to push on the stream" />
+  </sbe:message>
+
+  <sbe:message name="PushStreamResponse" id="405" description="Result of pushing a payload to a stream">
+
+  </sbe:message>
+
+  <sbe:message name="ErrorResponse" id="406" description="Returned whenever a request fails">
+    <field name="code" id="1" type="errorCode" description="The specific error code" />
+    <data name="message" id="2" type="varDataEncoding" />
   </sbe:message>
 </sbe:messageSchema>

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/SerializationTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/SerializationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.transport.stream.impl.messages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
@@ -64,6 +65,20 @@ final class SerializationTest {
   }
 
   @Test
+  void shouldSerializeAddStreamResponse() {
+    // given
+    final var response = new AddStreamResponse();
+
+    // when
+    response.write(buffer, 0);
+    final var deserialized = new AddStreamResponse();
+
+    // then
+    assertThatCode(() -> deserialized.wrap(buffer, 0, response.getLength()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
   void shouldSerializeRemoveStreamRequest() {
     // given
     final var streamId = UUID.randomUUID();
@@ -76,6 +91,20 @@ final class SerializationTest {
 
     // then
     assertThat(deserialized.streamId()).isEqualTo(streamId);
+  }
+
+  @Test
+  void shouldSerializeRemoveStreamResponse() {
+    // given
+    final var response = new RemoveStreamResponse();
+
+    // when
+    response.write(buffer, 0);
+    final var deserialized = new RemoveStreamResponse();
+
+    // then
+    assertThatCode(() -> deserialized.wrap(buffer, 0, response.getLength()))
+        .doesNotThrowAnyException();
   }
 
   @Test
@@ -93,5 +122,35 @@ final class SerializationTest {
     // then
     assertThat(deserialized.streamId()).isEqualTo(streamId);
     assertThat(deserialized.payload()).isEqualTo(BufferUtil.wrapString("foo"));
+  }
+
+  @Test
+  void shouldSerializePushStreamResponse() {
+    // given
+    final var response = new PushStreamResponse();
+
+    // when
+    response.write(buffer, 0);
+    final var deserialized = new PushStreamResponse();
+
+    // then
+    assertThatCode(() -> deserialized.wrap(buffer, 0, response.getLength()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldSerializeErrorResponse() {
+    // given
+    final var response =
+        new ErrorResponse().code(ErrorCode.EXHAUSTED).message("Stream is exhausted");
+
+    // when
+    response.write(buffer, 0);
+    final var deserialized = new ErrorResponse();
+    deserialized.wrap(buffer, 0, response.getLength());
+
+    // then
+    assertThat(deserialized.code()).isEqualTo(ErrorCode.EXHAUSTED);
+    assertThat(deserialized.message()).isEqualTo("Stream is exhausted");
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/buffer/BufferWriter.java
+++ b/util/src/main/java/io/camunda/zeebe/util/buffer/BufferWriter.java
@@ -29,14 +29,4 @@ public interface BufferWriter {
    * @param offset the offset in the buffer that the writer begins writing at
    */
   void write(MutableDirectBuffer buffer, int offset);
-
-  /**
-   * Writes this instance into a newly allocated buffer before reading it back using {@code dest}.
-   *
-   * @param dest the destination reader
-   * @throws NullPointerException if dest is null
-   */
-  default void copyTo(final BufferReader dest) {
-    BufferUtil.copy(this, dest);
-  }
 }


### PR DESCRIPTION
## Description

This PR adds a new response type for the `add-stream` topic, a new response type for the `push-stream` topic, a new response type for the `remove-stream` topic, as well as a new all purpose error response type.

> The `push-stream` and `remove-stream` response handling will be done in a follow up PR.

No new response types added for the `remove-all` topic, which is considered a best-effort request anyway, and isn't retried on failure.

Regarding the `add-stream` error handling, since the current behavior is that we retry _all_ errors, I didn't change that. I'll create a follow up issue to handle this and close the client if the stream cannot be added due to an unrecoverable error. Right now, we keep the same behavior as before, i.e. retry forever, even on a malformed request.

I also didn't want to go to far and end up with PRs that are much too big, which I didn't continue with updating that behavior.

## Related issues

related to #15195 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
