### PR TITLE
Handle stream remove response and application level errors

### DIFF
--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
@@ -31,7 +31,7 @@ final class ClientStreamRegistration<M extends BufferWriter> {
   private final MemberId serverId;
 
   private State state = State.INITIAL;
-  private CompletionStage<?> pendingRequest;
+  private CompletionStage<byte[]> pendingRequest;
 
   ClientStreamRegistration(final AggregatedClientStream<M> stream, final MemberId serverId) {
     this.stream = stream;
@@ -54,11 +54,11 @@ final class ClientStreamRegistration<M extends BufferWriter> {
     return state;
   }
 
-  CompletionStage<?> pendingRequest() {
+  CompletionStage<byte[]> pendingRequest() {
     return pendingRequest;
   }
 
-  void setPendingRequest(final CompletionStage<?> pendingRequest) {
+  void setPendingRequest(final CompletionStage<byte[]> pendingRequest) {
     this.pendingRequest = pendingRequest;
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
@@ -31,7 +31,7 @@ final class ClientStreamRegistration<M extends BufferWriter> {
   private final MemberId serverId;
 
   private State state = State.INITIAL;
-  private CompletionStage<byte[]> pendingRequest;
+  private CompletionStage<?> pendingRequest;
 
   ClientStreamRegistration(final AggregatedClientStream<M> stream, final MemberId serverId) {
     this.stream = stream;
@@ -54,11 +54,11 @@ final class ClientStreamRegistration<M extends BufferWriter> {
     return state;
   }
 
-  CompletionStage<byte[]> pendingRequest() {
+  CompletionStage<?> pendingRequest() {
     return pendingRequest;
   }
 
-  void setPendingRequest(final CompletionStage<byte[]> pendingRequest) {
+  void setPendingRequest(final CompletionStage<?> pendingRequest) {
     this.pendingRequest = pendingRequest;
   }
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -13,9 +13,7 @@ import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
 import io.camunda.zeebe.scheduler.Actor;
-import io.camunda.zeebe.transport.stream.impl.messages.AddStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.MessageUtil;
-import io.camunda.zeebe.transport.stream.impl.messages.RemoveStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.ExponentialBackoff;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -23,9 +21,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.LongUnaryOperator;
-import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.ArrayUtil;
-import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +37,6 @@ public final class RemoteStreamTransport<M> extends Actor {
   private static final Logger LOG = LoggerFactory.getLogger(RemoteStreamTransport.class);
   private static final int INITIAL_RETRY_DELAY_MS = 100;
 
-  private final MutableDirectBuffer writeBuffer = new UnsafeBuffer();
   private final ClusterCommunicationService transport;
   private final RemoteStreamApiHandler<M> requestHandler;
   private final LongUnaryOperator retryDelaySupplier;
@@ -66,14 +61,14 @@ public final class RemoteStreamTransport<M> extends Actor {
     transport.replyTo(
         StreamTopics.ADD.topic(),
         MessageUtil::parseAddRequest,
-        this::onAdd,
-        Function.identity(),
+        requestHandler::add,
+        MessageUtil::encodeResponse,
         actor::run);
     transport.replyTo(
         StreamTopics.REMOVE.topic(),
         MessageUtil::parseRemoveRequest,
-        this::onRemove,
-        Function.identity(),
+        requestHandler::remove,
+        MessageUtil::encodeResponse,
         actor::run);
     transport.replyTo(
         StreamTopics.REMOVE_ALL.topic(),
@@ -93,20 +88,6 @@ public final class RemoteStreamTransport<M> extends Actor {
 
   public void removeAll(final MemberId member) {
     actor.run(() -> requestHandler.removeAll(member));
-  }
-
-  private byte[] onAdd(final MemberId sender, final AddStreamRequest request) {
-    final var response = requestHandler.add(sender, request);
-    final var buffer = new byte[response.getLength()];
-    writeBuffer.wrap(buffer);
-    response.write(writeBuffer, 0);
-
-    return buffer;
-  }
-
-  private byte[] onRemove(final MemberId sender, final RemoveStreamRequest request) {
-    requestHandler.remove(sender, request);
-    return ArrayUtil.EMPTY_BYTE_ARRAY;
   }
 
   private byte[] onRemoveAll(final MemberId sender, final byte[] ignored) {

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl.messages;
 
+import io.camunda.zeebe.transport.stream.api.StreamResponseException;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -99,5 +100,21 @@ public final class ErrorResponse implements StreamResponse {
   @Override
   public String toString() {
     return "ErrorResponse{" + "message=" + message() + ", code=" + code + '}';
+  }
+
+  public StreamResponseException asException() {
+    return new StacklessException(this);
+  }
+
+  private static final class StacklessException extends StreamResponseException {
+
+    public StacklessException(final ErrorResponse response) {
+      super(response);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+      return this;
+    }
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/MessageUtil.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/MessageUtil.java
@@ -34,4 +34,11 @@ public final class MessageUtil {
 
     return request;
   }
+
+  public static byte[] encodeResponse(final StreamResponse response) {
+    final var buffer = new byte[response.getLength()];
+    response.write(new UnsafeBuffer(buffer), 0);
+
+    return buffer;
+  }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamResponseDecoder.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamResponseDecoder.java
@@ -11,12 +11,18 @@ import io.camunda.zeebe.util.Either;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-public final class StreamResponseReader {
+public final class StreamResponseDecoder {
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
   private final DirectBuffer buffer = new UnsafeBuffer();
 
-  public <T extends StreamResponse> Either<ErrorResponse, T> read(
+  public <T extends StreamResponse> Either<ErrorResponse, T> decode(
       final byte[] bytes, final T response) {
+    // for backwards compatibility, accept empty responses as success
+    // to be removed with 8.5
+    if (bytes.length == 0) {
+      return Either.right(response);
+    }
+
     buffer.wrap(bytes);
     headerDecoder.wrap(buffer, 0);
 

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -20,7 +21,10 @@ import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
+import io.camunda.zeebe.transport.stream.impl.messages.AddStreamResponse;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
+import io.camunda.zeebe.transport.stream.impl.messages.RemoveStreamResponse;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.time.Duration;
@@ -30,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,9 +56,15 @@ class ClientStreamManagerTest {
 
   @BeforeEach
   void setup() {
-
     when(mockTransport.send(any(), any(), any(), any(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
+        .thenReturn(CompletableFuture.completedFuture(ArrayUtil.EMPTY_BYTE_ARRAY));
+    when(mockTransport.send(eq(StreamTopics.ADD.topic()), any(), any(), any(), any(), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(BufferUtil.bufferAsArray(new AddStreamResponse())));
+    when(mockTransport.send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), any(), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                BufferUtil.bufferAsArray(new RemoveStreamResponse())));
   }
 
   @Test

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -13,12 +13,17 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.cluster.messaging.MessagingException;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import io.atomix.cluster.messaging.MessagingException.ProtocolException;
+import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.transport.stream.impl.ClientStreamRegistration.State;
 import io.camunda.zeebe.transport.stream.impl.messages.AddStreamResponse;
@@ -32,18 +37,21 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 final class ClientStreamRequestManagerTest {
 
   private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
+  private final TestConcurrencyControl concurrencyControl = spy(new TestConcurrencyControl());
   private final ClientStreamRequestManager<TestMetadata> requestManager =
-      new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl());
+      new ClientStreamRequestManager<>(mockTransport, concurrencyControl);
   private final AggregatedClientStream<TestMetadata> clientStream =
       new AggregatedClientStream<>(
           UUID.randomUUID(),
@@ -286,7 +294,7 @@ final class ClientStreamRequestManagerTest {
 
   @ParameterizedTest
   @EnumSource(value = ErrorCode.class)
-  void shouldRetryRemoveOnErrorResponse(final ErrorCode code) {
+  void shouldNotRetryRemoveOnErrorResponse(final ErrorCode code) {
     // given
     final var errorResponse = new ErrorResponse().code(code).message("Failed");
     final var errorResponseBuffer = new byte[errorResponse.getLength()];
@@ -302,8 +310,9 @@ final class ClientStreamRequestManagerTest {
     requestManager.remove(clientStream, serverId);
 
     // then
-    verify(mockTransport, times(2))
+    verify(mockTransport, times(1))
         .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+    verify(concurrencyControl, never()).schedule(any(), any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
 
@@ -349,6 +358,49 @@ final class ClientStreamRequestManagerTest {
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
 
+  @ParameterizedTest
+  @MethodSource("provideMessagingFailures")
+  void shouldNotRetryRemoveOnMessagingFailure(final MessagingException error) {
+    // given
+    final var pendingRequest = new CompletableFuture<byte[]>();
+    final var serverId = MemberId.anonymous();
+    requestManager.add(clientStream, serverId);
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(pendingRequest);
+
+    // whe
+    requestManager.remove(clientStream, serverId);
+    pendingRequest.completeExceptionally(error);
+
+    // then
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+    verify(concurrencyControl, never()).schedule(any(), any());
+    assertThat(clientStream.isConnected(serverId)).isFalse();
+  }
+
+  @Test
+  void shouldNotRetryRemoveOnRemoteHandlerFailure() {
+    // given
+    final var pendingRequest = new CompletableFuture<byte[]>();
+    final var serverId = MemberId.anonymous();
+    requestManager.add(clientStream, serverId);
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(pendingRequest);
+
+    // whe
+    requestManager.remove(clientStream, serverId);
+    pendingRequest.completeExceptionally(new RemoteHandlerFailure("failed"));
+
+    // then
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+    verify(concurrencyControl, never()).schedule(any(), any());
+    assertThat(clientStream.isConnected(serverId)).isFalse();
+  }
+
   @Test
   void shouldNotRetryAddIfRemoving() {
     // given
@@ -384,6 +436,13 @@ final class ClientStreamRequestManagerTest {
         .unicast(eq(StreamTopics.REMOVE_ALL.topic()), any(), any(), eq(server1), anyBoolean());
     verify(mockTransport)
         .unicast(eq(StreamTopics.REMOVE_ALL.topic()), any(), any(), eq(server2), anyBoolean());
+  }
+
+  private static Stream<MessagingException> provideMessagingFailures() {
+    return Stream.of(
+        new NoSuchMemberException("failed"),
+        new ProtocolException(),
+        new RemoteHandlerFailure("failed"));
   }
 
   private static final class TestMetadata implements BufferWriter {


### PR DESCRIPTION
## Description

This PR adds handling of the `remove-stream` topic response and possible errors. Since it was much easier to stop retrying on specific cases, we stop retrying the `remove-stream` request and mark the stream as removed on the following errors:

- Any `ErrorResponse` (since all of them are unrecoverable for now)
- `RemoteHandlerFailure` (since this means the server can't handle the request unexpectedly, so it won't recover)

We still retry on `NoSuchMemberException`, `ConnectionException`, `TimeoutException`, and any other `IOException`.

## Related issues

related to #15195 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
