### PR TITLE
Handle remote stream push responses and errors

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
@@ -187,6 +187,27 @@ public interface ClusterCommunicationService {
       Executor executor);
 
   /**
+   * Adds a new subscriber for the specified message subject which must return a reply. If the
+   * sender is not a known member, the handler is not called, and a {@link
+   * io.atomix.cluster.messaging.MessagingException.NoSuchMemberException} is returned to the
+   * sender.
+   *
+   * @param subject message subject
+   * @param decoder decoder to deserializing incoming message
+   * @param handler handler for handling message, receiving the sender's member ID and the decoded
+   *     message
+   * @param encoder to serialize the outgoing reply
+   * @param executor executor to run this handler on
+   * @param <M> incoming message type
+   */
+  <M, R> void replyToAsync(
+      String subject,
+      Function<byte[], M> decoder,
+      Function<M, CompletableFuture<R>> handler,
+      Function<R, byte[]> encoder,
+      Executor executor);
+
+  /**
    * Removes a subscriber for the specified message subject.
    *
    * @param subject message subject

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
@@ -194,8 +194,8 @@ public interface ClusterCommunicationService {
    *
    * @param subject message subject
    * @param decoder decoder to deserializing incoming message
-   * @param handler handler for handling message, receiving the sender's member ID and the decoded
-   *     message
+   * @param handler handler receives the decoded message and returns a future which is completed
+   *     with the reply (which will be encoded using the given encoder)
    * @param encoder to serialize the outgoing reply
    * @param executor executor to run this handler on
    * @param <M> incoming message type

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/StreamResponseException.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/StreamResponseException.java
@@ -7,15 +7,30 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 
 /** An exception returned */
 public class StreamResponseException extends UnrecoverableException {
 
+  private final ErrorCode code;
+  private final String message;
+
   public StreamResponseException(final ErrorResponse response) {
     super(
         "Remote stream server error: [code=%s, message='%s']"
             .formatted(response.code(), response.message()));
+
+    code = response.code();
+    message = response.message();
+  }
+
+  public ErrorCode code() {
+    return code;
+  }
+
+  public String message() {
+    return message;
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
+import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
+import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
+import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
+import io.camunda.zeebe.transport.stream.impl.messages.PushStreamResponse;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamResponse;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.agrona.collections.ArrayUtil;
+
+final class ClientStreamApiHandler {
+  private final ClientStreamManager<?> clientStreamManager;
+  private final Executor executor;
+
+  ClientStreamApiHandler(
+      final ClientStreamManager<?> clientStreamManager, final Executor executor) {
+    this.clientStreamManager = clientStreamManager;
+    this.executor = executor;
+  }
+
+  CompletableFuture<StreamResponse> handlePushRequest(final PushStreamRequest request) {
+    final CompletableFuture<StreamResponse> responseFuture = new CompletableFuture<>();
+
+    final ActorFuture<Void> payloadPushed = new CompletableActorFuture<>();
+    clientStreamManager.onPayloadReceived(request, payloadPushed);
+    payloadPushed.onComplete((ok, error) -> handlePayloadPushed(responseFuture, error), executor);
+
+    return responseFuture;
+  }
+
+  byte[] handleRestartRequest(final MemberId sender, final byte[] ignored) {
+    clientStreamManager.onServerRemoved(MemberId.from(sender.id()));
+    clientStreamManager.onServerJoined(MemberId.from(sender.id()));
+    return ArrayUtil.EMPTY_BYTE_ARRAY;
+  }
+
+  private void handlePayloadPushed(
+      final CompletableFuture<StreamResponse> response, final Throwable error) {
+    if (error == null) {
+      response.complete(new PushStreamResponse());
+      return;
+    }
+
+    final var errorResponse = new ErrorResponse();
+    switch (error) {
+      case final StreamExhaustedException e -> errorResponse
+          .code(ErrorCode.EXHAUSTED)
+          .message(e.getMessage());
+      case final ClientStreamBlockedException e -> errorResponse
+          .code(ErrorCode.BLOCKED)
+          .message(e.getMessage());
+      case final NoSuchStreamException e -> errorResponse
+          .code(ErrorCode.NOT_FOUND)
+          .message(e.getMessage());
+      default -> errorResponse.code(ErrorCode.INTERNAL_ERROR).message(error.getMessage());
+    }
+
+    response.complete(errorResponse);
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.stream.impl.messages.MessageUtil;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.ExponentialBackoff;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -62,13 +63,13 @@ public final class RemoteStreamTransport<M> extends Actor {
         StreamTopics.ADD.topic(),
         MessageUtil::parseAddRequest,
         requestHandler::add,
-        MessageUtil::encodeResponse,
+        BufferUtil::bufferAsArray,
         actor::run);
     transport.replyTo(
         StreamTopics.REMOVE.topic(),
         MessageUtil::parseRemoveRequest,
         requestHandler::remove,
-        MessageUtil::encodeResponse,
+        BufferUtil::bufferAsArray,
         actor::run);
     transport.replyTo(
         StreamTopics.REMOVE_ALL.topic(),

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -89,15 +89,13 @@ public final class RemoteStreamerImpl<M, P extends BufferWriter> extends Actor
     return Optional.empty();
   }
 
-  private CompletableFuture<Void> send(final PushStreamRequest request, final MemberId receiver) {
-    return transport
-        .send(
-            StreamTopics.PUSH.topic(),
-            request,
-            BufferUtil::bufferAsArray,
-            Function.identity(),
-            receiver,
-            REQUEST_TIMEOUT)
-        .thenApply(ok -> null);
+  private CompletableFuture<byte[]> send(final PushStreamRequest request, final MemberId receiver) {
+    return transport.send(
+        StreamTopics.PUSH.topic(),
+        request,
+        BufferUtil::bufferAsArray,
+        Function.identity(),
+        receiver,
+        REQUEST_TIMEOUT);
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/MessageUtil.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/MessageUtil.java
@@ -34,11 +34,4 @@ public final class MessageUtil {
 
     return request;
   }
-
-  public static byte[] encodeResponse(final StreamResponse response) {
-    final var buffer = new byte[response.getLength()];
-    response.write(new UnsafeBuffer(buffer), 0);
-
-    return buffer;
-  }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandlerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
+import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
+import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
+import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+final class ClientStreamApiHandlerTest {
+  private final ClientStreamManager<?> clientStreamManager = mock(ClientStreamManager.class);
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionToErrorMap")
+  void shouldMapExceptionToErrorResponse(final ExceptionErrorCase testCase) {
+    // given
+    final var apiHandler = new ClientStreamApiHandler(clientStreamManager, Runnable::run);
+    final var request = new PushStreamRequest();
+    final var payloadPushed = ArgumentCaptor.forClass(CompletableActorFuture.class);
+    //noinspection unchecked
+    doNothing().when(clientStreamManager).onPayloadReceived(eq(request), payloadPushed.capture());
+
+    // when
+    final var response = apiHandler.handlePushRequest(request);
+    payloadPushed.getValue().completeExceptionally(testCase.exception());
+
+    // then
+    assertThat(response)
+        .succeedsWithin(Duration.ZERO)
+        .asInstanceOf(InstanceOfAssertFactories.type(ErrorResponse.class))
+        .returns(testCase.code(), ErrorResponse::code);
+  }
+
+  private static Stream<ExceptionErrorCase> provideExceptionToErrorMap() {
+    return Stream.of(
+        new ExceptionErrorCase(new StreamExhaustedException("failed"), ErrorCode.EXHAUSTED),
+        new ExceptionErrorCase(new ClientStreamBlockedException("failed"), ErrorCode.BLOCKED),
+        new ExceptionErrorCase(new NoSuchStreamException("failed"), ErrorCode.NOT_FOUND),
+        new ExceptionErrorCase(new RuntimeException("failed"), ErrorCode.INTERNAL_ERROR));
+  }
+
+  private record ExceptionErrorCase(Throwable exception, ErrorCode code)
+      implements Named<ExceptionErrorCase> {
+
+    @Override
+    public String getName() {
+      return "%s -> %s".formatted(exception.getClass().getSimpleName(), code.name());
+    }
+
+    @Override
+    public ExceptionErrorCase getPayload() {
+      return this;
+    }
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImplTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamConsu
 import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamPusher.Transport;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
+import io.camunda.zeebe.transport.stream.impl.messages.PushStreamResponse;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -109,14 +110,14 @@ class RemoteStreamImplTest {
     }
 
     @Override
-    public CompletableFuture<Void> send(final PushStreamRequest request, final MemberId receiver)
-        throws Exception {
+    public CompletableFuture<byte[]> send(
+        final PushStreamRequest request, final MemberId receiver) {
       attemptedStreams.add(request.streamId());
       attempt++;
       if (attempt <= succeedAfterAttempt) {
         return CompletableFuture.failedFuture(new RuntimeException("force fail"));
       }
-      return CompletableFuture.completedFuture(null);
+      return CompletableFuture.completedFuture(BufferUtil.bufferAsArray(new PushStreamResponse()));
     }
   }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamPusher.Transport;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
+import io.camunda.zeebe.transport.stream.impl.messages.PushStreamResponse;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -136,12 +138,13 @@ final class RemoteStreamPusherTest {
   }
 
   private static final class TestTransport implements Transport {
-    private CompletableFuture<Void> response = CompletableFuture.completedFuture(null);
+    private CompletableFuture<byte[]> response =
+        CompletableFuture.completedFuture(BufferUtil.bufferAsArray(new PushStreamResponse()));
     private Message message;
     private Exception synchronousException;
 
     @Override
-    public CompletableFuture<Void> send(final PushStreamRequest request, final MemberId receiver)
+    public CompletableFuture<byte[]> send(final PushStreamRequest request, final MemberId receiver)
         throws Exception {
       if (synchronousException != null) {
         throw synchronousException;


### PR DESCRIPTION
## Description

This PR adds handling of stream push responses and errors. Although the response type is empty for now, it's still handled for future proofing if we wish to extend it. The empty array is still accepted as a valid response until 8.5.

To simplify things, I extracted the handling of incoming requests in the `ClientStreamServiceImpl` to a separate class `ClientStreamApiHandler`. Tests mostly focus on the error mapping since the actual push logic is handled by the `ClientStreamManager`.

> **Note**
> We could move that to the API handler as well in a follow up.

No special error treatment here - we essentially retry all push errors with a different consumer (i.e. gateway), since in all cases there's a chance it might succeed.

No handling of time outs - this is still part of a follow up to decide whether it makes sense to retry time outs of not.

## Related issues

closes #15195 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
