### PR TITLE
Build quickly with maven

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ This is a small overview of the contents of the different modules:
 
 ### Test Execution
 
-Tests can be executed via maven (`mvn verify`) or in your prefered IDE. The Zeebe Team uses mostly [Intellij IDEA](https://www.jetbrains.com/idea/), where we also [provide settings for](https://github.com/camunda/zeebe/tree/main/.idea).
+Tests can be executed via maven (`mvn verify`) or in your preferred IDE. The Zeebe Team uses mostly [Intellij IDEA](https://www.jetbrains.com/idea/), where we also [provide settings for](https://github.com/camunda/zeebe/tree/main/.idea).
 
 > Note: If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@
 
 ## Build Zeebe from source
 
-Zeebe is a multi-module maven project. To build all components,
-run the command: `mvn clean install -DskipTests` in the root folder.
+Zeebe is a multi-module maven project. To **quickly** build all components,
+run the command: `mvn clean install -Dquickly` in the root folder.
 
 > NOTE: All Java modules in Zeebe are built and tested with JDK 21. Most modules use language level
 > 21, exceptions are: zeebe-bpmn-model, zeebe-client-java, zeebe-gateway-protocol,
@@ -27,6 +27,11 @@ run the command: `mvn clean install -DskipTests` in the root folder.
 >
 > NOTE: The Java and the Go modules are built and tested with Docker 20.10.5 [with IPv6 support](https://docs.docker.com/config/daemon/ipv6/).
 
+For contributions to Zeebe, building quickly is typically sufficient.
+However, users of Zeebe are recommended to build the full distribution.
+
+To fully build the Zeebe distribution, run the command: `mvn clean install -DskipTests` in the root folder.
+This is slightly slower than building quickly, but ensures the distribution is assembled completely.
 The resulting Zeebe distribution can be found in the folder `dist/target`, i.e.
 
 ```
@@ -34,7 +39,7 @@ dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.tar.gz
 dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.zip
 ```
 
-The distribution can be containerized with Docker (i.e. build a Docker image) by running:
+This distribution can be containerized with Docker (i.e. build a Docker image) by running:
 
 ```
 docker build \
@@ -70,6 +75,10 @@ This is a small overview of the contents of the different modules:
 Tests can be executed via maven (`mvn verify`) or in your preferred IDE. The Zeebe Team uses mostly [Intellij IDEA](https://www.jetbrains.com/idea/), where we also [provide settings for](https://github.com/camunda/zeebe/tree/main/.idea).
 
 > Note: If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it
+
+> [!TIP]
+> To execute the tests quickly, run `mvn verify -Dquickly -DskipTests=false`.
+> The tests will be skipped when using `-Dquickly` without `-DskipTests=false`.
 
 ### Build profiling
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,14 @@
 Zeebe is a multi-module maven project. To **quickly** build all components,
 run the command: `mvn clean install -Dquickly` in the root folder.
 
-> NOTE: All Java modules in Zeebe are built and tested with JDK 21. Most modules use language level
+> [!NOTE]
+> All Java modules in Zeebe are built and tested with JDK 21. Most modules use language level
 > 21, exceptions are: zeebe-bpmn-model, zeebe-client-java, zeebe-gateway-protocol,
 > zeebe-gateway-protocol-impl, zeebe-protocol and zeebe-protocol-jackson which use language level 8
 >
-> NOTE: The Go client and zbctl are built and tested with Go 1.15
+> The Go client and zbctl are built and tested with Go 1.15
 >
-> NOTE: The Java and the Go modules are built and tested with Docker 20.10.5 [with IPv6 support](https://docs.docker.com/config/daemon/ipv6/).
+> The Java and the Go modules are built and tested with Docker 20.10.5 [with IPv6 support](https://docs.docker.com/config/daemon/ipv6/).
 
 For contributions to Zeebe, building quickly is typically sufficient.
 However, users of Zeebe are recommended to build the full distribution.
@@ -74,11 +75,13 @@ This is a small overview of the contents of the different modules:
 
 Tests can be executed via maven (`mvn verify`) or in your preferred IDE. The Zeebe Team uses mostly [Intellij IDEA](https://www.jetbrains.com/idea/), where we also [provide settings for](https://github.com/camunda/zeebe/tree/main/.idea).
 
-> Note: If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it
-
 > [!TIP]
 > To execute the tests quickly, run `mvn verify -Dquickly -DskipTests=false`.
 > The tests will be skipped when using `-Dquickly` without `-DskipTests=false`.
+
+#### Test Troubleshooting
+
+- If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it.
 
 ### Build profiling
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -174,12 +174,14 @@
 
     <!--
       you can use the following to disable some or all goals:
+        - quickly will skip all non-essential goals, like checks, tests, and assembly
         - skipTests will skip all tests
         - skipITs will skip integration tests
         - skipUTs will skip unit tests
         - skipChecks will non-test checks, such as licensing, checkstyle, backwards compat, etc.
       -->
-    <skipTests>false</skipTests>
+    <quickly>false</quickly>
+    <skipTests>${quickly}</skipTests>
     <skipUTs>${skipTests}</skipUTs>
     <skipITs>${skipTests}</skipITs>
     <jacoco.skip>${skipUTs}</jacoco.skip>
@@ -191,7 +193,7 @@
       that way, you can use skipChecks, but you can also still use checkstyle.skip if you only want
       to disable checkstyle
       -->
-    <skipChecks>false</skipChecks>
+    <skipChecks>${quickly}</skipChecks>
     <checkstyle.skip>${skipChecks}</checkstyle.skip>
     <revapi.skip>${skipChecks}</revapi.skip>
     <license.skip>${skipChecks}</license.skip>
@@ -200,6 +202,9 @@
     <sort.skip>${skipChecks}</sort.skip>
     <spotless.apply.skip>${skipChecks}</spotless.apply.skip>
     <spotless.checks.skip>${skipChecks}</spotless.checks.skip>
+
+    <!-- disable other non-essential goals -->
+    <assembly.skipAssembly>${quickly}</assembly.skipAssembly>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

You can now build Zeebe quickly using `mvn install -Dquickly`.

The `quickly` flag skips all non-essential goals like checks, tests, and assembly.

Building quickly is typically around 5s faster than just skipping tests and checks. This is inline with the expectation where assembly takes about 6 seconds.

Measurements (using Apple M1Pro):
| Command | Duration single-threaded `T1` | Duration multi-threaded `T1C-1` |
|--------|--------|--------|
| `mvnd clean install -DskipTests -DskipChecks` | 46.6s | 30.5s |
| `mvnd clean install -Dquickly` | 41.4s | 24.9s | 
| `mvnd install -DskipTests -DskipChecks` | 16.9s | 12.6s |
| `mvnd install -Dquickly` | 11.1s | 7.1s | 

## Related issues

<!-- Which issues are closed by this PR or are related -->

No related issue, this was today's slacktime effort

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
